### PR TITLE
Automatically cancel old workflow actions

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,4 +1,4 @@
-name: Cancel
+name: Cancel Previous Jobs
 
 on:
   workflow_call:

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cancel:
-    name: 'Cancel Previous Runs'
+    name: run
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,15 @@
+name: Cancel
+
+on:
+  workflow_call:
+
+jobs:
+  cancel:
+    name: 'Cancel Previous Runs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ env:
   vcpkgGitRef: 0bf3923f9fab4001c00f0f429682a0853b5749e0
 
 jobs:
+  # Cancel previous workflow runs
+  cancel:
+    uses: lf-lang/lingua-franca/.github/workflows/cancel.yml@cancel-old-workflows
+
   # Test the Maven build.
   build:
     uses: lf-lang/lingua-franca/.github/workflows/build.yml@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   vcpkgGitRef: 0bf3923f9fab4001c00f0f429682a0853b5749e0
 
 jobs:
-  # Cancel previous workflow runs
+  # Cancel previous workflow runs.
   cancel:
     uses: lf-lang/lingua-franca/.github/workflows/cancel.yml@cancel-old-workflows
 


### PR DESCRIPTION
This PR adds automatic cancellation of old GitHub Actions workflows triggered by an event on the same branch.

See [here](https://github.com/marketplace/actions/cancel-workflow-action) for more information.