### PR TITLE
Attributes

### DIFF
--- a/org.lflang.diagram/src/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.xtend
+++ b/org.lflang.diagram/src/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.xtend
@@ -92,7 +92,11 @@ import org.lflang.generator.ReactorInstance
 import org.lflang.generator.TimerInstance
 import org.lflang.generator.TriggerInstance
 import org.lflang.generator.TriggerInstance.BuiltinTriggerVariable
+import org.lflang.lf.Action
 import org.lflang.lf.Model
+import org.lflang.lf.Reaction
+import org.lflang.lf.Reactor
+import org.lflang.lf.Timer
 
 import static extension org.eclipse.emf.ecore.util.EcoreUtil.*
 import static extension org.lflang.ASTUtils.*
@@ -1078,8 +1082,31 @@ class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
 	
 	private def Iterable<KNode> createUserComments(EObject element, KNode targetNode) {
 		if (SHOW_USER_LABELS.booleanValue) {
-			val commentText = ASTUtils.findAnnotationInComments(element, "@label")
-			
+			var String commentText
+			// The list of elements where labels could be placed.
+			switch element {
+				Reaction : {
+					var list = element.getAttributes.filter[ it.attrName.toString === 'label' ]
+					if (list.length != 0)
+						commentText = list.get(0).getAttrParms.get(0).getValue.replaceAll("^\"|\"$", "")
+				}
+				Reactor : {
+					var list = element.getAttributes.filter[ it.attrName.toString === 'label' ]
+					if (list.length != 0)
+						commentText = list.get(0).getAttrParms.get(0).getValue.replaceAll("^\"|\"$", "")
+				}
+				Action : {
+					var list = element.getAttributes.filter[ it.attrName.toString === 'label' ]
+					if (list.length != 0)
+						commentText = list.get(0).getAttrParms.get(0).getValue.replaceAll("^\"|\"$", "")
+				}
+				Timer : {
+					var list = element.getAttributes.filter[ it.attrName.toString === 'label' ]
+					if (list.length != 0)
+						commentText = list.get(0).getAttrParms.get(0).getValue.replaceAll("^\"|\"$", "")
+				}
+			}
+
 			if (!commentText.nullOrEmpty) {
 				val comment = createNode()
 		        comment.setLayoutOption(CoreOptions.COMMENT_BOX, true)

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -85,7 +85,7 @@ QualifiedNameWithWildcard:
  * Declaration of a reactor class.
  */
 Reactor:
-    {Reactor} ((federated?='federated' | main?='main')? & realtime?='realtime'?) 'reactor' (name=ID)? 
+    {Reactor} (attributes+=Attribute)* ((federated?='federated' | main?='main')? & realtime?='realtime'?) 'reactor' (name=ID)? 
     ('<' typeParms+=TypeParm (',' typeParms+=TypeParm)* '>')?
     ('(' parameters+=Parameter (',' parameters+=Parameter)* ')')?
     ('at' host=Host)?
@@ -138,7 +138,7 @@ TargetDecl:
  *  - if the `time` type is specified, either a proper time interval and unit
  *  must be given, or a literal or code that denotes zero.
  */
- StateVar:
+StateVar:
     'state' name=ID (
         (':' (type=Type))? 
         ((parens+='(' (init+=Value (','  init+=Value)*)? parens+=')')
@@ -170,7 +170,7 @@ Output:
 // E.g. (0) or (NOW) or (NOW, ONCE) or (100, 1000)
 // The latter means fire with period 1000, offset 100.
 Timer:
-    'timer' name=ID ('(' offset=Value (',' period=Value)? ')')? ';'?;
+    (attributes+=Attribute)* 'timer' name=ID ('(' offset=Value (',' period=Value)? ')')? ';'?;
 
 Boolean:
     TRUE | FALSE
@@ -187,6 +187,7 @@ Boolean:
 // For all actions, minSpacing is the minimum difference between
 // the tags of two subsequently scheduled events.
 Action:
+    (attributes+=Attribute)*
     (origin=ActionOrigin)? 'action' name=ID 
     ('(' minDelay=Value (',' minSpacing=Value (',' policy=STRING)? )? ')')?
     (':' type=Type)? ';'?;
@@ -255,6 +256,9 @@ Attribute:
 ;
 
 AttrParm:
+    (name=ID '=')? value=AttrParmValue;
+
+AttrParmValue:
     STRING
 ;
 

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -192,6 +192,7 @@ Action:
     (':' type=Type)? ';'?;
 
 Reaction:
+    (attributes+=Attribute)*
     ('reaction')
     ('(' (triggers+=TriggerRef (',' triggers+=TriggerRef)*)? ')')?
     (sources+=VarRef (',' sources+=VarRef)*)?
@@ -246,6 +247,15 @@ Delay:
 // Chooses the serializer to use for the connection
 Serializer:
     'serializer' type=STRING
+;
+
+/////////// Attributes
+Attribute:
+    '@' attrName=AttrName ('(' attrParms+=AttrParm (',' attrParms+=AttrParm)* ')')?
+;
+
+AttrParm:
+    STRING
 ;
 
 /////////// For target parameters
@@ -487,6 +497,9 @@ enum ActionOrigin:
 
 enum Visibility:
     NONE | PRIVATE='private' | PUBLIC='public';
+
+enum AttrName:
+    LABEL='label';
 
 // Note: time units are not keywords, otherwise it would reserve
 // a lot of useful identifiers (like 's' or 'd').

--- a/org.lflang/src/org/lflang/validation/LFValidator.java
+++ b/org.lflang/src/org/lflang/validation/LFValidator.java
@@ -56,6 +56,8 @@ import org.lflang.TimeValue;
 import org.lflang.lf.Action;
 import org.lflang.lf.ActionOrigin;
 import org.lflang.lf.Assignment;
+import org.lflang.lf.Attribute;
+import org.lflang.lf.AttrParm;
 import org.lflang.lf.Connection;
 import org.lflang.lf.Deadline;
 import org.lflang.lf.Host;
@@ -1438,6 +1440,82 @@ public class LFValidator extends BaseLFValidator {
                 ) {
                     error("interleaved can only be used for multiports contained within banks.", Literals.VAR_REF__INTERLEAVED);
                 }
+            }
+        }
+    }
+
+    @Check(CheckType.FAST)
+    public void checkReactionAttributes(Reaction reaction) {
+        EList<Attribute> attrs = reaction.getAttributes();
+        for (Attribute attr : attrs) {
+            switch (attr.getAttrName().toString()) {
+                case "label" :
+                    EList<AttrParm> parms = attr.getAttrParms();
+                    if (parms.size() > 1) {
+                        error("The label attribute only takes 1 parameter.", Literals.REACTION__ATTRIBUTES);
+                    }
+                    String parmName = parms.get(0).getName();
+                    if (parmName != null && !parmName.equals("name")) {
+                        error("Invalid attribute parameter name. The supported parameter name is \"name.\"", Literals.REACTION__ATTRIBUTES);
+                    }
+                    break;
+            }
+        }
+    }
+
+    @Check(CheckType.FAST)
+    public void checkReactorAttributes(Reactor reactor) {
+        EList<Attribute> attrs = reactor.getAttributes();
+        for (Attribute attr : attrs) {
+            switch (attr.getAttrName().toString()) {
+                case "label" :
+                    EList<AttrParm> parms = attr.getAttrParms();
+                    if (parms.size() > 1) {
+                        error("The label attribute only takes 1 parameter.", Literals.REACTOR__ATTRIBUTES);
+                    }
+                    String parmName = parms.get(0).getName();
+                    if (parmName != null && !parmName.equals("name")) {
+                        error("Invalid attribute parameter name. The supported parameter name is \"name.\"", Literals.REACTOR__ATTRIBUTES);
+                    }
+                    break;
+            }
+        }
+    }
+
+    @Check(CheckType.FAST)
+    public void checkActionAttributes(Action action) {
+        EList<Attribute> attrs = action.getAttributes();
+        for (Attribute attr : attrs) {
+            switch (attr.getAttrName().toString()) {
+                case "label" :
+                    EList<AttrParm> parms = attr.getAttrParms();
+                    if (parms.size() > 1) {
+                        error("The label attribute only takes 1 parameter.", Literals.ACTION__ATTRIBUTES);
+                    }
+                    String parmName = parms.get(0).getName();
+                    if (parmName != null && !parmName.equals("name")) {
+                        error("Invalid attribute parameter name. The supported parameter name is \"name.\"", Literals.ACTION__ATTRIBUTES);
+                    }
+                    break;
+            }
+        }
+    }
+
+    @Check(CheckType.FAST)
+    public void checkTimerAttributes(Timer timer) {
+        EList<Attribute> attrs = timer.getAttributes();
+        for (Attribute attr : attrs) {
+            switch (attr.getAttrName().toString()) {
+                case "label" :
+                    EList<AttrParm> parms = attr.getAttrParms();
+                    if (parms.size() > 1) {
+                        error("The label attribute only takes 1 parameter.", Literals.TIMER__ATTRIBUTES);
+                    }
+                    String parmName = parms.get(0).getName();
+                    if (parmName != null && !parmName.equals("name")) {
+                        error("Invalid attribute parameter name. The supported parameter name is \"name.\"", Literals.TIMER__ATTRIBUTES);
+                    }
+                    break;
             }
         }
     }


### PR DESCRIPTION
This is a draft pull request tracking the progress of an annotation system in LF.

This PR extends the syntax to support "attributes," which has the form `@<attrName>(<paramName1> = <paramValue1>, <paramName2> = <paramValue2>, ...)`. `<paramName>` is optional, though @oowekyala pointed out that it would be good to have named parameters to conform with Java annotation grammar.

As a proof of concept, the label mechanism is implemented using an `@label` attribute.

Example: Label.lf
```
target C {
    threads: 1,
    keepalive: true
};

@label(name="This is a controller.")
reactor Controller {
    
    output out:bool;
    
    @label("startup reaction")
    reaction(startup) -> out {==}
}

@label("This is a vision system.")
reactor Vision {
    @label("A timer")
    timer t;
    
    input _in:bool;
    output out:bool;
    state ramp_exists:bool(false);
    
    @label(name="Action") 
    logical action act;
    
    @label(name="Processing visual input")
    reaction(_in) -> out, act {==}
}

reactor Door {
    input _in:bool;
    state door:bool;
    
    reaction(_in) {==}
}

@label("Top-level reactor")
main reactor {
    
    controller  = new Controller();
    vision      = new Vision();
    door        = new Door();
    
    controller.out -> vision._in;
    vision.out -> door._in;
}
```
![label](https://user-images.githubusercontent.com/7968955/155447819-a5759cb7-294d-45eb-aecd-4b903f2736f0.png)

TODOs:
- [ ] Address a `Duplicate AttrParm 'name'` issue.
- [ ] Support a clean way to incorporate DSLs, such as logic, into attributes based on the attribute name.