### PR TITLE
Fix Eclipse Problems after VSCode Branch Merge

### DIFF
--- a/oomph/LinguaFranca.setup
+++ b/oomph/LinguaFranca.setup
@@ -375,6 +375,8 @@
               url="https://github.com/fabioz/Pydev/releases/download/pydev_9_0_1/"/>
           <repository
               url="https://download.eclipse.org/wildwebdeveloper/releases/0.13.0/"/>
+          <repository
+              url="https://rtsys.informatik.uni-kiel.de/~kieler/updatesite/sprotty/0.9.0/"/>
         </repositoryList>
       </targlet>
     </setupTask>

--- a/org.lflang.lds/category.xml
+++ b/org.lflang.lds/category.xml
@@ -4,4 +4,5 @@
     <bundle id="org.lflang"/>
     <bundle id="org.lflang.ide"/>
     <bundle id="org.lflang.diagram"/>
+    <bundle id="org.jetbrains.kotlin.bundled-compiler"/>
 </site>

--- a/org.lflang.lds/pom.xml
+++ b/org.lflang.lds/pom.xml
@@ -57,7 +57,6 @@
           <arguments>
             <argument>${python.script}</argument>
             <argument>--noswt</argument>
-            <argument>--ignore-conflicts</argument>
             <argument>${update.site.jars}</argument>
             <argument>${executableName}</argument>
             <argument>${mainClass}</argument>

--- a/org.lflang.lds/uberjar.py
+++ b/org.lflang.lds/uberjar.py
@@ -34,7 +34,18 @@ from fnmatch import fnmatch
 from os.path import isfile, isdir, join, abspath, relpath, dirname, basename
 
 IGNORED_JARS = [
-    'org.apache.ant*'
+    'org.apache.ant*',
+    # The following libraries are part of the org.jetbrains.kotlin.bundled-compiler plugin but are not required at runtime.
+    'kotlin-compiler.jar',
+    'intellij-core-analysis.jar',
+    'kotlin-plugin-parts.jar',
+    'kotlin-script-runtime.jar',
+    'kotlin-scripting-compiler.jar',
+    'ide-dependencies.jar',
+    'kotlin-scripting-compiler-impl.jar',
+    'kotlin-scripting-common.jar',
+    'kotlin-scripting-jvm.jar',
+    'ide-common.jar'
 ]
 IGNORE_NESTED_JARS = [
 ]
@@ -71,6 +82,7 @@ IGNORED_FILES = [
     'META-INF/NOTICE.txt',
     'META-INF/NOTICE',
     'META-INF/p2.inf',
+    'META-INF/versions/*/module-info.class',
     'OSGI-INF/l10n/bundle.properties',
     'docs/*',
     '*readme.txt',
@@ -173,7 +185,7 @@ def extract(args, extracted, merged, klighd):
     jars = sorted(os.listdir(args.source))
     processed_jars = [] # Tuples of plugin name and jar
     for jar in jars:
-        if not jar.endswith('.jar'):
+        if not jar.endswith('.jar') or any(fnmatch(jar, ign) for ign in IGNORED_JARS):
             print('Skipping file:', jar)
             continue
         elif klighd and any(fnmatch(jar, ign) for ign in KLIGHD_JARS_BLACKLIST) and not any(fnmatch(jar, req) for req in KLIGHD_JARS_WHITELIST):

--- a/org.lflang/META-INF/MANIFEST.MF
+++ b/org.lflang/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.xtext,
  com.google.guava,
  org.eclipse.xtend.lib.macro,
  org.apache.commons.cli;bundle-version="1.4",
- org.jetbrains.kotlin.bundled-compiler,
+ org.jetbrains.kotlin.bundled-compiler;resolution:=optional,
  org.eclipse.lsp4j;bundle-version="0.10.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.lflang,


### PR DESCRIPTION
Commit [8080ed8](https://github.com/lf-lang/lingua-franca/commit/8080ed85a55910df537c23c0486361aaafdf3337) reverted a workaround that enabled error-free working in Eclipse in the presence of Kotlin files (PR #437). Consequently, the master currently has an error present only in Eclipse.

According to the commit message this was done in order to include Kotlin in the LS.
This PR adds Kotlin to the LS in a different way and re-applies the solution to resolve the Eclipse problem with the Kotlin dependency.

Additionally, it adds the sprotty update site (transient dependency of the Klighd LS) to the oomph setup because oomph seems to have problems resolving the dependency indirectly via Klighd.