### PR TITLE
Removed broken dependency on `org.eclipse.xpand.feature.group`

### DIFF
--- a/org.lflang.targetplatform/org.lflang.targetplatform.target
+++ b/org.lflang.targetplatform/org.lflang.targetplatform.target
@@ -21,7 +21,6 @@
       <unit id="org.eclipse.lsp4j.generator" version="0.0.0"/>
       <unit id="org.eclipse.platform.doc.isv" version="0.0.0"/>
       <unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.xpand.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
       <unit id="javax.xml" version="0.0.0"/>
       <unit id="jakarta.xml.bind" version="0.0.0"/>


### PR DESCRIPTION
There was a spurious dependency in the Oomph configuration that was causing the build to fail. This PR removes that dependency.