### PR TITLE
Epoch: Repair regex.

### DIFF
--- a/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
@@ -5209,7 +5209,7 @@ class CGenerator extends GeneratorBase {
     // The third match is a character position within the line.
     // The fourth match will be the error message.
     static final Pattern compileErrorPattern = Pattern.compile(
-        "^(file://(?<path>.*)):(?<line>[0-9]+):(?<column>[0-9]+):(?<message>.*)$"
+        "^(file:/(?<path>.*)):(?<line>[0-9]+):(?<column>[0-9]+):(?<message>.*)$"
     );
     
     /** Given a line of text from the output of a compiler, return


### PR DESCRIPTION
This corrects a mistake that I inserted into the C generator three months ago (in [this](https://github.com/lf-lang/lingua-franca/commit/7b563035c38db648a8e09bf6851196511c4ba9be) commit).