### PR TITLE
Do not break Eclipse build

### DIFF
--- a/org.lflang.diagram/src/org/lflang/diagram/lsp/Progress.java
+++ b/org.lflang.diagram/src/org/lflang/diagram/lsp/Progress.java
@@ -101,6 +101,6 @@ public class Progress {
      * @param notification
      */
     private void notifyProgress(WorkDoneProgressNotification notification) {
-        client.notifyProgress(new ProgressParams(Either.forRight(token), notification));
+        client.notifyProgress(new ProgressParams(Either.forRight(token), Either.forLeft(notification)));
     }
 }

--- a/org.lflang.targetplatform/org.lflang.targetplatform.target
+++ b/org.lflang.targetplatform/org.lflang.targetplatform.target
@@ -33,7 +33,7 @@
       <unit id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
       <unit id="com.fasterxml.jackson.core.jackson-annotations" version="0.0.0"/>
       <unit id="com.fasterxml.jackson.core.jackson-databind" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/releases/2021-06"/>
+      <repository location="http://download.eclipse.org/releases/2021-09"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.eclipse.xtext.runtime.feature.group" version="0.0.0"/>
@@ -44,7 +44,7 @@
       <unit id="com.google.inject" version="0.0.0"/>
       <unit id="jakarta.activation" version="0.0.0"/>
       <unit id="javax.activation" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository/"/>
+      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20210825222808/repository/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.jetbrains.kotlin.feature.feature.group" version="0.0.0"/>
@@ -56,11 +56,11 @@
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.python.pydev.feature.feature.group" version="0.0.0"/>
-      <repository location="https://www.pydev.org/updates/"/>
+      <repository location="https://github.com/fabioz/Pydev/releases/download/pydev_9_0_1"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/wildwebdeveloper/releases/0.12.0/"/>
+      <repository location="https://download.eclipse.org/wildwebdeveloper/releases/0.13.0/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="de.cau.cs.kieler.klighd.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
This allows the Maven build and Eclipse build to work at the same time. (I have only tested the Maven build, but the Eclipse build "should" be fine.) It breaks the language server, but that is fine.