### PR TITLE
Broaden a pylint ignore.

### DIFF
--- a/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
@@ -216,7 +216,7 @@ public class PythonGenerator extends CGenerator {
         return String.join("\n", 
             "# List imported names, but do not use pylint's --extension-pkg-allow-list option",
             "# so that these names will be assumed present without having to compile and install.",
-            "from LinguaFranca"+topLevelName+" import (  # pylint: disable=no-name-in-module",
+            "from LinguaFranca"+topLevelName+" import (  # pylint: disable=no-name-in-module, import-error",
             "    Tag, action_capsule_t, compare_tags, get_current_tag, get_elapsed_logical_time,",
             "    get_elapsed_physical_time, get_logical_time, get_microstep, get_physical_time,",
             "    get_start_time, port_capsule, port_instance_token, request_stop, schedule_copy,",


### PR DESCRIPTION
This is just a one-line patch. I am not sure why it's necessary (it worked before!), but it seems harmless in the sense that it won't conceal any errors that would otherwise have been detected.

This change has been tested in Epoch.