### PR TITLE
Fix Compilation Error in Diagrams Package due to Missing Dependency

### DIFF
--- a/org.lflang.diagram/META-INF/MANIFEST.MF
+++ b/org.lflang.diagram/META-INF/MANIFEST.MF
@@ -21,5 +21,6 @@ Require-Bundle: de.cau.cs.kieler.klighd;bundle-version="2.0.0",
  org.lflang.ide;bundle-version="0.1.0",
  org.eclipse.xtext.ide;bundle-version="2.25.0",
  org.eclipse.lsp4j;bundle-version="0.10.0",
- org.eclipse.lsp4j.jsonrpc;bundle-version="0.10.0"
+ org.eclipse.lsp4j.jsonrpc;bundle-version="0.10.0",
+ org.eclipse.sprotty;bundle-version="0.9.0"
 Bundle-Vendor: University of California, Berkeley


### PR DESCRIPTION
Added dependency indirectly referenced from required class file

Fixes #840