### PR TITLE
Build TypeScript examples instead of just validating them

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/AbstractTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/AbstractTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractTest extends TestBase {
     @Test
     public void validateExamples() {
         runTestsForTargets(Message.DESC_EXAMPLES,
-                TestCategory.EXAMPLE::equals, Configurators::noChanges, TestLevel.BUILD,
+                TestCategory.EXAMPLE::equals, Configurators::noChanges, TestLevel.VALIDATION,
                 false);
     }
 

--- a/org.lflang.tests/src/org/lflang/tests/AbstractTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/AbstractTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractTest extends TestBase {
     @Test
     public void validateExamples() {
         runTestsForTargets(Message.DESC_EXAMPLES,
-                TestCategory.EXAMPLE::equals, Configurators::noChanges, TestLevel.VALIDATION,
+                TestCategory.EXAMPLE::equals, Configurators::noChanges, TestLevel.BUILD,
                 false);
     }
 

--- a/org.lflang.tests/src/org/lflang/tests/Configurators.java
+++ b/org.lflang.tests/src/org/lflang/tests/Configurators.java
@@ -73,7 +73,7 @@ public class Configurators {
      * @param test The test to configure.
      * @return True
      */
-    static boolean noChanges(LFTest test) {
+    public static boolean noChanges(LFTest test) {
         return true;
     }
 

--- a/org.lflang.tests/src/org/lflang/tests/runtime/TypeScriptTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/runtime/TypeScriptTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.lflang.Target;
 import org.lflang.tests.AbstractTest;
+import org.lflang.tests.Configurators;
+import org.lflang.tests.TestRegistry.TestCategory;
 
 /**
  * Collection of tests for the TypeScript target.
@@ -67,5 +69,13 @@ public class TypeScriptTest extends AbstractTest {
     @Override
     public void runDockerTests() {
         super.runDockerTests();
+    }
+
+    @Test
+    @Override
+    public void validateExamples() {
+        runTestsForTargets(Message.DESC_EXAMPLES,
+                           TestCategory.EXAMPLE::equals, Configurators::noChanges, TestLevel.BUILD,
+                           false);
     }
 }


### PR DESCRIPTION
Because dependencies are managed through the node package manager, it is straightforward to also build the examples rather than just validate them.