### PR TITLE
Validator cleanups

### DIFF
--- a/org.lflang/src/org/lflang/ModelInfo.java
+++ b/org.lflang/src/org/lflang/ModelInfo.java
@@ -43,6 +43,7 @@ import org.lflang.lf.Instantiation;
 import org.lflang.lf.Model;
 import org.lflang.lf.Parameter;
 import org.lflang.lf.Reactor;
+import org.lflang.lf.STP;
 
 
 /**
@@ -78,6 +79,12 @@ public class ModelInfo {
      * interval.
      */
     public Set<Deadline> overflowingDeadlines;
+    
+    /**
+     * The set of STP offsets that use a too-large constant to specify their time
+     * interval.
+     */
+    public Set<STP> overflowingSTP;
 
     /**
      * The set of parameters used to specify a deadline while having been
@@ -145,6 +152,7 @@ public class ModelInfo {
         this.overflowingAssignments = new HashSet<>();
         this.overflowingDeadlines = new HashSet<>();
         this.overflowingParameters = new HashSet<>();
+        this.overflowingSTP = new HashSet<>();
 
         // Visit all deadlines in the model; detect possible overflow.
         for (var deadline : filter(toIterable(model.eAllContents()), Deadline.class)) {
@@ -156,6 +164,13 @@ public class ModelInfo {
             // If any of the upstream parameters overflow, report this deadline.
             if (detectOverflow(new HashSet<>(), deadline.getDelay().getParameter())) {
                 this.overflowingDeadlines.add(deadline);
+            }
+        }
+        // Visit all deadlines in the model; detect possible overflow.
+        for (var stp : filter(toIterable(model.eAllContents()), STP.class)) {
+            // If the time value overflows, mark this deadline as overflowing.
+            if (isTooLarge(JavaAstUtils.getLiteralTimeValue(stp.getValue()))) {
+                this.overflowingSTP.add(stp);
             }
         }
     }

--- a/org.lflang/src/org/lflang/ModelInfo.java
+++ b/org.lflang/src/org/lflang/ModelInfo.java
@@ -166,7 +166,7 @@ public class ModelInfo {
                 this.overflowingDeadlines.add(deadline);
             }
         }
-        // Visit all deadlines in the model; detect possible overflow.
+        // Visit all STP offsets in the model; detect possible overflow.
         for (var stp : filter(toIterable(model.eAllContents()), STP.class)) {
             // If the time value overflows, mark this deadline as overflowing.
             if (isTooLarge(JavaAstUtils.getLiteralTimeValue(stp.getValue()))) {

--- a/org.lflang/src/org/lflang/validation/LFValidator.java
+++ b/org.lflang/src/org/lflang/validation/LFValidator.java
@@ -112,7 +112,7 @@ import com.google.inject.Inject;
  * @author{Matt Weber <matt.weber@berkeley.edu>}
  * @author{Christian Menard <christian.menard@tu-dresden.de>}
  * @author{Hou Seng Wong <stevenhouseng@gmail.com>}
- * @uathor{Clément Fournier <clement.fournier76@gmail.com>}
+ * @author{Clément Fournier <clement.fournier76@gmail.com>}
  */
 public class LFValidator extends BaseLFValidator {
 


### PR DESCRIPTION
This PR cleans up LFValidator:
* Organize methods for easier browsing.
* Make fields private that are not used anywhere else.
* Remove fields that are not used anywhere at all.
* Rename private static constants to use consistent convention.

This should be merged quickly because of the major file structure reorganization, which will likely lead to conflicts.

There is only one minor functional change: The checkSTPOffset() method was not actually performing any check. Now it is (so there is a supporting change in ModelInfo).