### PR TITLE
Big and NQueens C Benchmarks

### DIFF
--- a/benchmark/C/Savina/src/include/deque.c
+++ b/benchmark/C/Savina/src/include/deque.c
@@ -1,0 +1,213 @@
+/**
+@file
+@author Arthur Deng
+@author Edward A. Lee
+@section LICENSE
+Copyright (c) 2021, The University of California at Berkeley.
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+@section DESCRIPTION
+This provides an implementation of a double-ended queue.
+Each node contains a void* pointer.
+To use this, include the following in your target properties:
+To use this, include the following in your target properties:
+<pre>
+target C {
+    cmake-include: "/lib/c/reactor-c/util/deque.cmake"
+    files: ["/lib/c/reactor-c/util/deque.c", "/lib/c/reactor-c/util/deque.h"]
+};
+</pre>
+In addition, you need this in your Lingua Franca file:
+<pre>
+preamble {=
+    #include "deque.h"
+=}
+</pre>
+To create a deque, use calloc to ensure that it gets initialized
+with null pointers and zero size:
+<pre>
+    deque_t* my_deque = (deque_t*) calloc(1, sizeof(deque_t));
+</pre>
+Alternatively, you can call initialize:
+<pre>
+    deque my_deque;
+    deque_initialize(&my_deque);
+</pre>
+*/
+
+#include "deque.h"
+
+/**
+ * A node in the queue.
+ */
+typedef struct deque_node_t {
+    struct deque_node_t *next;
+    struct deque_node_t *prev;
+    void* value;
+} deque_node_t;
+
+/**
+ * Initialize the specified deque to an empty deque.
+ * @param d The deque.
+ */
+void deque_initialize(deque_t* d) {
+    if (d != NULL) {
+        d->front = NULL;
+        d->back = NULL;
+        d->size = 0;
+    }
+}
+
+/**
+ * Return true if the queue is empty.
+ * @param d The deque.
+ */
+bool deque_is_empty(deque_t* d) {
+    if (d != NULL) {
+        return (d->front == NULL);
+    }
+    return true;
+}
+
+/**
+ * Return the size of the queue.
+ * @param d The deque.
+ * @return The size of the queue.
+ */
+size_t deque_size(deque_t* d) {
+	return d->size;
+}
+
+/**
+ * Internal function to create a node to insert in the deque.
+ * Users should not call this function. It is used internally
+ * by deque_push_front and deque_push_back. It allocates memory
+ * that is freed in popped using deque_pop_back and deque_pop_front.
+ * @param value The payload of the node.
+ */
+deque_node_t* _deque_create_node(void* value) {
+    deque_node_t *new_node = (deque_node_t *) calloc(1, sizeof(deque_node_t));
+    new_node->value = value;
+    return new_node;
+}
+
+/**
+ * Push a value to the front of the queue.
+ * @param d The queue.
+ * @param value The value to push.
+ */
+void deque_push_front(deque_t* d, void* value) {
+    deque_node_t *n = _deque_create_node(value);
+    if (d->front == NULL) {
+    	d->back = d->front = n;
+        d->size = 1;
+    } else {
+        d->front->prev = n;
+        n->next = d->front;
+        d->front = n;
+        d->size++;
+    }
+}
+
+/**
+ * Push a value to the back of the queue.
+ * @param d The queue.
+ * @param value The value to push.
+ */
+void deque_push_back(deque_t* d, void* value) {
+    deque_node_t *n = _deque_create_node(value);
+    if (d->back == NULL) {
+        d->back = d->front = n;
+        d->size++;
+    } else {
+        d->back->next = n;
+        n->prev = d->back;
+        d->back = n;
+        d->size++;
+    }
+}
+
+/**
+ * Pop a value from the front of the queue, removing it from the queue.
+ * @param d The queue.
+ * @return The value on the front of the queue or NULL if the queue is empty.
+ */
+void* deque_pop_front(deque_t* d) {
+    if (d == NULL || d->front == NULL) {
+        return NULL;
+    }
+
+    void* value = d->front->value;
+    deque_node_t *temp = d->front; // temporary pointer for freeing up memory
+
+    if (d->front == d->back) {
+        // popping last element in deque
+        d->front = d->back = NULL;
+    } else {
+        d->front = d->front->next;
+    }
+    free(temp); // free memory for popped node
+    d->size--;
+    return value;
+}
+
+/**
+ * Pop a value from the back of the queue, removing it from the queue.
+ * @param d The queue.
+ * @return The value on the back of the queue or NULL if the queue is empty.
+ */
+void* deque_pop_back(deque_t* d) {
+    if (d == NULL || d->back == NULL) {
+        return NULL;
+    }
+
+    void* value = d->back->value;
+    deque_node_t *temp = d->back; // temporary pointer for freeing up memory
+    if (d->front == d->back) {
+        // popping last element in deque
+        d->front = d->back = NULL;
+    } else {
+        d->back = d->back->prev;
+    }
+    free(temp);
+    d->size--;
+    return value;
+}
+
+/**
+ * Peek at the value on the front of the queue, leaving it on the queue.
+ * @param d The queue.
+ * @return The value on the front of the queue or NULL if the queue is empty.
+ */
+void* deque_peek_back(deque_t* d) {
+    if (d == NULL || d->back == NULL) {
+        return NULL;
+    }
+    return d->back->value;
+}
+
+/**
+ * Peek at the value on the back of the queue, leaving it on the queue.
+ * @param d The queue.
+ * @return The value on the back of the queue or NULL if the queue is empty.
+ */
+void* deque_peek_front(deque_t* d) {
+    if (d == NULL || d->front == NULL) {
+        return NULL;
+    }
+    return d->front->value;
+}

--- a/benchmark/C/Savina/src/include/deque.cmake
+++ b/benchmark/C/Savina/src/include/deque.cmake
@@ -1,0 +1,1 @@
+target_sources(${LF_MAIN_TARGET} PRIVATE deque.c)

--- a/benchmark/C/Savina/src/include/deque.h
+++ b/benchmark/C/Savina/src/include/deque.h
@@ -1,0 +1,128 @@
+/**
+@file
+@author Arthur Deng
+@author Edward A. Lee
+@section LICENSE
+Copyright (c) 2021, The University of California at Berkeley.
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+@section DESCRIPTION
+This is the header file for an implementation of a double-ended queue.
+Each node in the queue contains a void* pointer.
+To use this, include the following in your target properties:
+<pre>
+target C {
+    cmake-include: "/lib/c/reactor-c/util/deque.cmake"
+    files: ["/lib/c/reactor-c/util/deque.c", "/lib/c/reactor-c/util/deque.h"]
+};
+</pre>
+In addition, you need this in your Lingua Franca file:
+<pre>
+preamble {=
+    #include "deque.h"
+=}
+</pre>
+To create a deque, use calloc to ensure that it gets initialized
+with null pointers and zero size:
+<pre>
+    deque_t* my_deque = (deque_t*) calloc(1, sizeof(deque_t));
+</pre>
+Alternatively, you can call initialize:
+<pre>
+    deque my_deque;
+    deque_initialize(&my_deque);
+</pre>
+*/
+
+#ifndef DEQUE_H
+#define DEQUE_H
+
+#include <stddef.h>  // Defines size_t
+#include <stdbool.h> // Defines bool
+#include <stdlib.h>  // Defines malloc and free
+
+/**
+ * A double-ended queue data structure.
+ */
+typedef struct deque_t {
+    struct deque_node_t* front;
+    struct deque_node_t* back;
+    size_t size;
+} deque_t;
+
+/**
+ * Initialize the specified deque to an empty deque.
+ * @param d The deque.
+ */
+void deque_initialize(deque_t* d);
+
+/**
+ * Return true if the queue is empty.
+ * @param d The deque.
+ */
+bool deque_is_empty(deque_t* d);
+
+/**
+ * Return the size of the queue.
+ * @param d The deque.
+ * @return The size of the queue.
+ */
+size_t deque_size(deque_t* d);
+
+/**
+ * Push a value to the front of the queue.
+ * @param d The queue.
+ * @param value The value to push.
+ */
+void deque_push_front(deque_t* d, void* value);
+
+/**
+ * Push a value to the back of the queue.
+ * @param d The queue.
+ * @param value The value to push.
+ */
+void deque_push_back(deque_t* d, void* value);
+
+/**
+ * Pop a value from the front of the queue, removing it from the queue.
+ * @param d The queue.
+ * @return The value on the front of the queue or NULL if the queue is empty.
+ */
+void* deque_pop_front(deque_t* d);
+
+/**
+ * Pop a value from the back of the queue, removing it from the queue.
+ * @param d The queue.
+ * @return The value on the back of the queue or NULL if the queue is empty.
+ */
+void* deque_pop_back(deque_t* d);
+
+/**
+ * Peek at the value on the front of the queue, leaving it on the queue.
+ * @param d The queue.
+ * @return The value on the front of the queue or NULL if the queue is empty.
+ */
+void* deque_peek_back(deque_t* d);
+
+/**
+ * Peek at the value on the back of the queue, leaving it on the queue.
+ * @param d The queue.
+ * @return The value on the back of the queue or NULL if the queue is empty.
+ */
+void* deque_peek_front(deque_t* d);
+
+#endif // DEQUE_H

--- a/benchmark/C/Savina/src/micro/Big.lf
+++ b/benchmark/C/Savina/src/micro/Big.lf
@@ -1,0 +1,147 @@
+/**
+ * A benchmark that implements a many-to-many message passing scenario. Several
+ * workers are created, each of which sends a ping message to one other worker.
+ * To which worker the ping message is sent is decided randomly. The worker
+ * who receives the ping message replies with a pong. Uppon receiving the pong,
+ * the worker sends the next ping message.
+ *
+ * In LF, the challenging aspect about this benchmark is its sparse activity.
+ * While each worker is connected to all other workers, it will only send a
+ * message to precisely one of them for each tag. Since we need to ensure that
+ * input ports have a single writer, each worker has to create multiport inputs,
+ * where each port instance corresponds to one potential source of ping or pong
+ * messages. In order to determine from which worker we received a ping or pong
+ * message, we need to iterate over all ports and check `if_present()`. However,
+ * this becomes very expensive for a large number of workers. For 120 workers we
+ * send a total of 120 pings and 120 pongs per iteration, but we need to check
+ * up to 14400 ping ports and 14400 pong ports in each iteration. Obviously this
+ * introduces a large overhead.
+ *
+ * @author Hannes Klein
+ * @author Felix Wittwer
+ * @author Christian Menard
+ * @author Arthur Deng
+ */
+
+
+
+target C{
+    /* [[[cog
+      if (threaded_runtime=="True"):
+          cog.outl(f"threads: {threads},")
+      else:
+          cog.outl("threads: 0,")
+    ]]] */  
+    /// [[[end]]]
+    files: "../include/PseudoRandom.h"
+};
+
+// Despite the name, this only collects "finished" messages from all workers
+// and lets the benchmark runner know when all the workers finished
+reactor Sink(num_workers:size_t(10)) {
+    // number of exit messages received
+    state num_messages: size_t(0);
+    
+    
+    input[num_workers] worker_finished :bool;
+    
+    reaction(startup) {=
+        // reset state
+        self->num_messages = 0;
+    =}
+    
+    reaction(worker_finished) {=
+        // collect all exit messages, finish when all the messages have been received.
+        int i;
+        for(i = 0; i < self->num_workers; i++) {
+            if(worker_finished[i]->is_present) {
+                self->num_messages += 1;
+                if(self->num_messages == self->num_workers) {
+                    return;
+                }
+            }
+        }
+    =}
+}
+
+reactor Worker(bank_index: size_t(0), num_messages: size_t(20000), num_workers:size_t(10)) {
+    
+    preamble {=
+        #include "PseudoRandom.h"
+        #include "stdint.h"
+    =}
+    
+    state num_pings: size_t(0);
+    state random: PseudoRandom;
+    state exp_pong: size_t({=SIZE_MAX=});
+    
+    input[num_workers] in_ping: bool;
+    input[num_workers] in_pong: bool;
+    output[num_workers] out_ping: bool;
+    output[num_workers] out_pong: bool;
+    output finished : bool;
+    logical action next;
+    
+    // send ping
+    reaction (next) -> out_ping {=
+        self->num_pings++;
+        int to = nextInt(&(self->random)) % self->num_workers; 
+        self->exp_pong = to;
+        SET(out_ping[to], true);
+    =}
+    
+    // reply with pong
+    reaction(in_ping) -> out_pong {=
+        size_t i;
+        for(i = 0; i < self->num_workers; i++) {
+            if (in_ping[i]->is_present) { 
+                SET(out_pong[i], true);
+            }
+        }
+    =}
+    
+    // receive pong and send next ping
+    reaction (in_pong) -> next, finished {=
+        size_t i;
+        for(i = 0; i < self->num_workers; i++) {
+            if (in_pong[i]->is_present) {
+                if (i != self->exp_pong) {
+                    fprintf(stderr, "Expected pong from %zu but received pong from %zu", self->exp_pong, i);
+                }
+            }
+        }
+        
+        // send next ping
+        if (self->num_pings == self->num_messages) {
+            SET(finished, true);
+        } else {
+            schedule(next, 0);
+        }
+    =}
+    
+    reaction (startup) -> next {=
+        // reset state
+        self->num_pings = 0;
+        self->exp_pong = SIZE_MAX;
+        initPseudoRandom(&(self->random), self->bank_index);
+        
+        // start execution
+        schedule(next, 0);
+    =}
+}
+
+/* [[[cog
+    cog.outl(f'main reactor (numPingsPerReactor:int({numPingsPerReactor}), numReactors:int({numReactors}))')
+]]] */
+main reactor (numPingsPerReactor:size_t(20000), numReactors:size_t(120)) 
+/// [[[end]]]
+{
+
+    sink = new Sink(num_workers=numReactors);
+    worker = new[numReactors] Worker(num_messages=numPingsPerReactor, num_workers=numReactors);
+  
+    worker.finished -> sink.worker_finished;
+    
+    worker.out_ping -> interleaved(worker.in_ping);    
+    worker.out_pong -> interleaved(worker.in_pong);
+}

--- a/benchmark/C/Savina/src/parallelism/NQueens.lf
+++ b/benchmark/C/Savina/src/parallelism/NQueens.lf
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 TU Dresden
+ * Copyright (C) 2020 TU Dresden and UC Berkeley
  * 
  * This benchmark implements a solution to the N queens problem. In particular,
  * the benchmark implements a recursive search algorithm that finds all possible
@@ -44,6 +44,7 @@ target C{
       else:
           cog.outl("threads: 0")
     ]]] */
+    //logging: debug,
     cmake-include: "../include/deque.cmake",
     files: ["../include/deque.c", "../include/deque.h"]
     
@@ -52,7 +53,6 @@ target C{
 
 preamble {=
     #include "deque.h"
-    
     typedef struct work_item_t {
         size_t *data;
         size_t depth;
@@ -134,15 +134,14 @@ reactor Manager(num_workers: size_t(20), solutions_limit: size_t(1500000), size:
         
         // start execution
         work_item_t* item = (work_item_t *) calloc(1, sizeof(struct work_item_t)); // freed when item is passed into Worker (line 191)
+        
         deque_push_back(self->manager_work_queue, item); 
         //next.schedule();
         schedule(next, 0);
-        printf("start done\n");
     =}
 
     reaction(done) {=
         // expected solutions for various problem sizes
-        
         size_t solutions[] = {
             1,
             0,
@@ -179,6 +178,11 @@ reactor Manager(num_workers: size_t(20), solutions_limit: size_t(1500000), size:
     =}
     
     reaction (next) -> next, done, do_work {=
+        
+//        DEBUG_PRINT("============================\n"); 
+//        printf("%p\n", do_work);
+//        printf("%p\n", &self->num_solutions);
+//        printf("%p\n", self->manager_work_queue); 
         if (deque_is_empty(self->manager_work_queue)) {
             // we are done if there is no more work
             // done.schedule();
@@ -194,9 +198,6 @@ reactor Manager(num_workers: size_t(20), solutions_limit: size_t(1500000), size:
             // and schedule the next iteration
             schedule(next, 0);
         }
-        
-        
-        
     =}
     
     reaction (solutions_found) {=
@@ -241,9 +242,6 @@ reactor Worker(bank_index: size_t(0), size: size_t(12), threshold: size_t(4)) {
         size_t *a = do_work->value.data;
         size_t depth = do_work->value.depth;
         
-        //reactor::log::Info() << "Worker " << bank_index << ": received " << a.size() 
-        //                     << " data items; depth=" << depth;
-        
         if(self->size == depth) {
             // It is unclear when exactly this evaluates to true and what this means. 
             // However, this seems to be essential for some sizes, including size=1.
@@ -286,24 +284,26 @@ reactor Worker(bank_index: size_t(0), size: size_t(12), threshold: size_t(4)) {
             }
             if (!deque_is_empty(work_queue)) {
                 SET(more_work, work_queue);
-            }
+            } 
         }
         
         free(a); // frees memory of current sequence
     =}
-   
-    
-    // Searches for results recursively and returns the number of found solutions.
-    
 }
 
+
+/* [[[cog
+        cog.outl(f'main reactor (numTransactions:int({numTransactions}), numAccounts:int({numAccounts}))')
+    ]]] */
 main reactor (
     size: size_t(12),
-    threshold: size_t(7),
+    threshold: size_t(4),
     solutionsLimit: size_t(1500000),
     priorities: size_t(10),
     numWorkers: size_t(20)
-) {
+) 
+/// [[[end]]]
+{
     manager = new Manager(num_workers=numWorkers, solutions_limit=solutionsLimit, size=size);
     workers = new[numWorkers] Worker(size=size, threshold=threshold);
 

--- a/benchmark/C/Savina/src/parallelism/NQueens.lf
+++ b/benchmark/C/Savina/src/parallelism/NQueens.lf
@@ -44,7 +44,7 @@ target C{
       else:
           cog.outl("threads: 0")
     ]]] */
-    //logging: debug,
+    logging: warn,
     cmake-include: "../include/deque.cmake",
     files: ["../include/deque.c", "../include/deque.h"]
     
@@ -213,7 +213,7 @@ reactor Manager(num_workers: size_t(20), solutions_limit: size_t(1500000), size:
         }
         if (s > 0) {
             self->num_solutions += s;
-            printf(" Found %zu solutions; Total solutions %zu\n", s, self->num_solutions);
+            info_print(" Found %zu solutions; Total solutions %zu\n", s, self->num_solutions);
         }
     =}
     

--- a/benchmark/C/Savina/src/parallelism/NQueens.lf
+++ b/benchmark/C/Savina/src/parallelism/NQueens.lf
@@ -1,0 +1,314 @@
+/**
+ * Copyright (C) 2020 TU Dresden
+ * 
+ * This benchmark implements a solution to the N queens problem. In particular,
+ * the benchmark implements a recursive search algorithm that finds all possible
+ * solution. Given N (size), the board has a size of N x N fields and N queens
+ * need to be placed such that no two queens threaten each other.
+ * The algorithm starts from an empty board. Then, the first
+ * queen is placed on the first line. There are N different options, and in the
+ * first operation, all of them are valid. These possible solutions are recorded
+ * in a list. In the second iteration, all possible solutions are expanded by
+ * adding a second queen to all N positions in the second line. Thereby, each
+ * solution is checked for validity and is discarded if invalid. This process
+ * continues until the Nth iteration completed and all solutions have been
+ * found.
+ * 
+ * In this benchmark, the workload is distributed across multiple workers. Each
+ * worker receives an initial position, and then adds a queen to the next line.
+ * The worker sends all valid solutions back to the manager which then again
+ * distributes the positions to the workers for further processing. Only for the
+ * last `threshold` iterations, the workers directly implement the search to the
+ * end and don't produce new work items.
+ *
+ * This benchmark is very similar to the A* (GuidedSearch) benchmark. An
+ * important difference of this LF implementation compared to the Akka
+ * implementation is the handling of messages send back from the workers to the
+ * manager. In the Akka implementation, each work item produced by the workers is
+ * sent as an individual message. This is not easily possible as each port in LF
+ * is limited to a single value per tag. Thus, we accumulate multiple work items
+ * in a single list, and send this list back to the manager. An alternative
+ * solution could use a logical action and call schedule multiple times to defer
+ * sending a message. It could be worthwhile to try this out, but it would also
+ * complicate the design.
+ * 
+ * @author Christian Menard
+ * @author Hannes Klein
+ * @author Arthur Deng
+ */
+
+target C{
+    /* [[[cog
+      if (threaded_runtime=="True"):
+          cog.outl(f"threads: {threads}")
+      else:
+          cog.outl("threads: 0")
+    ]]] */
+    cmake-include: "../include/deque.cmake",
+    files: ["../include/deque.c", "../include/deque.h"]
+    
+    /// [[[end]]]
+};
+
+preamble {=
+    #include "deque.h"
+    
+    typedef struct work_item_t {
+        size_t *data;
+        size_t depth;
+    } work_item_t;
+    
+    typedef deque_t work_queue_t;
+    
+    int i; // declaration for counter used in loops
+    
+    /**
+     * Checks whether the board is a valid configuration of queens where no two queens are on the same 
+     * straight or diagonal line.
+     */
+    int board_valid(size_t n, size_t *a) {
+        size_t p = 0, q = 0;
+        size_t x = 0, y = 0;
+        for (x = 0; x < n; x++) {
+            p = a[x];
+            for (y = x + 1; y < n; y++) {
+                q = a[y];
+                if(q == p || q == p - (y - x) || q == p + (y - x)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+    
+    /**
+     * Function to recursively solve the problem. Called inside the Worker reactor when depth is greater than 
+     * or equal to "threshold" (parameter passed in to the benchmark)
+     */
+    size_t nqueens_kernel_seq(size_t *a, size_t depth, size_t size) {
+        if(size == depth) {
+            return 1;
+        }
+        size_t num_solutions = 0;
+        size_t *b = (size_t *) malloc (sizeof(size_t) * (depth + 1));
+        size_t cnt = 0;
+        // recursive calls
+        while (cnt < size) {
+            size_t idx = 0;
+            
+            // copy current configuration into new array b and set next row to contain a queen
+            // at position "cnt"
+            for (idx = 0; idx < depth + 1; idx++) {
+                b[idx] = a[idx];
+            }
+            // set 
+            b[depth] = cnt;
+            // if new configuration is valid call nqueens_kernel_seq on the new configuration
+            if (board_valid(depth + 1, b)) {
+                num_solutions += nqueens_kernel_seq(b, depth + 1, size);
+            }
+            cnt++;
+        }
+        free(b);
+        return num_solutions;
+    }
+=}
+
+reactor Manager(num_workers: size_t(20), solutions_limit: size_t(1500000), size: size_t(12)) {
+    
+    state num_solutions: size_t(0);
+    state manager_work_queue: {=work_queue_t *=};
+
+    output[num_workers] do_work: work_item_t;
+    input[num_workers] solutions_found: size_t;
+    input[num_workers] more_work: {=work_queue_t *=};
+    
+    logical action next;
+    logical action done;
+
+    reaction (startup) -> do_work, next {=
+        self->manager_work_queue = (work_queue_t *) calloc(1, sizeof(struct deque_t)); // freed in shutdown reaction
+        
+        // reset local state
+        self->num_solutions = 0;
+        
+        // start execution
+        work_item_t* item = (work_item_t *) calloc(1, sizeof(struct work_item_t)); // freed when item is passed into Worker (line 191)
+        deque_push_back(self->manager_work_queue, item); 
+        //next.schedule();
+        schedule(next, 0);
+        printf("start done\n");
+    =}
+
+    reaction(done) {=
+        // expected solutions for various problem sizes
+        
+        size_t solutions[] = {
+            1,
+            0,
+            0,
+            2,
+            10,     /* 5 */
+            4,
+            40,
+            92,
+            352,
+            724,    /* 10 */
+            2680,
+            14200,
+            73712,
+            365596,
+            2279184, /* 15 */
+            14772512,
+            95815104,
+            666090624,
+            4968057848,
+            39029188884 /* 20 */
+        };
+        
+        // validate the result
+        size_t expected = solutions[self->size-1];
+        bool valid = self->num_solutions == expected;
+        if (self->solutions_limit < expected) {
+            valid = self->num_solutions >= self->solutions_limit && self->num_solutions <= expected;
+        }
+        // The validation check above is a corrected version. The original Savina implementation will
+        // wrongly mark results as invalid if the solutions limit is above the expected solution.
+        //reactor::log::Info() << std::boolalpha << "Result valid = " << valid << std::noboolalpha;
+        printf("Result valid =  %d\n", valid);
+    =}
+    
+    reaction (next) -> next, done, do_work {=
+        if (deque_is_empty(self->manager_work_queue)) {
+            // we are done if there is no more work
+            // done.schedule();
+            schedule(done, 0);
+        } else {
+            // send a work item to each worker (until there is no more work)
+            for (i = 0; i < self->num_workers && !deque_is_empty(self->manager_work_queue); i++) {
+                work_item_t *val = deque_pop_front(self->manager_work_queue);
+                SET(do_work[i], *val);
+                free(val);
+                
+            }
+            // and schedule the next iteration
+            schedule(next, 0);
+        }
+        
+        
+        
+    =}
+    
+    reaction (solutions_found) {=
+        // accumulate all the solutions found
+        size_t s = 0;
+        
+        for (i = 0; i < self->num_workers; i++) {
+            if(solutions_found[i]->is_present) {
+                s += solutions_found[i]->value;
+            }
+        }
+        if (s > 0) {
+            self->num_solutions += s;
+            printf(" Found %zu solutions; Total solutions %zu\n", s, self->num_solutions);
+        }
+    =}
+    
+    reaction (more_work) {=
+        // append all work items received from the workers to the internal work queue
+        for (i = 0; i < self->num_workers; i++) {
+            if(more_work[i]->is_present) {
+                work_queue_t *items = more_work[i]->value;
+                while (!deque_is_empty(items)) {
+                    deque_push_back(self->manager_work_queue, deque_pop_front(items));
+                }
+                free(items);
+            }
+        }
+    =}
+    reaction (shutdown) {=
+        free(self->manager_work_queue);
+    =}
+}
+
+reactor Worker(bank_index: size_t(0), size: size_t(12), threshold: size_t(4)) {
+
+    input do_work: work_item_t;
+    output solutions_found: size_t;
+    output more_work: {=work_queue_t *=};
+    
+    reaction(do_work) -> solutions_found, more_work {=
+        size_t *a = do_work->value.data;
+        size_t depth = do_work->value.depth;
+        
+        //reactor::log::Info() << "Worker " << bank_index << ": received " << a.size() 
+        //                     << " data items; depth=" << depth;
+        
+        if(self->size == depth) {
+            // It is unclear when exactly this evaluates to true and what this means. 
+            // However, this seems to be essential for some sizes, including size=1.
+            SET(solutions_found, 1);
+            // abort the reaction
+            return;
+        }
+        
+        if(depth >= self->threshold) {
+            // If depth is greater or equal to the threshold, the worker searches for solutions.
+            size_t num_solutions = nqueens_kernel_seq(a, depth, self->size);
+            if (num_solutions > 0) {
+                SET(solutions_found, num_solutions);
+            }
+        } else {
+            // Otherwise, if depth is less than the threshold, the worker splits up the workload and
+            // produces new work items.
+            size_t newDepth = depth + 1;
+            // prepare a mutable work queue to be sent later
+            work_queue_t *work_queue = (work_queue_t *) calloc(1, sizeof(struct deque_t)); //freed in Manager (line 225)
+            for (i = 0; i < self->size; i++) {
+                // prepare a mutable work item
+                size_t *vec = (size_t *) calloc(newDepth, sizeof(size_t)); // freed when the work_item_t is handled in another Worker (line 292)
+                work_item_t* item = (work_item_t *) calloc(1, sizeof(struct work_item_t)); // freed when popped from manager_work_queue (line 191)
+                item->data = vec;
+                item->depth = newDepth;
+                size_t *b = item->data;
+                // copy depth items from a to b
+                int j = 0;
+                for (j = 0; j < depth; j++) {
+                    b[j] = a[j];
+                }
+
+                b[depth] = i;
+                
+                // add the item to the list if is valid
+                if(board_valid(newDepth, b)) {
+                    deque_push_back(work_queue, item);
+                }
+            }
+            if (!deque_is_empty(work_queue)) {
+                SET(more_work, work_queue);
+            }
+        }
+        
+        free(a); // frees memory of current sequence
+    =}
+   
+    
+    // Searches for results recursively and returns the number of found solutions.
+    
+}
+
+main reactor (
+    size: size_t(12),
+    threshold: size_t(7),
+    solutionsLimit: size_t(1500000),
+    priorities: size_t(10),
+    numWorkers: size_t(20)
+) {
+    manager = new Manager(num_workers=numWorkers, solutions_limit=solutionsLimit, size=size);
+    workers = new[numWorkers] Worker(size=size, threshold=threshold);
+
+    
+    manager.do_work -> workers.do_work;
+    workers.solutions_found -> manager.solutions_found;
+    workers.more_work -> manager.more_work;    
+}

--- a/benchmark/C/Savina/src/parallelism/NQueens.lf
+++ b/benchmark/C/Savina/src/parallelism/NQueens.lf
@@ -129,14 +129,14 @@ reactor Manager(num_workers: size_t(20), solutions_limit: size_t(1500000), size:
     reaction (startup) -> do_work, next {=
         self->manager_work_queue = (work_queue_t *) calloc(1, sizeof(struct deque_t)); // freed in shutdown reaction
         
-        // reset local state
+        // set local state
         self->num_solutions = 0;
         
         // start execution
         work_item_t* item = (work_item_t *) calloc(1, sizeof(struct work_item_t)); // freed when item is passed into Worker (line 191)
         
         deque_push_back(self->manager_work_queue, item); 
-        //next.schedule();
+        
         schedule(next, 0);
     =}
 
@@ -171,21 +171,24 @@ reactor Manager(num_workers: size_t(20), solutions_limit: size_t(1500000), size:
         if (self->solutions_limit < expected) {
             valid = self->num_solutions >= self->solutions_limit && self->num_solutions <= expected;
         }
+        
         // The validation check above is a corrected version. The original Savina implementation will
         // wrongly mark results as invalid if the solutions limit is above the expected solution.
-        //reactor::log::Info() << std::boolalpha << "Result valid = " << valid << std::noboolalpha;
-        printf("Result valid =  %d\n", valid);
+        printf("Result valid = %d\n", valid);
     =}
     
     reaction (next) -> next, done, do_work {=
+        //FIXME: When the benchmark is run, the 20 (= number of Workers) warning messages of freeing already freed token (see below) 
+        // is printed every time this reaction happens. 
+        //"WARNING: Token being freed that has already been freed: 0x60000011c510"
         
 //        DEBUG_PRINT("============================\n"); 
 //        printf("%p\n", do_work);
 //        printf("%p\n", &self->num_solutions);
-//        printf("%p\n", self->manager_work_queue); 
+//        printf("%p\n", self->manager_work_queue);
+
         if (deque_is_empty(self->manager_work_queue)) {
             // we are done if there is no more work
-            // done.schedule();
             schedule(done, 0);
         } else {
             // send a work item to each worker (until there is no more work)
@@ -193,7 +196,6 @@ reactor Manager(num_workers: size_t(20), solutions_limit: size_t(1500000), size:
                 work_item_t *val = deque_pop_front(self->manager_work_queue);
                 SET(do_work[i], *val);
                 free(val);
-                
             }
             // and schedule the next iteration
             schedule(next, 0);
@@ -201,7 +203,7 @@ reactor Manager(num_workers: size_t(20), solutions_limit: size_t(1500000), size:
     =}
     
     reaction (solutions_found) {=
-        // accumulate all the solutions found
+        // accumulate all the solutions found by looping through solutions_found and increment num_solutions
         size_t s = 0;
         
         for (i = 0; i < self->num_workers; i++) {
@@ -260,7 +262,7 @@ reactor Worker(bank_index: size_t(0), size: size_t(12), threshold: size_t(4)) {
             // Otherwise, if depth is less than the threshold, the worker splits up the workload and
             // produces new work items.
             size_t newDepth = depth + 1;
-            // prepare a mutable work queue to be sent later
+            // prepare a work queue to be sent later
             work_queue_t *work_queue = (work_queue_t *) calloc(1, sizeof(struct deque_t)); //freed in Manager (line 225)
             for (i = 0; i < self->size; i++) {
                 // prepare a mutable work item
@@ -306,8 +308,6 @@ main reactor (
 {
     manager = new Manager(num_workers=numWorkers, solutions_limit=solutionsLimit, size=size);
     workers = new[numWorkers] Worker(size=size, threshold=threshold);
-
-    
     manager.do_work -> workers.do_work;
     workers.solutions_found -> manager.solutions_found;
     workers.more_work -> manager.more_work;    

--- a/benchmark/runner/conf/benchmark/savina_micro_big.yaml
+++ b/benchmark/runner/conf/benchmark/savina_micro_big.yaml
@@ -29,3 +29,12 @@ targets:
     run_args:
       messages: ["--numPingsPerReactor", "<value>"]
       actors: ["--numReactors", "<value>"]
+  lf-c:
+    copy_sources:
+      - "${lf_path}/benchmark/C/Savina/src/micro"
+      - "${lf_path}/benchmark/C/Savina/src/include"
+    lf_file: "micro/Big.lf"
+    binary: "Big"
+    gen_args:
+      messages: ["-D", "numPingsPerReactor=<value>"]
+      actors: ["-D", "numReactorss=<value>"]

--- a/benchmark/runner/conf/benchmark/savina_parallelism_nqueenk.yaml
+++ b/benchmark/runner/conf/benchmark/savina_parallelism_nqueenk.yaml
@@ -38,3 +38,15 @@ targets:
       priorities: ["--priorities", "<value>"]
       solution_limit: ["--solutionsLimit", "<value>"]
       num_workers: ["--numWorkers", "<value>"]
+  lf-c:
+    copy_sources:
+      - "${lf_path}/benchmark/C/Savina/src/parallelism"
+      - "${lf_path}/benchmark/C/Savina/src/include"
+    lf_file: "parallelism/NQueens.lf"
+    binary: "NQueens"
+    gen_args:
+      size: ["-D", "size=<value>"]
+      threshold: ["-D", "threshold=<value>"]
+      priorities: ["-D", "priorities=<value>"]
+      solutions_limit: ["-D", "solutionsLimit=<value>"]
+      num_workers: ["-D", "numWorkers=<value>"]


### PR DESCRIPTION
There is an issue in the NQueens benchmark of getting the warnings of freeing already freed tokens every time `reaction(next)` is triggered in Manager. Every time "next" is triggered, 20 (current number of Workers) warnings appear. It shouldn't be due to any `free()` calls as I tried commenting out all the `free()` and the issue persisted.