### PR TITLE
[CI] Bring back PNPM cache.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
   # Run language server tests.
   lsp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@pnpm-cache
 
   # Run the C integration tests.
   c-tests:
@@ -82,4 +82,4 @@ jobs:
 
   # Run the TypeScript integration tests.
   ts-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@pnpm-cache

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -33,6 +33,11 @@ jobs:
         uses: actions/setup-node@v2.1.2
       - name: Install pnpm
         run: npm i -g pnpm
+      - name: Cache .pnpm-store
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-${{ hashFiles('org.lflang/src/lib/ts/package.json') }}
       - name: Setup Rust
         uses: ATiltedTree/setup-rust@v1
         with:

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -25,6 +25,11 @@ jobs:
         uses: actions/setup-node@v2.1.2
       - name: Install pnpm
         run: npm i -g pnpm
+      - name: Cache .pnpm-store
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-${{ hashFiles('org.lflang/src/lib/ts/package.json') }}
       - name: Install Dependencies Ubuntu
         run: sudo apt-get install libprotobuf-dev protobuf-compiler
         if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
The PNPM cache step was deleted [here](c7011df59059c402b0d0c0b3d0ce2c1ed9c7004a) because we were hashing lock files that did not exist and later hashing an enormous number of lock files. This adds back a modified version in an attempt to prevent transient failures like [this](https://github.com/lf-lang/lingua-franca/runs/5492769558?check_suite_focus=true).