### PR TITLE
FileConfig cleanup

### DIFF
--- a/org.lflang/src/org/lflang/FileConfig.java
+++ b/org.lflang/src/org/lflang/FileConfig.java
@@ -463,7 +463,7 @@ public class FileConfig {
      *  @param destination The file system path that the source file is copied to.
      * @throws IOException If the given source cannot be copied.
      */
-    public void copyFileFromClassPath(String source, String destination) throws IOException {
+    public void copyFileFromClassPath(String source, Path destination) throws IOException {
         InputStream sourceStream = this.getClass().getResourceAsStream(source);
 
         // Copy the file.
@@ -477,10 +477,9 @@ public class FileConfig {
                         "Also try to refresh and clean the project explorer if working from eclipse.");
             }
             // Make sure the directory exists
-            File destFile = new File(destination);
-            destFile.getParentFile().mkdirs();
+            destination.toFile().getParentFile().mkdirs();
 
-            Files.copy(sourceStream, Paths.get(destination), StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(sourceStream, destination, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException ex) {
             throw new IOException(
                 "A required target resource could not be copied: " + source + "\n" +
@@ -497,9 +496,9 @@ public class FileConfig {
      * @param files The list of files to copy.
      * @throws IOException If any of the given files cannot be copied.
      */
-    public void copyFilesFromClassPath(String srcDir, String dstDir, List<String> files) throws IOException {
+    public void copyFilesFromClassPath(String srcDir, Path dstDir, List<String> files) throws IOException {
         for (String file : files) {
-            copyFileFromClassPath(srcDir + '/' + file, dstDir + File.separator + file);
+            copyFileFromClassPath(srcDir + '/' + file, dstDir.resolve(file));
         }
     }
     
@@ -540,7 +539,7 @@ public class FileConfig {
            if (lastSeparator > 0) {
                filenameWithoutPath = fileName.substring(lastSeparator + 1); // FIXME: brittle. What if the file is in a subdirectory?
            }
-           copyFileFromClassPath(fileName, dstDir + File.separator + filenameWithoutPath);
+           copyFileFromClassPath(fileName, dstDir.resolve(filenameWithoutPath));
            return filenameWithoutPath;
        } catch (IOException ex) {
            // Ignore. Previously reported as a warning.

--- a/org.lflang/src/org/lflang/FileConfig.java
+++ b/org.lflang/src/org/lflang/FileConfig.java
@@ -424,17 +424,6 @@ public class FileConfig {
     /**
      * Copy a given file from 'source' to 'destination'.
      *
-     * @param source The source file path string.
-     * @param destination The destination file path string.
-     * @throws IOException if copy fails.
-     */
-    public static void copyFile(String source, String destination)  throws IOException {
-        copyFile(Paths.get(source), Paths.get(destination));
-    }
-
-    /**
-     * Copy a given file from 'source' to 'destination'.
-     *
      * @param source The source file path.
      * @param destination The destination file path.
      * @throws IOException if copy fails.

--- a/org.lflang/src/org/lflang/FileConfig.java
+++ b/org.lflang/src/org/lflang/FileConfig.java
@@ -242,15 +242,6 @@ public class FileConfig {
     }
     
     /**
-     * Get the specified path as an Eclipse IResource or, if it is not found, then
-     * return the iResource for the main file.
-     * 
-     */
-    public IResource getIResource(File file) {
-        return getIResource(file.toURI());
-    }
-    
-    /**
      * Get the specified uri as an Eclipse IResource or, if it is not found, then
      * return the iResource for the main file.
      * For some inexplicable reason, Eclipse uses a mysterious parallel to the file

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
@@ -602,7 +602,7 @@ class CGenerator extends GeneratorBase {
             }
             
             // Copy the core lib
-            fileConfig.copyFilesFromClassPath("/lib/c/reactor-c/core", fileConfig.getSrcGenPath + File.separator + "core", coreFiles)
+            fileConfig.copyFilesFromClassPath("/lib/c/reactor-c/core", fileConfig.getSrcGenPath.resolve("core"), coreFiles)
             // Copy the header files
             copyTargetHeaderFile()
             
@@ -1530,8 +1530,8 @@ class CGenerator extends GeneratorBase {
      * Copy target-specific header file to the src-gen directory.
      */
     def copyTargetHeaderFile() {
-        fileConfig.copyFileFromClassPath("/lib/c/reactor-c/include/ctarget.h", fileConfig.getSrcGenPath + File.separator + "ctarget.h")
-        fileConfig.copyFileFromClassPath("/lib/c/reactor-c/lib/ctarget.c", fileConfig.getSrcGenPath + File.separator + "ctarget.c")
+        fileConfig.copyFileFromClassPath("/lib/c/reactor-c/include/ctarget.h", fileConfig.getSrcGenPath.resolve("ctarget.h"))
+        fileConfig.copyFileFromClassPath("/lib/c/reactor-c/lib/ctarget.c", fileConfig.getSrcGenPath.resolve("ctarget.c"))
     }
 
     ////////////////////////////////////////////

--- a/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
@@ -27,11 +27,11 @@
 package org.lflang.generator.cpp
 
 import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.xtext.generator.IFileSystemAccess2
-import org.lflang.*
-import org.lflang.TargetConfig.Mode
+import org.lflang.ErrorReporter
 import org.lflang.Target
-import org.lflang.generator.canGenerate
+import org.lflang.TargetConfig.Mode
+import org.lflang.TimeUnit
+import org.lflang.TimeValue
 import org.lflang.generator.CodeMap
 import org.lflang.generator.GeneratorBase
 import org.lflang.generator.GeneratorResult
@@ -39,9 +39,13 @@ import org.lflang.generator.IntegratedBuilder
 import org.lflang.generator.JavaGeneratorUtils
 import org.lflang.generator.LFGeneratorContext
 import org.lflang.generator.TargetTypes
+import org.lflang.generator.canGenerate
+import org.lflang.isGeneric
 import org.lflang.lf.Action
 import org.lflang.lf.VarRef
 import org.lflang.scoping.LFGlobalScopeProvider
+import org.lflang.toDefinition
+import org.lflang.toUnixString
 import org.lflang.util.LFCommand
 import java.nio.file.Files
 import java.nio.file.Path
@@ -103,9 +107,9 @@ class CppGenerator(
 
         // copy static library files over to the src-gen directory
         val genIncludeDir = srcGenPath.resolve("__include__")
-        fileConfig.copyFileFromClassPath("$libDir/lfutil.hh", genIncludeDir.resolve("lfutil.hh").toString())
-        fileConfig.copyFileFromClassPath("$libDir/time_parser.hh", genIncludeDir.resolve("time_parser.hh").toString())
-        fileConfig.copyFileFromClassPath("$libDir/3rd-party/cxxopts.hpp", genIncludeDir.resolve("CLI").resolve("cxxopts.hpp").toString())
+        fileConfig.copyFileFromClassPath("$libDir/lfutil.hh", genIncludeDir.resolve("lfutil.hh"))
+        fileConfig.copyFileFromClassPath("$libDir/time_parser.hh", genIncludeDir.resolve("time_parser.hh"))
+        fileConfig.copyFileFromClassPath("$libDir/3rd-party/cxxopts.hpp", genIncludeDir.resolve("CLI").resolve("cxxopts.hpp"))
 
         // keep a list of all source files we generate
         val cppSources = mutableListOf<Path>()

--- a/org.lflang/src/org/lflang/generator/python/PythonGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/python/PythonGenerator.xtend
@@ -1403,15 +1403,15 @@ class PythonGenerator extends CGenerator {
         // This will also overwrite previous versions.
         fileConfig.copyFileFromClassPath(
             "/lib/py/reactor-c-py/include/pythontarget.h",
-            fileConfig.getSrcGenPath.resolve("pythontarget.h").toString
+            fileConfig.getSrcGenPath.resolve("pythontarget.h")
         )
         fileConfig.copyFileFromClassPath(
             "/lib/py/reactor-c-py/lib/pythontarget.c",
-            fileConfig.getSrcGenPath.resolve("pythontarget.c").toString
+            fileConfig.getSrcGenPath.resolve("pythontarget.c")
         )
         fileConfig.copyFileFromClassPath(
             "/lib/c/reactor-c/include/ctarget.h",
-            fileConfig.getSrcGenPath.resolve("ctarget.h").toString
+            fileConfig.getSrcGenPath.resolve("ctarget.h")
         )
     }
 

--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -26,7 +26,6 @@
 package org.lflang.generator.ts
 
 import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.xtext.generator.IFileSystemAccess2
 import org.eclipse.xtext.util.CancelIndicator
 import org.lflang.ErrorReporter
 import org.lflang.inferredType
@@ -214,7 +213,7 @@ class TSGenerator(
         for (runtimeFile in RUNTIME_FILES) {
             fileConfig.copyFileFromClassPath(
                 "$LIB_PATH/reactor-ts/src/core/$runtimeFile",
-                tsFileConfig.tsCoreGenPath().resolve(runtimeFile).toString()
+                tsFileConfig.tsCoreGenPath().resolve(runtimeFile)
             )
         }
     }
@@ -235,7 +234,7 @@ class TSGenerator(
                     "No '" + configFile + "' exists in " + fileConfig.srcPath +
                             ". Using default configuration."
                 )
-                fileConfig.copyFileFromClassPath("$LIB_PATH/$configFile", configFileDest.toString())
+                fileConfig.copyFileFromClassPath("$LIB_PATH/$configFile", configFileDest)
             }
         }
     }


### PR DESCRIPTION
In spirit of #956, this modifies `copyFileFromClasspath` to expect the destination given as a `Path`. This PR further fixes most of the warnings reported by IntelliJ IDEA in `FileConfig`.