### PR TITLE
Avoid searching the reaction queue.

### DIFF
--- a/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
@@ -2387,7 +2387,7 @@ class CGenerator extends GeneratorBase {
                 // self->_lf__reaction_«reactionCount».index = 0;
                 // self->_lf__reaction_«reactionCount».chain_id = 0;
                 // self->_lf__reaction_«reactionCount».pos = 0;
-                // self->_lf__reaction_«reactionCount».running = false;
+                // self->_lf__reaction_«reactionCount».status = inactive;
                 // self->_lf__reaction_«reactionCount».deadline = 0LL;
                 // self->_lf__reaction_«reactionCount».is_STP_violated = false;
                 pr(reaction, constructorCode, '''


### PR DESCRIPTION
This is the follow-through on an idea posed by @lhstrh about ensuring that the same reaction does not get scheduled twice. Rather than searching the reaction queue to see if the reaction is already queued, it is preferable to simply mark the reaction as queued within a status field in the reaction struct.

For the C runtime, it is hoped that execution times will noticeably decrease for the following benchmarks:
* Chameneos
* Big
* Fork Join (throughput)
* Logistic Map

This is because on my machine, with the default (not cogged) parameters, these benchmarks appear to spend a fair amount of time executing the pqueue function `find_equal_same_priority`.