### PR TITLE
Fix #494 - ReactionInstance crashes when reaction references unknown dependency

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaScopingTest.xtend
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaScopingTest.xtend
@@ -115,5 +115,41 @@ class LinguaFrancaScopingTest {
             XtextLinkingDiagnostic.LINKING_DIAGNOSTIC,
             "Couldn't resolve reference to Variable 'y'")
     }
-    
+
+    @Test
+    def void unresolvedReferenceInTriggerClause() {
+        '''
+            target C;
+            main reactor {
+                reaction(unknown) {==}
+            }
+        '''.parse.assertError(LfPackage::eINSTANCE.varRef,
+            XtextLinkingDiagnostic.LINKING_DIAGNOSTIC,
+            "Couldn't resolve reference to Variable 'unknown'.")
+    }
+
+    @Test
+    def void unresolvedReferenceInUseClause() {
+        '''
+            target C;
+            main reactor {
+                reaction() unknown {==}
+            }
+        '''.parse.assertError(LfPackage::eINSTANCE.varRef,
+            XtextLinkingDiagnostic.LINKING_DIAGNOSTIC,
+            "Couldn't resolve reference to Variable 'unknown'.")
+    }
+
+    @Test
+    def void unresolvedReferenceInEffectsClause() {
+        '''
+            target C;
+            main reactor {
+                reaction() -> unknown {==}
+            }
+        '''.parse.assertError(LfPackage::eINSTANCE.varRef,
+            XtextLinkingDiagnostic.LINKING_DIAGNOSTIC,
+            "Couldn't resolve reference to Variable 'unknown'.")
+    }
+
 }

--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.xtend
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.xtend
@@ -361,7 +361,7 @@ class LinguaFrancaValidationTest {
         ''').assertError(LfPackage::eINSTANCE.connection, null,
             "Cannot connect: Port named 'in' is already effect of a reaction.")
     }
-	
+
     /**
      * Disallow connection of multiple ports to the same input port.
      */
@@ -388,7 +388,7 @@ class LinguaFrancaValidationTest {
         ''').assertError(LfPackage::eINSTANCE.connection, null,
             "Cannot connect: Port named 'in' may only appear once on the right side of a connection.")
     }
-    
+
     /**
      * Detect cycles in the instantiation graph.
      */

--- a/org.lflang/src/org/lflang/generator/ReactionInstance.xtend
+++ b/org.lflang/src/org/lflang/generator/ReactionInstance.xtend
@@ -165,13 +165,12 @@ class ReactionInstance extends NamedInstance<Reaction> {
                         portInstance.dependsOnReactions.add(this);
                     }
                 }
-            } else {
-                // Effect must be an Action.
+            } else if (effect.variable instanceof Action) {
                 var actionInstance = parent.lookupActionInstance(
                     effect.variable as Action)
                 this.effects.add(actionInstance)
                 actionInstance.dependsOnReactions.add(this)
-            }
+            } // else it may be an unresolved reference
         }
         // Create a deadline instance if one has been defined.
         if (this.definition.deadline !== null) {


### PR DESCRIPTION
Fix #494 