### PR TITLE
Python iterable multiports

### DIFF
--- a/test/Python/src/multiport/BankToBankMultiport.lf
+++ b/test/Python/src/multiport/BankToBankMultiport.lf
@@ -8,8 +8,8 @@ reactor Source(width(1)) {
     output[width] out;
     state s(0);
     reaction(t) -> out {=
-        for i in range(len(out)):
-            out[i].set(self.s)
+        for port in out:
+            port.set(self.s)
             self.s += 1
     =}
 }
@@ -18,9 +18,9 @@ reactor Destination(width(1)) {
     input[width] _in;
     reaction(_in) {=
         sm = 0
-        for i in range(len(_in)):
-            if _in[i].is_present is True:
-                sm += _in[i].value         
+        for port in _in:
+            if port.is_present:
+                sm += port.value         
 
         print("Sum of received: ", sm)
         if sm != self.s:

--- a/test/Python/src/multiport/BankToBankMultiportAfter.lf
+++ b/test/Python/src/multiport/BankToBankMultiportAfter.lf
@@ -3,39 +3,7 @@ target Python {
     timeout: 2 sec,
     fast: true
 };
-reactor Source(width(1)) {
-    timer t(0, 200 msec);
-    output[width] out;
-    state s(0);
-    reaction(t) -> out {=
-        for i in range(len(out)):
-            out[i].set(self.s)
-            self.s += 1
-    =}
-}
-reactor Destination(width(1)) {
-    state s(6);
-    input[width] _in;
-    reaction(_in) {=
-        sm = 0
-        for i in range(len(_in)):
-            if _in[i].is_present is True:
-                sm += _in[i].value
-        print("Sum of received: ", sm)
-        if sm != self.s:
-            sys.stderr.write("ERROR: Expected {:d}.\n".format(self.s))
-            exit(1)
-
-        self.s += 16
-    =}
-    reaction(shutdown) {=
-        if self.s <= 6:
-            sys.stderr.write("ERROR: Destination received no input!\n")
-            exit(1)
-
-        print("Success.")
-    =}
-}
+import Source, Destination from "BankToBankMultiport.lf"
 main reactor BankToBankMultiportAfter(bank_width(4)) { 
 	a = new[bank_width] Source(width = 4);
 	b = new[bank_width] Destination(width = 4);

--- a/test/Python/src/multiport/BankToMultiport.lf
+++ b/test/Python/src/multiport/BankToMultiport.lf
@@ -5,7 +5,6 @@ reactor Source(
     bank_index(0)
 ) {
     output out;
-    
     reaction (startup) -> out {=
         out.set(self.bank_index)
     =}
@@ -16,12 +15,12 @@ reactor Sink(width(4)) {
     state received(false);
     
     reaction (_in) {=
-        for i in range(len(_in)):
-            if _in[i].is_present is True:
-                print("Received on channel {:d}: {:d}\n".format(i, _in[i].value))
+        for (idx, port) in enumerate(_in):
+            if port.is_present is True:
+                print("Received on channel {:d}: {:d}".format(idx, port.value))
                 self.received = True
-                if _in[i].value != i:
-                    sys.stderr.write("ERROR: expected {:d}\n".format(i))
+                if port.value != idx:
+                    sys.stderr.write("ERROR: expected {:d}\n".format(idx))
                     exit(1)
     =}
     reaction(shutdown) {=

--- a/test/Python/src/multiport/MultiportFromBank.lf
+++ b/test/Python/src/multiport/MultiportFromBank.lf
@@ -17,10 +17,10 @@ reactor Destination {
     input[3] _in;
     state received(0);
     reaction(_in) {=
-        for i in range(len(_in)):
-            print("Destination channel " + str(i) + " received " + str(_in[i].value))
-            if i != _in[i].value:
-                sys.stderr.write("ERROR: Expected " + str(i))
+        for (idx, port) in enumerate(_in):
+            print("Destination channel " + str(idx) + " received " + str(port.value))
+            if idx != port.value:
+                sys.stderr.write("ERROR: Expected " + str(idx))
                 exit(1)
 
         self.received = True

--- a/test/Python/src/multiport/MultiportFromBankHierarchy.lf
+++ b/test/Python/src/multiport/MultiportFromBankHierarchy.lf
@@ -3,7 +3,8 @@
 target Python {
     timeout: 2 sec,
     fast: true
-}; 
+};
+import Destination from "MultiportFromBank.lf"
 reactor Source(
     bank_index(0)
 ) {
@@ -17,27 +18,6 @@ reactor Container {
     s = new[3] Source();
     s.out -> out;
 }
-reactor Destination {
-    input[3] _in;
-    state received(0);
-    reaction(_in) {=
-        for i in range(len(_in)):
-            print("Destination channel " + str(i) + " received " + str(_in[i].value));
-            if i != _in[i].value:
-                sys.stderr.write("ERROR: Expected "+ str(i) + ".\n")
-                exit(1)
-
-        self.received = True
-    =}
-    reaction(shutdown) {=
-        if self.received is not True:
-            sys.stderr.write("ERROR: Destination received no input!\n")
-            exit(1)
-
-        print("Success.")
-    =}
-}
-
 main reactor MultiportFromBankHierarchy {
     a = new Container();
     b = new Destination();

--- a/test/Python/src/multiport/MultiportFromBankHierarchyAfter.lf
+++ b/test/Python/src/multiport/MultiportFromBankHierarchyAfter.lf
@@ -4,41 +4,8 @@ target Python {
     timeout: 2 sec,
     fast: true
 }; 
-reactor Source(
-    bank_index(0)
-) {
-    output out;
-    reaction(startup) -> out {=
-        out.set(self.bank_index)
-    =}
-}
-reactor Container {
-    output[3] out;
-    s = new[3] Source();
-    s.out -> out;
-}
-reactor Destination {
-    input[3] _in;
-    state received(false);
-    reaction(_in) {=
-        for i in range(len(_in)):
-            print("Destination channel {:d} received {:d}.\n".format(i, _in[i].value))
-            if i != _in[i].value:
-                sys.stderr.write("ERROR: Expected {:d}.\n".format(i))
-                exit(1)
-        if get_elapsed_logical_time() != SEC(1):
-            sys.stderr.write("ERROR: Expected to receive input after one second.\n")
-            exit(2)
-        self.received = True
-    =}
-    reaction(shutdown) {=
-        if self.received is not True:
-            sys.stderr.write("ERROR: Destination received no input!\n")
-            exit(1)
-        print("Success.\n")
-    =}
-}
-
+import Container from "MultiportFromBankHierarchy.lf"
+import Destination from "MultiportFromBank.lf"
 main reactor MultiportFromBankHierarchyAfter {
     a = new Container();
     b = new Destination();

--- a/test/Python/src/multiport/MultiportFromHierarchy.lf
+++ b/test/Python/src/multiport/MultiportFromHierarchy.lf
@@ -8,8 +8,8 @@ reactor Source {
     output[4] out;
     state s(0);
     reaction(t) -> out {=
-        for i in range(4):
-            out[i].set(self.s)
+        for port in out:
+            port.set(self.s)
             self.s = self.s + 1
     =}
 }
@@ -18,9 +18,9 @@ reactor Destination {
     input[4] _in;
     reaction(_in) {=
         sm = 0
-        for i in range(len(_in)):
-            if (_in[i].is_present):
-                sm += _in[i].value
+        for port in _in:
+            if port.is_present:
+                sm += port.value
         print("Sum of received: " + str(sm))
         if (sm != self.s):
             sys.stderr.write("ERROR: Expected " + str(self.s) + ".\n")

--- a/test/Python/src/multiport/MultiportFromReaction.lf
+++ b/test/Python/src/multiport/MultiportFromReaction.lf
@@ -8,9 +8,9 @@ reactor Destination(width(1)) {
     input[width] _in;
     reaction(_in) {=
         sm = 0;
-        for i in range(len(_in)):
-            if _in[i].is_present:
-                sm += _in[i].value
+        for port in _in:
+            if port.is_present:
+                sm += port.value
         print("Sum of received: ", sm)
         if sm != self.s:
             sys.stderr.write("ERROR: Expected {:d}.\n".format(self.s))
@@ -22,7 +22,7 @@ reactor Destination(width(1)) {
         if self.s <= 6:
             sys.stderr.write("ERROR: Destination received no input!\n")
             exit(1)
-        print("Success.\n")
+        print("Success.")
     =}
 }
 main reactor MultiportFromReaction {
@@ -30,11 +30,11 @@ main reactor MultiportFromReaction {
     state s(0);
     b = new Destination(width = 4);
     reaction(t) -> b._in {=
-        for i in range(len(b._in)):
-            print("Before SET, b.in[{:d}].is_present has value {:d}".format(i, b._in[i].is_present))
-            b._in[i].set(self.s)
+        for (idx, port) in enumerate(b._in):
+            print("Before SET, b.in[{:d}].is_present has value {:d}".format(idx, port.is_present))
+            port.set(self.s)
             self.s += 1
-            print("AFTER set, b.in[{:d}].is_present has value {:d}".format(i, b._in[i].is_present))
-            print("AFTER set, b.in[{:d}].value has value {:d}".format(i, b._in[i].value))
+            print("AFTER set, b.in[{:d}].is_present has value {:d}".format(idx, port.is_present))
+            print("AFTER set, b.in[{:d}].value has value {:d}".format(idx, port.value))
     =}
 }

--- a/test/Python/src/multiport/MultiportIn.lf
+++ b/test/Python/src/multiport/MultiportIn.lf
@@ -26,8 +26,8 @@ reactor Destination {
     input[4] _in;
     reaction(_in) {=
         sum = 0
-        for i in range(len(_in)):
-            sum += _in[i].value
+        for port in _in:
+            sum += port.value
 
         print("Sum of received: " + str(sum))
         if sum != self.s:

--- a/test/Python/src/multiport/MultiportInParameterized.lf
+++ b/test/Python/src/multiport/MultiportInParameterized.lf
@@ -26,8 +26,8 @@ reactor Destination(width(1)) {
     input[width] _in;
     reaction(_in) {=
         sm = 0
-        for i in range(len(_in)):
-            sm += _in[i].value
+        for port in _in:
+            sm += port.value
         print("Sum of received: ", sm)
         if sm != self.s:
             sys.stderr.write("ERROR: Expected {:d}.\n".format(self.s))
@@ -38,7 +38,7 @@ reactor Destination(width(1)) {
         if self.s == 0:
             sys.stderr.write("ERROR: Destination received no input!\n")
             exit(1)
-        print("Success.\n");
+        print("Success.");
     =}
 }
 

--- a/test/Python/src/multiport/MultiportMutableInput.lf
+++ b/test/Python/src/multiport/MultiportMutableInput.lf
@@ -15,9 +15,9 @@ reactor Print(scale(1)) {
     input[2] _in;
     reaction(_in) {=
         expected = 42
-        for j in range(2):
-            print("Received on channel {:d}: ".format(j), _in[j].value)
-            if _in[j].value != expected:
+        for (idx, port) in enumerate(_in):
+            print("Received on channel {:d}: ".format(idx), port.value)
+            if port.value != expected:
                 sys.stderr.write("ERROR: Expected {:d}!\n".format(expected))
                 exit(1)
             expected *= 2
@@ -28,10 +28,10 @@ reactor Scale(scale(2)) {
     mutable input[2] _in;
     output[2] out;
     reaction(_in) -> out {=
-        for j in range(2):
+        for (idx, port) in enumerate(_in):
             # Modify the input, allowed because mutable.
-            _in[j].value *= self.scale
-            out[j].set(_in[j].value)
+            port.value *= self.scale
+            out[idx].set(port.value)
     =}
 }
 main reactor MultiportMutableInput {

--- a/test/Python/src/multiport/MultiportMutableInputArray.lf
+++ b/test/Python/src/multiport/MultiportMutableInputArray.lf
@@ -15,9 +15,9 @@ reactor Source {
 reactor Print(scale(1)) {
     input[2] _in;
     reaction(_in) {=
-        for j in range(2):
-            print("Received on channel ", _in[j].value)
-            if _in[j].value != [(self.scale*i) for i in range(3*j,(3*j)+3)]:
+        for (idx, port) in enumerate(_in):
+            print("Received on channel ", port.value)
+            if port.value != [(self.scale*i) for i in range(3*idx,(3*idx)+3)]:
                 sys.stderr.write("ERROR: Value received by Print does not match expectation!\n")
                 exit(1)
     =}
@@ -27,11 +27,10 @@ reactor Scale(scale(2)) {
     mutable input[2] _in;
     output[2] out;
     reaction(_in) -> out {=
-        for j in range(len(_in)):
-            for i in range(len(_in[j].value)):
-                if (_in[j].is_present):
-                    _in[j].value[i] *= self.scale
-            out[j].set(_in[j].value)
+        for (idx, port) in enumerate(_in):
+            if port.is_present:
+                port.value = [value*self.scale for value in port.value]
+            out[idx].set(port.value)
     =}
 }
 

--- a/test/Python/src/multiport/MultiportOut.lf
+++ b/test/Python/src/multiport/MultiportOut.lf
@@ -8,8 +8,8 @@ reactor Source {
     output[4] out;
     state s(0);
     reaction(t) -> out {=
-        for i in range(0,4):
-            out[i].set(self.s)
+        for port in out:
+            port.set(self.s)
         
         self.s+=1
     =}
@@ -26,9 +26,9 @@ reactor Destination {
     input[4] _in;
     reaction(_in) {=
         sum = 0
-        for i in range(len(_in)):
-            if _in[i].is_present:
-                sum += _in[i].value
+        for port in _in:
+            if port.is_present:
+                sum += port.value
                 
         print("Sum of received: " + str(sum))
         if sum != self.s:

--- a/test/Python/src/multiport/MultiportToBank.lf
+++ b/test/Python/src/multiport/MultiportToBank.lf
@@ -6,8 +6,8 @@ target Python {
 reactor Source {
     output[3] out;
     reaction(startup) -> out {=
-        for i in range(len(out)):
-            out[i].set(i)
+        for (idx, port) in enumerate(out):
+            port.set(idx)
     =}
 }
 reactor Destination(

--- a/test/Python/src/multiport/MultiportToBankAfter.lf
+++ b/test/Python/src/multiport/MultiportToBankAfter.lf
@@ -3,13 +3,7 @@ target Python {
     timeout: 2 sec,
     fast: true
 }; 
-reactor Source {
-    output[3] out;
-    reaction(startup) -> out {=
-        for i in range(len(out)):
-            out[i].set(i);
-    =}
-}
+import Source from "MultiportToBank.lf"
 reactor Destination(
     bank_index(0)
 ) {

--- a/test/Python/src/multiport/MultiportToBankHierarchy.lf
+++ b/test/Python/src/multiport/MultiportToBankHierarchy.lf
@@ -4,13 +4,7 @@ target Python {
     timeout: 2 sec,
     fast: true
 }; 
-reactor Source {
-    output[3] out;
-    reaction(startup) -> out {=
-        for i in range(len(out)):
-            out[i].set(i)
-    =}
-}
+import Source from "MultiportToBank.lf"
 reactor Destination(
     bank_index(0)
 ) {

--- a/test/Python/src/multiport/MultiportToHierarchy.lf
+++ b/test/Python/src/multiport/MultiportToHierarchy.lf
@@ -9,8 +9,8 @@ reactor Source {
     output[4] out;
     state s(0);
     reaction(t) -> out {=
-        for i in range(len(out)):
-            out[i].set(self.s)
+        for port in out:
+            port.set(self.s)
             self.s += 1
     =}
 }
@@ -19,9 +19,9 @@ reactor Destination(width(4)) {
     input[width] _in;
     reaction(_in) {=
         sm = 0
-        for i in range(len(_in)):
-            if _in[i].is_present:
-                sm += _in[i].value
+        for port in _in:
+            if port.is_present:
+                sm += port.value
         print("Sum of received: ", sm)
         if sm != self.s:
             sys.stderr.write("ERROR: Expected {:d}.\n".format(self.s))

--- a/test/Python/src/multiport/MultiportToMultiport.lf
+++ b/test/Python/src/multiport/MultiportToMultiport.lf
@@ -2,7 +2,8 @@
 target Python {
     timeout: 2 sec,
     fast: true
-}; 
+};
+import Destination from "MultiportToHierarchy.lf"
 reactor Source(width(1)) {
     timer t(0, 200 msec);
     output[width] out;
@@ -14,27 +15,6 @@ reactor Source(width(1)) {
             self.s += 1
             print("AFTER set, out[{:d}]->is_present has value ".format(i), out[i].is_present)
             print("AFTER set, out[{:d}]->value has value ".format(i), out[i].value)
-    =}
-}
-reactor Destination(width(1)) {
-    state s(6);
-	input[width] _in;
-	reaction(_in) {=
-        sm = 0
-        for i in range(len(_in)):
-            if _in[i].is_present:
-                sm += _in[i].value
-        print("Sum of received: ", sm)
-        if sm != self.s:
-            sys.stderr.write("ERROR: Expected {:d}.\n".format(self.s))
-            exit(1)
-        self.s += 16
-    =}
-    reaction(shutdown) {=
-        if self.s <= 6:
-            sys.stderr.write("ERROR: Destination received no input!\n")
-            exit(1)
-        print("Success.")
     =}
 }
 main reactor MultiportToMultiport { 

--- a/test/Python/src/multiport/MultiportToMultiport2.lf
+++ b/test/Python/src/multiport/MultiportToMultiport2.lf
@@ -5,21 +5,21 @@ target Python;
 reactor Source(width(2)) {
     output[width] out;
     reaction (startup) -> out {=
-        for i in range(len(out)):
-            out[i].set(i)
+        for (idx, port) in enumerate(out):
+            port.set(idx)
     =}
 }
 
 reactor Destination(width(2)) {
     input[width] _in;
     reaction (_in) {=
-        for i in range(len(_in)):
-            if _in[i].is_present:
-                print("Received on channel {:d}: ".format(i), _in[i].value)
+        for (idx, port) in enumerate(_in):
+            if port.is_present:
+                print("Received on channel {:d}: ".format(idx), port.value)
                 # NOTE: For testing purposes, this assumes the specific
                 # widths instantiated below.
-                if _in[i].value != i % 3:
-                    sys.stderr.write("ERROR: expected {:d}!\n".format(i % 3))
+                if port.value != idx % 3:
+                    sys.stderr.write("ERROR: expected {:d}!\n".format(idx % 3))
                     exit(1)
     =}
 }

--- a/test/Python/src/multiport/MultiportToMultiport2After.lf
+++ b/test/Python/src/multiport/MultiportToMultiport2After.lf
@@ -2,24 +2,17 @@
 // See also MultiportToMultiport.
 target Python;
 
-reactor Source(width(2)) {
-    output[width] out;
-    reaction (startup) -> out {=
-        for i in range(len(out)):
-            out[i].set(i)
-    =}
-}
-
+import Source from "MultiportToMultiport2.lf"
 reactor Destination(width(2)) {
     input[width] _in;
     reaction (_in) {=
-        for i in range(len(_in)):
-            if _in[i].is_present:
-                print("Received on channel {:d}: ".format(i), _in[i].value)
+        for (idx, port) in enumerate(_in):
+            if port.is_present:
+                print("Received on channel {:d}: ".format(idx), port.value)
                 # NOTE: For testing purposes, this assumes the specific
                 # widths instantiated below.
-                if _in[i].value != i % 3:
-                    sys.stderr.write("ERROR: expected {:d}!\n".format(i % 3))
+                if port.value != idx % 3:
+                    sys.stderr.write("ERROR: expected {:d}!\n".format(idx % 3))
                     exit(1)
         if get_elapsed_logical_time() != SEC(1):
             sys.stderr.write("ERROR: Expected to receive input after one second.\n")

--- a/test/Python/src/multiport/MultiportToMultiportArray.lf
+++ b/test/Python/src/multiport/MultiportToMultiportArray.lf
@@ -9,8 +9,8 @@ reactor Source {
     output[2] out;
     state s(0);
     reaction(t) -> out {=
-        for i in range(2):
-            out[i].set([self.s, self.s + 1, self.s + 2])
+        for port in out:
+            port.set([self.s, self.s + 1, self.s + 2])
             self.s += 3
     =}
 }
@@ -20,9 +20,9 @@ reactor Destination {
     input[2] _in;
     reaction(_in) {=
         sm = 0
-        for i in range(len(_in)):
-            if _in[i].is_present:
-                sm += sum(_in[i].value)
+        for port in _in:
+            if port.is_present:
+                sm += sum(port.value)
 
         print("Sum of received: ", sm);
         if sm != self.s:

--- a/test/Python/src/multiport/MultiportToMultiportParameter.lf
+++ b/test/Python/src/multiport/MultiportToMultiportParameter.lf
@@ -3,40 +3,8 @@ target Python {
     timeout: 2 sec,
     fast: true
 }; 
-reactor Source(width(1)) {
-    timer t(0, 200 msec);
-    output[width] out;
-    state s(0);
-    reaction(t) -> out {=
-        for i in range(len(out)):
-            print("Before SET, out[{:d}]->is_present has value %d".format(i), out[i].is_present)
-            out[i].set(self.s)
-            self.s += 1
-            print("AFTER set, out[{:d}]->is_present has value ".format(i), out[i].is_present)
-            print("AFTER set, out[{:d}]->value has value ".format(i), out[i].value)
-    =}
-}
-reactor Destination(width(1)) {
-    state s(6);
-    input[width] _in;
-    reaction(_in) {=
-        sm = 0
-        for i in range(len(_in)):
-            if _in[i].is_present:
-                sm += _in[i].value
-        print("Sum of received: ", sm)
-        if sm != self.s:
-            sys.stderr.write("ERROR: Expected {:d}.\n".format(self.s))
-            exit(1)
-        self.s += 16
-    =}
-    reaction(shutdown) {=
-        if self.s <= 6:
-            sys.stderr.write("ERROR: Destination received no input!\n")
-            exit(1)
-        print("Success.")
-    =}
-}
+import Source from "MultiportToMultiport.lf"
+import Destination from "MultiportToHierarchy.lf"
 main reactor MultiportToMultiportParameter (width(4)) { 
     a = new Source(width = width);
     b = new Destination(width = width);

--- a/test/Python/src/multiport/MultiportToPort.lf
+++ b/test/Python/src/multiport/MultiportToPort.lf
@@ -7,9 +7,9 @@ target Python {
 reactor Source {
     output[2] out;
     reaction(startup) -> out {=
-        for i in range(len(out)):
-            print("Source sending ", i)
-            out[i].set(i)
+        for (idx, port) in enumerate(out):
+            print("Source sending ", idx)
+            port.set(idx)
     =}
 }
 reactor Destination(expected(0)) {

--- a/test/Python/src/multiport/MultiportToReaction.lf
+++ b/test/Python/src/multiport/MultiportToReaction.lf
@@ -8,8 +8,8 @@ reactor Source(width(1)) {
     state s(0);
     output[width] out;
     reaction(t) -> out {=
-        for i in range(len(out)):
-            out[i].set(self.s)
+        for port in out:
+            port.set(self.s)
             self.s += 1
     =}
 }
@@ -17,9 +17,9 @@ main reactor {
     state s(6);
     reaction(b.out) {=
         sm = 0
-        for i in range(len(b.out)):
-            if b.out[i].is_present:
-                sm += b.out[i].value
+        for port in b.out:
+            if port.is_present:
+                sm += port.value
         print("Sum of received: ", sm)
         if sm != self.s:
             sys.stderr.write("ERROR: Expected {:d}.\n".format(self.s))


### PR DESCRIPTION
This makes multiports in the Python target iterable, which makes accessing them more Pythonic.

For example, previously, a `multiport` could only be iterated on as:
```Python
for i in range(len(multiport)):
    print(multiport[i].value)
```
Now, you could iterate over each port directly:
```Python
for port in multiport:
    print(port.value)
```