### PR TITLE
Filter out connections that break dependencies

### DIFF
--- a/org.lflang/src/org/lflang/graph/TopologyGraph.java
+++ b/org.lflang/src/org/lflang/graph/TopologyGraph.java
@@ -149,9 +149,9 @@ public class TopologyGraph extends PrecedenceGraph<NamedInstance<?>> {
      */
     private void recordDependency(ReactionInstance reaction, PortInstance orig,
             PortInstance dest) {
-        // Note: a reaction also has a parent, but it might not have a
-        // grandparent.
-        // Hence, the first argument given to getConnection might be null.
+        // Note: a reaction always has a parent, but it might not have a
+        // grandparent. Hence, the first argument given to getConnection might
+        // be null.
         if (!dependencyBroken(
                 getConnection(reaction.parent.parent, orig, dest))) {
             addEdge(dest, orig);


### PR DESCRIPTION
Fixes https://github.com/lf-lang/lingua-franca/issues/447, but problems remain in the code generator when it comes to the handling of physical connections. I think we should merge this in and address the remaining problem separately.