### PR TITLE
fix build rti path

### DIFF
--- a/.github/actions/build-rti-docker/action.yml
+++ b/.github/actions/build-rti-docker/action.yml
@@ -5,4 +5,3 @@ runs:
   steps: 
     - run: .github/actions/build-rti-docker/build-rti-image.sh
       shell: bash
-      

--- a/.github/actions/build-rti-docker/action.yml
+++ b/.github/actions/build-rti-docker/action.yml
@@ -3,6 +3,6 @@ description: Build and install
 runs:
   using: "composite"
   steps: 
-    - run: .github/actions/install-rti/build-rti-image.sh
+    - run: .github/actions/build-rti-docker/build-rti-image.sh
       shell: bash
       


### PR DESCRIPTION
the path to the .sh in `.github/actions/build-rti-docker` is wrong, which caused tests to fail in master. 
This PR corrects the path. 