### PR TITLE
The files target property: Add support for directories

### DIFF
--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -442,9 +442,9 @@ public class CGenerator extends GeneratorBase {
             var actions = Iterables.filter(IteratorExtensions.toIterable(resource.getAllContents()), Action.class);
             for (Action action : actions) {
                 if (Objects.equal(action.getOrigin(), ActionOrigin.PHYSICAL)) {
-                    // If the unthreaded runtime is requested, use the threaded runtime instead
+                    // If the unthreaded runtime is not requested by the user, use the threaded runtime instead
                     // because it is the only one currently capable of handling asynchronous events.
-                    if (!targetConfig.threading) {
+                    if (!targetConfig.threading && !targetConfig.setByUser.contains(TargetProperty.THREADING)) {
                         targetConfig.threading = true;
                         errorReporter.reportWarning(
                             action,

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -1028,7 +1028,7 @@ public class CGenerator extends GeneratorBase {
     }
     
     /**
-     * Copy all files listed in the target property `files` and `cmake-include` 
+     * Copy all files or directories listed in the target property `files` and `cmake-include` 
      * into the src-gen folder of the main .lf file
      * 
      * @param targetConfig The targetConfig to read the `files` and `cmake-include` from.

--- a/org.lflang/src/org/lflang/generator/c/CUtil.java
+++ b/org.lflang/src/org/lflang/generator/c/CUtil.java
@@ -571,7 +571,7 @@ public class CUtil {
     public static String copyFileOrResource(String fileName, Path srcDir,
             Path dstDir) {
         // Try to copy the file or directory from the file system.
-        Path file = findFileOrFolder(fileName, srcDir);
+        Path file = findFileOrDirectory(fileName, srcDir);
         if (file != null) {
             Path target = dstDir.resolve(file.getFileName());
             try {
@@ -639,19 +639,18 @@ public class CUtil {
     }
 
     /**
-     * Search for a given file or folder name in the given directory.
+     * Search for a given file or directory name in the given directory.
      * If not found, search in directories in LF_CLASSPATH.
      * If there is no LF_CLASSPATH environment variable, use CLASSPATH,
-     * if it is defined.
-     * The first file or folder that is found will be returned. Otherwise,
-     * null is returned.
+     * if it is defined. The first file or directory that is found will 
+     * be returned. Otherwise, null is returned.
      *
-     * @param fileName The file name or relative path + file name
-     * in plain string format
-     * @param directory String representation of the director to search in.
-     * @return A Java file or null if not found
+     * @param fileName The file or directory name or relative path + name
+     * as a String.
+     * @param directory String representation of the directory to search in.
+     * @return A Java Path or null if not found.
      */
-    public static Path findFileOrFolder(String fileName, Path directory) {
+    public static Path findFileOrDirectory(String fileName, Path directory) {
         Path foundFile;
 
         // Check in local directory

--- a/org.lflang/src/org/lflang/generator/c/CUtil.java
+++ b/org.lflang/src/org/lflang/generator/c/CUtil.java
@@ -553,7 +553,7 @@ public class CUtil {
     }
 
     /**
-     * Copy the 'fileName' (which could also point to a directory) from the
+     * Copy the 'fileName' (which also could be a directory name) from the
      * 'srcDirectory' to the 'destinationDirectory'. This function has a
      * fallback search mechanism, where if `fileName` is not found in the
      * `srcDirectory`, it will try to find `fileName` via the following
@@ -564,9 +564,9 @@ public class CUtil {
      *        can be '/path/to/class/resource'. @see java.lang.Class.getResourceAsStream()
      *
      * @param fileName Name of the file or directory.
-     * @param srcDir   Where the file is currently located
-     * @param dstDir   Where the file should be placed
-     * @return The name of the file in destinationDirectory
+     * @param srcDir   Where the file or directory is currently located.
+     * @param dstDir   Where the file or directory should be placed.
+     * @return The name of the file or directory in destinationDirectory.
      */
     public static String copyFileOrResource(String fileName, Path srcDir,
             Path dstDir) {
@@ -584,24 +584,16 @@ public class CUtil {
                 return file.getFileName().toString();
             } catch (IOException e) {
                 // Files has failed to copy the file or directory, possibly
-                // since
-                // it doesn't exist. Will try to find it as a
+                // since it doesn't exist. Will try to find it as a
                 // resource before giving up.
             }
         }
 
         String filenameWithoutPath = fileName;
         int lastSeparator = fileName.lastIndexOf(File.separator);
-        if (lastSeparator > 0) {
-            filenameWithoutPath = fileName.substring(lastSeparator + 1); // FIXME:
-                                                                         // brittle.
-                                                                         // What
-                                                                         // if
-                                                                         // the
-                                                                         // file
-                                                                         // is
-                                                                         // in a
-                                                                         // subdirectory?
+        if (lastSeparator > 0) { 
+            // FIXME: Brittle. What if the file is in a subdirectory?
+            filenameWithoutPath = fileName.substring(lastSeparator + 1);
         }
         // Try to copy the file or directory as a resource.
         try {
@@ -609,7 +601,7 @@ public class CUtil {
                     dstDir.resolve(filenameWithoutPath));
             return filenameWithoutPath;
         } catch (IOException ex) {
-            // Try one more time as a directory
+            // Will try one more time as a directory
         }
 
         try {

--- a/org.lflang/src/org/lflang/generator/c/CUtil.java
+++ b/org.lflang/src/org/lflang/generator/c/CUtil.java
@@ -566,7 +566,7 @@ public class CUtil {
      * @param fileName Name of the file or directory.
      * @param srcDir   Where the file or directory is currently located.
      * @param dstDir   Where the file or directory should be placed.
-     * @return The name of the file or directory in destinationDirectory.
+     * @return The name of the file or directory in destinationDirectory or an empty string on failure.
      */
     public static String copyFileOrResource(String fileName, Path srcDir,
             Path dstDir) {

--- a/org.lflang/src/org/lflang/generator/c/CUtil.java
+++ b/org.lflang/src/org/lflang/generator/c/CUtil.java
@@ -583,8 +583,8 @@ public class CUtil {
                 }
                 return file.getFileName().toString();
             } catch (IOException e) {
-                // Files has failed to copy the file or directory, possibly
-                // since it doesn't exist. Will try to find it as a
+                // Failed to copy the file or directory, most likely
+                // because it doesn't exist. Will try to find it as a
                 // resource before giving up.
             }
         }

--- a/test/C/src/target/Files.lf
+++ b/test/C/src/target/Files.lf
@@ -1,0 +1,19 @@
+/**
+ * Test the files target property.
+ */
+target C {
+    files: ["../include", "include/dummy.h"]
+};
+
+preamble {=
+    #include "include/hello.h"
+    #include "dummy.h"
+=}
+
+main reactor {
+    reaction(startup) {=
+        hello_t t;
+        dummy_t d;
+        info_print("SUCCESS.");
+    =}
+}

--- a/test/C/src/target/include/dummy.h
+++ b/test/C/src/target/include/dummy.h
@@ -1,0 +1,8 @@
+#ifndef DUMMY_H
+#define DUMMY_H
+
+typedef struct dummy_t {
+    int value;
+ } dummy_t;
+
+#endif // DUMMY_H


### PR DESCRIPTION
This adds support for including entire directories in the `files` target property (e.g., `files: ["/etc"]`).

I found this to be very convenient. Imagine a game that requires a number of images that are located in a folder.
It would be convenient to be able to use `files: ["images"]` instead of listing each image file one by one.