### PR TITLE
Report raw, unparsed error streams as a last resort.

### DIFF
--- a/org.lflang/src/org/lflang/generator/rust/RustGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/rust/RustGenerator.kt
@@ -136,7 +136,9 @@ class RustGenerator(
         } else if (context.cancelIndicator.isCanceled) {
             context.finish(GeneratorResult.CANCELLED)
         } else {
-            if (!errorsOccurred()) errorReporter.reportError("cargo failed with error code $cargoReturnCode")
+            if (!errorsOccurred()) errorReporter.reportError(
+                "cargo failed with error code $cargoReturnCode and reported the following error(s):\n${cargoCommand.errors}"
+            )
             context.finish(GeneratorResult.FAILED)
         }
     }

--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -378,7 +378,7 @@ class TSGenerator(
         val protoc = commandFactory.createCommand("protoc", protocArgs, tsFileConfig.srcPath)
 
         if (protoc == null) {
-            errorReporter.reportError("Processing .proto files requires libprotoc >= 3.6.1")
+            errorReporter.reportError("Processing .proto files requires libprotoc >= 3.6.1.")
             return
         }
 
@@ -393,7 +393,7 @@ class TSGenerator(
 //                targetConfig.compileLibraries.add('-l')
 //                targetConfig.compileLibraries.add('protobuf-c')
         } else {
-            errorReporter.reportError("protoc returns error code $returnCode")
+            errorReporter.reportError("protoc failed with error code $returnCode.")
         }
         // FIXME: report errors from this command.
     }
@@ -426,7 +426,7 @@ class TSGenerator(
         if (babel.run(cancelIndicator) == 0) {
             println("SUCCESS (compiling generated TypeScript code)")
         } else {
-            errorReporter.reportError("Compiler failed.")
+            errorReporter.reportError("Compiler failed with the following errors:\n${babel.errors}")
         }
     }
 


### PR DESCRIPTION
Fixes #936.

Incidentally, a small change is also added in the TypeScript generator in anticipation of a similar edge case. A quick glance at the other code generators suggests that they should not have this problem currently.