### PR TITLE
change lsp ci yaml to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
   # Run language server tests.
   lsp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@vscode-validate-generated-code-cleanups
+    uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@master
 
   # Run the C integration tests.
   c-tests:


### PR DESCRIPTION
The ci-yaml in master points to a nonexistent branch for lsp tests.