### PR TITLE
Refactoring: Purge code generators of IFileSystemAccess2.

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/TestBase.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestBase.java
@@ -379,7 +379,7 @@ public abstract class TestBase {
         }
 
         fileAccess.setOutputPath(FileConfig.findPackageRoot(test.srcFile, s -> {}).resolve(FileConfig.DEFAULT_SRC_GEN_DIR).toString());
-        test.fileConfig = new FileConfig(r, fileAccess, context);
+        test.fileConfig = new FileConfig(r, FileConfig.getSrcGenRoot(fileAccess), context);
 
         // Set the no-compile flag the test is not supposed to reach the build stage.
         if (level.compareTo(TestLevel.BUILD) < 0) {

--- a/org.lflang/src/org/lflang/generator/GeneratorBase.xtend
+++ b/org.lflang/src/org/lflang/generator/GeneratorBase.xtend
@@ -38,7 +38,6 @@ import java.util.regex.Pattern
 import java.util.stream.Collectors
 import org.eclipse.core.resources.IMarker
 import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.xtext.generator.IFileSystemAccess2
 import org.eclipse.xtext.util.CancelIndicator
 import org.lflang.ASTUtils
 import org.lflang.ErrorReporter
@@ -280,11 +279,10 @@ abstract class GeneratorBase extends AbstractLFValidator {
      * {@link #GeneratorBase.reactors reactors} list. If errors occur during
      * generation, then a subsequent call to errorsOccurred() will return true.
      * @param resource The resource containing the source code.
-     * @param fsa The file system access (used to write the result).
      * @param context Context relating to invocation of the code generator.
      * In stand alone mode, this object is also used to relay CLI arguments.
      */
-    def void doGenerate(Resource resource, IFileSystemAccess2 fsa, LFGeneratorContext context) {
+    def void doGenerate(Resource resource, LFGeneratorContext context) {
         
         JavaGeneratorUtils.setTargetConfig(
             context, JavaGeneratorUtils.findTarget(fileConfig.resource), targetConfig, errorReporter
@@ -335,7 +333,7 @@ abstract class GeneratorBase extends AbstractLFValidator {
         val allResources = JavaGeneratorUtils.getResources(reactors)
         resources.addAll(allResources.stream()  // FIXME: This filter reproduces the behavior of the method it replaces. But why must it be so complicated? Why are we worried about weird corner cases like this?
             .filter [it | it != fileConfig.resource || (mainDef !== null && it === mainDef.reactorClass.eResource)]
-            .map [it | JavaGeneratorUtils.getLFResource(it, fsa, context, errorReporter)]
+            .map [it | JavaGeneratorUtils.getLFResource(it, fileConfig.getSrcGenBasePath(), context, errorReporter)]
             .collect(Collectors.toList())
         )
         JavaGeneratorUtils.accommodatePhysicalActionsIfPresent(allResources, target, targetConfig, errorReporter);

--- a/org.lflang/src/org/lflang/generator/JavaGeneratorUtils.java
+++ b/org.lflang/src/org/lflang/generator/JavaGeneratorUtils.java
@@ -277,8 +277,8 @@ public class JavaGeneratorUtils {
      * given resource.
      * @param resource The {@code Resource} to be
      *                 represented as an {@code LFResource}
-     * @param fsa An object that provides access to the file
-     *            system
+     * @param srcGenBasePath The root directory for any
+     * generated sources associated with the resource.
      * @param context The generator invocation context.
      * @param errorReporter An error message acceptor.
      * @return the {@code LFResource} representation of the
@@ -286,7 +286,7 @@ public class JavaGeneratorUtils {
      */
     public static LFResource getLFResource(
         Resource resource,
-        IFileSystemAccess2 fsa,
+        Path srcGenBasePath,
         LFGeneratorContext context,
         ErrorReporter errorReporter
     ) {
@@ -299,7 +299,7 @@ public class JavaGeneratorUtils {
         }
         FileConfig fc;
         try {
-            fc = new FileConfig(resource, fsa, context);
+            fc = new FileConfig(resource, srcGenBasePath, context);
         } catch (IOException e) {
             throw new RuntimeException("Failed to instantiate an imported resource because an I/O error "
                                            + "occurred.");
@@ -323,9 +323,9 @@ public class JavaGeneratorUtils {
 
     /** 
      * If the mode is Mode.EPOCH (the code generator is running in an
-     * an Eclipse IDE), then refresh the project. This will ensure that
+     * Eclipse IDE), then refresh the project. This will ensure that
      * any generated files become visible in the project.
-     * @param resrouce The resource.
+     * @param resource The resource.
      * @param compilerMode An indicator of whether Epoch is running.
      */
     public static void refreshProject(Resource resource, Mode compilerMode) {

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
@@ -37,7 +37,6 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.xtext.generator.IFileSystemAccess2
 import org.eclipse.xtext.util.CancelIndicator
 import org.lflang.ASTUtils
 import org.lflang.ErrorReporter
@@ -417,16 +416,14 @@ class CGenerator extends GeneratorBase {
      * specified resource. This is the main entry point for code
      * generation.
      * @param resource The resource containing the source code.
-     * @param fsa The file system access (used to write the result).
      * @param context The context in which the generator is
      *     invoked, including whether it is cancelled and
      *     whether it is a standalone context
      */
-    override void doGenerate(Resource resource, IFileSystemAccess2 fsa,
-            LFGeneratorContext context) {
+    override void doGenerate(Resource resource, LFGeneratorContext context) {
         
         // The following generates code needed by all the reactors.
-        super.doGenerate(resource, fsa, context)
+        super.doGenerate(resource, context)
         accommodatePhysicalActionsIfPresent()
         setCSpecificDefaults(context)
         generatePreamble()

--- a/org.lflang/src/org/lflang/generator/cpp/CppFileConfig.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppFileConfig.kt
@@ -34,8 +34,8 @@ import org.lflang.name
 import java.io.IOException
 import java.nio.file.Path
 
-class CppFileConfig(resource: Resource, fsa: IFileSystemAccess2, context: LFGeneratorContext) :
-    FileConfig(resource, fsa, context) {
+class CppFileConfig(resource: Resource, srcGenBasePath: Path, context: LFGeneratorContext) :
+    FileConfig(resource, srcGenBasePath, context) {
 
     /**
      * Clean any artifacts produced by the C++ code generator.

--- a/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
@@ -63,8 +63,8 @@ class CppGenerator(
                 .bufferedReader().readLine().trim()
     }
 
-    override fun doGenerate(resource: Resource, fsa: IFileSystemAccess2, context: LFGeneratorContext) {
-        super.doGenerate(resource, fsa, context)
+    override fun doGenerate(resource: Resource, context: LFGeneratorContext) {
+        super.doGenerate(resource, context)
 
         if (!canGenerate(errorsOccurred(), mainDef, errorReporter, context)) return
 

--- a/org.lflang/src/org/lflang/generator/python/PythonGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/python/PythonGenerator.xtend
@@ -35,7 +35,6 @@ import java.util.LinkedHashSet
 import java.util.LinkedList
 import java.util.List
 import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.xtext.generator.IFileSystemAccess2
 import org.eclipse.xtext.util.CancelIndicator
 import org.lflang.ErrorReporter
 import org.lflang.FileConfig
@@ -869,10 +868,9 @@ class PythonGenerator extends CGenerator {
 
     /**
      * Generate the necessary Python files.
-     * @param fsa The file system access (used to write the result).
      * @param federate The federate instance
      */
-    def generatePythonFiles(IFileSystemAccess2 fsa, FederateInstance federate) {
+    def generatePythonFiles(FederateInstance federate) {
         var file = new File(fileConfig.getSrcGenPath.toFile, topLevelName + ".py")
         if (file.exists) {
             file.delete
@@ -1312,10 +1310,9 @@ class PythonGenerator extends CGenerator {
      *  specified resource. This is the main entry point for code
      *  generation.
      *  @param resource The resource containing the source code.
-     *  @param fsa The file system access (used to write the result).
-     *  @param context FIXME: Undocumented argument. No idea what this is.
+     *  @param context Context relating to invocation of the code generator.
      */
-    override void doGenerate(Resource resource, IFileSystemAccess2 fsa, LFGeneratorContext context) {
+    override void doGenerate(Resource resource, LFGeneratorContext context) {
 
         // If there are federates, assign the number of threads in the CGenerator to 1        
         if (isFederated) {
@@ -1329,7 +1326,7 @@ class PythonGenerator extends CGenerator {
         targetConfig.useCmake = false; // Force disable the CMake because 
         // it interferes with the Python target functionality
         val cGeneratedPercentProgress = (IntegratedBuilder.VALIDATED_PERCENT_PROGRESS + 100) / 2
-        super.doGenerate(resource, fsa, new SubContext(
+        super.doGenerate(resource, new SubContext(
             context,
             IntegratedBuilder.VALIDATED_PERCENT_PROGRESS,
             cGeneratedPercentProgress
@@ -1356,7 +1353,7 @@ class PythonGenerator extends CGenerator {
             }
             // Don't generate code if there is no main reactor
             if (this.main !== null) {
-                val codeMapsForFederate = generatePythonFiles(fsa, federate)
+                val codeMapsForFederate = generatePythonFiles(federate)
                 codeMaps.putAll(codeMapsForFederate)
                 if (!targetConfig.noCompile) {
                     compilingFederatesContext.reportProgress(

--- a/org.lflang/src/org/lflang/generator/rust/RustFileConfig.kt
+++ b/org.lflang/src/org/lflang/generator/rust/RustFileConfig.kt
@@ -25,7 +25,6 @@
 package org.lflang.generator.rust
 
 import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.xtext.generator.IFileSystemAccess2
 import org.lflang.FileConfig
 import org.lflang.generator.CodeMap
 import org.lflang.generator.LFGeneratorContext
@@ -35,8 +34,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.system.measureTimeMillis
 
-class RustFileConfig(resource: Resource, fsa: IFileSystemAccess2, context: LFGeneratorContext) :
-    FileConfig(resource, fsa, context) {
+class RustFileConfig(resource: Resource, srcGenBasePath: Path, context: LFGeneratorContext) :
+    FileConfig(resource, srcGenBasePath, context) {
 
     /**
      * Clean any artifacts produced by the C++ code generator.

--- a/org.lflang/src/org/lflang/generator/rust/RustGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/rust/RustGenerator.kt
@@ -64,8 +64,8 @@ class RustGenerator(
     @Suppress("UNUSED_PARAMETER") unused: LFGlobalScopeProvider
 ) : GeneratorBase(fileConfig, errorReporter) {
 
-    override fun doGenerate(resource: Resource, fsa: IFileSystemAccess2, context: LFGeneratorContext) {
-        super.doGenerate(resource, fsa, context)
+    override fun doGenerate(resource: Resource, context: LFGeneratorContext) {
+        super.doGenerate(resource, context)
 
         if (!canGenerate(errorsOccurred(), mainDef, errorReporter, context)) return
 

--- a/org.lflang/src/org/lflang/generator/ts/TSFileConfig.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSFileConfig.kt
@@ -26,7 +26,6 @@
 package org.lflang.generator.ts
 
 import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.xtext.generator.IFileSystemAccess2
 import org.lflang.FileConfig
 import org.lflang.generator.LFGeneratorContext
 import java.io.IOException
@@ -42,8 +41,8 @@ import java.nio.file.Path
  *  @author {Hokeun Kim <hokeunkim@berkeley.edu>}
  */
 class TSFileConfig(
-    resource: Resource, fsa: IFileSystemAccess2, context: LFGeneratorContext
-) : FileConfig(resource, fsa, context) {
+    resource: Resource, srcGenBasePath: Path, context: LFGeneratorContext
+) : FileConfig(resource, srcGenBasePath, context) {
 
     /**
      * Clean any artifacts produced by the TypeScript code generator.
@@ -51,13 +50,13 @@ class TSFileConfig(
     @Throws(IOException::class)
     override fun doClean() {
         super.doClean()
-        deleteDirectory(getSrcGenPath())
+        deleteDirectory(srcGenPath)
     }
 
     /**
      * Path to TypeScript source code.
      */
-    fun tsSrcGenPath(): Path = getSrcGenPath().resolve("src")
+    fun tsSrcGenPath(): Path = srcGenPath.resolve("src")
 
     /**
      * Path to TypeScript core source code.

--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -143,12 +143,10 @@ class TSGenerator(
      *  specified resource. This is the main entry point for code
      *  generation.
      *  @param resource The resource containing the source code.
-     *  @param fsa The file system access (used to write the result).
      *  @param context The context of this build.
      */
-    override fun doGenerate(resource: Resource, fsa: IFileSystemAccess2,
-                            context: LFGeneratorContext) {
-        super.doGenerate(resource, fsa, context)
+    override fun doGenerate(resource: Resource, context: LFGeneratorContext) {
+        super.doGenerate(resource, context)
 
         if (!canGenerate(errorsOccurred(), mainDef, errorReporter, context)) return
         if (!isOsCompatible()) return
@@ -165,7 +163,7 @@ class TSGenerator(
         copyConfigFiles()
 
         val codeMaps = HashMap<Path, CodeMap>()
-        for (federate in federates) generateCode(fsa, federate, codeMaps)
+        for (federate in federates) generateCode(federate, codeMaps)
         // For small programs, everything up until this point is virtually instantaneous. This is the point where cancellation,
         // progress reporting, and IDE responsiveness become real considerations.
         if (targetConfig.noCompile) {
@@ -245,7 +243,7 @@ class TSGenerator(
     /**
      * Generate the code corresponding to [federate], recording any resulting mappings in [codeMaps].
      */
-    private fun generateCode(fsa: IFileSystemAccess2, federate: FederateInstance, codeMaps: MutableMap<Path, CodeMap>) {
+    private fun generateCode(federate: FederateInstance, codeMaps: MutableMap<Path, CodeMap>) {
         var tsFileName = fileConfig.name
         // TODO(hokeun): Consider using FedFileConfig when enabling federated execution for TypeScript.
         // For details, see https://github.com/icyphy/lingua-franca/pull/431#discussion_r676302102
@@ -272,7 +270,7 @@ class TSGenerator(
         tsCode.append(reactorGenerator.generateReactorInstanceAndStart(this.mainDef, mainParameters))
         val codeMap = CodeMap.fromGeneratedCode(tsCode.toString())
         codeMaps[tsFilePath] = codeMap
-        fsa.generateFile(fileConfig.srcGenBasePath.relativize(tsFilePath).toString(), codeMap.generatedCode)
+        JavaGeneratorUtils.writeToFile(codeMap.generatedCode, tsFilePath.toString())
 
         if (targetConfig.dockerOptions != null && isFederated) {
             println("WARNING: Federated Docker file generation is not supported on the Typescript target. No docker file is generated.")
@@ -281,8 +279,8 @@ class TSGenerator(
             val dockerComposeFile = fileConfig.srcGenPath.resolve("docker-compose.yml")
             val dockerGenerator = TSDockerGenerator(tsFileName)
             println("docker file written to $dockerFilePath")
-            fsa.generateFile(fileConfig.srcGenBasePath.relativize(dockerFilePath).toString(), dockerGenerator.generateDockerFileContent())
-            fsa.generateFile(fileConfig.srcGenBasePath.relativize(dockerComposeFile).toString(), dockerGenerator.generateDockerComposeFileContent())
+            JavaGeneratorUtils.writeToFile(dockerGenerator.generateDockerFileContent(), dockerFilePath.toString())
+            JavaGeneratorUtils.writeToFile(dockerGenerator.generateDockerComposeFileContent(), dockerComposeFile.toString())
         }
     }
 


### PR DESCRIPTION
#929 is not the first bug that was related to `IFileSystemAccess2` (see acf98595). In #929, writing to a file caused an error in `org.eclipse.core.runtime.SubMonitor`, a progress reporting class which I could not find the source code for. It is annoying for trivial operations like writing to files to cause `IllegalStateException`s in seemingly unrelated parts of the framework whose state is only ever touched in other, distant parts of our code base.

For this reason, this PR eliminates `IFileSystemAccess2` wherever possible. In  #149, @cmnrd gave a valid reason why we should use the `IFileSystemAccess2` interface (it specifies the `src-gen` directory), but this PR preserves the code that gets the location of the `src-gen` directory from the `IFileSystemAccess2`.

**EDIT:** This change has been tested in Epoch by compiling at least one test program in Epoch for each target.