### PR TITLE
Limit token types to types ending with * or []

### DIFF
--- a/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
@@ -5570,18 +5570,18 @@ class CGenerator extends GeneratorBase {
         return !type.isUndefined && sharedPointerVariable.matcher(types.getTargetType(type)).find()
     }
        
-    /** Given a type for an input or output, return true if it should be
-     *  carried by a lf_token_t struct rather than the type itself.
-     *  It should be carried by such a struct if the type ends with *
-     *  (it is a pointer) or [] (it is a array with unspecified length).
-     *  @param type The type specification.
+    /** 
+     * Given a type for an input or output, return true if it should be
+     * carried by a lf_token_t struct rather than the type itself.
+     * It should be carried by such a struct if the type ends with *
+     * (it is a pointer) or [] (it is a array with unspecified length).
+     * @param type The type specification.
      */
     protected def isTokenType(InferredType type) {
-        if (type.isUndefined)
-            return false
+        if (type.isUndefined) return false
         // This is a hacky way to do this. It is now considered to be a bug (#657)
         val targetType = types.getVariableDeclaration(type, "", false) 
-        return type.isVariableSizeList || targetType.contains("*")
+        return type.isVariableSizeList || targetType.trim.endsWith("*")
     }
     
     /** If the type specification of the form {@code type[]},

--- a/test/C/src/federated/DistributedCountPhysicalAfterDelay.lf
+++ b/test/C/src/federated/DistributedCountPhysicalAfterDelay.lf
@@ -1,52 +1,48 @@
 /** 
- * Test a particularly simple form of a distributed deterministic system
- * where a federation that receives timestamped messages only over connections
- * that are marked 'physical' (using the ~> arrow).
- * Therefore, no additional coordination of the
- * advancement of time (HLA or Ptides) is needed.
- * This version imposes an after delay on the physical connection.
+ * Test a distributed system where a federation 
+ * receives messages only over connections
+ * that are marked 'physical' (using the 
+ * ~> arrow) with an after delay. The receiver 
+ * verifies that the after delay is correctly 
+ * imposed.
  * 
  * @author Edward A. Lee
  * @author Soroush Bateni
  */
-target C {
-    timeout: 1 sec
-};
-reactor Count {
-    timer t(200 msec, 1 sec);
-    state s:int(0);
-    output out:int;
-    reaction(t) -> out {=
-        SET(out, self->s);
-        self->s++;
-    =}
-}
+target C;
+import Count from "../lib/Count.lf"
+
 reactor Print {
     input in:int;
-    state c:int(0);
+    state c:int(1);
     reaction(in) {=
         interval_t elapsed_time = get_elapsed_logical_time();
-        printf("At time %lld, received %d.\n", elapsed_time, in->value);
+        printf("At time %ld, received %d.\n", elapsed_time, in->value);
         if (in->value != self->c) {
             fprintf(stderr, "ERROR: Expected to receive %d.\n", self->c);
             exit(1);
         }
-        if (!(elapsed_time > (SEC(1) * self->c) + MSEC(600))) {
-            fprintf(stderr, "ERROR: Expected received time to be strictly greater than %lld.\n", MSEC(600) + (SEC(1) * self->c));
+        if (!(elapsed_time > MSEC(600))) {
+            fprintf(stderr, "ERROR: Expected received time to be strictly greater than %ld.\n", MSEC(600));
             exit(3);
         }
         self->c++;
+        request_stop();
     =}
     reaction(shutdown) {=
-        if (self->c != 1) {
-            fprintf(stderr, "ERROR: Expected to receive 1 item. Received %d.\n", self->c);
+        if (self->c != 2) {
+            fprintf(
+                stderr, "ERROR: Expected to receive 1 item. Received %d.\n",
+                self->c - 1
+            );
             exit(2);
         }
         printf("SUCCESS: Successfully received 1 item.\n");
     =}
 }
 federated reactor at localhost {
-    c = new Count();
+    c = new Count(offset = 200 msec, period = 0);
     p = new Print();
-    c.out ~> p.in after 400 msec;    // Indicating a 'physical' connection.
+    c.out ~> p.in after 400 msec;    // Indicating a 'physical' connection with
+                                     // a 400 msec after delay.
 }

--- a/test/Python/src/StructAsTypeDirect.lf
+++ b/test/Python/src/StructAsTypeDirect.lf
@@ -7,17 +7,18 @@ import hello
 reactor Source {
     output out;
     reaction(startup) -> out {=
-        out.value = hello.hello()
-        out.value.name = "Earth"
-        out.value.value = 42
-        out.set(out.value)
+        out_value = out.value
+        out_value = hello.hello()
+        out_value.name = "Earth"
+        out_value.value = 42
+        out.set(out_value)
     =}
 }
 // expected parameter is for testing.
 reactor Print(expected(42)) {
     input _in;
     reaction(_in) {=
-        print("Received: name = {:s}, value = {:d}\n".format(_in.value.name, _in.value.value))
+        print("Received: name = {:s}, value = {:d}".format(_in.value.name, _in.value.value))
         if _in.value.value != self.expected:
             sys.stderr.write("ERROR: Expected value to be {:d}.\n".format(self.expected))
             exit(1)


### PR DESCRIPTION
This is not a great fix, but we really need this in master because otherwise all uses of types of the form `{= ... =}` will fail in the C generator.