### PR TITLE
Enable tycho-versions-plugin to manage versioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,13 @@
 
             <plugins>
 
+                <!-- This plugin sets the version of the current project and child projects with the same version, and updates references as necessary.-->
+                <plugin>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>tycho-versions-plugin</artifactId>
+                    <version>${tychoVersion}</version>
+                </plugin>
+
                 <!-- This plugin helps finding the latest plugin or dependency versions for your modules. Open up the terminal and execute this command to find the plugin versions you have to update:
                 mvn versions:display-plugin-updates -->
                 <plugin>
@@ -177,6 +184,12 @@
         </pluginManagement>
 
         <plugins>
+
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-versions-plugin</artifactId>
+                <version>${tychoVersion}</version>
+            </plugin>
 
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>


### PR DESCRIPTION
To bump the Maven and OSGi configuration version numbers to `0.1.0`:
```
mvn org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=0.1.0
mvn org.eclipse.tycho:tycho-versions-plugin:update-eclipse-metadata
```
Thankfully, when the suffix`-SNAPSHOT` is used in the `newVersion`, then `update-eclipse-metadata` updates the Eclipse files with a corresponding `.qualifier` suffix.