### PR TITLE
Do not swallow errors in imported files. Report them.

### DIFF
--- a/org.lflang/src/org/lflang/generator/JavaGeneratorUtils.java
+++ b/org.lflang/src/org/lflang/generator/JavaGeneratorUtils.java
@@ -21,6 +21,7 @@ import org.eclipse.xtext.generator.IGeneratorContext;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.IResourceValidator;
+import org.eclipse.xtext.validation.Issue;
 import org.lflang.ErrorReporter;
 import org.lflang.FileConfig;
 import org.lflang.Target;
@@ -219,15 +220,15 @@ public class JavaGeneratorUtils {
             Resource resource = reactor.eResource();
             if (visited.contains(resource)) continue;
             visited.add(resource);
+            List<Issue> issues = validator.validate(resource, CheckMode.ALL, context.getCancelIndicator());
             if (
-                bad.contains(resource) || validator.validate(
-                    resource, CheckMode.ALL, context.getCancelIndicator()
-                ).size() > 0
+                bad.contains(resource) || issues.size() > 0
             ) {
                 for (Reactor downstreamReactor : instantiationGraph.getDownstreamAdjacentNodes(reactor)) {
                     for (Import importStatement : ((Model) downstreamReactor.eContainer()).getImports()) {
                         errorReporter.reportError(importStatement, String.format(
-                            "Unresolved compilation issues in '%s'.", importStatement.getImportURI()
+                            "Unresolved compilation issues in '%s': "
+                                + issues.toString(), importStatement.getImportURI()
                         ));
                         bad.add(downstreamReactor.eResource());
                     }


### PR DESCRIPTION
When cycles involve imported files, as in issue #446, the error reporting was funky. All it tells you is that there are "unresolved compilation problems" in the imported file, but nowhere does it tell you what the problems are.  This small PR fixes that and closes #446.

There is still the bug in issue #855, which is that the validator doesn't get fully run upon saving the file, only when you invoke the code generator, so cycles are not reported at all until you code generate (they are, however, displayed in red in the diagram).