### PR TITLE
Support cmake include files with spaces in path

### DIFF
--- a/org.lflang/src/org/lflang/generator/c/CCmakeGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CCmakeGenerator.java
@@ -205,7 +205,7 @@ class CCmakeGenerator {
         
         // Add the include file
         for (String includeFile : targetConfig.cmakeIncludesWithoutPath) {
-            cMakeCode.append("include("+includeFile+")\n");
+            cMakeCode.append("include(\""+includeFile+"\")\n");
         } 
         
         return cMakeCode;

--- a/org.lflang/src/org/lflang/generator/cpp/CppCmakeGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppCmakeGenerator.kt
@@ -139,7 +139,7 @@ class CppCmakeGenerator(private val targetConfig: TargetConfig, private val file
                 |        RUNTIME DESTINATION $S{CMAKE_INSTALL_BINDIR}
                 |)
                 |
-            ${" |"..(includeFiles?.joinToString("\n") { "include($it)" } ?: "") }
+            ${" |"..(includeFiles?.joinToString("\n") { "include(\"$it\")" } ?: "") }
             """.trimMargin()
         }
     }


### PR DESCRIPTION
This is a quick fix to support paths with spaces in cmake includes. Currently, spaces in paths will trigger syntax errors in cmake