### PR TITLE
Support after on connections composed of multiple single ports

### DIFF
--- a/org.lflang/src/org/lflang/ASTUtils.xtend
+++ b/org.lflang/src/org/lflang/ASTUtils.xtend
@@ -173,24 +173,19 @@ class ASTUtils {
     }
     
     /**
-     * Return true if any port on the left or right of the connection involves
-     * a bank of reactors or a multiport.
+     * Return true if the connection involves multiple ports on the left or right side of the connection, or
+     * if the port on the left or right of the connection involves a bank of reactors or a multiport.
      * @param connection The connection.
      */
     private static def boolean isWide(Connection connection) {
-        for (leftPort : connection.leftPorts) {
-            if ((leftPort.variable as Port).widthSpec !== null
-                || leftPort.container?.widthSpec !== null
-            ) {
-                return true
-            }
+        if (connection.leftPorts.size > 1 || connection.rightPorts.size > 1) {
+            return true;
         }
-        for (rightPort : connection.rightPorts) {
-            if ((rightPort.variable as Port).widthSpec !== null
-                || rightPort.container?.widthSpec !== null
-            ) {
-                return true
-            }
+        val leftPort = connection.leftPorts.get(0);
+        val rightPort = connection.rightPorts.get(0);
+        if ((leftPort.variable as Port).widthSpec !== null || leftPort.container?.widthSpec !== null ||
+            (rightPort.variable as Port).widthSpec !== null || rightPort.container?.widthSpec !== null) {
+            return true
         }
         return false
     }

--- a/test/C/src/multiport/PipelineAfter.lf
+++ b/test/C/src/multiport/PipelineAfter.lf
@@ -1,0 +1,43 @@
+target C;
+
+reactor Source {
+    output out:unsigned;
+    
+    reaction (startup) -> out {=
+        SET(out, 40);
+    =}
+}
+
+reactor Compute {
+    input in:unsigned;
+    output out:unsigned;
+    
+    reaction (in) -> out {=
+        SET(out, in->value + 2);
+    =}
+}
+
+reactor Sink {
+    input in:unsigned;
+    
+    reaction (in) {=
+        printf("Received %d\n", in->value);
+        if (in->value != 42) {
+            printf("ERROR: expected 42!\n");
+            exit(1);
+        }
+        if (get_elapsed_logical_time() != SEC(1)) {
+            printf("ERROR: Expected to receive input after one second.\n");
+            exit(2);
+        }
+    =}
+    
+}
+
+main reactor {
+    source = new Source();
+    compute = new Compute();
+    sink = new Sink();
+
+    source.out, compute.out -> compute.in, sink.in after 500 msec;
+}

--- a/test/Cpp/src/multiport/PipelineAfter.lf
+++ b/test/Cpp/src/multiport/PipelineAfter.lf
@@ -1,0 +1,43 @@
+target Cpp;
+
+reactor Source {
+    output out:unsigned;
+    
+    reaction (startup) -> out {=
+        out.set(40);
+    =}
+}
+
+reactor Compute {
+    input in:unsigned;
+    output out:unsigned;
+    
+    reaction (in) -> out {=
+        out.set(*in.get() + 2);
+    =}
+}
+
+reactor Sink {
+    input in:unsigned;
+    
+    reaction (in) {=
+        std::cout << "Received " << *in.get() << '\n';
+        if (*in.get() != 42) {
+            std::cerr << "Error: expected 42!\n";
+            exit(1);
+        }
+        if (get_elapsed_logical_time() != 1s) {
+            std::cerr << "ERROR: Expected to receive input after 1 second.\n";
+            exit(2);
+        }
+    =}
+    
+}
+
+main reactor {
+    source = new Source();
+    compute = new Compute();
+    sink = new Sink();
+
+    source.out, compute.out -> compute.in, sink.in after 500 msec;
+}


### PR DESCRIPTION
Currently, if we connect multiple individual ports (not multiports) like so `o1, o2 -> i1, i2`, then after delays do not work as expected. If only single ports are involved, the connection is still treated as a single port connection. This PR modifies the `isWide` method to also return true, if multiple ports are listed on either side. This small change is sufficient to get after delays working as expected on such connections. I also added a C and a C++ test.