### PR TITLE
Fix port type mismatch in AnytimePrime.lf

### DIFF
--- a/experimental/C/src/AnytimePrime.lf
+++ b/experimental/C/src/AnytimePrime.lf
@@ -55,7 +55,7 @@ reactor Prime {
 }
 
 reactor Print {
-    input in:int;
+    input in:{=long long=};
     reaction(in) {=
         printf("Largest prime found within the deadline: %d\n", in->value);
     =}


### PR DESCRIPTION
Match the type of Print's in port to Prime's out port.