### PR TITLE
Scale back LSP tests

### DIFF
--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -51,7 +51,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
       - name: Perform tests for C target with default scheduler
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.CTest.* --tests org.lflang.tests.lsp.LspTests.lspWithDependenciesTestC
+          ./gradlew test --tests org.lflang.tests.runtime.CTest.*
         if: ${{ !inputs.use-cpp && !inputs.scheduler }}
       - name: Perform tests for C target with specified scheduler (no LSP tests)
         run: |

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ inputs.runtime-ref }} 
       - name: Run C++ tests;
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.CppTest.* --tests org.lflang.tests.lsp.LspTests.lspWithDependenciesTestCpp
+          ./gradlew test --tests org.lflang.tests.runtime.CppTest.*
       - name: Report to CodeCov
         uses: codecov/codecov-action@v2.1.0
         with:

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -57,7 +57,7 @@ jobs:
           brew install protobuf-c
         if: ${{ runner.os == 'macOS' }}
       - name: Run language server Python tests without PyLint
-        run: ./gradlew test --tests org.lflang.tests.lsp.LspTests.pythonSyntaxOnlyValidationTest
+        run: ./gradlew test --tests org.lflang.tests.lsp.LspTests.pythonValidationTestSyntaxOnly
       - name: Report to CodeCov
         uses: codecov/codecov-action@v2.1.0
         with:

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -57,7 +57,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
       - name: Run Python tests
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.PythonTest.* --tests org.lflang.tests.lsp.LspTests.lspWithDependenciesTestPython
+          ./gradlew test --tests org.lflang.tests.runtime.PythonTest.*
       - name: Report to CodeCov
         uses: codecov/codecov-action@v2.1.0
         with:

--- a/.github/workflows/rs-tests.yml
+++ b/.github/workflows/rs-tests.yml
@@ -37,7 +37,7 @@ jobs:
         if: ${{ inputs.runtime-ref }}  
       - name: Run Rust tests
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.RustTest.* --tests org.lflang.tests.lsp.LspTests.lspWithDependenciesTestRust
+          ./gradlew test --tests org.lflang.tests.runtime.RustTest.*
       - name: Report to CodeCov
         uses: codecov/codecov-action@v2.1.0
         with:

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -47,7 +47,7 @@ jobs:
         if: ${{ inputs.runtime-ref }}
       - name: Perform TypeScript tests
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* --tests org.lflang.tests.lsp.LspTests.lspWithDependenciesTestTypeScript
+          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.*
       - name: Report to CodeCov
         uses: codecov/codecov-action@v2.1.0
         with:

--- a/org.lflang.tests/src/org/lflang/tests/lsp/ErrorInserter.java
+++ b/org.lflang.tests/src/org/lflang/tests/lsp/ErrorInserter.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
  *
  * @author Peter Donovan <peterdonovan@berkeley.edu>
  */
+@SuppressWarnings("ClassCanBeRecord")
 class ErrorInserter {
 
     /** A basic error inserter builder on which more specific error inserters can be built. */
@@ -125,6 +126,21 @@ class ErrorInserter {
             if (!swapFile(path).toFile().renameTo(path.toFile())) {
                 throw new IOException("Failed to restore the altered LF file to its original state.");
             }
+        }
+
+        @Override
+        public String toString() {
+            int lengthOfPrefix = 6;
+            StringBuilder ret = new StringBuilder(
+                lines.stream().mapToInt(String::length).reduce(0, Integer::sum)
+                + lines.size() * lengthOfPrefix
+            );
+            for (int i = 0; i < lines.size(); i++) {
+                ret.append(badLines.contains(i) ? "-> " : "   ")
+                   .append(String.format("%1$2s ", i))
+                   .append(lines.get(i)).append("\n");
+            }
+            return ret.toString();
         }
 
         /** Return the lines where this differs from the test from which it was derived. */

--- a/org.lflang.tests/src/org/lflang/tests/lsp/LspTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/lsp/LspTests.java
@@ -50,7 +50,7 @@ class LspTests {
 
     /** Test for false negatives in Python syntax-only validation. */
     @Test
-    void pythonSyntaxOnlyValidationTest() throws IOException {
+    void pythonValidationTestSyntaxOnly() throws IOException {
         targetLanguageValidationTest(Target.Python, ErrorInserter.PYTHON_SYNTAX_ONLY);
     }
 

--- a/org.lflang.tests/src/org/lflang/tests/lsp/LspTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/lsp/LspTests.java
@@ -22,6 +22,7 @@ import org.lflang.generator.GeneratorResult;
 import org.lflang.generator.IntegratedBuilder;
 import org.lflang.generator.LanguageServerErrorReporter;
 import org.lflang.tests.LFTest;
+import org.lflang.tests.TestBase;
 import org.lflang.tests.TestRegistry;
 import org.lflang.tests.TestRegistry.TestCategory;
 import org.lflang.tests.lsp.ErrorInserter.AlteredTest;
@@ -95,7 +96,13 @@ class LspTests {
                     boolean result = NOT_SUPPORTED.test(diagnostics) || diagnostics.stream().anyMatch(
                         diagnostic -> diagnostic.getRange().getStart().getLine() == badLine
                     );
-                    System.out.println(result ? " Success." : " but the expected error could not be found.");
+                    if (result) {
+                        System.out.println(" Success.");
+                    } else {
+                        System.out.println(" but the expected error could not be found.");
+                        System.out.println("The following test failed:\n" + TestBase.THIN_LINE);
+                        System.out.println(alteredTest + "\n" + TestBase.THIN_LINE);
+                    }
                     return result;
                 }
             )),
@@ -167,7 +174,7 @@ class LspTests {
     }
 
     /**
-     * Returns the predicate that a list of diagnostics contains the given keyword.
+     * Return the predicate that a list of diagnostics contains the given keyword.
      * @param keyword A keyword that a list of diagnostics should be searched for.
      * @return The predicate, "X mentions {@code keyword}."
      */
@@ -178,7 +185,7 @@ class LspTests {
     }
 
     /**
-     * Returns the predicate that a list of diagnostics contains the given text.
+     * Return the predicate that a list of diagnostics contains the given text.
      * @param requiredText A keyword that a list of diagnostics should be searched for.
      * @return The predicate, "X includes {@code requiredText}."
      */

--- a/org.lflang.tests/src/org/lflang/tests/lsp/LspTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/lsp/LspTests.java
@@ -134,11 +134,11 @@ class LspTests {
             client.clearDiagnostics();
             if (alterer != null) {
                 try (AlteredTest altered = alterer.alterTest(test.srcFile)) {
-                    runTest(altered.getPath(), false);
+                    runTest(altered.getPath());
                     Assertions.assertTrue(requirementGetter.apply(altered).test(client.getReceivedDiagnostics()));
                 }
             } else {
-                runTest(test.srcFile, false);
+                runTest(test.srcFile);
                 Assertions.assertTrue(requirementGetter.apply(null).test(client.getReceivedDiagnostics()));
             }
         }
@@ -198,17 +198,14 @@ class LspTests {
     /**
      * Run the given test.
      * @param test An integration test.
-     * @param mustComplete Whether the build must be complete.
-     * @return The result of running the test.
      */
-    private GeneratorResult runTest(Path test, boolean mustComplete) {
+    private void runTest(Path test) {
         MockReportProgress reportProgress = new MockReportProgress();
         GeneratorResult result = builder.run(
             URI.createFileURI(test.toString()),
-            mustComplete, reportProgress,
+            false, reportProgress,
             () -> false
         );
         Assertions.assertFalse(reportProgress.failed());
-        return result;
     }
 }

--- a/org.lflang/src/org/lflang/generator/python/PythonValidator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonValidator.java
@@ -62,8 +62,8 @@ public class PythonValidator extends Validator {
         private String type;
         private String module;
         private String obj;
-        private int line;
-        private int column;
+        private Integer line;
+        private Integer column;
         private Integer endLine;
         private Integer endColumn;
         private Path path;
@@ -82,7 +82,13 @@ public class PythonValidator extends Validator {
         public void setMessage(String message) { this.message = message; }
         @JsonProperty("message-id")
         public void setMessageId(String messageId) { this.messageId = messageId; }
-        public Position getStart() { return Position.fromZeroBased(line - 1, column); }
+        public Position getStart() {
+            if (line != null && column != null) return Position.fromZeroBased(line - 1, column);
+            // Using 0 as fallback for the column will cause bugs by taking some positions out of line adjuster's range.
+            if (line != null) return Position.fromZeroBased(line - 1, 0);
+            // This fallback will always fail with the line adjuster, but at least the program will not crash.
+            return Position.ORIGIN;
+        }
         public Position getEnd() {
             return endLine == null || endColumn == null ? getStart().plus(" ") :
                    Position.fromZeroBased(endLine - 1, endColumn);

--- a/org.lflang/src/org/lflang/generator/python/PythonValidator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonValidator.java
@@ -84,7 +84,8 @@ public class PythonValidator extends Validator {
         public void setMessageId(String messageId) { this.messageId = messageId; }
         public Position getStart() {
             if (line != null && column != null) return Position.fromZeroBased(line - 1, column);
-            // Using 0 as fallback for the column will cause bugs by taking some positions out of line adjuster's range.
+            // Use 0 as fallback for the column. This will cause bugs by taking some positions out of the line
+            // adjuster's range.
             if (line != null) return Position.fromZeroBased(line - 1, 0);
             // This fallback will always fail with the line adjuster, but at least the program will not crash.
             return Position.ORIGIN;
@@ -286,7 +287,7 @@ public class PythonValidator extends Validator {
                             }
                         }
                     } catch (JsonProcessingException e) {
-                        System.out.printf("Failed to parse \"%s\":%n", validationOutput);
+                        System.err.printf("Failed to parse \"%s\":%n", validationOutput);
                         e.printStackTrace();
                         errorReporter.reportWarning(
                             "Failed to parse linter output. The Lingua Franca code generator is tested with Pylint "

--- a/org.lflang/src/org/lflang/generator/python/PythonValidator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonValidator.java
@@ -258,6 +258,7 @@ public class PythonValidator extends Validator {
             @Override
             public Strategy getOutputReportingStrategy() {
                 return (validationOutput, errorReporter, codeMaps) -> {
+                    if (validationOutput.isBlank()) return;
                     try {
                         for (PylintMessage message : mapper.readValue(validationOutput, PylintMessage[].class)) {
                             if (shouldIgnore(message)) continue;
@@ -285,7 +286,7 @@ public class PythonValidator extends Validator {
                             }
                         }
                     } catch (JsonProcessingException e) {
-                        System.out.println(validationOutput);
+                        System.out.printf("Failed to parse \"%s\":%n", validationOutput);
                         e.printStackTrace();
                         errorReporter.reportWarning(
                             "Failed to parse linter output. The Lingua Franca code generator is tested with Pylint "

--- a/org.lflang/src/org/lflang/generator/python/PythonValidator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonValidator.java
@@ -285,11 +285,12 @@ public class PythonValidator extends Validator {
                             }
                         }
                     } catch (JsonProcessingException e) {
+                        System.out.println(validationOutput);
+                        e.printStackTrace();
                         errorReporter.reportWarning(
                             "Failed to parse linter output. The Lingua Franca code generator is tested with Pylint "
                              + "version 2.12.2. Consider updating PyLint if you have an older version."
                         );
-                        e.printStackTrace();
                     }
                 };
             }


### PR DESCRIPTION
This scales back LSP tests because they have been taking a little more computational resources on GitHub Actions than is ideal. Additionally, the "build and run" tests are now redundant.