### PR TITLE
Formatted C++ examples for better readability

### DIFF
--- a/example/Cpp/src/CarBrake/CarBrake.lf
+++ b/example/Cpp/src/CarBrake/CarBrake.lf
@@ -13,76 +13,75 @@ reactor Camera {
 }
 
 reactor BrakingAssistant {
-    input frame: void;
+  input frame: void;
 	output trigger_brake: void;
-
 	
 	state counter: int(0);
 
 	reaction(frame) -> trigger_brake {=
-        // processing takes some time
+    // processing takes some time
  		std::this_thread::sleep_for(10ms);
  		
-        if (counter % 10 == 0) {
-            std::cout << "[automatic] Send the brake signal - " << get_physical_time() << std::endl;
-            trigger_brake.set();
-        }
-      	counter++;  
-    =}
+    if (counter % 10 == 0) {
+      std::cout << "[automatic] Send the brake signal - " << get_physical_time() << std::endl;
+      trigger_brake.set();
+    }
+    counter++;
+  =}
 }
 
 reactor BrakePedal {
-    physical action pedal;
-    output trigger_brake: void;
-    
-    state thread: std::thread;
-    
-    reaction(startup) -> pedal {=
-        this->thread = std::thread([&] () {
-            // press the brake pedal roughly every second
-			while (true) {
-				std::this_thread::sleep_for(1005ms);
-				std::cout << "[manual] Pressing the break pedal - " << get_physical_time() << std::endl;
-				pedal.schedule(0ms);
-			}
-        });
-    =}
-    
-    reaction(pedal) -> trigger_brake {=
-		std::cout << "[manual] Send the brake signal - " << get_physical_time() << std::endl;
-		trigger_brake.set();
-    =}
-    
-    reaction(shutdown) {=
-        thread.join();
-    =}
+  physical action pedal;
+  output trigger_brake: void;
+
+  state thread: std::thread;
+
+  reaction(startup) -> pedal {=
+    this->thread = std::thread([&] () {
+      // press the brake pedal roughly every second
+      while (true) {
+        std::this_thread::sleep_for(1005ms);
+        std::cout << "[manual] Pressing the break pedal - " << get_physical_time() << std::endl;
+        pedal.schedule(0ms);
+      }
+    });
+  =}
+
+  reaction(pedal) -> trigger_brake {=
+    std::cout << "[manual] Send the brake signal - " << get_physical_time() << std::endl;
+    trigger_brake.set();
+  =}
+
+  reaction(shutdown) {=
+    thread.join();
+  =}
 }
 
 reactor Brake {
-    public preamble {=
-        #include <thread>
-    =}
+  public preamble {=
+      #include <thread>
+  =}
 
 	input brake_assistant: void;
 	input brake_pedal: void;
 	
 	reaction(brake_pedal) {=
-        std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
-        std::cout << "[system] source: manual" << std::endl;
-    =} deadline (3msecs) {=
-        std::cout << "\033[1;31m[error]\033[0m Deadline on manual braking violated - " << get_physical_time() << std::endl;
-    =}
+    std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
+    std::cout << "[system] source: manual" << std::endl;
+  =} deadline (3msecs) {=
+    std::cout << "\033[1;31m[error]\033[0m Deadline on manual braking violated - " << get_physical_time() << std::endl;
+  =}
 	
 	reaction(brake_assistant) {=
-        std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
-        std::cout << "[system] source: assistant" << std::endl;
-    =} deadline (15msecs) {=
-        std::cout << "\033[1;31m[error]\033[0m Deadline on automatic braking violated - " << get_physical_time() << std::endl;
-    =}
+    std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
+    std::cout << "[system] source: assistant" << std::endl;
+  =} deadline (15msecs) {=
+    std::cout << "\033[1;31m[error]\033[0m Deadline on automatic braking violated - " << get_physical_time() << std::endl;
+  =}
 }
 
 main reactor {
-    camera = new Camera();
+  camera = new Camera();
 	assistant = new BrakingAssistant();
 	pedal = new BrakePedal();
 	brake = new Brake();

--- a/example/Cpp/src/CarBrake/CarBrake.lf
+++ b/example/Cpp/src/CarBrake/CarBrake.lf
@@ -13,80 +13,80 @@ reactor Camera {
 }
 
 reactor BrakingAssistant {
-  input frame: void;
-	output trigger_brake: void;
+    input frame: void;
+	  output trigger_brake: void;
 	
-	state counter: int(0);
+	  state counter: int(0);
 
-	reaction(frame) -> trigger_brake {=
-    // processing takes some time
- 		std::this_thread::sleep_for(10ms);
+	  reaction(frame) -> trigger_brake {=
+        // processing takes some time
+ 		    std::this_thread::sleep_for(10ms);
  		
-    if (counter % 10 == 0) {
-      std::cout << "[automatic] Send the brake signal - " << get_physical_time() << std::endl;
-      trigger_brake.set();
-    }
-    counter++;
-  =}
+        if (counter % 10 == 0) {
+            std::cout << "[automatic] Send the brake signal - " << get_physical_time() << std::endl;
+            trigger_brake.set();
+        }
+        counter++;
+    =}
 }
 
 reactor BrakePedal {
-  physical action pedal;
-  output trigger_brake: void;
+    physical action pedal;
+    output trigger_brake: void;
 
-  state thread: std::thread;
+    state thread: std::thread;
 
-  reaction(startup) -> pedal {=
-    this->thread = std::thread([&] () {
-      // press the brake pedal roughly every second
-      while (true) {
-        std::this_thread::sleep_for(1005ms);
-        std::cout << "[manual] Pressing the break pedal - " << get_physical_time() << std::endl;
-        pedal.schedule(0ms);
-      }
-    });
-  =}
+    reaction(startup) -> pedal {=
+        this->thread = std::thread([&] () {
+            // press the brake pedal roughly every second
+            while (true) {
+                std::this_thread::sleep_for(1005ms);
+                std::cout << "[manual] Pressing the break pedal - " << get_physical_time() << std::endl;
+                pedal.schedule(0ms);
+            }
+        });
+    =}
 
-  reaction(pedal) -> trigger_brake {=
-    std::cout << "[manual] Send the brake signal - " << get_physical_time() << std::endl;
-    trigger_brake.set();
-  =}
+    reaction(pedal) -> trigger_brake {=
+        std::cout << "[manual] Send the brake signal - " << get_physical_time() << std::endl;
+        trigger_brake.set();
+    =}
 
-  reaction(shutdown) {=
-    thread.join();
-  =}
+    reaction(shutdown) {=
+        thread.join();
+    =}
 }
 
 reactor Brake {
-  public preamble {=
-      #include <thread>
-  =}
+    public preamble {=
+        #include <thread>
+    =}
 
-	input brake_assistant: void;
-	input brake_pedal: void;
+	  input brake_assistant: void;
+	  input brake_pedal: void;
 	
-	reaction(brake_pedal) {=
-    std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
-    std::cout << "[system] source: manual" << std::endl;
-  =} deadline (3msecs) {=
-    std::cout << "\033[1;31m[error]\033[0m Deadline on manual braking violated - " << get_physical_time() << std::endl;
-  =}
+	  reaction(brake_pedal) {=
+        std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
+        std::cout << "[system] source: manual" << std::endl;
+    =} deadline (3msecs) {=
+        std::cout << "\033[1;31m[error]\033[0m Deadline on manual braking violated - " << get_physical_time() << std::endl;
+    =}
 	
-	reaction(brake_assistant) {=
-    std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
-    std::cout << "[system] source: assistant" << std::endl;
-  =} deadline (15msecs) {=
-    std::cout << "\033[1;31m[error]\033[0m Deadline on automatic braking violated - " << get_physical_time() << std::endl;
-  =}
+	  reaction(brake_assistant) {=
+        std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
+        std::cout << "[system] source: assistant" << std::endl;
+    =} deadline (15msecs) {=
+        std::cout << "\033[1;31m[error]\033[0m Deadline on automatic braking violated - " << get_physical_time() << std::endl;
+    =}
 }
 
 main reactor {
-  camera = new Camera();
-	assistant = new BrakingAssistant();
-	pedal = new BrakePedal();
-	brake = new Brake();
+    camera = new Camera();
+	  assistant = new BrakingAssistant();
+	  pedal = new BrakePedal();
+	  brake = new Brake();
 	
-	camera.frame -> assistant.frame;
-	assistant.trigger_brake -> brake.brake_assistant;
-	pedal.trigger_brake -> brake.brake_pedal;
+	  camera.frame -> assistant.frame;
+	  assistant.trigger_brake -> brake.brake_assistant;
+	  pedal.trigger_brake -> brake.brake_pedal;
 }

--- a/example/Cpp/src/CarBrake/CarBrake2.lf
+++ b/example/Cpp/src/CarBrake/CarBrake2.lf
@@ -4,91 +4,91 @@
  * on the ability to meet deadlines in the response to brake pedal actions.
  */
 target Cpp {
-    keepalive: true,
-    cmake-include: "threads.cmake"
+  keepalive: true,
+  cmake-include: "threads.cmake"
 };
 
 reactor Camera {
-    timer t(20msecs, 20msecs)
-    output frame: void
+  timer t(20msecs, 20msecs)
+  output frame: void
 
-    reaction (t) -> frame {=
-        frame.set(); // send a "frame"
-    =}
+  reaction (t) -> frame {=
+    frame.set(); // send a "frame"
+  =}
 }
 
 reactor BrakingAssistant {
-    input frame: void;
+  input frame: void;
 	output trigger_brake: void;
 
 	
 	state counter: int(0);
 
 	reaction(frame) -> trigger_brake {=
-        // processing takes some time
+    // processing takes some time
  		std::this_thread::sleep_for(10ms);
  		
-        if (counter % 10 == 0) {
-            std::cout << "[automatic] Send the brake signal - " << get_physical_time() << std::endl;
-            trigger_brake.set();
-        }
-      	counter++;  
-    =}
+    if (counter % 10 == 0) {
+      std::cout << "[automatic] Send the brake signal - " << get_physical_time() << std::endl;
+      trigger_brake.set();
+    }
+    counter++;  
+  =}
 }
 
 reactor BrakePedal {
-    physical action pedal;
-    output trigger_brake: void;
-    
-    state thread: std::thread;
-    
-    reaction(startup) -> pedal {=
-        this->thread = std::thread([&] () {
-            // press the brake pedal roughly every second
-			while (true) {
-				std::this_thread::sleep_for(1005ms);
-				std::cout << "[manual] Pressing the break pedal - " << get_physical_time() << std::endl;
-				pedal.schedule(0ms);
-			}
-        });
-    =}
-    
-    reaction(pedal) -> trigger_brake {=
+  physical action pedal;
+  output trigger_brake: void;
+
+  state thread: std::thread;
+
+  reaction(startup) -> pedal {=
+    this->thread = std::thread([&] () {
+      // press the brake pedal roughly every second
+
+      while (true) {
+        std::this_thread::sleep_for(1005ms);
+        std::cout << "[manual] Pressing the break pedal - " << get_physical_time() << std::endl;
+        pedal.schedule(0ms);
+      }
+    });
+  =}
+
+  reaction(pedal) -> trigger_brake {=
 		std::cout << "[manual] Send the brake signal - " << get_physical_time() << std::endl;
 		trigger_brake.set();
-    =}
-    
-    reaction(shutdown) {=
-        thread.join();
-    =}
+  =}
+
+  reaction(shutdown) {=
+    thread.join();
+  =}
 }
 
 reactor Brake {
-    public preamble {=
-        #include <thread>
-    =}
+  public preamble {=
+    #include <thread>
+  =}
 
 	input brake_assistant: void;
 	input brake_pedal: void;
 	
 	reaction(brake_pedal) {=
-        std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
-        std::cout << "[system] source: manual" << std::endl;
-    =} deadline (3msecs) {=
-        std::cout << "\033[1;31m[error]\033[0m Deadline on manual braking violated - " << get_physical_time() << std::endl;
-    =}
+    std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
+    std::cout << "[system] source: manual" << std::endl;
+  =} deadline (3msecs) {=
+    std::cout << "\033[1;31m[error]\033[0m Deadline on manual braking violated - " << get_physical_time() << std::endl;
+  =}
 	
 	reaction(brake_assistant) {=
-        std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
-        std::cout << "[system] source: assistant" << std::endl;
-    =} deadline (15msecs) {=
-        std::cout << "\033[1;31m[error]\033[0m Deadline on automatic braking violated - " << get_physical_time() << std::endl;
-    =}
+    std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
+    std::cout << "[system] source: assistant" << std::endl;
+  =} deadline (15msecs) {=
+    std::cout << "\033[1;31m[error]\033[0m Deadline on automatic braking violated - " << get_physical_time() << std::endl;
+  =}
 }
 
 reactor Braking {
-    input brake_assistant: void;
-    
+  input brake_assistant: void;
 	pedal = new BrakePedal();
 	brake = new Brake();
 	
@@ -97,10 +97,9 @@ reactor Braking {
 }
 
 reactor Vision {
-    output trigger_brake: void;
-    
-    camera = new Camera();
-	assistant = new BrakingAssistant();    
+  output trigger_brake: void;
+  camera = new Camera();
+	assistant = new BrakingAssistant();
 
 	camera.frame -> assistant.frame;
 	assistant.trigger_brake -> trigger_brake;

--- a/example/Cpp/src/CarBrake/CarBrake2.lf
+++ b/example/Cpp/src/CarBrake/CarBrake2.lf
@@ -4,110 +4,109 @@
  * on the ability to meet deadlines in the response to brake pedal actions.
  */
 target Cpp {
-  keepalive: true,
-  cmake-include: "threads.cmake"
+    keepalive: true,
+    cmake-include: "threads.cmake"
 };
 
 reactor Camera {
-  timer t(20msecs, 20msecs)
-  output frame: void
+    timer t(20msecs, 20msecs)
+    output frame: void
 
-  reaction (t) -> frame {=
-    frame.set(); // send a "frame"
-  =}
+    reaction (t) -> frame {=
+        frame.set(); // send a "frame"
+    =}
 }
 
 reactor BrakingAssistant {
-  input frame: void;
-	output trigger_brake: void;
+    input frame: void;
+	  output trigger_brake: void;
 
-	
-	state counter: int(0);
+	  state counter: int(0);
 
-	reaction(frame) -> trigger_brake {=
-    // processing takes some time
- 		std::this_thread::sleep_for(10ms);
+	  reaction(frame) -> trigger_brake {=
+        // processing takes some time
+ 		    std::this_thread::sleep_for(10ms);
  		
-    if (counter % 10 == 0) {
-      std::cout << "[automatic] Send the brake signal - " << get_physical_time() << std::endl;
-      trigger_brake.set();
-    }
-    counter++;  
-  =}
+        if (counter % 10 == 0) {
+            std::cout << "[automatic] Send the brake signal - " << get_physical_time() << std::endl;
+            trigger_brake.set();
+        }
+        counter++;  
+    =}
 }
 
 reactor BrakePedal {
-  physical action pedal;
-  output trigger_brake: void;
+    physical action pedal;
+    output trigger_brake: void;
 
-  state thread: std::thread;
+    state thread: std::thread;
 
-  reaction(startup) -> pedal {=
-    this->thread = std::thread([&] () {
-      // press the brake pedal roughly every second
+    reaction(startup) -> pedal {=
+        this->thread = std::thread([&] () {
+            // press the brake pedal roughly every second
 
-      while (true) {
-        std::this_thread::sleep_for(1005ms);
-        std::cout << "[manual] Pressing the break pedal - " << get_physical_time() << std::endl;
-        pedal.schedule(0ms);
-      }
-    });
-  =}
+            while (true) {
+                std::this_thread::sleep_for(1005ms);
+                std::cout << "[manual] Pressing the break pedal - " << get_physical_time() << std::endl;
+                pedal.schedule(0ms);
+            }
+        });
+    =}
 
-  reaction(pedal) -> trigger_brake {=
-		std::cout << "[manual] Send the brake signal - " << get_physical_time() << std::endl;
-		trigger_brake.set();
-  =}
+    reaction(pedal) -> trigger_brake {=
+		    std::cout << "[manual] Send the brake signal - " << get_physical_time() << std::endl;
+		    trigger_brake.set();
+    =}
 
-  reaction(shutdown) {=
-    thread.join();
-  =}
+    reaction(shutdown) {=
+        thread.join();
+    =}
 }
 
 reactor Brake {
-  public preamble {=
-    #include <thread>
-  =}
+    public preamble {=
+        #include <thread>
+    =}
 
-	input brake_assistant: void;
-	input brake_pedal: void;
-	
-	reaction(brake_pedal) {=
-    std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
-    std::cout << "[system] source: manual" << std::endl;
-  =} deadline (3msecs) {=
-    std::cout << "\033[1;31m[error]\033[0m Deadline on manual braking violated - " << get_physical_time() << std::endl;
-  =}
-	
-	reaction(brake_assistant) {=
-    std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
-    std::cout << "[system] source: assistant" << std::endl;
-  =} deadline (15msecs) {=
-    std::cout << "\033[1;31m[error]\033[0m Deadline on automatic braking violated - " << get_physical_time() << std::endl;
-  =}
+    input brake_assistant: void;
+    input brake_pedal: void;
+
+    reaction(brake_pedal) {=
+        std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
+        std::cout << "[system] source: manual" << std::endl;
+    =} deadline (3msecs) {=
+        std::cout << "\033[1;31m[error]\033[0m Deadline on manual braking violated - " << get_physical_time() << std::endl;
+    =}
+
+    reaction(brake_assistant) {=
+        std::cout << "[system] Brake triggered - " << get_physical_time() << std::endl;
+        std::cout << "[system] source: assistant" << std::endl;
+    =} deadline (15msecs) {=
+        std::cout << "\033[1;31m[error]\033[0m Deadline on automatic braking violated - " << get_physical_time() << std::endl;
+    =}
 }
 
 reactor Braking {
-  input brake_assistant: void;
-	pedal = new BrakePedal();
-	brake = new Brake();
-	
-	pedal.trigger_brake -> brake.brake_pedal;
-	brake_assistant -> brake.brake_assistant;
+    input brake_assistant: void;
+    pedal = new BrakePedal();
+    brake = new Brake();
+
+    pedal.trigger_brake -> brake.brake_pedal;
+    brake_assistant -> brake.brake_assistant;
 }
 
 reactor Vision {
-  output trigger_brake: void;
-  camera = new Camera();
-	assistant = new BrakingAssistant();
+    output trigger_brake: void;
+    camera = new Camera();
+    assistant = new BrakingAssistant();
 
-	camera.frame -> assistant.frame;
-	assistant.trigger_brake -> trigger_brake;
+    camera.frame -> assistant.frame;
+    assistant.trigger_brake -> trigger_brake;
 }
 
 main reactor {
-	braking = new Braking();
-	vision = new Vision();
-	
-	vision.trigger_brake ~> braking.brake_assistant;
+    braking = new Braking();
+    vision = new Vision();
+
+    vision.trigger_brake ~> braking.brake_assistant;
 }

--- a/example/Cpp/src/Patterns/FullyConnected_00_Broadcast.lf
+++ b/example/Cpp/src/Patterns/FullyConnected_00_Broadcast.lf
@@ -12,27 +12,28 @@ target Cpp {
 }
 
 reactor Node(bank_index: size_t(0), num_nodes: size_t(4)) {
-  input[num_nodes] in: size_t
-  output out: size_t
+    input[num_nodes] in: size_t
+    output out: size_t
 
-  reaction (startup) -> out{=
-    std::cout << "Hello from node " << bank_index << "!\n";
-    // broadcast my ID to everyone
-    out.set(bank_index);
-  =}
+    reaction (startup) -> out{=
+        std::cout << "Hello from node " << bank_index << "!\n";
+        // broadcast my ID to everyone
+        out.set(bank_index);
+    =}
 
-  reaction (in) {=
-    std::cout << "Node " << bank_index << " received messages from ";
-    for (auto& port : in) {
-      if (port.is_present()) {
-        std::cout << *port.get() << ", ";
-      }
-    }
-    std::cout << '\n';
-  =}
+    reaction (in) {=
+        std::cout << "Node " << bank_index << " received messages from ";
+        for (auto& port : in) {
+            if (port.is_present()) {
+                std::cout << *port.get() << ", ";
+            }
+        }
+        std::cout << '\n';
+    =}
 }
 
 main reactor(num_nodes: size_t(4)) {
-  nodes = new[num_nodes] Node(num_nodes=num_nodes);
-  (nodes.out)+ -> nodes.in;
+    nodes = new[num_nodes] Node(num_nodes=num_nodes);
+    (nodes.out)+ -> nodes.in;
 }
+

--- a/example/Cpp/src/Patterns/FullyConnected_00_Broadcast.lf
+++ b/example/Cpp/src/Patterns/FullyConnected_00_Broadcast.lf
@@ -12,27 +12,27 @@ target Cpp {
 }
 
 reactor Node(bank_index: size_t(0), num_nodes: size_t(4)) {
-    input[num_nodes] in: size_t
-    output out: size_t
-    
-    reaction (startup) -> out{=
-     	std::cout << "Hello from node " << bank_index << "!\n";
-     	// broadcast my ID to everyone
-     	out.set(bank_index);    
-    =}
-    
-    reaction (in) {=
-        std::cout << "Node " << bank_index << " received messages from ";
-     	for (auto& port : in) {
-            if (port.is_present()) {
-                std::cout << *port.get() << ", ";
-            }
-        }   
-        std::cout << '\n';
-    =}
+  input[num_nodes] in: size_t
+  output out: size_t
+
+  reaction (startup) -> out{=
+    std::cout << "Hello from node " << bank_index << "!\n";
+    // broadcast my ID to everyone
+    out.set(bank_index);
+  =}
+
+  reaction (in) {=
+    std::cout << "Node " << bank_index << " received messages from ";
+    for (auto& port : in) {
+      if (port.is_present()) {
+        std::cout << *port.get() << ", ";
+      }
+    }
+    std::cout << '\n';
+  =}
 }
 
 main reactor(num_nodes: size_t(4)) {
-    nodes = new[num_nodes] Node(num_nodes=num_nodes);
-    (nodes.out)+ -> nodes.in;
+  nodes = new[num_nodes] Node(num_nodes=num_nodes);
+  (nodes.out)+ -> nodes.in;
 }

--- a/example/Cpp/src/Patterns/FullyConnected_01_Addressable.lf
+++ b/example/Cpp/src/Patterns/FullyConnected_01_Addressable.lf
@@ -10,31 +10,32 @@
  */
 
 target Cpp {
-  threads: 1
+    threads: 1
 }
 
 reactor Node(bank_index: size_t(0), num_nodes: size_t(4)) {
-  input[num_nodes] in: size_t
-  output[num_nodes] out: size_t
+    input[num_nodes] in: size_t
+    output[num_nodes] out: size_t
 
-  reaction (startup) -> out{=
-    std::cout << "Hello from node " << bank_index << "!\n";
-    // send my ID only to my right neighbour
-    out[(bank_index + 1) % num_nodes].set(bank_index);
-  =}
+    reaction (startup) -> out{=
+        std::cout << "Hello from node " << bank_index << "!\n";
+        // send my ID only to my right neighbour
+        out[(bank_index + 1) % num_nodes].set(bank_index);
+    =}
 
-  reaction (in) {=
-    std::cout << "Node " << bank_index << " received messages from ";
-    for (auto& port : in) {
-      if (port.is_present()) {
-        std::cout << *port.get() << ", ";
-      }
-    }
-    std::cout << '\n';
-  =}
+    reaction (in) {=
+        std::cout << "Node " << bank_index << " received messages from ";
+        for (auto& port : in) {
+            if (port.is_present()) {
+                std::cout << *port.get() << ", ";
+            }
+        }
+        std::cout << '\n';
+    =}
 }
 
 main reactor(num_nodes: size_t(4)) {
-  nodes = new[num_nodes] Node(num_nodes=num_nodes);
-  nodes.out -> interleaved(nodes.in);
+    nodes = new[num_nodes] Node(num_nodes=num_nodes);
+    nodes.out -> interleaved(nodes.in);
 }
+

--- a/example/Cpp/src/Patterns/FullyConnected_01_Addressable.lf
+++ b/example/Cpp/src/Patterns/FullyConnected_01_Addressable.lf
@@ -10,31 +10,31 @@
  */
 
 target Cpp {
-    threads: 1
+  threads: 1
 }
 
 reactor Node(bank_index: size_t(0), num_nodes: size_t(4)) {
-    input[num_nodes] in: size_t
-    output[num_nodes] out: size_t
-    
-    reaction (startup) -> out{=
-     	std::cout << "Hello from node " << bank_index << "!\n";
-     	// send my ID only to my right neighbour
-     	out[(bank_index + 1) % num_nodes].set(bank_index);    
-    =}
-    
-    reaction (in) {=
-        std::cout << "Node " << bank_index << " received messages from ";
-     	for (auto& port : in) {
-            if (port.is_present()) {
-                std::cout << *port.get() << ", ";
-            }
-        }   
-        std::cout << '\n';
-    =}
+  input[num_nodes] in: size_t
+  output[num_nodes] out: size_t
+
+  reaction (startup) -> out{=
+    std::cout << "Hello from node " << bank_index << "!\n";
+    // send my ID only to my right neighbour
+    out[(bank_index + 1) % num_nodes].set(bank_index);
+  =}
+
+  reaction (in) {=
+    std::cout << "Node " << bank_index << " received messages from ";
+    for (auto& port : in) {
+      if (port.is_present()) {
+        std::cout << *port.get() << ", ";
+      }
+    }
+    std::cout << '\n';
+  =}
 }
 
 main reactor(num_nodes: size_t(4)) {
-    nodes = new[num_nodes] Node(num_nodes=num_nodes);
-    nodes.out -> interleaved(nodes.in);
+  nodes = new[num_nodes] Node(num_nodes=num_nodes);
+  nodes.out -> interleaved(nodes.in);
 }

--- a/example/Cpp/src/Patterns/MatrixConnectedRowsAndColumns.lf
+++ b/example/Cpp/src/Patterns/MatrixConnectedRowsAndColumns.lf
@@ -4,73 +4,73 @@
 // dimension. Nodes are organized in Rows which are grouped to form the matrix.
 
 target Cpp {
-  threads: 1
+    threads: 1
 };
 
 public preamble {=
-  struct Pos {
-    size_t col;
-    size_t row;
-  };
+    struct Pos {
+        size_t col;
+        size_t row;
+    };
 
-  std::ostream& operator<<(std::ostream& os, const Pos& pos);
+    std::ostream& operator<<(std::ostream& os, const Pos& pos);
 =}
 
 private preamble {=
-  std::ostream& operator<<(std::ostream& os, const Pos& pos) {
-    os << '(' << pos.col << ',' << pos.row << ')';
-    return os;
-	}
+    std::ostream& operator<<(std::ostream& os, const Pos& pos) {
+        os << '(' << pos.col << ',' << pos.row << ')';
+        return os;
+    }
 =}
 
 reactor Node(bank_index: size_t(0), row_index: size_t(0), num_rows: size_t(4), num_cols:size_t(4)) {
-  input[num_cols] fromRow: Pos
-  input[num_rows] fromCol: Pos
+    input[num_cols] fromRow: Pos
+    input[num_rows] fromCol: Pos
 
-  output toRowAndCol: Pos
+    output toRowAndCol: Pos
 
-  state pos: Pos{bank_index, row_index}
+    state pos: Pos{bank_index, row_index}
 
-  reaction (startup) -> toRowAndCol {=
-    std::cout << "Hello from " << pos << '\n';
-    // send my position to everyone else in my row and column
-    toRowAndCol.set(pos);
-  =}
+    reaction (startup) -> toRowAndCol {=
+        std::cout << "Hello from " << pos << '\n';
+        // send my position to everyone else in my row and column
+        toRowAndCol.set(pos);
+    =}
 
-  reaction (fromRow) {=
-    std::cout << pos << " received row messages from: ";
-    for (auto& port : fromRow) {
-      if (port.is_present()) {
-        std::cout << *port.get() << ", ";
-      }
-    }
-    std::cout << '\n';
-  =}
+    reaction (fromRow) {=
+        std::cout << pos << " received row messages from: ";
+        for (auto& port : fromRow) {
+            if (port.is_present()) {
+                std::cout << *port.get() << ", ";
+            }
+        }
+        std::cout << '\n';
+    =}
 
-  reaction (fromCol) {=
-    std::cout << pos << " received col messages from: ";
-    for (auto& port : fromCol) {
-      if (port.is_present()) {
-        std::cout << *port.get() << ", ";
-      }
-    }
-    std::cout << '\n';
-  =}
+    reaction (fromCol) {=
+        std::cout << pos << " received col messages from: ";
+        for (auto& port : fromCol) {
+            if (port.is_present()) {
+                std::cout << *port.get() << ", ";
+            }
+        }
+        std::cout << '\n';
+    =}
 }
 
 reactor Row(bank_index: size_t(0), num_rows:size_t(4), num_cols:size_t(4)) {
-  nodes = new[num_cols] Node(row_index=bank_index, num_rows=num_rows, num_cols=num_cols)
+    nodes = new[num_cols] Node(row_index=bank_index, num_rows=num_rows, num_cols=num_cols)
 
-  input[{=num_rows * num_cols=}] fromCol: Pos
-  output[num_cols] toCol: Pos
+    input[{=num_rows * num_cols=}] fromCol: Pos
+    output[num_cols] toCol: Pos
 
-  (nodes.toRowAndCol)+ -> nodes.fromRow
-  nodes.toRowAndCol -> toCol 
-  fromCol -> interleaved(nodes.fromCol)
+    (nodes.toRowAndCol)+ -> nodes.fromRow
+    nodes.toRowAndCol -> toCol 
+    fromCol -> interleaved(nodes.fromCol)
 }
 
 main reactor (num_rows:size_t(4), num_cols:size_t(4)) {
-  rows = new[num_rows] Row(num_rows=num_rows, num_cols=num_cols)
-  (rows.toCol)+ -> rows.fromCol;
+    rows = new[num_rows] Row(num_rows=num_rows, num_cols=num_cols)
+    (rows.toCol)+ -> rows.fromCol;
 }
 

--- a/example/Cpp/src/Patterns/MatrixConnectedRowsAndColumns.lf
+++ b/example/Cpp/src/Patterns/MatrixConnectedRowsAndColumns.lf
@@ -4,72 +4,73 @@
 // dimension. Nodes are organized in Rows which are grouped to form the matrix.
 
 target Cpp {
-    threads: 1
+  threads: 1
 };
 
 public preamble {=
-    struct Pos {
-      size_t col;
-      size_t row;  
-    };
-    
-    std::ostream& operator<<(std::ostream& os, const Pos& pos);
+  struct Pos {
+    size_t col;
+    size_t row;
+  };
+
+  std::ostream& operator<<(std::ostream& os, const Pos& pos);
 =}
 
-private preamble {=    
-    std::ostream& operator<<(std::ostream& os, const Pos& pos) {
-    	os << '(' << pos.col << ',' << pos.row << ')';
-    	return os;
+private preamble {=
+  std::ostream& operator<<(std::ostream& os, const Pos& pos) {
+    os << '(' << pos.col << ',' << pos.row << ')';
+    return os;
 	}
 =}
 
 reactor Node(bank_index: size_t(0), row_index: size_t(0), num_rows: size_t(4), num_cols:size_t(4)) {
-    input[num_cols] fromRow: Pos
-    input[num_rows] fromCol: Pos
+  input[num_cols] fromRow: Pos
+  input[num_rows] fromCol: Pos
 
-    output toRowAndCol: Pos
-    
-    state pos: Pos{bank_index, row_index}
-    
-    reaction (startup) -> toRowAndCol {=
-        std::cout << "Hello from " << pos << '\n';
-        // send my position to everyone else in my row and column
-        toRowAndCol.set(pos);
-    =}
-    
-    reaction (fromRow) {=
-        std::cout << pos << " received row messages from: ";
-        for (auto& port : fromRow) {
-            if (port.is_present()) {
-                std::cout << *port.get() << ", ";
-            }
-        }
-        std::cout << '\n';
-    =}
-    
-    reaction (fromCol) {=
-        std::cout << pos << " received col messages from: ";
-        for (auto& port : fromCol) {
-            if (port.is_present()) {
-                std::cout << *port.get() << ", ";
-            }
-        }
-        std::cout << '\n';
-    =}
+  output toRowAndCol: Pos
+
+  state pos: Pos{bank_index, row_index}
+
+  reaction (startup) -> toRowAndCol {=
+    std::cout << "Hello from " << pos << '\n';
+    // send my position to everyone else in my row and column
+    toRowAndCol.set(pos);
+  =}
+
+  reaction (fromRow) {=
+    std::cout << pos << " received row messages from: ";
+    for (auto& port : fromRow) {
+      if (port.is_present()) {
+        std::cout << *port.get() << ", ";
+      }
+    }
+    std::cout << '\n';
+  =}
+
+  reaction (fromCol) {=
+    std::cout << pos << " received col messages from: ";
+    for (auto& port : fromCol) {
+      if (port.is_present()) {
+        std::cout << *port.get() << ", ";
+      }
+    }
+    std::cout << '\n';
+  =}
 }
 
 reactor Row(bank_index: size_t(0), num_rows:size_t(4), num_cols:size_t(4)) {
-    nodes = new[num_cols] Node(row_index=bank_index, num_rows=num_rows, num_cols=num_cols)
-    
-    input[{=num_rows * num_cols=}] fromCol: Pos
-    output[num_cols] toCol: Pos
-    
-    (nodes.toRowAndCol)+ -> nodes.fromRow
-    nodes.toRowAndCol -> toCol 
-    fromCol -> interleaved(nodes.fromCol)
+  nodes = new[num_cols] Node(row_index=bank_index, num_rows=num_rows, num_cols=num_cols)
+
+  input[{=num_rows * num_cols=}] fromCol: Pos
+  output[num_cols] toCol: Pos
+
+  (nodes.toRowAndCol)+ -> nodes.fromRow
+  nodes.toRowAndCol -> toCol 
+  fromCol -> interleaved(nodes.fromCol)
 }
 
 main reactor (num_rows:size_t(4), num_cols:size_t(4)) {
-    rows = new[num_rows] Row(num_rows=num_rows, num_cols=num_cols)
-    (rows.toCol)+ -> rows.fromCol;
+  rows = new[num_rows] Row(num_rows=num_rows, num_cols=num_cols)
+  (rows.toCol)+ -> rows.fromCol;
 }
+

--- a/example/Cpp/src/ROS/BasicROS.lf
+++ b/example/Cpp/src/ROS/BasicROS.lf
@@ -34,113 +34,115 @@
  */
 
 target Cpp {
-    keepalive: true,
-    logging: DEBUG,
-    no-compile: true
+  keepalive: true,
+  logging: DEBUG,
+  no-compile: true
 };
 
 public preamble {=
-    #include <functional>
-    #include <memory>
-    #include <string>
-    #include <iostream>
+  #include <functional>
+  #include <memory>
+  #include <string>
+  #include <iostream>
 
-    #include "rclcpp/rclcpp.hpp"
-    #include "std_msgs/msg/string.hpp"
-
+  #include "rclcpp/rclcpp.hpp"
+  #include "std_msgs/msg/string.hpp"
 =}
 
 reactor MessageGenerator {
-    public preamble {=
-        class MinimalPublisher : public rclcpp::Node {
-            public:
-                MinimalPublisher()
-                : Node("minimal_publisher")
-                {
+  public preamble {=
+    class MinimalPublisher : public rclcpp::Node {
+        public:
+            MinimalPublisher() : Node("minimal_publisher") {
                     publisher_ = this->create_publisher<std_msgs::msg::String>("topic", 10);
-                }
-            
-                rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
-        };        
-    =}
-    state minimal_publisher:{=std::shared_ptr<MinimalPublisher>=};
-    state i:int(0);
-    timer t(0, 500 msec);
-    reaction(startup) {=
-        std::cout << "Executing startup." << std::endl;
-        this->minimal_publisher = std::make_shared<MinimalPublisher>();
-    =}
-    reaction(t) {=        
-        auto message = std_msgs::msg::String();
-        std::cout << "Executing timer reaction." << std::endl;
-        message.data = "Hello, world! " + std::to_string(this->i++);
-        RCLCPP_INFO(this->minimal_publisher->get_logger(),
-                    "Sender publishing: '%s'", message.data.c_str());
-        this->minimal_publisher->publisher_->publish(message);
-        rclcpp::spin_some(this->minimal_publisher);
-        std::cout << "Done executing timer reaction." << std::endl;
-    =}
-    
-    reaction(shutdown) {=
-        std::cout << "Executing shutdown reaction." << std::endl;
-    	rclcpp::shutdown();
-    =}
+            }
+
+            rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
+        };
+  =}
+
+  state minimal_publisher:{=std::shared_ptr<MinimalPublisher>=};
+  state i:int(0);
+  timer t(0, 500 msec);
+
+  reaction(startup) {=
+    std::cout << "Executing startup." << std::endl;
+    this->minimal_publisher = std::make_shared<MinimalPublisher>();
+  =}
+
+  reaction(t) {=
+    auto message = std_msgs::msg::String();
+    std::cout << "Executing timer reaction." << std::endl;
+    message.data = "Hello, world! " + std::to_string(this->i++);
+    RCLCPP_INFO(this->minimal_publisher->get_logger(),
+                "Sender publishing: '%s'", message.data.c_str());
+    this->minimal_publisher->publisher_->publish(message);
+    rclcpp::spin_some(this->minimal_publisher);
+    std::cout << "Done executing timer reaction." << std::endl;
+  =}
+
+  reaction(shutdown) {=
+    std::cout << "Executing shutdown reaction." << std::endl;
+    rclcpp::shutdown();
+  =}
 }
 
 reactor MessageReceiver {
-    public preamble {=
-        class MinimalSubscriber : public rclcpp::Node {
-            public:
-                MinimalSubscriber(reactor::PhysicalAction<std::string>& physical_action, const reactor::Reactor& r)
-                : Node("minimal_subscriber"), physical_action_(physical_action), reactor_(r) {
-                    subscription_ = this->create_subscription<std_msgs::msg::String>(
-                      "topic", 10, std::bind(&MinimalSubscriber::topic_callback, this, std::placeholders::_1)
-                    );
-                }
+  public preamble {=
+    class MinimalSubscriber : public rclcpp::Node {
+      public:
+        MinimalSubscriber(reactor::PhysicalAction<std::string>& physical_action, const reactor::Reactor& r)
+          : Node("minimal_subscriber"), physical_action_(physical_action), reactor_(r) {
+          subscription_ = this->create_subscription<std_msgs::msg::String>(
+                "topic", 10, std::bind(&MinimalSubscriber::topic_callback, this, std::placeholders::_1)
+          );
+        }
 
-            private:
-                reactor::PhysicalAction<std::string>& physical_action_;
-                const reactor::Reactor& reactor_;
-                void topic_callback(const std_msgs::msg::String::SharedPtr msg) const {
-                    RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
-                    std::cout << "At physical time (" << reactor_.get_elapsed_physical_time() 
-                              << ") calling schedule_value with value " 
-                              << msg->data << " and length " << msg->data.length()
-                              << "." << std::endl;
-                    physical_action_.schedule(msg->data);
-                    // std::cout << "Done calling schedule_value." << std::endl;
-                }
-                rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
-        };
-    =}
-    physical action ros_message_a:std::string;
-    state minimal_subscriber:{=std::shared_ptr<MinimalSubscriber>=};
-    reaction(startup) ->  ros_message_a {=
-        // std::cout << "Executing startup." << std::endl;
-        char *argv[] = {(char*)"BasicROSPub", NULL};
-        rclcpp::init(1, argv);
-        this->minimal_subscriber = std::make_shared<MinimalSubscriber>(ros_message_a, *this);
-    =}
-    
-    reaction(ros_message_a){=
-        std::cout << "Physical action triggered." << std::endl;
-        std::cout << "Received: " << *(ros_message_a.get()) << std::endl;
-    =}
+      private:
+        reactor::PhysicalAction<std::string>& physical_action_;
+        const reactor::Reactor& reactor_;
+        void topic_callback(const std_msgs::msg::String::SharedPtr msg) const {
+          RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
+          std::cout << "At physical time (" << reactor_.get_elapsed_physical_time() 
+                    << ") calling schedule_value with value " 
+                    << msg->data << " and length " << msg->data.length()
+                    << "." << std::endl;
+          physical_action_.schedule(msg->data);
+          // std::cout << "Done calling schedule_value." << std::endl;
+      }
 
-    
-    timer t(0, 500 msec);
-    reaction(t) {=       
-        rclcpp::spin_some(this->minimal_subscriber);
-        // std::cout << "Timer triggered." << std::endl;
-    =}
-    
-    reaction(shutdown) {=
-        // std::cout << "Executing shutdown reaction." << std::endl;
-    	rclcpp::shutdown();
-    =}
+      rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
+    };
+  =}
+
+  physical action ros_message_a:std::string;
+  timer t(0, 500 msec);
+  state minimal_subscriber:{=std::shared_ptr<MinimalSubscriber>=};
+
+  reaction(startup) ->  ros_message_a {=
+    // std::cout << "Executing startup." << std::endl;
+    char *argv[] = {(char*)"BasicROSPub", NULL};
+    rclcpp::init(1, argv);
+    this->minimal_subscriber = std::make_shared<MinimalSubscriber>(ros_message_a, *this);
+  =}
+
+  reaction(ros_message_a){=
+    std::cout << "Physical action triggered." << std::endl;
+    std::cout << "Received: " << *(ros_message_a.get()) << std::endl;
+  =}
+
+  reaction(t) {=
+    rclcpp::spin_some(this->minimal_subscriber);
+    // std::cout << "Timer triggered." << std::endl;
+  =}
+
+  reaction(shutdown) {=
+    // std::cout << "Executing shutdown reaction." << std::endl;
+    rclcpp::shutdown();
+  =}
 }
 
 main reactor {
-    sender = new MessageGenerator();
-    receiver = new MessageReceiver();
+  sender = new MessageGenerator();
+  receiver = new MessageReceiver();
 }

--- a/example/Cpp/src/ROS/BasicROS.lf
+++ b/example/Cpp/src/ROS/BasicROS.lf
@@ -34,115 +34,113 @@
  */
 
 target Cpp {
-  keepalive: true,
-  logging: DEBUG,
-  no-compile: true
+    keepalive: true,
+    logging: DEBUG,
+    no-compile: true
 };
 
 public preamble {=
-  #include <functional>
-  #include <memory>
-  #include <string>
-  #include <iostream>
+    #include <functional>
+    #include <memory>
+    #include <string>
+    #include <iostream>
 
-  #include "rclcpp/rclcpp.hpp"
-  #include "std_msgs/msg/string.hpp"
+    #include "rclcpp/rclcpp.hpp"
+    #include "std_msgs/msg/string.hpp"
 =}
 
 reactor MessageGenerator {
-  public preamble {=
-    class MinimalPublisher : public rclcpp::Node {
-        public:
-            MinimalPublisher() : Node("minimal_publisher") {
+    public preamble {=
+        class MinimalPublisher : public rclcpp::Node {
+            public:
+                MinimalPublisher() : Node("minimal_publisher") {
                     publisher_ = this->create_publisher<std_msgs::msg::String>("topic", 10);
-            }
+                }
 
-            rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
+                rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
         };
-  =}
+    =}
 
-  state minimal_publisher:{=std::shared_ptr<MinimalPublisher>=};
-  state i:int(0);
-  timer t(0, 500 msec);
+    state minimal_publisher:{=std::shared_ptr<MinimalPublisher>=};
+    state i:int(0);
+    timer t(0, 500 msec);
 
-  reaction(startup) {=
-    std::cout << "Executing startup." << std::endl;
-    this->minimal_publisher = std::make_shared<MinimalPublisher>();
-  =}
+    reaction(startup) {=
+        std::cout << "Executing startup." << std::endl;
+        this->minimal_publisher = std::make_shared<MinimalPublisher>();
+    =}
 
-  reaction(t) {=
-    auto message = std_msgs::msg::String();
-    std::cout << "Executing timer reaction." << std::endl;
-    message.data = "Hello, world! " + std::to_string(this->i++);
-    RCLCPP_INFO(this->minimal_publisher->get_logger(),
-                "Sender publishing: '%s'", message.data.c_str());
-    this->minimal_publisher->publisher_->publish(message);
-    rclcpp::spin_some(this->minimal_publisher);
-    std::cout << "Done executing timer reaction." << std::endl;
-  =}
+    reaction(t) {=
+        auto message = std_msgs::msg::String();
+        std::cout << "Executing timer reaction." << std::endl;
+        message.data = "Hello, world! " + std::to_string(this->i++);
+        RCLCPP_INFO(this->minimal_publisher->get_logger(),
+                  "Sender publishing: '%s'", message.data.c_str());
+        this->minimal_publisher->publisher_->publish(message);
+        rclcpp::spin_some(this->minimal_publisher);
+        std::cout << "Done executing timer reaction." << std::endl;
+    =}
 
-  reaction(shutdown) {=
-    std::cout << "Executing shutdown reaction." << std::endl;
-    rclcpp::shutdown();
-  =}
+    reaction(shutdown) {=
+        std::cout << "Executing shutdown reaction." << std::endl;
+        rclcpp::shutdown();
+    =}
 }
 
 reactor MessageReceiver {
-  public preamble {=
-    class MinimalSubscriber : public rclcpp::Node {
-      public:
-        MinimalSubscriber(reactor::PhysicalAction<std::string>& physical_action, const reactor::Reactor& r)
-          : Node("minimal_subscriber"), physical_action_(physical_action), reactor_(r) {
-          subscription_ = this->create_subscription<std_msgs::msg::String>(
-                "topic", 10, std::bind(&MinimalSubscriber::topic_callback, this, std::placeholders::_1)
-          );
-        }
+    public preamble {=
+        class MinimalSubscriber : public rclcpp::Node {
+            public:
+                MinimalSubscriber(reactor::PhysicalAction<std::string>& physical_action, const reactor::Reactor& r)
+                    : Node("minimal_subscriber"), physical_action_(physical_action), reactor_(r) {
+                    subscription_ = this->create_subscription<std_msgs::msg::String>(
+                          "topic", 10, std::bind(&MinimalSubscriber::topic_callback, this, std::placeholders::_1)
+                    );
+                }
 
-      private:
-        reactor::PhysicalAction<std::string>& physical_action_;
-        const reactor::Reactor& reactor_;
-        void topic_callback(const std_msgs::msg::String::SharedPtr msg) const {
-          RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
-          std::cout << "At physical time (" << reactor_.get_elapsed_physical_time() 
-                    << ") calling schedule_value with value " 
-                    << msg->data << " and length " << msg->data.length()
-                    << "." << std::endl;
-          physical_action_.schedule(msg->data);
-          // std::cout << "Done calling schedule_value." << std::endl;
-      }
+            private:
+                reactor::PhysicalAction<std::string>& physical_action_;
+                const reactor::Reactor& reactor_;
 
-      rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
-    };
-  =}
+                void topic_callback(const std_msgs::msg::String::SharedPtr msg) const {
+                    RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
+                    std::cout << "At physical time (" << reactor_.get_elapsed_physical_time() 
+                              << ") calling schedule_value with value " 
+                              << msg->data << " and length " << msg->data.length()
+                              << "." << std::endl;
+                    physical_action_.schedule(msg->data);
+                }
 
-  physical action ros_message_a:std::string;
-  timer t(0, 500 msec);
-  state minimal_subscriber:{=std::shared_ptr<MinimalSubscriber>=};
+                rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
+        };
+    =}
 
-  reaction(startup) ->  ros_message_a {=
-    // std::cout << "Executing startup." << std::endl;
-    char *argv[] = {(char*)"BasicROSPub", NULL};
-    rclcpp::init(1, argv);
-    this->minimal_subscriber = std::make_shared<MinimalSubscriber>(ros_message_a, *this);
-  =}
+    physical action ros_message_a:std::string;
+    timer t(0, 500 msec);
+    state minimal_subscriber:{=std::shared_ptr<MinimalSubscriber>=};
 
-  reaction(ros_message_a){=
-    std::cout << "Physical action triggered." << std::endl;
-    std::cout << "Received: " << *(ros_message_a.get()) << std::endl;
-  =}
+    reaction(startup) ->  ros_message_a {=
+        char *argv[] = {(char*)"BasicROSPub", NULL};
+        rclcpp::init(1, argv);
+        this->minimal_subscriber = std::make_shared<MinimalSubscriber>(ros_message_a, *this);
+    =}
 
-  reaction(t) {=
-    rclcpp::spin_some(this->minimal_subscriber);
-    // std::cout << "Timer triggered." << std::endl;
-  =}
+    reaction(ros_message_a){=
+        std::cout << "Physical action triggered." << std::endl;
+        std::cout << "Received: " << *(ros_message_a.get()) << std::endl;
+    =}
 
-  reaction(shutdown) {=
-    // std::cout << "Executing shutdown reaction." << std::endl;
-    rclcpp::shutdown();
-  =}
+    reaction(t) {=
+        rclcpp::spin_some(this->minimal_subscriber);
+    =}
+
+    reaction(shutdown) {=
+        rclcpp::shutdown();
+    =}
 }
 
 main reactor {
-  sender = new MessageGenerator();
-  receiver = new MessageReceiver();
+    sender = new MessageGenerator();
+    receiver = new MessageReceiver();
 }
+


### PR DESCRIPTION
# Formatting C++ Examples

**What did I change ?**
- the C++ examples had very inconsistent and irritating indentation. 
- removed trailing white spaces
- moved some code around
- added some extra lines where necessary

**What did I test ?**
- [x] successfully compiled and run every changed example except ROS where for some reason only the code generator was triggered without compiling the results.   
