### PR TITLE
Make `lfc` robust to symlinks

### DIFF
--- a/bin/lfc
+++ b/bin/lfc
@@ -7,13 +7,12 @@
 #==========================================================
 
 set -euo pipefail
-base=""
-if [ ! "$0" = "${0##*/*}" ]; then  # Do we have a parent directory?
-	base="${0%/*}/"
-fi
-base="${base}../"
-lfbase="${base}org.lflang.lfc/"
-jarpath="${lfbase}build/libs/org.lflang.lfc-0.1.0-SNAPSHOT-all.jar"
+# Determine the current directory. This also works if this script is
+# invoked through a symbolic link.
+basedir=$(readlink -f $0 | xargs dirname)
+base="${basedir}/.."
+lfbase="${base}/org.lflang.lfc"
+jarpath="${lfbase}/build/libs/org.lflang.lfc-0.1.0-SNAPSHOT-all.jar"
 
 # Report fatal error.
 function fatal_error() {


### PR DESCRIPTION
Our `lfc` script runs a jar that it finds in a directory relative to its own. The way this path is currently determined is not robust to symbolic links. Specifically, if someone creates a link to `lfc`, the script will attempt to find the jar relative to the directory in which the link is relocated, not the directory in which the script is located.

Instead of using `$0`, we can use `$(readlink -f $0 | xargs dirname)`, which does not seem to have this problem.