### PR TITLE
Removed unnecessary xtend-gen folder from classpath.

### DIFF
--- a/oomph/LinguaFranca.setup
+++ b/oomph/LinguaFranca.setup
@@ -255,14 +255,7 @@
         targetURL="${git.clone.lingua.franca.location|uri}/org.lflang.ui.tests/src-gen/.dummy">
       <content></content>
     </setupTask>
-    <setupTask
-        xsi:type="setup:ResourceCreationTask"
-        excludedTriggers="BOOTSTRAP"
-        predecessor="git.clone.lingua.franca"
-        targetURL="${git.clone.lingua.franca.location|uri}/org.lflang.ui.tests/xtend-gen/.dummy">
-      <content></content>
-    </setupTask>
-    <description>The git repository does not contain the required src-gen and xtend-gen folders, hence they are created here.</description>
+    <description>The git repository does not contain the required src-gen folders, hence they are created here.</description>
   </setupTask>
   <setupTask
       xsi:type="projects:ProjectsImportTask">

--- a/org.lflang.diagram/.classpath
+++ b/org.lflang.diagram/.classpath
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="xtend-gen"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.lflang.diagram/build.properties
+++ b/org.lflang.diagram/build.properties
@@ -1,5 +1,4 @@
-source.. = src/,\
-           xtend-gen/
+source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\

--- a/org.lflang.tests/.classpath
+++ b/org.lflang.tests/.classpath
@@ -11,11 +11,6 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="test-bin" path="xtend-gen">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="src" output="test-bin" path="src-gen">
 		<attributes>
 			<attribute name="test" value="true"/>

--- a/org.lflang.tests/build.properties
+++ b/org.lflang.tests/build.properties
@@ -1,6 +1,5 @@
 source.. = src/,\
-           src-gen/,\
-           xtend-gen/
+           src-gen/
 bin.includes = .,\
                META-INF/,\
                about.html

--- a/org.lflang.ui.tests/build.properties
+++ b/org.lflang.ui.tests/build.properties
@@ -1,6 +1,5 @@
 source.. = src/,\
-           src-gen/,\
-           xtend-gen/
+           src-gen/
 bin.includes = .,\
                META-INF/,\
                about.html

--- a/org.lflang.ui/.classpath
+++ b/org.lflang.ui/.classpath
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="src-gen"/>
-	<classpathentry kind="src" path="xtend-gen"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.lflang.ui/build.properties
+++ b/org.lflang.ui/build.properties
@@ -1,6 +1,5 @@
 source.. = src/,\
-           src-gen/,\
-           xtend-gen/
+           src-gen/
 bin.includes = .,\
                META-INF/,\
                plugin.xml,\


### PR DESCRIPTION
There is no xtend in lignua franca, therefore, references to the xtend-gen folder can be safely removed.