### PR TITLE
Remove usages of IFileSystemAccess2 from C++ generator.

### DIFF
--- a/org.lflang/src/org/lflang/generator/JavaGeneratorUtils.java
+++ b/org.lflang/src/org/lflang/generator/JavaGeneratorUtils.java
@@ -1,6 +1,7 @@
 package org.lflang.generator;
 
 import java.io.BufferedWriter;
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -312,6 +313,7 @@ public class JavaGeneratorUtils {
      * @param path The file to write the code to.
      */
     public static void writeToFile(CharSequence text, String path) throws IOException {
+        new File(path).getParentFile().mkdirs();
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(path))) {
             for (int i = 0; i < text.length(); i++) {
                 writer.write(text.charAt(i));

--- a/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
@@ -36,6 +36,7 @@ import org.lflang.generator.CodeMap
 import org.lflang.generator.GeneratorBase
 import org.lflang.generator.GeneratorResult
 import org.lflang.generator.IntegratedBuilder
+import org.lflang.generator.JavaGeneratorUtils
 import org.lflang.generator.LFGeneratorContext
 import org.lflang.generator.TargetTypes
 import org.lflang.lf.Action
@@ -67,7 +68,7 @@ class CppGenerator(
 
         if (!canGenerate(errorsOccurred(), mainDef, errorReporter, context)) return
 
-        val codeMaps = generateFiles(fsa)
+        val codeMaps = generateFiles()
 
         if (targetConfig.noCompile || errorsOccurred()) {
             println("Exiting before invoking target compiler.")
@@ -95,9 +96,8 @@ class CppGenerator(
         }
     }
 
-    private fun generateFiles(fsa: IFileSystemAccess2): Map<Path, CodeMap> {
+    private fun generateFiles(): Map<Path, CodeMap> {
         val srcGenPath = fileConfig.srcGenPath
-        val relSrcGenPath = fileConfig.srcGenBasePath.relativize(srcGenPath)
 
         val mainReactor = mainDef.reactorClass.toDefinition()
 
@@ -115,8 +115,8 @@ class CppGenerator(
         val mainFile = Paths.get("main.cc")
         val mainCodeMap = CodeMap.fromGeneratedCode(CppMainGenerator(mainReactor, targetConfig, cppFileConfig).generateCode())
         cppSources.add(mainFile)
-        codeMaps[fileConfig.srcGenPath.resolve(mainFile)] = mainCodeMap
-        fsa.generateFile(relSrcGenPath.resolve(mainFile).toString(), mainCodeMap.generatedCode)
+        codeMaps[srcGenPath.resolve(mainFile)] = mainCodeMap
+        JavaGeneratorUtils.writeToFile(mainCodeMap.generatedCode, srcGenPath.resolve(mainFile).toString())
 
         // generate header and source files for all reactors
         for (r in reactors) {
@@ -126,12 +126,12 @@ class CppGenerator(
             val reactorCodeMap = CodeMap.fromGeneratedCode(generator.generateSource())
             if (!r.isGeneric)
                 cppSources.add(sourceFile)
-            codeMaps[fileConfig.srcGenPath.resolve(sourceFile)] = reactorCodeMap
+            codeMaps[srcGenPath.resolve(sourceFile)] = reactorCodeMap
             val headerCodeMap = CodeMap.fromGeneratedCode(generator.generateHeader())
-            codeMaps[fileConfig.srcGenPath.resolve(headerFile)] = headerCodeMap
+            codeMaps[srcGenPath.resolve(headerFile)] = headerCodeMap
 
-            fsa.generateFile(relSrcGenPath.resolve(headerFile).toString(), headerCodeMap.generatedCode)
-            fsa.generateFile(relSrcGenPath.resolve(sourceFile).toString(), reactorCodeMap.generatedCode)
+            JavaGeneratorUtils.writeToFile(headerCodeMap.generatedCode, srcGenPath.resolve(headerFile).toString())
+            JavaGeneratorUtils.writeToFile(reactorCodeMap.generatedCode, srcGenPath.resolve(sourceFile).toString())
         }
 
         // generate file level preambles for all resources
@@ -141,17 +141,17 @@ class CppGenerator(
             val headerFile = cppFileConfig.getPreambleHeaderPath(r.eResource)
             val preambleCodeMap = CodeMap.fromGeneratedCode(generator.generateSource())
             cppSources.add(sourceFile)
-            codeMaps[fileConfig.srcGenPath.resolve(sourceFile)] = preambleCodeMap
+            codeMaps[srcGenPath.resolve(sourceFile)] = preambleCodeMap
             val headerCodeMap = CodeMap.fromGeneratedCode(generator.generateHeader())
-            codeMaps[fileConfig.srcGenPath.resolve(headerFile)] = headerCodeMap
+            codeMaps[srcGenPath.resolve(headerFile)] = headerCodeMap
 
-            fsa.generateFile(relSrcGenPath.resolve(headerFile).toString(), headerCodeMap.generatedCode)
-            fsa.generateFile(relSrcGenPath.resolve(sourceFile).toString(), preambleCodeMap.generatedCode)
+            JavaGeneratorUtils.writeToFile(headerCodeMap.generatedCode, srcGenPath.resolve(headerFile).toString())
+            JavaGeneratorUtils.writeToFile(preambleCodeMap.generatedCode, srcGenPath.resolve(sourceFile).toString())
         }
 
         // generate the cmake script
         val cmakeGenerator = CppCmakeGenerator(targetConfig, cppFileConfig)
-        fsa.generateFile(relSrcGenPath.resolve("CMakeLists.txt").toString(), cmakeGenerator.generateCode(cppSources))
+        JavaGeneratorUtils.writeToFile(cmakeGenerator.generateCode(cppSources), srcGenPath.resolve("CMakeLists.txt").toString())
         return codeMaps
     }
 


### PR DESCRIPTION
Closes #929.

As mentioned in #149, there may be reasons why we still use `IFileSystemAccess2`. However, this should at least serve as an easy near-term solution.