### PR TITLE
Minor tweaks to cmake output parsing

### DIFF
--- a/org.lflang/src/org/lflang/generator/GeneratorBase.xtend
+++ b/org.lflang/src/org/lflang/generator/GeneratorBase.xtend
@@ -1178,7 +1178,7 @@ abstract class GeneratorBase extends AbstractLFValidator {
                     else
                         errorReporter.reportWarning(path, lineNumber, message.toString())
                       
-                    if (originalPath != path) {
+                    if (originalPath.compareTo(path) != 0) {
                         // Report an error also in the top-level resource.
                         // FIXME: It should be possible to descend through the import
                         // statements to find which one matches and mark all the
@@ -1216,7 +1216,7 @@ abstract class GeneratorBase extends AbstractLFValidator {
                 if (message.length > 0) {
                     message.append("\n")
                 } else {
-                    if (line.toLowerCase.contains('warning:')) {
+                    if (!line.toLowerCase.contains('error:')) {
                         severity = IMarker.SEVERITY_WARNING
                     }
                 }
@@ -1230,7 +1230,7 @@ abstract class GeneratorBase extends AbstractLFValidator {
                 errorReporter.reportWarning(path, lineNumber, message.toString())
             }
 
-            if (originalPath != path) {
+            if (originalPath.compareTo(path) != 0) {
                 // Report an error also in the top-level resource.
                 // FIXME: It should be possible to descend through the import
                 // statements to find which one matches and mark all the

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
@@ -5012,7 +5012,7 @@ class CGenerator extends GeneratorBase {
     // form of "file:/path/file.lf". The second match will be a line number.
     // The third match is a character position within the line.
     // The fourth match will be the error message.
-    static final Pattern compileErrorPattern = Pattern.compile("^(file:/.*):([0-9]+):([0-9]+):(.*)$");
+    static final Pattern compileErrorPattern = Pattern.compile("^file:(/.*):([0-9]+):([0-9]+):(.*)$");
     
     /** Given a line of text from the output of a compiler, return
      *  an instance of ErrorFileAndLine if the line is recognized as
@@ -5035,7 +5035,7 @@ class CGenerator extends GeneratorBase {
             result.character = matcher.group(3)
             result.message = matcher.group(4)
             
-            if (result.message.toLowerCase.contains("warning:")) {
+            if (!result.message.toLowerCase.contains("error:")) {
                 result.isError = false
             }
             return result


### PR DESCRIPTION
This slightly tweaks the parsing of the C compiler/CMake to avoid reporting errors without seeing an actual `error:`.
It also prevents the occurrence of a spurious `Error in imported file` when the error is not in an imported file. 