### PR TITLE
Test Maven build in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,4 +49,4 @@ jobs:
             org.lflang.rca/target/products/*.tar.gz
             org.lflang.rca/target/products/*.zip
             build_upload/*
-          if: ${{ inputs.nightly == true }}
+        if: ${{ inputs.nightly == true }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,13 +32,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Gradle Wrapper Validation
+      - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Build the lfc compiler
+      - name: Build and package Lfc CLI
         run: .github/scripts/package_lfc.sh
-      - name: Build Eclipse product
-        run: mvn compile
-      - name: Package IDE
+      - name: Build and package Epoch CLI
         run: mvn package
 
       - name: Deploy nightly release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: Build toolchain
+
+on:
+  workflow_call:
+    inputs:
+      nightly:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Java JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4
+        with:
+          maven-version: 3.8.1
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-      
+      - name: Check out lingua-franca repository
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1
+      - name: Build the lfc compiler
+        run: .github/scripts/package_lfc.sh
+      - name: Build Eclipse product
+        run: mvn compile
+      - name: Package IDE
+        run: mvn package
+
+      - name: Deploy nightly release
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: "${{ secrets.NIGHTLY_BUILD }}"
+          automatic_release_tag: 'nightly'
+          prerelease: true
+          files: |
+            org.lflang.rca/target/products/*.tar.gz
+            org.lflang.rca/target/products/*.zip
+            build_upload/*
+          if: ${{ inputs.nightly == true }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,9 @@ jobs:
           submodules: recursive
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Build and package Lfc CLI
+      - name: Build and package lfc
         run: .github/scripts/package_lfc.sh
-      - name: Build and package Epoch CLI
+      - name: Build and package epoch
         run: mvn package
 
       - name: Deploy nightly release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ env:
   vcpkgGitRef: 0bf3923f9fab4001c00f0f429682a0853b5749e0
 
 jobs:
+  # Test the Maven build.
+  build:
+    uses: lf-lang/lingua-franca/.github/workflows/build.yml@ci
+
   # Run the unit tests.
   unit-tests:
     uses: lf-lang/lingua-franca/.github/workflows/unit-tests.yml@master

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,60 +1,13 @@
 name: Nightly build
 
-# Trigger the workflow every day at 5 AM (UTC) i.e., 10 PM Pacific.
+# Trigger the workflow every day at 5 AM (UTC).
 on:
   schedule:
     - cron: '0 5 * * *'
   workflow_dispatch:
 
 jobs:
-  package:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      # Setup Build dependencies
-      - name: Set up Java JDK
-        uses: actions/setup-java@v2
-        with:
-          java-version: 11
-          distribution: zulu
-      - name: Set up Maven
-        uses: stCarolas/setup-maven@v4
-        with:
-          maven-version: 3.8.1
-      
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      
-      # Check out the repository under $GITHUB_WORKSPACE, so the job can access it
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
-      - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1
-
-      # Build products
-      - name: Build the lfc compiler
-        run: .github/scripts/package_lfc.sh
-      - name: Build Eclipse product
-        run: mvn compile
-      - name: Package IDE
-        run: mvn package
-
-      - name: Deploy release
-        uses: marvinpinto/action-automatic-releases@latest
-        with:
-          repo_token: "${{ secrets.NIGHTLY_BUILD }}"
-          automatic_release_tag: 'nightly'
-          prerelease: true
-          files: |
-            org.lflang.rca/target/products/*.tar.gz
-            org.lflang.rca/target/products/*.zip
-            build_upload/*
+  build:
+    uses: lf-lang/lingua-franca/.github/workflows/build.yml@master
+    with:
+      nightly: true

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,9 @@
 
 ## Libraries
 
+## Dependencies
+ - Kotlin `1.4.10` -> `1.6.10` (#866)
+
 # Version 0.1.0-alpha (06-04-2021)
 This is a preliminary release of the Lingua Franca Compiler (`lfc`), a **command-line compiler** that translates Lingua Franca programs into target language programs, and an **Eclipse-based IDE** (integrated development environment) that provides a sophisticated editor as well as a code generator. This release supports four target languages: C, C++, Python, and Typescript. See [documentation](https://github.com/icyphy/lingua-franca/wiki). Of the four target languages, C is the most complete. It supports all documented language features including an experimental implementation of [federated execution](https://github.com/icyphy/lingua-franca/wiki/Distributed-Execution).
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = "1.4.10" // sync with pom.xml
+    ext.kotlinVersion = "1.6.10" // sync with pom.xml
     repositories {
         mavenCentral()
     }

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
 
     <properties>
         <!-- Sync with build.gradle -->
-        <!-- Note that this version is forced upon us by https://github.com/JetBrains/kotlin-eclipse -->
         <kotlin.version>1.6.10</kotlin.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <properties>
         <!-- Sync with build.gradle -->
         <!-- Note that this version is forced upon us by https://github.com/JetBrains/kotlin-eclipse -->
-        <kotlin.version>1.4.10</kotlin.version>
+        <kotlin.version>1.6.10</kotlin.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <tycho-version>2.3.0</tycho-version>


### PR DESCRIPTION
This PR adds testing of the Maven build to our CI workflow. An initial run of the new workflow that the build had already broken. Fixes are included. Specifically:

**Problem 1**:
```
Error:  /home/runner/work/lingua-franca/lingua-franca/org.lflang/src/org/lflang/generator/rust/RustTypes.kt:[58,37] Super calls to Java default methods are prohibited in JVM target 1.6. Recompile with '-jvm-target 1.8'
```
**Solution 1**: bump Kotlin from `1.4.10` to `1.6.10`

**Problem 2**:
```
Error:  /home/runner/work/lingua-franca/lingua-franca/org.lflang.diagram/src/org/lflang/diagram/lsp/Progress.java:[104] 
Error:  	client.notifyProgress(new ProgressParams(Either.forRight(token), Either.forLeft(notification)));
Error:  	                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error:  The constructor ProgressParams(Either.forRight(token), Either.forLeft(notification)) is undefined
Error:  1 problem (1 error)
```
**Solution 2**: revert ee19274b9581fcd0f55543b715685b9ce0b2d19d (already done in `master`)

Fixes https://github.com/lf-lang/lingua-franca/issues/861