### PR TITLE
Docker files property

### DIFF
--- a/test/C/src/docker/FilesPropertyContainerized.lf
+++ b/test/C/src/docker/FilesPropertyContainerized.lf
@@ -1,0 +1,15 @@
+target C {
+    files: "../include/hello.h",
+    docker: true
+}
+
+preamble {=
+    #include "hello.h"
+=}
+
+main reactor {
+    reaction(startup) {=
+        hello_t hello;
+        printf("SUCCESS\n");
+    =}
+}

--- a/test/Python/src/docker/FilesPropertyContainerized.lf
+++ b/test/Python/src/docker/FilesPropertyContainerized.lf
@@ -1,0 +1,34 @@
+target Python {
+    files: "../include/hello.py",
+    docker: true
+};
+
+preamble {=
+    try:
+        import hello
+    except:
+        request_stop()
+=}
+
+main reactor {
+    preamble {=
+        try:
+            import hello
+        except:
+            request_stop()
+    =}
+    state passed(false);
+    timer t(1 msec);
+    
+    reaction(t) {=
+        self.passed = True
+    =}
+
+    reaction(shutdown) {=
+        if not self.passed:
+            print("Failed to import file listed in files target property")
+            exit(1)
+        else:
+            print("PASSED")
+    =}
+}


### PR DESCRIPTION
This PR adds tests to verify that the docker file generation works with "files" target property. 
see #887.

The Python target copies everything in `src-gen` to the docker container, so the above functionality works by default.
The C target needs a little tweak since docker does not allow copying of files outside of the build context into the container. I have implemented a fix.
The Typescript target does not seem to use the "files" target property at all during code generation. On top of that, the current docker implementation also copies everything from `src-gen` to the container. So I take that as resolved. 

