### PR TITLE
Heap space

### DIFF
--- a/org.lflang/src/org/lflang/ModelInfo.java
+++ b/org.lflang/src/org/lflang/ModelInfo.java
@@ -91,8 +91,6 @@ public class ModelInfo {
      */
     public TopologyGraph topologyGraph;
 
-    public List<ReactorInstance> topLevelReactorInstances;
-
     /** Cycles found during topology analysis. */
     private List<Set<NamedInstance<?>>> topologyCycles = List.of();
 
@@ -112,7 +110,7 @@ public class ModelInfo {
         this.instantiationGraph = new InstantiationGraph(model, true);
 
         if (this.instantiationGraph.getCycles().size() == 0) {
-            topLevelReactorInstances = new LinkedList<>();
+            List<ReactorInstance> topLevelReactorInstances = new LinkedList<>();
             var main = model.getReactors().stream().filter(it -> it.isMain() || it.isFederated()).findFirst();
             if (main.isPresent()) {
                 var inst = new ReactorInstance(main.get(), reporter);

--- a/org.lflang/src/org/lflang/generator/GeneratorBase.xtend
+++ b/org.lflang/src/org/lflang/generator/GeneratorBase.xtend
@@ -27,7 +27,6 @@
 package org.lflang.generator
 
 import java.io.File
-import java.io.FileOutputStream
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.ArrayList
@@ -1872,17 +1871,4 @@ abstract class GeneratorBase extends AbstractLFValidator implements TargetTypes 
             return new TimeValue(d.interval, d.unit).timeInTargetLanguage
         }
     }
-
-    /**
-     * Write the source code to file.
-     * @param code The code to be written.
-     * @param path The file to write the code to.
-     */
-    protected def writeSourceCodeToFile(byte[] code, String path) {
-        // Write the generated code to the output file.
-        var fOut = new FileOutputStream(new File(path), false);
-        fOut.write(code)
-        fOut.close()
-    }
-    
 }

--- a/org.lflang/src/org/lflang/generator/JavaGeneratorUtils.java
+++ b/org.lflang/src/org/lflang/generator/JavaGeneratorUtils.java
@@ -10,7 +10,7 @@ import java.lang.CharSequence;
  * generators.
  * This is created to ease our transition from Xtend and
  * possibly Eclipse. All functions in this class should
- * instead by in GeneratorUtils.kt, but Eclipse cannot
+ * instead be in GeneratorUtils.kt, but Eclipse cannot
  * handle Kotlin files.
  */
 public class JavaGeneratorUtils {

--- a/org.lflang/src/org/lflang/generator/JavaGeneratorUtils.java
+++ b/org.lflang/src/org/lflang/generator/JavaGeneratorUtils.java
@@ -1,0 +1,34 @@
+package org.lflang.generator;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.CharSequence;
+
+/**
+ * A helper class with functions that may be useful for code
+ * generators.
+ * This is created to ease our transition from Xtend and
+ * possibly Eclipse. All functions in this class should
+ * instead by in GeneratorUtils.kt, but Eclipse cannot
+ * handle Kotlin files.
+ */
+public class JavaGeneratorUtils {
+
+    private JavaGeneratorUtils() {
+        // utility class
+    }
+
+    /**
+     * Write the source code to file.
+     * @param code The code to be written.
+     * @param path The file to write the code to.
+     */
+    public static void writeSourceCodeToFile(CharSequence code, String path) throws IOException {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(path))) {
+            for (int i = 0; i < code.length(); i++) {
+                writer.write(code.charAt(i));
+            }
+        }
+    }
+}

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
@@ -63,6 +63,7 @@ import org.lflang.federated.serialization.FedROS2CPPSerialization
 import org.lflang.federated.serialization.SupportedSerializers
 import org.lflang.generator.ActionInstance
 import org.lflang.generator.GeneratorBase
+import org.lflang.generator.JavaGeneratorUtils
 import org.lflang.generator.ParameterInstance
 import org.lflang.generator.PortInstance
 import org.lflang.generator.ReactionInstance
@@ -836,21 +837,21 @@ class CGenerator extends GeneratorBase {
                 }
             }
             val targetFile = fileConfig.getSrcGenPath() + File.separator + cFilename
-            writeSourceCodeToFile(getCode().getBytes(), targetFile)
+            JavaGeneratorUtils.writeSourceCodeToFile(code, targetFile)
             
             
             if (targetConfig.useCmake) {
                 // If cmake is requested, generated the CMakeLists.txt
                 val cmakeGenerator = new CCmakeGenerator(targetConfig, fileConfig)
                 val cmakeFile = fileConfig.getSrcGenPath() + File.separator + "CMakeLists.txt"
-                writeSourceCodeToFile(
-                cmakeGenerator.generateCMakeCode(
+                JavaGeneratorUtils.writeSourceCodeToFile(
+                    cmakeGenerator.generateCMakeCode(
                         #[cFilename], 
                         topLevelName, 
                         errorReporter,
                         CCppMode,
                         mainDef !== null
-                    ).toString().getBytes(),
+                    ),
                     cmakeFile
                 )
             }
@@ -868,7 +869,7 @@ class CGenerator extends GeneratorBase {
                 // this. 
                 // Create an anonymous Runnable class and add it to the compileThreadPool
                 // so that compilation can happen in parallel.
-                val cleanCode = getCode.removeLineDirectives.getBytes();
+                val cleanCode = getCode.removeLineDirectives
                 val execName = topLevelName
                 val threadFileConfig = fileConfig;
                 val generator = this; // FIXME: currently only passed to report errors with line numbers in the Eclipse IDE
@@ -887,7 +888,7 @@ class CGenerator extends GeneratorBase {
                             // If compilation failed, remove any bin files that may have been created.
                             threadFileConfig.deleteBinFiles()
                         }
-                        writeSourceCodeToFile(cleanCode, targetFile)
+                        JavaGeneratorUtils.writeSourceCodeToFile(cleanCode, targetFile)
                     }
                 });
             }
@@ -1310,7 +1311,7 @@ class CGenerator extends GeneratorBase {
             # Use ENTRYPOINT not CMD so that command-line arguments go through
             ENTRYPOINT ["./bin/«topLevelName»"]
         ''')
-        writeSourceCodeToFile(contents.toString.getBytes, dockerFile)
+        JavaGeneratorUtils.writeSourceCodeToFile(contents, dockerFile)
         println('''Dockerfile for «topLevelName» written to ''' + dockerFile)
         println('''
             #####################################
@@ -1356,7 +1357,7 @@ class CGenerator extends GeneratorBase {
             # Use ENTRYPOINT not CMD so that command-line arguments go through
             ENTRYPOINT ["./build/RTI"]
         ''')
-        writeSourceCodeToFile(contents.toString.getBytes, dockerFile)
+        JavaGeneratorUtils.writeSourceCodeToFile(contents, dockerFile)
         println("Dockerfile for RTI written to " + dockerFile)
         println('''
             #####################################

--- a/org.lflang/src/org/lflang/generator/python/PythonGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/python/PythonGenerator.xtend
@@ -47,6 +47,7 @@ import org.lflang.federated.PythonGeneratorExtension
 import org.lflang.federated.launcher.FedPyLauncher
 import org.lflang.federated.serialization.FedNativePythonSerialization
 import org.lflang.federated.serialization.SupportedSerializers
+import org.lflang.generator.JavaGeneratorUtils
 import org.lflang.generator.ParameterInstance
 import org.lflang.generator.ReactionInstance
 import org.lflang.generator.ReactorInstance
@@ -804,7 +805,7 @@ class PythonGenerator extends CGenerator {
         if (!file.getParentFile().exists()) {
             file.getParentFile().mkdirs();
         }
-        writeSourceCodeToFile(generatePythonCode(federate).toString.bytes, file.absolutePath)
+        JavaGeneratorUtils.writeSourceCodeToFile(generatePythonCode(federate), file.absolutePath)
         
         val setupPath = fileConfig.getSrcGenPath.resolve("setup.py")
         // Handle Python setup
@@ -816,7 +817,7 @@ class PythonGenerator extends CGenerator {
         }
             
         // Create the setup file
-        writeSourceCodeToFile(generatePythonSetupFile.toString.bytes, setupPath.toString)
+        JavaGeneratorUtils.writeSourceCodeToFile(generatePythonSetupFile, setupPath.toString)
              
         
     }
@@ -1918,7 +1919,7 @@ class PythonGenerator extends CGenerator {
              && apk del gcc musl-dev
             ENTRYPOINT ["python3", "src-gen/«filename».py"]
         ''')
-        writeSourceCodeToFile(contents.toString.getBytes, dockerFile)
+        JavaGeneratorUtils.writeSourceCodeToFile(contents, dockerFile)
         println("Dockerfile written to " + dockerFile)
         println('''
             #####################################


### PR DESCRIPTION
The changes in this PR do not noticeably improve the behavior of Epoch, LFC, or anything else, from the perspective of the user. This is because:
* The C generator's memory usage is dominated by the quantity of generated code held in `StringBuilder`s, and these changes don't change the quantity of generated code. They will make it possible to write to the file using less space, but this does not matter because after the first file write, the generated code gets duplicated in the process of removing line directives. Then, the second file write is never reached because GCC never finishes compiling.
* The C++ generator does not use the utility function that is changed in this PR, and although it is affected by the reference held in the validator, in practice this makes no difference because the C++ generator does not seem to use much memory in comparison to the validator. By the time `doGenerate` is called, it does not matter how much memory can be freed because if an out-of-memory error was ever going to occur, it probably would have happened already in the validator.

Nonetheless, perhaps we should merge this branch anyway. I think the changes are consistent with best practices, and they give us two fewer things to worry about if we have more heap space problems in the future. Also, examination in a profiler seems to indicate that they have the desired effect on memory usage.

Other changes could be made, but I think we might defer them. These include:
* **Writing directly to a file instead of to a StringBuilder.** This would allow us to generate arbitrarily large quantities of generated code without running out of memory. I am not sure this is appropriate because:
  * It might constrain the types of string manipulation that we are able to do. For example, it could be hard to copy the style of the C++ generator, where segments of a file get plugged into a template string.
  * We might not even _want_ to be able to produce huge quantities of generated code. In order to cause heap space issues, the size of a generated file would probably have to be a few hundred MB. At that point, the code could be rather difficult to compile.
  * Breaking up generated code into multiple files is an alternative approach that we might want to use in the future anyway, for other reasons.
* **Not holding a copy of the generated code with line directives removed.** It is possible that soon, we will not use line directives at all, so this may become a moot point.
* **Improving the validator (maybe the graph algorithms?) to use less memory**. Currently, this might help the C++ generator but not the C generator. This seems like a reasonable choice, but from what I have heard we are not very concerned about out-of-memory errors in the C++ generator currently (since Edward mostly solved the problem originally posed in #433). If it turns out that we actually do care about that issue because we want to compile C++ target programs with hundreds of thousands of reactors, then I am happy to work on this.