### PR TITLE
Remove warning about keepalive from Rust target

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.xtend
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.xtend
@@ -174,29 +174,6 @@ class LinguaFrancaValidationTest {
     }
     
 
-    @Test
-    def void warnIfThereIsAPhysicalActionButNoExplicitKeepalive() {
-        parseWithoutError('''
-            target C;
-            main reactor {
-                physical action act;
-                reaction(startup) {= /*...*/ =}
-            }
-        ''').assertWarning(LfPackage::eINSTANCE.action, null,
-            "Setting keepalive to true because of key_press. This can be overridden")
-    }
-
-    @Test
-    def void noKeepaliveWarningInRustTarget() {
-        parseWithoutError('''
-            target Rust;
-            main reactor {
-                physical action act;
-                reaction(startup) {= /*...*/ =}
-            }
-        ''').assertNoIssues()
-    }
-
     /**
      * Ensure that "__" is not allowed at the start of an output name.
      */

--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.xtend
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.xtend
@@ -164,9 +164,6 @@ class LinguaFrancaValidationTest {
             "Names of objects (inputs, outputs, actions, timers, parameters, state, reactor definitions, and reactor instantiation) may not start with \"__\": __bar")
     }
     
-    /**
-     * 
-     */
     @Test
     def void disallowMainWithDifferentNameThanFile() {
         parseWithoutError('''
@@ -176,6 +173,30 @@ class LinguaFrancaValidationTest {
             "Name of main reactor must match the file name (or be omitted)")
     }
     
+
+    @Test
+    def void warnIfThereIsAPhysicalActionButNoExplicitKeepalive() {
+        parseWithoutError('''
+            target C;
+            main reactor {
+                physical action act;
+                reaction(startup) {= /*...*/ =}
+            }
+        ''').assertWarning(LfPackage::eINSTANCE.action, null,
+            "Setting keepalive to true because of key_press. This can be overridden")
+    }
+
+    @Test
+    def void noKeepaliveWarningInRustTarget() {
+        parseWithoutError('''
+            target Rust;
+            main reactor {
+                physical action act;
+                reaction(startup) {= /*...*/ =}
+            }
+        ''').assertNoIssues()
+    }
+
     /**
      * Ensure that "__" is not allowed at the start of an output name.
      */

--- a/org.lflang/src/org/lflang/Target.java
+++ b/org.lflang/src/org/lflang/Target.java
@@ -462,6 +462,10 @@ public enum Target {
         return this.keywords.contains(ident);
     }
 
+    /**
+     * Return true if the target supports multiports and banks
+     * of reactors.
+     */
     public boolean supportsMultiports() {
         switch (this) {
         case C:
@@ -474,6 +478,12 @@ public enum Target {
         return false;
     }
 
+
+    /**
+     * Return true if the target supports widths of banks and
+     * multiports that depend on reactor parameters (not only
+     * on constants).
+     */
     public boolean supportsParameterizedWidths() {
         switch (this) {
         case C:
@@ -483,6 +493,15 @@ public enum Target {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Return true if the keepalive option is set automatically
+     * for this target if physical actions are detected in the
+     * program (and keepalive was not explicitly unset by the user).
+     */
+    public boolean setsKeepAliveOptionAutomatically() {
+        return this != Rust;
     }
 
     /**

--- a/org.lflang/src/org/lflang/TargetProperty.java
+++ b/org.lflang/src/org/lflang/TargetProperty.java
@@ -539,6 +539,16 @@ public enum TargetProperty {
     }
 
     /**
+     * Return the name of the property in lingua franca. This
+     * is suitable for use as a key in a target properties block.
+     * It may be an invalid identifier in other languages (may
+     * contains dashes {@code -}).
+     */
+    public String getDisplayName() {
+        return description;
+    }
+
+    /**
      * Set the given configuration using the given target properties.
      *
      * @param config     The configuration object to update.
@@ -582,24 +592,21 @@ public enum TargetProperty {
      * function will do nothing if the list of target properties doesn't
      * include the property given by 'propertyName'.
      *
-     * @param config The target config to apply the update to.
-     * @param propertyName The name of the target property.
+     * @param config     The target config to apply the update to.
+     * @param property   The target property.
      * @param properties AST node that holds all the target properties.
      * @param err        Error reporter on which property format errors will be reported
      */
-    public static void updateOne(TargetConfig config, String propertyName, List<KeyValuePair> properties, ErrorReporter err) {
-        TargetProperty p = forName(propertyName);
-        if (p != null) {
-            properties.stream()
-                .filter(property -> property.getName().equals(propertyName))
-                .findFirst()
-                .map(KeyValuePair::getValue)
-                .ifPresent(value -> p.updater.parseIntoTargetConfig(
-                    config,
-                    value,
-                    err
-                ));
-        }
+    public static void updateOne(TargetConfig config, TargetProperty property, List<KeyValuePair> properties, ErrorReporter err) {
+        properties.stream()
+            .filter(p -> p.getName().equals(property.getDisplayName()))
+            .findFirst()
+            .map(KeyValuePair::getValue)
+            .ifPresent(value -> property.updater.parseIntoTargetConfig(
+                config,
+                value,
+                err
+            ));
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/GeneratorBase.xtend
+++ b/org.lflang/src/org/lflang/generator/GeneratorBase.xtend
@@ -333,6 +333,10 @@ abstract class GeneratorBase extends AbstractLFValidator implements TargetTypes 
      * Set keepalive to true.
      */
     protected def void accommodatePhysicalActionsIfPresent(Resource resource) {
+        if (!target.setsKeepAliveOptionAutomatically) {
+            return; // nothing to do
+        }
+
         // If there are any physical actions, ensure the threaded engine is used and that
         // keepalive is set to true, unless the user has explicitly set it to false.
         for (action : resource.allContents.toIterable.filter(Action)) {
@@ -345,7 +349,7 @@ abstract class GeneratorBase extends AbstractLFValidator implements TargetTypes 
                     targetConfig.keepalive = true
                     errorReporter.reportWarning(
                         action,
-                        '''Setting «TargetProperty.KEEPALIVE.description» to true because of «action.name».«
+                        '''Setting «TargetProperty.KEEPALIVE.displayName» to true because of «action.name».«
                         » This can be overridden by setting the «TargetProperty.KEEPALIVE.description»«
                         » target property manually.'''
                     );

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
@@ -588,14 +588,14 @@ class CGenerator extends GeneratorBase {
                     // Update the cmake-include
                     TargetProperty.updateOne(
                         this.targetConfig, 
-                        TargetProperty.CMAKE_INCLUDE.description,
+                        TargetProperty.CMAKE_INCLUDE,
                         target.config.pairs ?: emptyList,
                         errorReporter
                     )
                     // Update the files
                     TargetProperty.updateOne(
                         this.targetConfig, 
-                        TargetProperty.FILES.description,
+                        TargetProperty.FILES,
                         target.config.pairs ?: emptyList,
                         errorReporter
                     )


### PR DESCRIPTION
Remove warning added by b3b225b (#594) from the Rust target: the Rust target doesn't need the keepalive option. The warning looks like so:

```
Compiled binary is in /home/clem/.eclipse/lingua-franca-master/git/lingua-franca/example/Rust/bin
lfc: warning: Setting keepalive to true because of key_press. This can be overridden by setting the keepalive target property manually.
 --> Snake/KeyboardEvents.lf:20:5
   |
19 | 
20 |     physical action key_press: Key;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Setting keepalive to true because of key_press. This can be overridden by setting the keepalive target property manually.
   |
21 | 
```