### PR TITLE
Fixed Problem with Mode Transitions and Edges in VS Code

### DIFF
--- a/org.lflang.diagram/src/org/lflang/diagram/synthesis/styles/LinguaFrancaStyleExtensions.java
+++ b/org.lflang.diagram/src/org/lflang/diagram/synthesis/styles/LinguaFrancaStyleExtensions.java
@@ -104,11 +104,18 @@ public class LinguaFrancaStyleExtensions extends AbstractSynthesisExtensions {
         _kRenderingExtensions.setLineWidth(r, 2);
         _kRenderingExtensions.setSelectionLineWidth(r, 3);
         
-        if (r.eContainer() instanceof KEdge || r.eContainer() instanceof KPort) {  // also color potential arrow heads
+        // Set background color the body if its a port or an line decorator
+        if (r.eContainer() instanceof KPort || r.eContainer() instanceof KPolyline) {
             _kRenderingExtensions.setBackground(r, Colors.RED);
             _kRenderingExtensions.getBackground(r).setPropagateToChildren(true);
             _kRenderingExtensions.getForeground(r).setPropagateToChildren(true);
             _kRenderingExtensions.getLineWidth(r).setPropagateToChildren(true);
+        } else if (r.eContainer() instanceof KEdge && r instanceof KPolyline) {
+            // As a workaround for a rendering issue in Klighd VSCode, the style is applied to polyline
+            // children directly because a propagated background would lead to a filled edge area.
+            // See https://github.com/kieler/klighd-vscode/issues/67
+            // If fixed this commit can be reverted
+            ((KPolyline) r).getChildren().stream().forEach(c -> errorStyle(c));
         }
     }
     

--- a/org.lflang.diagram/src/org/lflang/diagram/synthesis/util/ModeDiagrams.java
+++ b/org.lflang.diagram/src/org/lflang/diagram/synthesis/util/ModeDiagrams.java
@@ -386,7 +386,6 @@ public class ModeDiagrams extends AbstractSynthesisExtensions {
         var spline = _kEdgeExtensions.addSpline(edge);
         _kRenderingExtensions.setLineWidth(spline, 1.5f);
         _kRenderingExtensions.setForeground(spline, MODE_FG);
-        _kRenderingExtensions.setBackground(spline, MODE_FG);
         _linguaFrancaStyleExtensions.boldLineSelectionStyle(spline);
 
         if (transition.type == ModeTransitionType.HISTORY) {


### PR DESCRIPTION
Fix/workaround for [issue #31 in vscode-lingua-franca](https://github.com/lf-lang/vscode-lingua-franca/issues/31).

Setting the background color on an edge has no effect in Eclipse Klighd but results in a filled area in VSC Klighd.