### PR TITLE
Support list initializer syntax in Python

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.xtend
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.xtend
@@ -611,7 +611,29 @@ class LinguaFrancaValidationTest {
             }
         }
     }
-    
+
+    @Test
+    def void forbidListLiterals() {
+        parseWithoutError('''
+            target C;
+            reactor Contained {
+                state x: int[]([1, 2]);
+            }
+        ''').assertError(LfPackage::eINSTANCE.listLiteral,
+            null, 'Target C does not support LF list literals')
+    }
+
+
+    @Test
+    def void allowListLiteralsInPython() {
+        parseWithoutError('''
+            target Python;
+            reactor Contained {
+                state x([1, 2]);
+            }
+        ''').assertNoErrors()
+    }
+
     
     /**
      * Tests for state and parameter declarations, including native lists.

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -341,10 +341,10 @@ Type:
 ;
 
 ArraySpec:
-    ofVariableLength?='[]' | '[' length=INT ']';
+    '[' ( ofVariableLength?=']' | length=INT ']' );
     
 WidthSpec:
-    ofVariableLength?='[]' | '[' (terms+=WidthTerm) ('+' terms+=WidthTerm)* ']';
+    '[' ( ofVariableLength?=']' | (terms+=WidthTerm) ('+' terms+=WidthTerm)* ']' );
     
 WidthTerm:
     width=INT 
@@ -527,7 +527,7 @@ Token:
     // Braces
     '(' | ')' | '{' | '}' |
     // Brackets
-    '[' | ']' | '<' | '>' | '[]' |
+    '[' | ']' | '<' | '>' |
     // Punctuation
     ':' | ';' | ',' | '.' | '::' |
     // Slashes

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -323,7 +323,7 @@ Expr :
 // If it is a constant, the validator should check that if the value
 // is non-zero, it is accompanied by a unit.
 Value:
-    (parameter=[Parameter] | time=Time | literal=Literal | code=Code);
+    (parameter=[Parameter] | time=Time | literal=Literal | list=ListLiteral | code=Code);
 
 
 Time:
@@ -383,6 +383,11 @@ Generic:
 
 SignedInt:
     INT | NEGINT
+;
+
+// list literals support even empty lists, and a trailing comma.
+ListLiteral:
+    '[' ( items+=Value (',' items+=Value)* )? ','? ']'
 ;
 
 Literal:

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -385,9 +385,14 @@ SignedInt:
     INT | NEGINT
 ;
 
-// list literals support even empty lists, and a trailing comma.
+// List literals support even empty lists, and a trailing comma.
+
+// Note: this expansion is weirdly written, but without the
+// emptyList property, Xtext fails to push a ListLiteral node
+// when the list is empty... Another bug of Xtext.
 ListLiteral:
-    '[' ( items+=Value (',' items+=Value)* )? ','? ']'
+    '[' (items+=Value (',' items+=Value)* ','? ']'
+        | ','? emptyList?=']')
 ;
 
 Literal:

--- a/org.lflang/src/org/lflang/Target.java
+++ b/org.lflang/src/org/lflang/Target.java
@@ -397,6 +397,14 @@ public enum Target {
         this(description, requiresTypes, "N/A", "N/A", keywords);
     }
 
+    /**
+     * Returns true if the target supports list literals in LF syntax.
+     * If not, list literals produce validator errors.
+     */
+    public boolean supportsLfListLiterals() {
+        return this == Python;
+    }
+
 
     /**
      * Return the target that matches the given string.

--- a/org.lflang/src/org/lflang/validation/LFValidatorImpl.xtend
+++ b/org.lflang/src/org/lflang/validation/LFValidatorImpl.xtend
@@ -64,6 +64,7 @@ import org.lflang.lf.Instantiation
 import org.lflang.lf.KeyValuePair
 import org.lflang.lf.KeyValuePairs
 import org.lflang.lf.LfPackage.Literals
+import org.lflang.lf.ListLiteral
 import org.lflang.lf.Model
 import org.lflang.lf.NamedHost
 import org.lflang.lf.Output
@@ -368,6 +369,13 @@ class LFValidatorImpl extends AbstractLFValidator {
                     error("Width must be a positive integer.", Literals.WIDTH_SPEC__TERMS)
                 }
             }
+        }
+    }
+
+    @Check(FAST)
+    def checkListLiteral(ListLiteral list) {
+        if (!target.supportsLfListLiterals()) {
+            error("Target " + target + " does not support LF list literals", Literals.LIST_LITERAL__ITEMS)
         }
     }
 

--- a/test/Python/src/ListLiterals.lf
+++ b/test/Python/src/ListLiterals.lf
@@ -2,10 +2,19 @@
 // For this test, success is just compiling and running.
 target Python;
 
+
+reactor Sub(seq([1,2])) {
+
+}
+
 main reactor {
     state l12([1,2]);
     state empty([]);
     state empty2([,]);
+
+    sub  = new Sub(seq = [1, 2]);
+    sub2 = new Sub(seq = (1, 2));
+    sub3 = new Sub(seq = ([1, 2]));
 
     reaction(startup) {=
         assert self.empty == []

--- a/test/Python/src/ListLiterals.lf
+++ b/test/Python/src/ListLiterals.lf
@@ -1,0 +1,16 @@
+// This example illustrates state variables and parameters on the wiki.
+// For this test, success is just compiling and running.
+target Python;
+
+main reactor {
+    state l12([1,2]);
+    state empty([]);
+    state empty2([,]);
+
+    reaction(startup) {=
+        assert self.empty == []
+        assert self.empty2 == []
+        assert self.l12 == [1, 2]
+        print("Success")
+    =}
+}

--- a/test/Python/src/MovingAverage.lf
+++ b/test/Python/src/MovingAverage.lf
@@ -18,7 +18,7 @@ reactor MASource {
     =}
 }
 reactor MovingAverageImpl {
-    state delay_line(0.0, 0.0, 0.0);
+    state delay_line([0.0, 0.0, 0.0]);
     state index(0);
     input m_in;
     output out;

--- a/test/Python/src/NativeListsAndTimes.lf
+++ b/test/Python/src/NativeListsAndTimes.lf
@@ -5,10 +5,11 @@
 main reactor(x(0), 
             y(0),       // Units are missing but not required
             z(1 msec),  // Type is missing but not required
-            p(1, 2, 3, 4),      // List of integers 
-            q(1 msec, 2 msec, 3 msec), // list of time values
-            r({=0=}),   // Zero-valued target code also is a valid time
-            g(1 msec, 2 msec)   // List of time values
+            p(1, 2, 3, 4),      // tuple of integers
+            pList([1, 2, 3, 4]),    // List of integers
+            q(1 msec, 2 msec, 3 msec), // tuple of time values
+            qList([1 msec, 2 msec, 3 msec]), // list of time values
+            r({=0=})   // Zero-valued target code also is a valid time
             ) {
     state s(y); // Reference to explicitly typed time parameter
     state t(z); // Reference to implicitly typed time parameter
@@ -18,12 +19,24 @@ main reactor(x(0),
     timer tock(1 sec);  // Implicit type time
     timer toe(z);       // Implicit type time
     state baz(p);       // Implicit type int[]
+    state bazList(pList);
     state period(z);    // Implicit type time
     state bar(1 msec, 2 msec, 3 msec);  // tuple of time values
-    state bar([1 msec, 2 msec, 3 msec]);  // list of time values
+    state barList([1 msec, 2 msec, 3 msec]);  // list of time values
     state notype(1, 2, 3, 4);   // tuple
-    state notype([1, 2, 3, 4]); // list
-    reaction(tick) {=
-        # Target code
+    state notypeList([1, 2, 3, 4]); // list
+
+    reaction(startup) {=
+        assert self.notype == (1,2,3,4)
+        assert self.p == (1,2,3,4)
+        assert self.pList == [1,2,3,4]
+        assert self.pList != (1,2,3,4)
+        assert self.notypeList != (1,2,3,4)
+        assert self.notypeList == [1,2,3,4]
+        assert self.baz == (1,2,3,4)
+        assert self.bazList == [1,2,3,4]
+
+        assert self.bar == (MSEC(1),MSEC(2),MSEC(3))
+        assert self.barList == [MSEC(1),MSEC(2),MSEC(3)]
     =}
 }

--- a/test/Python/src/NativeListsAndTimes.lf
+++ b/test/Python/src/NativeListsAndTimes.lf
@@ -19,8 +19,10 @@ main reactor(x(0),
     timer toe(z);       // Implicit type time
     state baz(p);       // Implicit type int[]
     state period(z);    // Implicit type time
-    state bar(1 msec, 2 msec, 3 msec);  // list of time values
-    state notype(1, 2, 3, 4);
+    state bar(1 msec, 2 msec, 3 msec);  // tuple of time values
+    state bar([1 msec, 2 msec, 3 msec]);  // list of time values
+    state notype(1, 2, 3, 4);   // tuple
+    state notype([1, 2, 3, 4]); // list
     reaction(tick) {=
         # Target code
     =}


### PR DESCRIPTION

Implement list literals for Python. Now:

- using `(1, 2, 3)` as an initializer creates a tuple (previously created a list)
- using `([1, 2, 3])` as an initializer creates a list

This makes LF syntax in line with python syntax itself and allows writing
- initializers with an empty list `([])`
- initializers with a one element list `([1])`

Previously these scenarios required fat braces, eg `{=[]=}`.

Using list literals in other targets than Python produces a validator error. When this is merged I'll follow up with the necessary changes for Rust to support this. TS could also support it.

The python code generator is simplified as there is no more special treatment for lists in parameters. Previously, initializing a parameter with `(1, 2)` created a tuple, while the same initializer for a state variable creates a list. I argue that this was hard to learn and not ergonomic, because
- the difference is not obvious to a user reading the code
- it breaks a useful refactoring flow, that abstracts a state variable initializer to a parameter. Namely, when you have the following:
```python
reactor R {
   state var(...)
}
```
you can easily abstract it by turning it into
```python
reactor R(p(...)) {
   state var(p)
}
```
and the code means the same, regardless of what "`...`" is. Previously, this was not true for python if `...` is a comma separated list, because the refactoring effectively makes the state variable be initialized to an immutable tuple instead of a mutable list, which may cause unexpected errors at runtime.

I understand that this was supposed to honor the principle that parameters should be immutable, whereas state variables are not. However I think as shown above, this corner case has potent downsides, and doesn't buy us safety anyway: you could always initialize your parameter to a mutable thing, eg `{=[1,2]=}`, put mutable objects inside the tuple fields, or even set the parameter variable itself (I think), as Python doesn't support final bindings.