### PR TITLE
Improve warning message for unrecognized target parameters

### DIFF
--- a/org.lflang/src/org/lflang/validation/LFValidator.java
+++ b/org.lflang/src/org/lflang/validation/LFValidator.java
@@ -503,7 +503,7 @@ public class LFValidator extends BaseLFValidator {
             if (prop == null) {
                 String options = TargetProperty.getOptions().stream()
                                                .map(p -> p.description).sorted()
-                                               .collect(Collectors.joining(" "));
+                                               .collect(Collectors.joining(", "));
                 warning(
                     "Unrecognized target parameter: " + param.getName() +
                         ". Recognized parameters are: " + options,


### PR DESCRIPTION
Currently, this is printed if a target parameter is not recognized:

```
 Unrecognized target parameter: ros. Recognized parameters are: BUILD, BUILD_TYPE, CLOCK_SYNC, CLOCK_SYNC_OPTIONS, CMAKE_INCLUDE, CMAKE, COMPILER, DOCKER, EXTERNAL_RUNTIME_PATH, FAST, FILES, FLAGS, COORDINATION, COORDINATION_OPTIONS, KEEPALIVE, LOGGING, NO_COMPILE, NO_RUNTIME_VALIDATION, PROTOBUFS, ROS2, RUNTIME_VERSION, SINGLE_FILE_PROJECT, THREADS, TIMEOUT, TRACING, EXPORT_DEPENDENCY_GAPH, EXPORT_TO_YAML, RUST_INCLUDE, CARGO_FEATURES, CARGO_DEPENDENCIES.
```

With this change, the actual parameter names are printed in alphabetical order:

```
Unrecognized target parameter: ros. Recognized parameters are: build build-type cargo-dependencies cargo-features clock-sync clock-sync-options cmake cmake-include compiler coordination coordination-options docker export-dependency-graph export-to-yaml external-runtime-path fast files flags keepalive logging no-compile no-runtime-validation protobufs ros2 runtime-version rust-include single-file-project threads timeout tracing
```