### PR TITLE
vscode-validate-generated-code cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
   # Run language server tests.
   lsp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@vscode-validate-generated-code-cleanups
 
   # Run the C integration tests.
   c-tests:

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -29,12 +29,6 @@ jobs:
         uses: actions/setup-java@v1.4.3
         with:
           java-version: 11
-      - name: Check out lingua-franca repository
-        uses: actions/checkout@v2
-        with:
-          repository: lf-lang/lingua-franca
-          submodules: true
-          ref: ${{ inputs.compiler-ref }}
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.1.2
       - name: Install pnpm
@@ -61,6 +55,12 @@ jobs:
           vcpkgDirectory: ${{ github.workspace }}/vcpkg/
           vcpkgTriplet: x64-windows-static
         if: ${{ runner.os == 'Windows' }}
+      - name: Check out lingua-franca repository
+        uses: actions/checkout@v2
+        with:
+          repository: lf-lang/lingua-franca
+          submodules: true
+          ref: ${{ inputs.compiler-ref }}
       - name: Run language server Python tests without PyLint
         run: ./gradlew test --tests org.lflang.tests.lsp.LspTests.pythonSyntaxOnlyValidationTest
       - name: Report to CodeCov

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,6 @@
 # Version 0.1.0-beta-SNAPSHOT
+- LF programs with the TypeScript target can now be compiled on Windows (#850).
+- Generated code is validated on save for all targets except C (#828)
 
 ## Language
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 # Version 0.1.0-beta-SNAPSHOT
 - LF programs with the TypeScript target can now be compiled on Windows (#850).
-- Generated code is validated on save for all targets except C (#828)
+- In the VS Code extension, generated code is validated when an LF file is saved for all targets except C (#828). Generated C code is only validated when it is fully compiled.
 
 ## Language
 

--- a/org.lflang/src/org/lflang/generator/python/PythonValidator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonValidator.java
@@ -246,7 +246,8 @@ public class PythonValidator extends Validator {
             public Strategy getOutputReportingStrategy() {
                 return (validationOutput, errorReporter, codeMaps) -> {
                     try {
-                        for (PylintMessage message : mapper.readValue(validationOutput, PylintMessage[].class)) {
+                        if (validationOutput.isBlank()) return;
+                        for (PylintMessage message : mapper.readValue(validationOutput.strip(), PylintMessage[].class)) {
                             if (shouldIgnore(message)) continue;
                             CodeMap map = codeMaps.get(message.getPath(fileConfig.getSrcGenPath()));
                             if (map != null) {


### PR DESCRIPTION
Yesterday, I merged a branch called `vscode-validate-generated-code` that included many changes. There were some things that I forgot to check first. This caused Eclipse errors, broke the Maven build, and caused #859. Fixes for the first two of these problems have already been merged. However, #859 still stands, and there are a couple other odds and ends that are cleaned up in this branch as well.