### PR TITLE
Cpp: Add functionality for dumping the reactor structure to a yaml file

### DIFF
--- a/org.lflang/src/org/lflang/TargetConfig.java
+++ b/org.lflang/src/org/lflang/TargetConfig.java
@@ -217,7 +217,7 @@ public class TargetConfig {
      * If true, the resulting binary will output a graph visualizing all reaction dependencies.
      *
      * This option is currently only used for C++ and Rust. This export function is a valuable tool
-     * for debugging LF programs and helps to understand the dependencies inferred by the C++ runtime.
+     * for debugging LF programs and helps to understand the dependencies inferred by the runtime.
      */
     public boolean exportDependencyGraph = false;
 

--- a/org.lflang/src/org/lflang/TargetConfig.java
+++ b/org.lflang/src/org/lflang/TargetConfig.java
@@ -216,10 +216,20 @@ public class TargetConfig {
     /**
      * If true, the resulting binary will output a graph visualizing all reaction dependencies.
      *
-     * This option is currently only used for C++. This export function is a valuable tool for debugging
-     * LF programs and helps to understand the dependencies inferred by the C++ runtime.
+     * This option is currently only used for C++ and Rust. This export function is a valuable tool
+     * for debugging LF programs and helps to understand the dependencies inferred by the C++ runtime.
      */
     public boolean exportDependencyGraph = false;
+
+
+    /**
+     * If true, the resulting binary will output a yaml file describing the whole reactor structure
+     * of the program.
+     *
+     * This option is currently only used for C++. This export function is a valuable tool for debugging
+     * LF programs and performing external analysis.
+     */
+    public boolean exportToYaml = false;
 
 
     /** Rust-specific configuration. */

--- a/org.lflang/src/org/lflang/TargetProperty.java
+++ b/org.lflang/src/org/lflang/TargetProperty.java
@@ -378,8 +378,18 @@ public enum TargetProperty {
                            List.of(Target.CPP, Target.Rust),
                            (config, value, err) -> {
         config.exportDependencyGraph = ASTUtils.toBoolean(value);
-
     }),
+
+    /**
+     * Directive to let the runtime export the program structure to a yaml file.
+     *
+     * This is a debugging feature and currently only used for C++ programs.
+     */
+    EXPORT_TO_YAML("export-to-yaml", PrimitiveType.BOOLEAN,
+                           List.of(Target.CPP),
+                           (config, value, err) -> {
+                               config.exportToYaml = ASTUtils.toBoolean(value);
+                           }),
 
     /**
      * List of module files to link into the crate as top-level.

--- a/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
@@ -55,7 +55,7 @@ class CppGenerator(
         const val libDir = "/lib/cpp"
 
         /** Default version of the reactor-cpp runtime to be used during compilation */
-        const val defaultRuntimeVersion = "dc62c6f05f493a8a6401e75e58539d482bec6e57"
+        const val defaultRuntimeVersion = "f5e6ebf02a9ec68d64ea5e7e7519fcb475afcd58"
     }
 
     override fun doGenerate(resource: Resource, fsa: IFileSystemAccess2, context: IGeneratorContext) {

--- a/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
@@ -55,7 +55,7 @@ class CppGenerator(
         const val libDir = "/lib/cpp"
 
         /** Default version of the reactor-cpp runtime to be used during compilation */
-        const val defaultRuntimeVersion = "1d5ef9d9dc25bcf30bc4eb94b2316b32f456aaa2"
+        const val defaultRuntimeVersion = "dc62c6f05f493a8a6401e75e58539d482bec6e57"
     }
 
     override fun doGenerate(resource: Resource, fsa: IFileSystemAccess2, context: IGeneratorContext) {

--- a/org.lflang/src/org/lflang/generator/cpp/CppMainGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppMainGenerator.kt
@@ -116,11 +116,13 @@ class CppMainGenerator(
             |    t = std::make_unique<Timeout>("Timeout", & e, timeout);
             |  }
             |
-            |  // execute the reactor program
+            |  // assemble reactor program
             |  e.assemble();
+        ${" |".. if (targetConfig.exportDependencyGraph) "e.export_dependency_graph(\"${main.name}.dot\");" else ""}
+            |
+            |  // start execution
             |  auto thread = e.startup();
             |  thread.join();
-        ${" |".. if (targetConfig.exportDependencyGraph) "e.export_dependency_graph(\"${main.name}.dot\");" else ""}
             |  return 0;
             |}
         """.trimMargin()

--- a/org.lflang/src/org/lflang/generator/cpp/CppMainGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppMainGenerator.kt
@@ -119,6 +119,7 @@ class CppMainGenerator(
             |  // assemble reactor program
             |  e.assemble();
         ${" |".. if (targetConfig.exportDependencyGraph) "e.export_dependency_graph(\"${main.name}.dot\");" else ""}
+        ${" |".. if (targetConfig.exportToYaml) "e.dump_to_yaml(\"${main.name}.yaml\");" else ""}
             |
             |  // start execution
             |  auto thread = e.startup();


### PR DESCRIPTION
Similar to `export-dependency-graph` this PR adds a target property `export-to-yaml` which instructs the C++ runtime to export detailed information about the program structure to a yaml file. This is very useful for analyzing LF programs outside of the LF compiler. For instance, @Elocien is currently trying to investigate execution traces to find optimization opportunities.

The exporting functionality is implemented in lf-lang/reactor-cpp#4.