### PR TITLE
Introduce a target property to trigger export of the runtime dependency graph

### DIFF
--- a/org.lflang/src/org/lflang/TargetConfig.java
+++ b/org.lflang/src/org/lflang/TargetConfig.java
@@ -200,6 +200,14 @@ public class TargetConfig {
     public TracingOptions tracing = null;
 
 
+    /**
+     * If true, the resulting binary will output a graph visualizing all reaction dependencies.
+     *
+     * This option is currently only used for C++. This export function is a valuable tool for debugging
+     * LF programs and helps to understand the dependencies inferred by the C++ runtime.
+     */
+    public boolean exportDependencyGraph = false;
+
 
     /**
      * Settings related to clock synchronization.

--- a/org.lflang/src/org/lflang/TargetProperty.java
+++ b/org.lflang/src/org/lflang/TargetProperty.java
@@ -1,6 +1,7 @@
 package org.lflang;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -323,7 +324,18 @@ public enum TargetProperty {
                         }
                     }
                 }
-            });
+            }),
+
+
+    /**
+     * Directive to let the runtime export its internal dependency graph.
+     *
+     * This is a debugging feature and currently only used for C++ programs.
+     */
+    EXPORT_DEPENDENCY_GAPH("export-dependency-graph", PrimitiveType.BOOLEAN, Collections.singletonList(Target.CPP),
+                           (config, value) -> {
+        config.exportDependencyGraph = ASTUtils.toBoolean(value);
+    });
     
     /**
      * String representation of this target property.

--- a/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
@@ -51,7 +51,7 @@ class CppGenerator(
         const val libDir = "/lib/Cpp"
 
         /** Default version of the reactor-cpp runtime to be used during compilation */
-        const val defaultRuntimeVersion = "c56febce6a291d5e2727266bb819a839e3f6c71f"
+        const val defaultRuntimeVersion = "eaa514d4a2a44e6ec57422e1a90481cf15c942fd"
     }
 
     override fun doGenerate(resource: Resource, fsa: IFileSystemAccess2, context: IGeneratorContext) {

--- a/org.lflang/src/org/lflang/generator/cpp/CppMainGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppMainGenerator.kt
@@ -113,9 +113,9 @@ class CppMainGenerator(
             |
             |  // execute the reactor program
             |  e.assemble();
-            |  auto thread = e . startup ();
+            |  auto thread = e.startup();
             |  thread.join();
-            |
+        ${" |".. if (targetConfig.exportDependencyGraph) "e.export_dependency_graph(\"${main.name}.dot\");" else ""}
             |  return 0;
             |}
         """.trimMargin()


### PR DESCRIPTION
This change introduces the `export-dependency-graph` target property. This is a useful debugging tool for C++ programs. If set to true, the resulting program will produce a *.dot file after its normal execution. This .dot file visualizes the internal dependency graph produced by the reactor-cpp runtime.