### PR TITLE
Make linting optional in standalone mode

### DIFF
--- a/.github/scripts/test-lfc.sh
+++ b/.github/scripts/test-lfc.sh
@@ -47,6 +47,10 @@ bin/lfc --federated --rti rti test/C/src/Minimal.lf
 # -h,--help                          Display this information.
 bin/lfc --help
 
+# -l, --lint                         Enable linting during build.
+bin/lfc -l test/Python/src/Minimal.lf
+bin/lfc --lint test/Python/src/Minimal.lf
+
 # -n,--no-compile                    Do not invoke target compiler.
 bin/lfc -n test/C/src/Minimal.lf
 bin/lfc --no-compile test/C/src/Minimal.lf

--- a/org.lflang.lfc/src/org/lflang/lfc/Main.java
+++ b/org.lflang.lfc/src/org/lflang/lfc/Main.java
@@ -106,6 +106,7 @@ public class Main {
         COMPILER(null, "target-compiler", true, false, "Target compiler to invoke.", true),
         CLEAN("c", "clean", false, false, "Clean before building.", true),
         HELP("h", "help", false, false, "Display this information.", true),
+        LINT("l", "lint", true, false, "Enable or disable linting of generated code.", true),
         NO_COMPILE("n", "no-compile", false, false, "Do not invoke target compiler.", true),
         FEDERATED("f", "federated", false, false, "Treat main reactor as federated.", false),
         THREADS("t", "threads", true, false, "Specify the default number of threads.", true),
@@ -120,7 +121,7 @@ public class Main {
         public final Option option;
 
         /**
-         * Whether or not to pass this option to the code generator.
+         * Whether to pass this option to the code generator.
          */
         public final boolean passOn;
 

--- a/org.lflang.lfc/src/org/lflang/lfc/Main.java
+++ b/org.lflang.lfc/src/org/lflang/lfc/Main.java
@@ -106,7 +106,7 @@ public class Main {
         COMPILER(null, "target-compiler", true, false, "Target compiler to invoke.", true),
         CLEAN("c", "clean", false, false, "Clean before building.", true),
         HELP("h", "help", false, false, "Display this information.", true),
-        LINT("l", "lint", true, false, "Enable or disable linting of generated code.", true),
+        LINT("l", "lint", false, false, "Enable or disable linting of generated code.", true),
         NO_COMPILE("n", "no-compile", false, false, "Do not invoke target compiler.", true),
         FEDERATED("f", "federated", false, false, "Treat main reactor as federated.", false),
         THREADS("t", "threads", true, false, "Specify the default number of threads.", true),

--- a/org.lflang/src/org/lflang/generator/Validator.java
+++ b/org.lflang/src/org/lflang/generator/Validator.java
@@ -72,17 +72,27 @@ public abstract class Validator {
      * @param context The context of the current build.
      */
     private boolean validationEnabled(LFGeneratorContext context) {
-        String lint = context.getArgs().getProperty("lint", context.getMode() == Mode.STANDALONE ? "false" : "true");
+        boolean defaultValue = validationEnabledByDefault(context);
+        String lint = context.getArgs().getProperty("lint", defaultValue ? "true" : "false");
         if (lint.equalsIgnoreCase("true")) return true;
         else if (lint.equalsIgnoreCase("false")) return false;
         else {
             errorReporter.reportWarning(String.format(
                 "Unrecognized value for \"lint\" property: \"%s\". Acceptable values are \"true\" and \"false\". "
-                    + "Assuming default value of \"false\".",
-                lint
+                    + "Assuming default value of \"%s\".",
+                lint, defaultValue ? "true" : "false"
             ));
-            return false;
+            return defaultValue;
         }
+    }
+
+    /**
+     * Return whether validation of generated code is enabled by default.
+     * @param context The context of the current build.
+     * @return Whether validation of generated code is enabled by default.
+     */
+    protected boolean validationEnabledByDefault(LFGeneratorContext context) {
+        return context.getMode() != Mode.STANDALONE;
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/Validator.java
+++ b/org.lflang/src/org/lflang/generator/Validator.java
@@ -72,18 +72,7 @@ public abstract class Validator {
      * @param context The context of the current build.
      */
     private boolean validationEnabled(LFGeneratorContext context) {
-        boolean defaultValue = validationEnabledByDefault(context);
-        String lint = context.getArgs().getProperty("lint", defaultValue ? "true" : "false");
-        if (lint.equalsIgnoreCase("true")) return true;
-        else if (lint.equalsIgnoreCase("false")) return false;
-        else {
-            errorReporter.reportWarning(String.format(
-                "Unrecognized value for \"lint\" property: \"%s\". Acceptable values are \"true\" and \"false\". "
-                    + "Assuming default value of \"%s\".",
-                lint, defaultValue ? "true" : "false"
-            ));
-            return defaultValue;
-        }
+        return context.getArgs().containsKey("lint") || validationEnabledByDefault(context);
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
@@ -83,7 +83,7 @@ class CppGenerator(
                 //  We must compile in order to install the dependencies. Future validations will be faster.
                 doCompile(context, codeMaps)
             } else if (runCmake(context).first == 0) {
-                CppValidator(cppFileConfig, errorReporter, codeMaps).doValidate(context.cancelIndicator)
+                CppValidator(cppFileConfig, errorReporter, codeMaps).doValidate(context)
                 context.finish(GeneratorResult.GENERATED_NO_EXECUTABLE.apply(codeMaps))
             } else {
                 context.unsuccessfulFinish()

--- a/org.lflang/src/org/lflang/generator/python/PythonGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/python/PythonGenerator.xtend
@@ -1299,7 +1299,7 @@ class PythonGenerator extends CGenerator {
                         100 * federateCount / federates.size()
                     )
                     // If there are no federates, compile and install the generated code
-                    new PythonValidator(fileConfig, errorReporter, codeMaps, protoNames).doValidate(context.cancelIndicator)
+                    new PythonValidator(fileConfig, errorReporter, codeMaps, protoNames).doValidate(context)
                     if (!errorsOccurred() && context.mode != Mode.LSP_MEDIUM) {
                         compilingFederatesContext.reportProgress(
                             String.format("Validation complete. Compiling and installing %d/%d Python modules...", federateCount, federates.size()),

--- a/org.lflang/src/org/lflang/generator/rust/RustGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/rust/RustGenerator.kt
@@ -86,7 +86,7 @@ class RustGenerator(
             )
             val exec = fileConfig.binPath.toAbsolutePath().resolve(gen.executableName)
             Files.deleteIfExists(exec) // cleanup, cargo doesn't do it
-            if (context.mode == TargetConfig.Mode.LSP_MEDIUM) RustValidator(fileConfig, errorReporter, codeMaps).doValidate(context.cancelIndicator)
+            if (context.mode == TargetConfig.Mode.LSP_MEDIUM) RustValidator(fileConfig, errorReporter, codeMaps).doValidate(context)
             else invokeRustCompiler(context, gen.executableName, codeMaps)
         }
     }

--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -389,10 +389,10 @@ class TSGenerator(
      */
     private fun passesChecks(validator: TSValidator, parsingContext: LFGeneratorContext): Boolean {
         parsingContext.reportProgress("Linting generated code...", 0)
-        validator.doLint(parsingContext.cancelIndicator)
+        validator.doLint(parsingContext)
         if (errorsOccurred()) return false
         parsingContext.reportProgress("Validating generated code...", 25)
-        validator.doValidate(parsingContext.cancelIndicator)
+        validator.doValidate(parsingContext)
         return !errorsOccurred()
     }
 

--- a/org.lflang/src/org/lflang/generator/ts/TSValidator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSValidator.kt
@@ -9,6 +9,7 @@ import org.lflang.ErrorReporter
 import org.lflang.generator.CodeMap
 import org.lflang.generator.DiagnosticReporting
 import org.lflang.generator.HumanReadableReportingStrategy
+import org.lflang.generator.LFGeneratorContext
 import org.lflang.generator.Position
 import org.lflang.generator.ValidationStrategy
 import org.lflang.generator.Validator
@@ -152,9 +153,9 @@ class TSValidator(
 
     /**
      * Run a relatively fast linter on the generated code.
-     * @param cancelIndicator The indicator of whether this build process is cancelled.
+     * @param context The context of the current build.
      */
-    fun doLint(cancelIndicator: CancelIndicator) {
-        TSLinter(fileConfig, errorReporter, codeMaps).doValidate(cancelIndicator)
+    fun doLint(context: LFGeneratorContext) {
+        TSLinter(fileConfig, errorReporter, codeMaps).doValidate(context)
     }
 }

--- a/org.lflang/src/org/lflang/generator/ts/TSValidator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSValidator.kt
@@ -158,4 +158,7 @@ class TSValidator(
     fun doLint(context: LFGeneratorContext) {
         TSLinter(fileConfig, errorReporter, codeMaps).doValidate(context)
     }
+
+    // If this is not true, then the user might as well be writing JavaScript.
+    override fun validationEnabledByDefault(context: LFGeneratorContext?): Boolean = true
 }


### PR DESCRIPTION
This change disables validation of generated code when in standalone mode but allows the user to request validation explicitly using the `lint` compiler option. For example,
```
bin/lfc --lint test/TypeScript/src/SimpleDeadline.lf
```
may fail with the error
```
lfc: error: Unexpected var, use let or const instead. [SimpleDeadline.ts:167:25]
```
whereas the file might compile without problems without the `--lint` flag.

This affects the **Python** and **TypeScript** targets. For the compiled languages, any errors from the compilation process should still be reported.
* All forms of syntax checking are disabled by default for Python in standalone mode.
* Type checking using `tsc` is not disabled. However, linting using `eslint` is disabled by default in standalone mode.

Incidentally, this may slightly speed up CI, but the validators will still be tested by LSP tests.