### PR TITLE
Make the eclipse error reporter more robust

### DIFF
--- a/org.lflang.lfc/src/org/lflang/lfc/StandaloneIssueAcceptor.java
+++ b/org.lflang.lfc/src/org/lflang/lfc/StandaloneIssueAcceptor.java
@@ -2,9 +2,7 @@ package org.lflang.lfc;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
-import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.xtext.diagnostics.Severity;
@@ -49,7 +47,7 @@ public class StandaloneIssueAcceptor implements ValidationMessageAcceptor {
             diagnostic.getLine(),
             diagnostic.getColumn(),
             diagnostic.getLength(),
-            getPath(object)
+            getPath(diagnostic)
         );
 
         accept(lfIssue);
@@ -59,27 +57,14 @@ public class StandaloneIssueAcceptor implements ValidationMessageAcceptor {
     /**
      * Best effort to get a fileName. May return null.
      */
-    private static Path getFileNameBestEffort(EObject obj) {
-        Path path;
-        URI uri = obj.eResource().getURI();
+    private Path getPath(EObjectDiagnosticImpl diagnostic) {
+        Path file = null;
         try {
-            path = FileConfig.toPath(uri);
-        } catch (IOException ioe) {
-            String fString = uri.toFileString();
-            path = fString != null ? Paths.get(fString) : null;
+            file = FileConfig.toPath(diagnostic.getUriToProblem());
+        } catch (IOException e) {
+            // just continue with null
         }
-        return path;
-    }
-
-
-    private Path getPath(EObject object) {
-        Path path;
-        try {
-            path = FileConfig.toPath(object.eResource());
-        } catch (IOException ignored) {
-            path = getFileNameBestEffort(object);
-        }
-        return path;
+        return file;
     }
 
 

--- a/org.lflang/META-INF/MANIFEST.MF
+++ b/org.lflang/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.eclipse.xtext,
  com.google.guava,
  org.eclipse.xtend.lib.macro,
  org.apache.commons.cli;bundle-version="1.4",
- org.jetbrains.kotlin.bundled-compiler;resolution:=optional
+ org.jetbrains.kotlin.bundled-compiler;resolution:=optional,
+ org.eclipse.core.runtime;bundle-version="3.23.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.lflang,
  org.lflang.generator,

--- a/org.lflang/src/org/lflang/generator/EclipseErrorReporter.java
+++ b/org.lflang/src/org/lflang/generator/EclipseErrorReporter.java
@@ -34,7 +34,8 @@ import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.diagnostics.Severity;
+import org.eclipse.xtext.validation.EObjectDiagnosticImpl;
 import org.lflang.ErrorReporter;
 import org.lflang.FileConfig;
 import org.lflang.Mode;
@@ -66,15 +67,20 @@ public class EclipseErrorReporter implements ErrorReporter {
      * @param severity One of IMarker.SEVERITY_ERROR or IMarker.SEVERITY_WARNING
      * @param obj      The Ecore object, or null if it is not known.
      */
-    private String report(String message, int severity, EObject obj) {
-        final Integer line = obj == null ? null : NodeModelUtils.getNode(obj).getStartLine();
-        Path file = null;
-        try {
-            file = obj == null ? null : FileConfig.toPath(obj.eResource());
-        } catch (IOException e) {
-            // just continue with null
+    private String report(String message, Severity severity, EObject obj) {
+        if (obj != null) {
+             final EObjectDiagnosticImpl diagnostic = new EObjectDiagnosticImpl(severity, null, message, obj, null, -1, null);
+             final int line = diagnostic.getLine();
+             Path file = null;
+             try {
+                 file = FileConfig.toPath(diagnostic.getUriToProblem());
+             } catch (IOException e) {
+                // just continue with null
+             }
+             return report(message, severity, line, file);
         }
-        return report(message, severity, line, file);
+        
+        return report(message, severity, null, null);
     }
 
     /**
@@ -89,8 +95,8 @@ public class EclipseErrorReporter implements ErrorReporter {
      * @param line     The line number or null if it is not known.
      * @param file     The file, or null if it is not known.
      */
-    private String report(String message, int severity, Integer line, Path file) {
-        final boolean isError = severity == IMarker.SEVERITY_ERROR;
+    private String report(String message, Severity severity, Integer line, Path file) {
+        final boolean isError = severity == Severity.ERROR;
         if (isError) {
             errorsOccurred = true;
         }
@@ -122,7 +128,7 @@ public class EclipseErrorReporter implements ErrorReporter {
                 marker.setAttribute(IMarker.LOCATION,
                         line == null ? "1" : line.toString());
                 // Mark as an error or warning.
-                marker.setAttribute(IMarker.SEVERITY, severity);
+                marker.setAttribute(IMarker.SEVERITY, isError ? IMarker.SEVERITY_ERROR : IMarker.SEVERITY_WARNING);
                 marker.setAttribute(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
 
                 marker.setAttribute(IMarker.USER_EDITABLE, false);
@@ -148,7 +154,7 @@ public class EclipseErrorReporter implements ErrorReporter {
      */
     @Override
     public String reportError(String message) {
-        return report(message, IMarker.SEVERITY_ERROR, null, null);
+        return report(message, Severity.ERROR, null, null);
     }
 
     /**
@@ -158,7 +164,7 @@ public class EclipseErrorReporter implements ErrorReporter {
      */
     @Override
     public String reportWarning(String message) {
-        return report(message, IMarker.SEVERITY_WARNING, null, null);
+        return report(message, Severity.WARNING, null, null);
     }
 
     /**
@@ -169,7 +175,7 @@ public class EclipseErrorReporter implements ErrorReporter {
      */
     @Override
     public String reportError(EObject obj, String message) {
-        return report(message, IMarker.SEVERITY_ERROR, obj);
+        return report(message, Severity.ERROR, obj);
     }
 
     /**
@@ -180,7 +186,7 @@ public class EclipseErrorReporter implements ErrorReporter {
      */
     @Override
     public String reportWarning(EObject obj, String message) {
-        return report(message, IMarker.SEVERITY_WARNING, obj);
+        return report(message, Severity.WARNING, obj);
     }
 
     /**
@@ -193,7 +199,7 @@ public class EclipseErrorReporter implements ErrorReporter {
      */
     @Override
     public String reportError(Path file, Integer line, String message) {
-        return report(message, IMarker.SEVERITY_ERROR, line, file);
+        return report(message, Severity.ERROR, line, file);
     }
 
     /**
@@ -206,7 +212,7 @@ public class EclipseErrorReporter implements ErrorReporter {
      */
     @Override
     public String reportWarning(Path file, Integer line, String message) {
-        return report(message, IMarker.SEVERITY_WARNING, line, file);
+        return report(message, Severity.WARNING, line, file);
     }
 
     /**


### PR DESCRIPTION
I investigated the NPE issue that @edwardalee mentioned in #554. Apparently we both noticed the same issue in a different way. Eclipse reports on the console the `NullPointerException` and shows in the LF file an error marker that only says "null". The reason for this is that there is a warning reported on a connection that was introduced via an AST transformation. This newly introduced AST node, however, doesn't correspond to a node in the source file. Thus, the node couldn't be resolved and `NodeModelUtils.getNode()` returned null.

Interestingly @oowekyala already implemented a solution in the StandaloneErrorReporter. It uses the `EObjectDiagnosticImpl` class that appears to have a smarter lookup mechanism and that finds the correct location to report the warning. This PR implements the same mechanism in the EclipseErrorReporter.

I also hit the compilation error reported by @edwardalee in #554:
```
The type org.eclipse.core.runtime.jobs.ISchedulingRule cannot be resolved. It is indirectly referenced from required .class 
```
I assume that this is an artifact of the recent version upgrade. I was able to fix it by adding `org.eclipse.core.runtime` to the manifest. However, I assume that  we also need to add this to oomph in order to make this available in new installations. @a-sr could you comment on this?