### PR TITLE
Fix Rust's Guided Search benchmark locking up, and other fixes

### DIFF
--- a/benchmark/Rust/Savina/src/lib/guided_search.rs
+++ b/benchmark/Rust/Savina/src/lib/guided_search.rs
@@ -136,7 +136,7 @@ impl Grid {
             }
         }
 
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::seed_from_u64(123456);
         let keys: Vec<u32> = self.all_nodes.keys().map(|x| *x).collect();
         for key in keys {
             let mut iter_count = 0;

--- a/benchmark/Rust/Savina/src/parallelism/GuidedSearch.lf
+++ b/benchmark/Rust/Savina/src/parallelism/GuidedSearch.lf
@@ -123,8 +123,10 @@ reactor Manager(numWorkers: usize(20), gridSize: u32(30), priorities: u32(30)) {
                 let gr = self.grid.read().unwrap();
                 gr.target_node_id()  
             };
-            while !self.nodesToVisit.is_empty() && worker_index < self.num_workers {
-                let start_node = self.nodesToVisit.pop_front().unwrap();
+            while let Some(start_node) = self.nodesToVisit.pop_front() {
+                if worker_index >= self.num_workers {
+                    break;
+                }
                 ctx.set(search.get(worker_index as usize), WorkMessage::new(start_node, target_node_id));
                 worker_index += 1;
             }

--- a/benchmark/Rust/Savina/src/parallelism/GuidedSearch.lf
+++ b/benchmark/Rust/Savina/src/parallelism/GuidedSearch.lf
@@ -163,7 +163,9 @@ reactor Worker(bank_index: usize(0), threshold: u32(1024)) {
     state bank_index(bank_index);
     state threshold(threshold);
     state grid: Arc<RwLock<Grid>>;
+    state rng: SmallRng({= SmallRng::seed_from_u64(0) =});
     
+    input start: unit;
     input gridShare: Arc<RwLock<Grid>>;
     input search: WorkMessage;
     output pathFound: unit;
@@ -179,8 +181,7 @@ reactor Worker(bank_index: usize(0), threshold: u32(1024)) {
         use std::collections::VecDeque;
         use std::sync::{RwLock, Arc};
         
-        fn busy_wait() {
-            let mut rng = SmallRng::from_entropy();
+        fn busy_wait(rng: &mut SmallRng) {
             for _ in 0..100 {
                 let res = rng.next_u32();
                 
@@ -189,6 +190,10 @@ reactor Worker(bank_index: usize(0), threshold: u32(1024)) {
                 let _ = v.read();
             }
         }
+    =}
+    
+    reaction(start) {=
+        self.rng = SmallRng::seed_from_u64(123456);
     =}
     
     reaction(gridShare) {=
@@ -214,7 +219,7 @@ reactor Worker(bank_index: usize(0), threshold: u32(1024)) {
         let mut nodes_processed = 0;
         while !work_queue.is_empty() && nodes_processed < self.threshold {
             nodes_processed += 1;
-            busy_wait();
+            busy_wait(&mut self.rng);
             
             let loop_node_id = work_queue.pop_front().unwrap();
             let loop_node_neighbor_ids = {
@@ -273,7 +278,7 @@ main reactor (numIterations: usize(12), threshold: u32(1024), gridSize: u32(30),
         print_system_info();
     =}
 
-    runner.start -> manager.start;
+    (runner.start)+ -> manager.start, workers.start;
     manager.finished -> runner.finished;
     
     (manager.gridShare)+ -> workers.gridShare;


### PR DESCRIPTION
Some small fixes regarding idiomacy and performance, but mainly fixing the random softlock.

This had to do with creating the grid from a variable random seed that would sometimes create grids with no path from source to target, resulting in the search loop to run forever. To quote from the commit:

> It seems like with a variable seed, sometimes a grid is created with no
> path from start to target, so we just have to use a static seed that
> creates a usable grid every time. The C++ benchmark does the same thing.