### PR TITLE
Add gradle task to run a single test from command line

### DIFF
--- a/org.lflang.tests/build.gradle
+++ b/org.lflang.tests/build.gradle
@@ -50,4 +50,13 @@ test {
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 	useJUnitPlatform()
     finalizedBy jacocoTestReport
+    workingDir = ".."
+}
+
+task runSingleTest(type: JavaExec) {
+    description = "Execute a single test, use with eg --args test/Python/src/Minimal.lf"
+    group = "test"
+    classpath = sourceSets.test.runtimeClasspath
+    workingDir = ".."
+    mainClass = 'org.lflang.tests.RunSingleTestMain'
 }

--- a/org.lflang.tests/src/org/lflang/tests/RunSingleTestMain.java
+++ b/org.lflang.tests/src/org/lflang/tests/RunSingleTestMain.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, TU Dresden.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.lflang.tests;
+
+import java.io.FileNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.lflang.Target;
+import org.lflang.tests.runtime.TestBase;
+
+/**
+ * Execute a single test case. Use it with the gradle task
+ * {@code gradle runSingleTest --args test/Python/src/Minimal.lf}
+ *
+ * @author Clément Fournier
+ */
+public class RunSingleTestMain {
+
+
+    private static final Pattern TEST_FILE_PATTERN = Pattern.compile("(test/(\\w+)/src)/([^/]++/)*(\\w+.lf)");
+
+    public static void main(String[] args) throws FileNotFoundException {
+        if (args.length != 1) {
+            throw new IllegalArgumentException("Expected 1 path to an LF file");
+        }
+        var path = Paths.get(args[0]);
+        if (!Files.exists(path)) {
+            throw new FileNotFoundException("No such test file: " + path);
+        }
+
+        Matcher matcher = TEST_FILE_PATTERN.matcher(args[0]);
+        if (!matcher.matches()) {
+            throw new FileNotFoundException("Not a test: " + path);
+        }
+
+        Path packageRoot = Paths.get(matcher.group(1)).toAbsolutePath();
+        Target target = Target.forName(matcher.group(2)).get();
+
+        TestBase.runSingleTestAndPrintResults(new LFTest(target, path.toAbsolutePath(), packageRoot));
+    }
+}

--- a/org.lflang.tests/src/org/lflang/tests/TestRegistry.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestRegistry.java
@@ -84,7 +84,7 @@ public class TestRegistry {
     /**
      * Path to the root of the repository.
      */
-    public static final Path LF_REPO_PATH = Paths.get(new File("").getAbsolutePath()).getParent();
+    public static final Path LF_REPO_PATH = Paths.get("").toAbsolutePath();
     
     /**
      * Path to the example directory in the repository.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,44 @@
+# LF system tests
+
+**System tests** are complete Lingua Franca programs that are compiled and executed automatically. A test passes if it successfully compiles and runs to completion with normal termination (return code 0). These tests are located in a subdirectory corresponding to their target language.
+
+### Running from the command line
+
+The simplest way to run the regression tests is to use a Bash script called `run-lf-tests` in `$LF/bin`, which takes the target language as a parameter:
+```
+run-lf-tests C
+run-lf-tests Cpp
+run-lf-tests Python
+run-lf-tests TS
+```
+
+You can also selectively run just some of the tests. For example, to run the system tests for an individual target language, do this:
+```
+./gradlew test --tests org.icyphy.tests.runtime.CTest.*
+./gradlew test --tests org.icyphy.tests.runtime.CppTest.*
+./gradlew test --tests org.icyphy.tests.runtime.PythonTest.*
+./gradlew test --tests org.icyphy.tests.runtime.TypeScriptTest.*
+```
+
+To run a single test case, use the `runSingleTest` gradle task along with the path to the test source file:
+```
+./gradlew runSingleTest --args test/C/src/Minimal.lf
+```
+
+It is also possible to run a subset of the tests. For example, the C tests are organized into the following categories:
+
+* **generic** tests are `.lf` files located in `$LF/test/C/src`.
+* **concurrent** tests are `.lf` files located in `$LF/test/C/src/concurrent`.
+* **federated** tests are `.lf` files located in `$LF/test/C/src/federated`.
+* **multiport** tests are `.lf` files located in `$LF/test/C/src/multiport`.
+
+To invoke only the tests in the `concurrent` category, for example, do this:
+```
+cd $LF/xtext
+./gradlew test --tests org.icyphy.tests.runtime.CTest.runConcurrentTests
+```
+
+
+### See also
+
+- [Regression Tests (wiki)](https://github.com/lf-lang/lingua-franca/wiki/Regression-Tests)


### PR DESCRIPTION
One can use it using `gradle runSingleTest --args test/Python/src/Minimal.lf`

TODO
- [x] document it somewhere in the wiki (or test/README.md)

I'm probably going to merge this into #488 