### PR TITLE
validator: Report an error if an LF file name starts with a number

### DIFF
--- a/org.lflang/src/org/lflang/validation/LFValidator.xtend
+++ b/org.lflang/src/org/lflang/validation/LFValidator.xtend
@@ -1164,6 +1164,11 @@ class LFValidator extends BaseLFValidator {
         } else {
             this.target = targetOpt.get();
         }
+
+        val lfFileName = FileConfig.nameWithoutExtension(target.eResource)
+        if (Character.isDigit(lfFileName.charAt(0))) {
+            errorReporter.reportError("LF file names must not start with a number")
+        }
     }
 
     /**


### PR DESCRIPTION
This is a quick fix for #340.

This change conflicts with #886, but I think the change is small enough to merge it now and backport to #886.