### PR TITLE
Replace ssh URL with https in gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/lf-lang/reactor-c.git
 [submodule "org.lflang/src/lib/py/reactor-c-py"]
 	path = org.lflang/src/lib/py/reactor-c-py
-	url = git@github.com:lf-lang/reactor-c-py.git
+	url = https://github.com/lf-lang/reactor-c-py.git


### PR DESCRIPTION
The reactor-c-py submodule uses an SSH remote, which causes problems if you're trying to do `git submodule update --init` on a machine on which you don't have SSH configured properly. It's less trouble to use http