### PR TITLE
Fix rendering of '0' time in diagram synthesis

### DIFF
--- a/org.lflang.diagram/src/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.xtend
+++ b/org.lflang.diagram/src/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.xtend
@@ -428,11 +428,11 @@ class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
 		).boldLineSelectionStyle
 		
 		val labelParts = newArrayList
-		if (timer.offset !== TimerInstance.DEFAULT_OFFSET) {
-			labelParts += timer.offset.toString
+		if (timer.offset !== TimerInstance.DEFAULT_OFFSET && timer.offset !== null) {
+        labelParts += timer.offset.toString
 		}
-		if (timer.period !== TimerInstance.DEFAULT_PERIOD) {
-			labelParts += timer.period.toString
+		if (timer.period !== TimerInstance.DEFAULT_PERIOD && timer.period !== null) {
+        labelParts += timer.period.toString
 		}
 		if (!labelParts.empty) {
 			node.addOutsideBottomCenteredNodeLabel(labelParts.join("(", ", ", ")")[it], 8)

--- a/org.lflang.diagram/src/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.xtend
+++ b/org.lflang.diagram/src/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.xtend
@@ -429,10 +429,13 @@ class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
 		
 		val labelParts = newArrayList
 		if (timer.offset !== TimerInstance.DEFAULT_OFFSET && timer.offset !== null) {
-        labelParts += timer.offset.toString
+            labelParts += timer.offset.toString
 		}
 		if (timer.period !== TimerInstance.DEFAULT_PERIOD && timer.period !== null) {
-        labelParts += timer.period.toString
+		    if (timer.offset === TimerInstance.DEFAULT_OFFSET) {
+		        labelParts += timer.offset.toString
+            }
+            labelParts += timer.period.toString
 		}
 		if (!labelParts.empty) {
 			node.addOutsideBottomCenteredNodeLabel(labelParts.join("(", ", ", ")")[it], 8)

--- a/org.lflang/src/org/lflang/ASTUtils.xtend
+++ b/org.lflang/src/org/lflang/ASTUtils.xtend
@@ -763,7 +763,9 @@ class ASTUtils {
      * @param t The time to be converted
      * @return A textual representation
      */
-    def static String toText(Time t) '''«t.interval» «t.unit.toString»'''
+    def static String toText(Time t) {
+        return t.toTimeValue.toString
+    }
         
     /**
      * Convert a value to its textual representation as it would

--- a/org.lflang/src/org/lflang/JavaAstUtils.java
+++ b/org.lflang/src/org/lflang/JavaAstUtils.java
@@ -179,13 +179,11 @@ public final class JavaAstUtils {
     }
 
     /**
-     * Assuming that the given value denotes a valid time,
+     * Assuming that the given value denotes a valid time literal,
      * return a time value.
      */
-    public static TimeValue getTimeValue(Value v) {;
-        if (v.getParameter() != null) {
-            return getDefaultAsTimeValue(v.getParameter());
-        } else if (v.getTime() != null) {
+    public static TimeValue getLiteralTimeValue(Value v) {;
+        if (v.getTime() != null) {
             return toTimeValue(v.getTime());
         } else if (v.getLiteral() != null && v.getLiteral().equals("0")) {
             return TimeValue.ZERO;
@@ -202,7 +200,7 @@ public final class JavaAstUtils {
         if (isOfTimeType(p)) {
             var init = p.getInit().get(0);
             if (init != null) {
-                return getTimeValue(init);
+                return getLiteralTimeValue(init);
             }
         }
         return null;

--- a/org.lflang/src/org/lflang/JavaAstUtils.java
+++ b/org.lflang/src/org/lflang/JavaAstUtils.java
@@ -182,11 +182,13 @@ public final class JavaAstUtils {
      * Assuming that the given value denotes a valid time,
      * return a time value.
      */
-    public static TimeValue getTimeValue(Value v) {
+    public static TimeValue getTimeValue(Value v) {;
         if (v.getParameter() != null) {
             return getDefaultAsTimeValue(v.getParameter());
         } else if (v.getTime() != null) {
             return toTimeValue(v.getTime());
+        } else if (v.getLiteral() != null && v.getLiteral().equals("0")) {
+            return TimeValue.ZERO;
         } else {
             return null;
         }

--- a/org.lflang/src/org/lflang/ModelInfo.java
+++ b/org.lflang/src/org/lflang/ModelInfo.java
@@ -153,7 +153,7 @@ public class ModelInfo {
         // Visit all deadlines in the model; detect possible overflow.
         for (var deadline : filter(toIterable(model.eAllContents()), Deadline.class)) {
             // If the time value overflows, mark this deadline as overflowing.
-            if (isTooLarge(JavaAstUtils.getTimeValue(deadline.getDelay()))) {
+            if (isTooLarge(JavaAstUtils.getLiteralTimeValue(deadline.getDelay()))) {
                 this.overflowingDeadlines.add(deadline);
             }
 
@@ -207,7 +207,7 @@ public class ModelInfo {
                         } else {
                             // The right-hand side of the assignment is a 
                             // constant; check whether it is too large.
-                            if (isTooLarge(JavaAstUtils.getTimeValue(assignment.getRhs().get(0)))) {
+                            if (isTooLarge(JavaAstUtils.getLiteralTimeValue(assignment.getRhs().get(0)))) {
                                 this.overflowingAssignments.add(assignment);
                                 overflow = true;
                             }

--- a/org.lflang/src/org/lflang/federated/CGeneratorExtension.java
+++ b/org.lflang/src/org/lflang/federated/CGeneratorExtension.java
@@ -34,6 +34,7 @@ import org.lflang.generator.c.CGenerator;
 import org.lflang.generator.ReactorInstance;
 import org.lflang.lf.Delay;
 import org.lflang.lf.Input;
+import org.lflang.lf.Parameter;
 import org.lflang.lf.Port;
 import org.lflang.lf.Reactor;
 import org.lflang.lf.ReactorDecl;
@@ -231,9 +232,16 @@ public class CGeneratorExtension {
      */
     public static String getNetworkDelayLiteral(Delay delay, CGenerator generator) {
         String additionalDelayString = "NEVER";
-
         if (delay != null) {
-            TimeValue tv = generator.main.getTimeValue(delay);
+            Parameter p = delay.getParameter();
+            TimeValue tv;
+            if (delay.getParameter() != null) {
+                // The parameter has to be parameter of the main reactor.
+                // And that value has to be a Time.
+                tv = JavaAstUtils.getDefaultAsTimeValue(p);
+            } else {
+                tv = JavaAstUtils.toTimeValue(delay.getTime());
+            }
             additionalDelayString = Long.toString(tv.toNanoSeconds());
         }
         return additionalDelayString;

--- a/org.lflang/src/org/lflang/federated/CGeneratorExtension.java
+++ b/org.lflang/src/org/lflang/federated/CGeneratorExtension.java
@@ -231,20 +231,10 @@ public class CGeneratorExtension {
      */
     public static String getNetworkDelayLiteral(Delay delay, CGenerator generator) {
         String additionalDelayString = "NEVER";
+
         if (delay != null) {
-            if (delay.getParameter() != null) {
-                // The parameter has to be parameter of the main reactor.
-                // And that value has to be a Time.
-                Value value = delay.getParameter().getInit().get(0);
-                if (value.getTime() != null) {
-                    additionalDelayString = Long.toString(JavaAstUtils.getTimeValue(value).toNanoSeconds());
-                } else if (value.getLiteral() != null) {
-                    // If no units are given, e.g. "0", then use the literal.
-                    additionalDelayString = value.getLiteral();
-                }
-            } else {
-                additionalDelayString = Long.toString(JavaAstUtils.toTimeValue(delay.getTime()).toNanoSeconds());
-            }
+            TimeValue tv = generator.main.getTimeValue(delay);
+            additionalDelayString = Long.toString(tv.toNanoSeconds());
         }
         return additionalDelayString;
     }

--- a/org.lflang/src/org/lflang/federated/FedASTUtils.java
+++ b/org.lflang/src/org/lflang/federated/FedASTUtils.java
@@ -456,7 +456,7 @@ public class FedASTUtils {
         }
 
         return STPList.stream()
-                      .map(JavaAstUtils::getTimeValue)
+                      .map(value -> generator.main.lookupReactorInstance(instance.instantiation).getTimeValue(value))
                       .filter(Objects::nonNull)
                       .reduce(TimeValue.ZERO, TimeValue::max);
     }

--- a/org.lflang/src/org/lflang/federated/FedASTUtils.java
+++ b/org.lflang/src/org/lflang/federated/FedASTUtils.java
@@ -456,7 +456,7 @@ public class FedASTUtils {
         }
 
         return STPList.stream()
-                      .map(value -> generator.main.lookupReactorInstance(instance.instantiation).getTimeValue(value))
+                      .map(JavaAstUtils::getLiteralTimeValue)
                       .filter(Objects::nonNull)
                       .reduce(TimeValue.ZERO, TimeValue::max);
     }

--- a/org.lflang/src/org/lflang/generator/ActionInstance.java
+++ b/org.lflang/src/org/lflang/generator/ActionInstance.java
@@ -67,22 +67,10 @@ public class ActionInstance extends TriggerInstance<Action> {
         }
         if (definition != null) {
             if (definition.getMinDelay() != null) {
-                Parameter parm = definition.getMinDelay().getParameter();
-                if (parm != null) {
-                    this.minDelay = JavaAstUtils.getTimeValue(
-                            parent.lookupParameterInstance(parm).init.get(0));
-                } else {
-                    this.minDelay = JavaAstUtils.getTimeValue(definition.getMinDelay());
-                }
+                this.minDelay = JavaAstUtils.getTimeValue(definition.getMinDelay());
             }
             if (definition.getMinSpacing() != null) {
-                Parameter parm = definition.getMinSpacing().getParameter();
-                if (parm != null) {
-                    this.minSpacing = JavaAstUtils.getTimeValue(
-                            parent.lookupParameterInstance(parm).init.get(0));
-                } else {
-                    this.minSpacing = JavaAstUtils.getTimeValue(definition.getMinSpacing());
-                }
+                this.minSpacing = JavaAstUtils.getTimeValue(definition.getMinSpacing());
             }
             if (definition.getOrigin() == ActionOrigin.PHYSICAL) {
                 physical = true;

--- a/org.lflang/src/org/lflang/generator/ActionInstance.java
+++ b/org.lflang/src/org/lflang/generator/ActionInstance.java
@@ -67,10 +67,10 @@ public class ActionInstance extends TriggerInstance<Action> {
         }
         if (definition != null) {
             if (definition.getMinDelay() != null) {
-                this.minDelay = JavaAstUtils.getTimeValue(definition.getMinDelay());
+                this.minDelay = parent.getTimeValue(definition.getMinDelay());
             }
             if (definition.getMinSpacing() != null) {
-                this.minSpacing = JavaAstUtils.getTimeValue(definition.getMinSpacing());
+                this.minSpacing = parent.getTimeValue(definition.getMinSpacing());
             }
             if (definition.getOrigin() == ActionOrigin.PHYSICAL) {
                 physical = true;

--- a/org.lflang/src/org/lflang/generator/DeadlineInstance.java
+++ b/org.lflang/src/org/lflang/generator/DeadlineInstance.java
@@ -46,9 +46,9 @@ public class DeadlineInstance {
 	 * Create a new deadline instance associated with the given reaction
 	 * instance.
 	 */
-	public DeadlineInstance(Deadline definition) {
+	public DeadlineInstance(Deadline definition, ReactionInstance reaction) {
         if (definition.getDelay() != null) {
-            this.maxDelay = JavaAstUtils.getTimeValue(definition.getDelay());
+            this.maxDelay = reaction.parent.getTimeValue(definition.getDelay());
         } else {
             this.maxDelay = TimeValue.ZERO;
         }

--- a/org.lflang/src/org/lflang/generator/DeadlineInstance.java
+++ b/org.lflang/src/org/lflang/generator/DeadlineInstance.java
@@ -46,14 +46,9 @@ public class DeadlineInstance {
 	 * Create a new deadline instance associated with the given reaction
 	 * instance.
 	 */
-	public DeadlineInstance(Deadline definition, ReactionInstance reaction) {
+	public DeadlineInstance(Deadline definition) {
         if (definition.getDelay() != null) {
-            Parameter parm = definition.getDelay().getParameter();
-            if (parm != null) {
-                this.maxDelay = JavaAstUtils.getTimeValue(reaction.parent.initialParameterValue(parm).get(0));
-            } else {
-                this.maxDelay = JavaAstUtils.getTimeValue(definition.getDelay());
-            }
+            this.maxDelay = JavaAstUtils.getTimeValue(definition.getDelay());
         } else {
             this.maxDelay = TimeValue.ZERO;
         }

--- a/org.lflang/src/org/lflang/generator/ReactionInstance.java
+++ b/org.lflang/src/org/lflang/generator/ReactionInstance.java
@@ -235,7 +235,7 @@ public class ReactionInstance extends NamedInstance<Reaction> {
         // Create a deadline instance if one has been defined.
         if (this.definition.getDeadline() != null) {
             this.declaredDeadline = new DeadlineInstance(
-                this.definition.getDeadline(), this);
+                this.definition.getDeadline());
         }
     }
 

--- a/org.lflang/src/org/lflang/generator/ReactionInstance.java
+++ b/org.lflang/src/org/lflang/generator/ReactionInstance.java
@@ -235,7 +235,7 @@ public class ReactionInstance extends NamedInstance<Reaction> {
         // Create a deadline instance if one has been defined.
         if (this.definition.getDeadline() != null) {
             this.declaredDeadline = new DeadlineInstance(
-                this.definition.getDeadline());
+                this.definition.getDeadline(), this);
         }
     }
 

--- a/org.lflang/src/org/lflang/generator/ReactorInstance.java
+++ b/org.lflang/src/org/lflang/generator/ReactorInstance.java
@@ -38,9 +38,12 @@ import java.util.Set;
 
 import org.lflang.ASTUtils;
 import org.lflang.ErrorReporter;
+import org.lflang.JavaAstUtils;
+import org.lflang.TimeValue;
 import org.lflang.generator.TriggerInstance.BuiltinTriggerVariable;
 import org.lflang.lf.Action;
 import org.lflang.lf.Connection;
+import org.lflang.lf.Delay;
 import org.lflang.lf.Input;
 import org.lflang.lf.Instantiation;
 import org.lflang.lf.Output;
@@ -672,6 +675,36 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
             return ASTUtils.width(widthSpec, parent.instantiations());
         }
         return ASTUtils.width(widthSpec, instantiations());
+    }
+
+    /**
+     * Assuming that the given value denotes a valid time, return a time value.
+     *
+     * If the value is given as a parameter reference, this will look up the
+     * precise time value assigned to this reactor instance.
+     */
+    public TimeValue getTimeValue(Value v) {
+        Parameter p = v.getParameter();
+        if (p != null) {
+            return JavaAstUtils.getLiteralTimeValue(lookupParameterInstance(p).init.get(0));
+        } else {
+            return JavaAstUtils.getLiteralTimeValue(v);
+        }
+    }
+
+    /**
+     * Assuming that the given delay denotes a valid time, return a time value.
+     *
+     * If the delay is given as a parameter reference, this will look up the
+     * precise time value assigned to this reactor instance.
+     */
+    public TimeValue getTimeValue(Delay d) {
+        Parameter p = d.getParameter();
+        if (p != null) {
+            return JavaAstUtils.getLiteralTimeValue(lookupParameterInstance(p).init.get(0));
+        } else {
+            return JavaAstUtils.toTimeValue(d.getTime());
+        }
     }
     
     //////////////////////////////////////////////////////

--- a/org.lflang/src/org/lflang/generator/TimerInstance.java
+++ b/org.lflang/src/org/lflang/generator/TimerInstance.java
@@ -62,20 +62,10 @@ public class TimerInstance extends TriggerInstance<Timer> {
         }
         if (definition != null) {
             if (definition.getOffset() != null) {
-                if (definition.getOffset().getParameter() != null) {
-                    Parameter parm = definition.getOffset().getParameter();
-                    this.offset = JavaAstUtils.getTimeValue(parent.initialParameterValue(parm).get(0));
-                } else {
-                    this.offset = JavaAstUtils.getTimeValue(definition.getOffset());
-                }
+                this.offset = JavaAstUtils.getTimeValue(definition.getOffset());
             }
             if (definition.getPeriod() != null) {
-                if (definition.getPeriod().getParameter() != null) {
-                    Parameter parm = definition.getPeriod().getParameter();
-                    this.period = JavaAstUtils.getTimeValue(parent.initialParameterValue(parm).get(0));
-                } else {
-                    this.period = JavaAstUtils.getTimeValue(definition.getPeriod());
-                }
+                this.period = JavaAstUtils.getTimeValue(definition.getPeriod());
             }
         }
     }

--- a/org.lflang/src/org/lflang/generator/TimerInstance.java
+++ b/org.lflang/src/org/lflang/generator/TimerInstance.java
@@ -62,10 +62,10 @@ public class TimerInstance extends TriggerInstance<Timer> {
         }
         if (definition != null) {
             if (definition.getOffset() != null) {
-                this.offset = JavaAstUtils.getTimeValue(definition.getOffset());
+                this.offset = parent.getTimeValue(definition.getOffset());
             }
             if (definition.getPeriod() != null) {
-                this.period = JavaAstUtils.getTimeValue(definition.getPeriod());
+                this.period = parent.getTimeValue(definition.getPeriod());
             }
         }
     }

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
@@ -1528,7 +1528,7 @@ class CGenerator extends GeneratorBase {
                 val reactorInstance = main.getChildReactorInstance(federate.instantiation)
                 for (param : reactorInstance.parameters) {
                     if (param.name.equalsIgnoreCase("STP_offset") && param.type.isTime) {
-                        val stp = param.init.get(0).getTimeValue
+                        val stp = param.init.get(0).getLiteralTimeValue
                         if (stp !== null) {                        
                             pr('''
                                 set_stp_offset(«stp.timeInTargetLanguage»);

--- a/org.lflang/src/org/lflang/validation/LFValidator.xtend
+++ b/org.lflang/src/org/lflang/validation/LFValidator.xtend
@@ -1260,13 +1260,8 @@ class LFValidator extends BaseLFValidator {
                             error("Invalid time literal.",
                                 Literals.VALUE__LITERAL)
                         }
-                } else if (value.code !== null && !value.code.isZero) {
-                    if (value.code.isInteger) {
-                            error("Missing time unit", Literals.VALUE__CODE)
-                        } else {
-                            error("Invalid time literal.",
-                                Literals.VALUE__CODE)
-                        }
+                } else if (value.code !== null) {
+                     error("Invalid time literal.", Literals.VALUE__CODE)
                 }
             }
         }


### PR DESCRIPTION
This fixes various instances of nullpointer exceptions for LF times without a unit (i.e. the literal `0`).

 While working on this, I noticed a lot of issues with the code that handles time. However, while I started to implement a few fixes, I realized that part of this clean up is already done in #544. As to avoid further conflicts, this PR only fixes the issues at hand. To keep track of the needed clean-up, I opened #810.

Closes #801, #803