### PR TITLE
Support after delays on broadcast connections in C++

### DIFF
--- a/org.lflang/src/org/lflang/ASTUtils.xtend
+++ b/org.lflang/src/org/lflang/ASTUtils.xtend
@@ -216,7 +216,7 @@ class ASTUtils {
         output.variable = delayClass.outputs.get(0)
         upstream.leftPorts.addAll(connection.leftPorts)
         upstream.rightPorts.add(input)
-        upstream.isIterated = connection.isIterated
+        upstream.iterated = connection.iterated
         downstream.leftPorts.add(output)
         downstream.rightPorts.addAll(connection.rightPorts)
 

--- a/org.lflang/src/org/lflang/ASTUtils.xtend
+++ b/org.lflang/src/org/lflang/ASTUtils.xtend
@@ -216,6 +216,7 @@ class ASTUtils {
         output.variable = delayClass.outputs.get(0)
         upstream.leftPorts.addAll(connection.leftPorts)
         upstream.rightPorts.add(input)
+        upstream.isIterated = connection.isIterated
         downstream.leftPorts.add(output)
         downstream.rightPorts.addAll(connection.rightPorts)
 

--- a/org.lflang/src/org/lflang/ASTUtils.xtend
+++ b/org.lflang/src/org/lflang/ASTUtils.xtend
@@ -177,7 +177,7 @@ class ASTUtils {
      * if the port on the left or right of the connection involves a bank of reactors or a multiport.
      * @param connection The connection.
      */
-    static def boolean isMultiportConnection(Connection connection) {
+    static def boolean hasMultipleConnections(Connection connection) {
         if (connection.leftPorts.size > 1 || connection.rightPorts.size > 1) {
             return true;
         }
@@ -257,7 +257,7 @@ class ASTUtils {
             typeParm.literal = generic
             delayInstance.typeParms.add(typeParm)
         }
-        if (connection.isMultiportConnection) {
+        if (connection.hasMultipleConnections) {
             val widthSpec = factory.createWidthSpec
             if (defineWidthFromConnection) {
                 // Add all right ports of the connection to the WidthSpec of the genertaed delay instance.

--- a/org.lflang/src/org/lflang/ASTUtils.xtend
+++ b/org.lflang/src/org/lflang/ASTUtils.xtend
@@ -177,7 +177,7 @@ class ASTUtils {
      * if the port on the left or right of the connection involves a bank of reactors or a multiport.
      * @param connection The connection.
      */
-    private static def boolean isWide(Connection connection) {
+    static def boolean isMultiportConnection(Connection connection) {
         if (connection.leftPorts.size > 1 || connection.rightPorts.size > 1) {
             return true;
         }
@@ -257,7 +257,7 @@ class ASTUtils {
             typeParm.literal = generic
             delayInstance.typeParms.add(typeParm)
         }
-        if (connection.isWide) {
+        if (connection.isMultiportConnection) {
             val widthSpec = factory.createWidthSpec
             if (defineWidthFromConnection) {
                 // Add all right ports of the connection to the WidthSpec of the genertaed delay instance.

--- a/org.lflang/src/org/lflang/AstExtensions.kt
+++ b/org.lflang/src/org/lflang/AstExtensions.kt
@@ -414,4 +414,4 @@ val Instantiation.reactor get() = this.reactorClass.toDefinition()
 /** Check if the receiver is a bank instantiation. */
 val Instantiation.isBank: Boolean get() = this.widthSpec != null
 
-val Connection.isMultiportConnection: Boolean get() = ASTUtils.isMultiportConnection(this)
+val Connection.hasMultipleConnections: Boolean get() = ASTUtils.hasMultipleConnections(this)

--- a/org.lflang/src/org/lflang/AstExtensions.kt
+++ b/org.lflang/src/org/lflang/AstExtensions.kt
@@ -413,3 +413,5 @@ val Instantiation.reactor get() = this.reactorClass.toDefinition()
 
 /** Check if the receiver is a bank instantiation. */
 val Instantiation.isBank: Boolean get() = this.widthSpec != null
+
+val Connection.isMultiportConnection: Boolean get() = ASTUtils.isMultiportConnection(this)

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -227,7 +227,7 @@ Instantiation:
 
 Connection:
     ((leftPorts += VarRef (',' leftPorts += VarRef)*)
-    | ( '(' leftPorts += VarRef (',' leftPorts += VarRef)* ')' isIterated ?= '+'?))
+    | ( '(' leftPorts += VarRef (',' leftPorts += VarRef)* ')' iterated ?= '+'?))
     ('->' | physical?='~>') 
     rightPorts += VarRef (',' rightPorts += VarRef)*
     (delay=Delay)?

--- a/org.lflang/src/org/lflang/generator/cpp/CppAssembleMethodGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppAssembleMethodGenerator.kt
@@ -27,7 +27,7 @@ package org.lflang.generator.cpp
 import org.lflang.generator.PrependOperator
 import org.lflang.isBank
 import org.lflang.isMultiport
-import org.lflang.isMultiportConnection
+import org.lflang.hasMultipleConnections
 import org.lflang.lf.*
 
 /**
@@ -133,7 +133,7 @@ class CppAssembleMethodGenerator(private val reactor: Reactor) {
     }
 
     private fun declareConnection(c: Connection, idx: Int): String {
-        return if (c.isMultiportConnection) {
+        return if (c.hasMultipleConnections) {
             declareMultiportConnection(c, idx)
         } else {
             val leftPort = c.leftPorts[0]

--- a/org.lflang/src/org/lflang/generator/cpp/CppAssembleMethodGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppAssembleMethodGenerator.kt
@@ -27,6 +27,7 @@ package org.lflang.generator.cpp
 import org.lflang.generator.PrependOperator
 import org.lflang.isBank
 import org.lflang.isMultiport
+import org.lflang.isMultiportConnection
 import org.lflang.lf.*
 
 /**
@@ -130,27 +131,6 @@ class CppAssembleMethodGenerator(private val reactor: Reactor) {
         ${" |"..if (reaction.deadline != null) setDeadline(reaction) else ""}
         """.trimMargin()
     }
-
-    private val Connection.isMultiportConnection: Boolean
-        get() {
-            // if there are multiple ports listed on the left or right side, this is a multiport connection
-            if (leftPorts.size > 1 || rightPorts.size > 1)
-                return true
-
-            // if the ports on either side are multiports, this is a multiport connection
-            val leftPort = leftPorts[0].variable as Port
-            val rightPort = rightPorts[0].variable as Port
-            if (leftPort.isMultiport || rightPort.isMultiport)
-                return true
-
-            // if the containers on either side are banks, this is a multiport connection
-            val leftContainer = leftPorts[0].container
-            val rightContainer = rightPorts[0].container
-            if (leftContainer?.isBank == true || rightContainer?.isBank == true)
-                return true
-
-            return false
-        }
 
     private fun declareConnection(c: Connection, idx: Int): String {
         return if (c.isMultiportConnection) {

--- a/org.lflang/src/org/lflang/generator/cpp/CppAssembleMethodGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppAssembleMethodGenerator.kt
@@ -178,7 +178,7 @@ class CppAssembleMethodGenerator(private val reactor: Reactor) {
             ${" |"..c.leftPorts.joinToString("\n") { addAllPortsToVector(it, "__lf_left_ports_$idx") }}
                 |std::vector<$portType> __lf_right_ports_$idx;
             ${" |"..c.rightPorts.joinToString("\n") { addAllPortsToVector(it, "__lf_right_ports_$idx") }}
-                |lfutil::bind_multiple_ports(__lf_left_ports_$idx, __lf_right_ports_$idx, ${c.isIsIterated});
+                |lfutil::bind_multiple_ports(__lf_left_ports_$idx, __lf_right_ports_$idx, ${c.isIterated});
             """.trimMargin()
         }
     }

--- a/test/Cpp/src/multiport/Broadcast.lf
+++ b/test/Cpp/src/multiport/Broadcast.lf
@@ -1,0 +1,27 @@
+target Cpp;
+
+reactor Source {
+    output out:unsigned;
+    
+    reaction (startup) -> out {=
+        out.set(42);
+    =}
+}
+
+reactor Sink(bank_index:size_t(0)) {
+    input in:unsigned;
+    
+    reaction (in) {=
+        std::cout << "Received " << *in.get() << '\n';
+        if (*in.get() != 42) {
+            std::cerr << "Error: expected " << 42 << "!\n";
+            exit(1);
+        }
+    =}
+}
+
+main reactor {
+    source = new Source();
+    sink = new[4] Sink();
+    (source.out)+ -> sink.in;
+}

--- a/test/Cpp/src/multiport/BroadcastAfter.lf
+++ b/test/Cpp/src/multiport/BroadcastAfter.lf
@@ -1,0 +1,43 @@
+target Cpp{
+  fast: true   
+}
+
+reactor Source {
+    output out:unsigned;
+    
+    reaction (startup) -> out {=
+        out.set(42);
+    =}
+}
+
+reactor Sink(bank_index: size_t(0)) {
+    input in:unsigned;
+    state received: bool{false};
+    
+    reaction (in) {=
+        std::cout << bank_index << " received " << *in.get() << '\n';
+        if (*in.get() != 42) {
+            std::cerr << "Error: expected " << 42 << "!\n";
+            exit(1);
+        }
+        if (get_elapsed_logical_time() != 1s) {
+            std::cerr << "ERROR: Expected to receive input after one second.\n";
+            exit(2);
+        }
+        received = true;
+    =}
+    
+    reaction(shutdown) {=
+        if (!received) {
+            std::cerr << "ERROR: Destination " << bank_index << " received no input!\n";
+            exit(1);
+        }
+        std::cout << "Success.\n";
+    =}
+}
+
+main reactor {
+    source = new Source();
+    sink = new[4] Sink();
+    (source.out)+ -> sink.in after 1 sec;
+}


### PR DESCRIPTION
Currently, after delays do not work on broadcast connections (using the `(...)+` syntax). In part, this is because the `iterated` property of the connection is not preserved in our AST transformation. I fixed this, so that the newly generated upstream connection is also iterated if the original connection was iterated. This solves the issue for C++. However, a similar test written in C still fails, and I haven't found out why. I will push the test that I have to `broadcast-after-c` based on this branch, and will open a separate issue.

This PR also does a few cleanups and adds C++ tests.