### PR TITLE
fix wrong conversion of toDefinition

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaDependencyAnalysisTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaDependencyAnalysisTest.java
@@ -145,7 +145,7 @@ class LinguaFrancaDependencyAnalysisTest {
             }
         }
 
-        ReactorInstance instance = new ReactorInstance((Reactor) mainDef.getReactorClass(), new DefaultErrorReporter());
+        ReactorInstance instance = new ReactorInstance(toDefinition(mainDef.getReactorClass()), new DefaultErrorReporter());
         Assertions.assertFalse(instance.getCycles().isEmpty());
     }
 


### PR DESCRIPTION
This PR fixes a mistake when porting the dependency analysis test

the original line of code in xtend is 
`val instance = new ReactorInstance(mainDef.reactorClass.toDefinition, new DefaultErrorReporter());`