### PR TITLE
fix the lfc zip artefact in nightly builds

### DIFF
--- a/.github/scripts/package_lfc.sh
+++ b/.github/scripts/package_lfc.sh
@@ -25,6 +25,5 @@ cp bin/lfc.ps1 "${outname}/bin/lfc.ps1"
 
 # zip/tar everything - the files will be put into the build_upload directory
 mkdir -p build_upload
-zip -r "build_upload/${outname}.zip" "${outname}"
+zip --symlinks -r "build_upload/${outname}.zip" "${outname}"
 tar cvf "build_upload/${outname}.tar.gz" "${outname}"
-


### PR DESCRIPTION
zip does not preserve symbolic links and replaces bin/lfc with the actual
script. This breaks our mechanism for identifying the correct path and leads
to errors when running lfc. This patch fixes the problem by adding the
--symlinks flag to the zip command, so that symbolic links are preserved.