### PR TITLE
Comment out Rust's guided search benchmark, because it locks up sometimes

### DIFF
--- a/benchmark/runner/conf/benchmark/savina_parallelism_astar.yaml
+++ b/benchmark/runner/conf/benchmark/savina_parallelism_astar.yaml
@@ -40,14 +40,15 @@ targets:
       priorities: ["-D", "priorities=<value>"]
       num_workers: ["-D", "numWorkers=<value>"]
       num_iterations: ["-D", "numIterations=<value>"]
-  lf-rust:
-    copy_sources:
-      - "${lf_path}/benchmark/Rust/Savina/src/lib"
-      - "${lf_path}/benchmark/Rust/Savina/src/parallelism"
-    lf_file: "parallelism/GuidedSearch.lf"
-    binary: "guided_search"
-    run_args:
-      threshold: ["--main-threshold", "<value>"]
-      grid_size: ["--main-grid-size", "<value>"]
-      priorities: ["--main-priorities", "<value>"]
-      num_workers: ["--main-num-workers", "<value>"]
+#  not ready, see: https://github.com/lf-lang/reactor-rust/issues/11
+#  lf-rust:
+#    copy_sources:
+#      - "${lf_path}/benchmark/Rust/Savina/src/lib"
+#      - "${lf_path}/benchmark/Rust/Savina/src/parallelism"
+#    lf_file: "parallelism/GuidedSearch.lf"
+#    binary: "guided_search"
+#    run_args:
+#      threshold: ["--main-threshold", "<value>"]
+#      grid_size: ["--main-grid-size", "<value>"]
+#      priorities: ["--main-priorities", "<value>"]
+#      num_workers: ["--main-num-workers", "<value>"]


### PR DESCRIPTION
See: https://github.com/lf-lang/reactor-rust/issues/11

This is to ensure everything runs smoothly when running all benchmarks for all targets.