### PR TITLE
Bump versions excludes

### DIFF
--- a/bin/bump-versions
+++ b/bin/bump-versions
@@ -23,6 +23,7 @@ to = ' >>> '
 parentDir = dirname(dirname(abspath(__file__)))
 manifestFind = parentDir
 mavenFind = join(parentDir, 'pom.xml')
+excluded = ['target', 'build']
 
 class colors: 
     RED = '\033[31m'
@@ -104,9 +105,13 @@ def updateManifestPackages(config, props, quiet):
                     return
 
 
+def excludeFromFind():
+    return ' '.join(f'! -path \"**/{it}/**\"' for it in excluded)
+
+
 def generateManifestViewCommand(matchName, version):
     return f'''
-    find {manifestFind} -name *.MF -type f -printf '{findPrintStyle}' -exec sed -n '/{matchName}.*;bundle-version/{{
+    find {manifestFind} -name *.MF {excludeFromFind()} -type f -printf '{findPrintStyle}' -exec sed -n '/{matchName}.*;bundle-version/{{
     h
     s/="[^"][^"]*"/="{version}"/g
     H
@@ -120,7 +125,7 @@ def generateManifestViewCommand(matchName, version):
 
 def generateManifestReplaceCommand(matchName, version):
     return f'''
-    find {manifestFind} -name *.MF -type f -exec sed -i '/{matchName}.*;bundle-version/{{
+    find {manifestFind} -name *.MF {excludeFromFind()} -type f -exec sed -i '/{matchName}.*;bundle-version/{{
     h
     s/="[^"][^"]*"/="{version}"/g
     }}' {{}} \;

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ subprojects {
     dependencies {
         implementation platform("org.eclipse.xtext:xtext-dev-bom:${xtextVersion}")
         // https://mvnrepository.com/artifact/com.google.inject/guice
-        implementation group: 'com.google.inject', name: 'guice', version: juiceVersion
+        implementation group: 'com.google.inject', name: 'guice', version: guiceVersion
         // https://mvnrepository.com/artifact/commons-cli/commons-cli
         implementation group: 'commons-cli', name: 'commons-cli', version: commonsCliVersion
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ version=0.1.0-SNAPSHOT
 
 [versions]
 commonsCliVersion=1.4
+guiceVersion=5.0.1
 jacocoVersion=0.8.7
-juiceVersion=5.0.1
 jupiterVersion=5.8.2
 jUnitPlatformVersion=1.8.2
 jUnitVersion=4.13.2


### PR DESCRIPTION
Locally, I have found that the version bump script detects a large number of manifest files from build directories in `org.lflang.rca` and `org.lflang.lds`. We do not track or maintain these manifest files, for they belong to other projects that we depend on. This addresses that.