### PR TITLE
attempt to fix 953

### DIFF
--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -17,7 +17,7 @@ jobs:
         run: sudo apt-get remove clang-*
         if: ${{ runner.os == 'Linux' }}
       - name: Uninstall packages MacOS
-        run: brew uninstall gcc
+        run: brew uninstall --ignore-dependencies gcc
         if: ${{ runner.os == 'macOS' }}
       - name: Uninstall packages Windows
         run: |


### PR DESCRIPTION
See #953 

This PR adds the `--ignore-dependencies` flag to the uninstall GCC instruction according to the error message.