### PR TITLE
Simplify conditional fed codegen

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -484,6 +484,45 @@ public class LinguaFrancaValidationTest {
 //             reactor Foo {
 //                 input in:int;
 //             }
+//             reactor Bar {
+//                 input in:int;
+//                 x1 = new Foo();
+//                 x2 = new Foo();
+//                 in -> x1.in;
+//                 reaction(startup) -> x2.in {=
+//                 =}
+//             }
+//         """
+// Java 11:
+        String testCase = String.join(System.getProperty("line.separator"),
+        "target C;",
+        "",
+        "reactor Foo {",
+        "   input in:int;",
+        "}",
+        "reactor Bar {",
+        "   input in:int;",
+        "   x1 = new Foo();",
+        "   x2 = new Foo();",
+        "   in -> x1.in;",
+        "   reaction(startup) -> x2.in {=",
+        "   =}",
+        "}");
+        validator.assertNoErrors(parseWithoutError(testCase));
+    }
+
+    /**
+     * Allow connection to the port of a contained reactor if another port with same name is effect of a reaction.
+     */
+    @Test
+    public void connectionToEffectPort3_5() throws Exception {
+// Java 17:
+//         String testCase = """
+//             target C;
+//
+//             reactor Foo {
+//                 input in:int;
+//             }
 //             main reactor {
 //                 input in:int;
 //                 x1 = new Foo();
@@ -508,7 +547,8 @@ public class LinguaFrancaValidationTest {
         "   reaction(startup) -> x2.in {=",
         "   =}",
         "}");
-        validator.assertNoErrors(parseWithoutError(testCase));
+        validator.assertError(parseWithoutError(testCase), LfPackage.eINSTANCE.getVariable(), null,
+                "Main reactor cannot have inputs.");
     }
 
     /**

--- a/org.lflang/src/org/lflang/federated/CGeneratorExtension.java
+++ b/org.lflang/src/org/lflang/federated/CGeneratorExtension.java
@@ -32,10 +32,10 @@ import org.lflang.TimeValue;
 import org.lflang.generator.ReactorInstance;
 import org.lflang.generator.c.CGenerator;
 import org.lflang.generator.c.CUtil;
+import org.lflang.lf.Action;
 import org.lflang.lf.Delay;
 import org.lflang.lf.Input;
 import org.lflang.lf.Parameter;
-import org.lflang.lf.Port;
 import org.lflang.lf.Reactor;
 import org.lflang.lf.ReactorDecl;
 import org.lflang.lf.VarRef;
@@ -102,8 +102,7 @@ public class CGeneratorExtension {
                 builder.append(
                         "// Initialize the array of pointers to network input port triggers\n"
                                 + "_fed.triggers_for_network_input_control_reactions_size = "
-                                + federate.networkInputControlReactionsTriggers
-                                .size()
+                                + federate.networkInputControlReactionsTriggers.size()
                                 + ";\n"
                                 + "_fed.triggers_for_network_input_control_reactions = (trigger_t**)malloc("
                                 + "_fed.triggers_for_network_input_control_reactions_size * sizeof(trigger_t*)"
@@ -151,7 +150,7 @@ public class CGeneratorExtension {
         String nameOfSelfStruct = CUtil.reactorRef(instance);
 
         // Initialize triggers for network input control reactions
-        for (Port trigger : federate.networkInputControlReactionsTriggers) {
+        for (Action trigger : federate.networkInputControlReactionsTriggers) {
             // Check if the trigger belongs to this reactor instance
             if (ASTUtils.allReactions(reactor).stream().anyMatch(r -> {
                 return r.getTriggers().stream().anyMatch(t -> {
@@ -167,8 +166,7 @@ public class CGeneratorExtension {
                         + trigger.getName()
                         + " to the global list of network input ports.\n"
                         + "_fed.triggers_for_network_input_control_reactions["
-                        + federate.networkInputControlReactionsTriggers
-                        .indexOf(trigger)
+                        + federate.networkInputControlReactionsTriggers.indexOf(trigger)
                         + "]= &" + nameOfSelfStruct + "" + "->_lf__"
                         + trigger.getName() + ";\n");
             }
@@ -176,7 +174,7 @@ public class CGeneratorExtension {
 
         nameOfSelfStruct = CUtil.reactorRef(instance);
 
-        // Initialize the trigger for network output control reactions if it doesn't exists
+        // Initialize the trigger for network output control reactions if it doesn't exist.
         if (federate.networkOutputControlReactionsTrigger != null) {
             builder.append("_fed.trigger_for_network_output_control_reactions=&"
                     + nameOfSelfStruct

--- a/org.lflang/src/org/lflang/federated/FederateInstance.java
+++ b/org.lflang/src/org/lflang/federated/FederateInstance.java
@@ -35,8 +35,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.base.Objects;
-
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.lflang.ASTUtils;
 import org.lflang.ErrorReporter;
@@ -60,6 +58,8 @@ import org.lflang.lf.Timer;
 import org.lflang.lf.TriggerRef;
 import org.lflang.lf.VarRef;
 import org.lflang.lf.Variable;
+
+import com.google.common.base.Objects;
 
 
 /** 
@@ -288,51 +288,7 @@ public class FederateInstance {
         
         return false;        
     }
-    
-    /**
-     * Return true if the specified reactor is not the top-level federated reactor,
-     * or if it is and the port should be included in the code generated
-     * for the federate. This means that the port has been used as a trigger, 
-     * a source, or an effect in a top-level reaction that belongs to this federate.
-     * 
-     * @param port The Port
-     * @return True if this federate contains the action in the specified reactor
-     */
-    public boolean contains(Port port) {
-        Reactor reactor  = (Reactor) port.eContainer();
-        if (!reactor.isFederated() || this.isSingleton()) return true;
-        
-        // If the port is used as a trigger, a source, or an effect for a top-level reaction
-        // that belongs to this federate, then return true.
-        for (Reaction react : ASTUtils.allReactions(reactor)) {
-            if (contains(react)) {
-                // Look in triggers
-                for (TriggerRef trigger : react.getTriggers() ) {
-                    if (trigger instanceof VarRef) {
-                        VarRef triggerAsVarRef = (VarRef) trigger;
-                        if (Objects.equal(triggerAsVarRef.getVariable(), (Variable) port)) {
-                            return true;
-                        }
-                    }
-                }
-                // Look in sources
-                for (VarRef source : convertToEmptyListIfNull(react.getSources())) {
-                    if (Objects.equal(source.getVariable(), (Variable) port)) {
-                        return true;
-                    }
-                }
-                // Look in effects
-                for (VarRef effect : convertToEmptyListIfNull(react.getEffects())) {
-                    if (Objects.equal(effect.getVariable(), (Variable) port)) {
-                        return true;
-                    }
-                }
-            }
-        }
-        
-        return false;
-    }
-        
+            
     /** 
      * Return true if the specified reaction should be included in the code generated for this
      * federate at the top-level. This means that if the reaction is triggered by or

--- a/org.lflang/src/org/lflang/federated/FederateInstance.java
+++ b/org.lflang/src/org/lflang/federated/FederateInstance.java
@@ -51,7 +51,6 @@ import org.lflang.lf.Delay;
 import org.lflang.lf.Input;
 import org.lflang.lf.Instantiation;
 import org.lflang.lf.Output;
-import org.lflang.lf.Port;
 import org.lflang.lf.Reaction;
 import org.lflang.lf.Reactor;
 import org.lflang.lf.Timer;
@@ -205,7 +204,7 @@ public class FederateInstance {
      * A list of triggers for network input control reactions. This is used to trigger
      * all the input network control reactions that might be nested in a hierarchy.
      */
-    public List<Port> networkInputControlReactionsTriggers = new ArrayList<>();
+    public List<Action> networkInputControlReactionsTriggers = new ArrayList<>();
     
     /**
      * The trigger that triggers the output control reaction of this
@@ -288,15 +287,17 @@ public class FederateInstance {
         
         return false;        
     }
-            
+
     /** 
      * Return true if the specified reaction should be included in the code generated for this
      * federate at the top-level. This means that if the reaction is triggered by or
      * sends data to a port of a contained reactor, then that reaction
      * is in the federate. Otherwise, return false.
      * 
-     * As a convenience measure, also return true if the reaction is not defined in the top-level 
-     * (federated) reactor, or if the top-level reactor is not federated.
+     * NOTE: This method assumes that it will not be called with reaction arguments
+     * that are within other federates. It should only be called on reactions that are
+     * either at the top level or within this federate. For this reason, for any reaction
+     * not at the top level, it returns true.
      *
      * @param reaction The reaction.
      */

--- a/org.lflang/src/org/lflang/generator/NamedInstance.java
+++ b/org.lflang/src/org/lflang/generator/NamedInstance.java
@@ -127,6 +127,21 @@ public abstract class NamedInstance<T extends EObject> {
     }
     
     /**
+     * Return the parent at the given depth or null if there is
+     * no parent at the given depth.
+     * @param d The depth.
+     */
+    public ReactorInstance getParent(int d) {
+        if (d >= depth || d < 0) return null;
+        ReactorInstance p = parent;
+        while (p != null) {
+            if (p.depth == d) return p;
+            p = p.parent;
+        }
+        return null;
+    }
+
+    /**
      * Return the width of this instance, which in this base class is 1.
      * Subclasses PortInstance and ReactorInstance change this to the
      * multiport and bank widths respectively.
@@ -165,19 +180,6 @@ public abstract class NamedInstance<T extends EObject> {
             container = container.parent;
         }
         return result;
-    }
-    
-    /**
-     * Return the root reactor if it is marked as as main or federated,
-     * and otherwise return null.
-     * @return The main/federated top-level parent.
-     */
-    public ReactorInstance main() {
-        ReactorInstance r = this.root();
-        if (r != null && r.isMainOrFederated()) {
-            return r;
-        }
-        return null;
     }
     
     /**

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.xtend
@@ -57,7 +57,6 @@ import org.lflang.federated.FederateInstance
 import org.lflang.federated.launcher.FedCLauncher
 import org.lflang.federated.serialization.FedROS2CPPSerialization
 import org.lflang.federated.serialization.SupportedSerializers
-import org.lflang.generator.ActionInstance
 import org.lflang.generator.CodeBuilder
 import org.lflang.generator.GeneratorBase
 import org.lflang.generator.GeneratorResult

--- a/org.lflang/src/org/lflang/generator/python/PythonGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/python/PythonGenerator.xtend
@@ -1208,47 +1208,36 @@ class PythonGenerator extends CGenerator {
      * Generate the aliases for inputs, outputs, and struct type definitions for 
      * actions of the specified reactor in the specified federate.
      * @param reactor The parsed reactor data structure.
-     * @param federate A federate name, or null to unconditionally generate.
      */
-    override generateAuxiliaryStructs(
-        ReactorDecl decl,
-        FederateInstance federate
-    ) {
+    override generateAuxiliaryStructs(ReactorDecl decl) {
         val reactor = decl.toDefinition
         // First, handle inputs.
         for (input : reactor.allInputs) {
-            if (federate === null || federate.contains(input as Port)) {
-                if (input.inferredType.isTokenType) {
-                    code.pr(input, '''
-                        typedef «generic_port_type_with_token» «variableStructType(input, decl)»;
-                    ''')
-                } else {
-                    code.pr(input, '''
-                        typedef «generic_port_type» «variableStructType(input, decl)»;
-                    ''')
-                }
-
+            if (input.inferredType.isTokenType) {
+                code.pr(input, '''
+                    typedef «generic_port_type_with_token» «variableStructType(input, decl)»;
+                ''')
+            } else {
+                code.pr(input, '''
+                    typedef «generic_port_type» «variableStructType(input, decl)»;
+                ''')
             }
-
         }
         // Next, handle outputs.
         for (output : reactor.allOutputs) {
-            if (federate === null || federate.contains(output as Port)) {
-                if (output.inferredType.isTokenType) {
-                    code.pr(output, '''
-                        typedef «generic_port_type_with_token» «variableStructType(output, decl)»;
-                    ''')
-                } else {
-                    code.pr(output, '''
-                        typedef «generic_port_type» «variableStructType(output, decl)»;
-                    ''')
-                }
-
+            if (output.inferredType.isTokenType) {
+                code.pr(output, '''
+                    typedef «generic_port_type_with_token» «variableStructType(output, decl)»;
+                ''')
+            } else {
+                code.pr(output, '''
+                    typedef «generic_port_type» «variableStructType(output, decl)»;
+                ''')
             }
         }
         // Finally, handle actions.
         for (action : reactor.allActions) {
-            if (federate === null || federate.contains(action)) {
+            if (currentFederate.contains(action)) {
                 code.pr(action, '''
                     typedef «generic_action_type» «variableStructType(action, decl)»;
                 ''')
@@ -1822,13 +1811,11 @@ class PythonGenerator extends CGenerator {
      * This function is provided to allow extensions of the CGenerator to append the structure of the self struct
      * @param selfStructBody The body of the self struct
      * @param decl The reactor declaration for the self struct
-     * @param instance The current federate instance
      * @param constructorCode Code that is executed when the reactor is instantiated
      */
     override generateSelfStructExtension(
         CodeBuilder selfStructBody, 
         ReactorDecl decl, 
-        FederateInstance instance, 
         CodeBuilder constructorCode
     ) {
         val reactor = decl.toDefinition

--- a/org.lflang/src/org/lflang/validation/LFValidator.java
+++ b/org.lflang/src/org/lflang/validation/LFValidator.java
@@ -425,6 +425,10 @@ public class LFValidator extends BaseLFValidator {
 
     @Check(CheckType.FAST)
     public void checkInput(Input input) {
+        Reactor parent = (Reactor)input.eContainer();
+        if (parent.isMain() || parent.isFederated()) {
+            error("Main reactor cannot have inputs.", Literals.VARIABLE__NAME);
+        }
         checkName(input.getName(), Literals.VARIABLE__NAME);
         if (target.requiresTypes) {
             if (input.getType() == null) {
@@ -554,6 +558,10 @@ public class LFValidator extends BaseLFValidator {
 
     @Check(CheckType.FAST)
     public void checkOutput(Output output) {
+        Reactor parent = (Reactor)output.eContainer();
+        if (parent.isMain() || parent.isFederated()) {
+            error("Main reactor cannot have outputs.", Literals.VARIABLE__NAME);
+        }
         checkName(output.getName(), Literals.VARIABLE__NAME);
         if (this.target.requiresTypes) {
             if (output.getType() == null) {

--- a/test/C/src/federated/TopLevelArtifacts.lf
+++ b/test/C/src/federated/TopLevelArtifacts.lf
@@ -15,8 +15,6 @@
  import TestCount from "../lib/TestCount.lf";
  
  federated reactor {
-    input in:int;
-    output out:int;
     state successes:int(0);
     reaction (startup) {=
         self->successes++;
@@ -27,15 +25,8 @@
         schedule(act, 0);
     =}
     logical action act(0);
-    reaction (act) in -> out {=
+    reaction (act) {=
         self->successes++;
-        if (in->is_present) {
-            error_print_and_exit("Input is present in the top-level reactor!");
-        }
-        SET(out, 1);
-        if (out->value != 1) {
-            error_print_and_exit("Ouput has unexpected value %d!", out->value);
-        }
     =}
     
     c = new Count();


### PR DESCRIPTION
This PR is a small step towards improving the C codegen structure. It includes the following:
* Disallow ports in top-level reactors and remove such ports from one test that had them.
* Merge nearly identical methods in CGenerator into one consolidated method.
* Homogenize the way that the generator determines which components are included in a federate.
* A few other small fixes.