### PR TITLE
Switched to building the Python extension module in-place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
   
   # Run the Python integration tests.
   py-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/py-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/py-tests.yml@python-build-update
     needs: cancel
     
   # Run the Rust integration tests.
@@ -105,6 +105,6 @@ jobs:
 
   # Run the serialization tests
   serialization-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/serialization-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/serialization-tests.yml@python-build-update
     needs: cancel
     

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           brew install coreutils
         if: ${{ runner.os == 'macOS' }}
+      - name: Install LinguaFrancaBase
+        run: pip3 install LinguaFrancaBase
       - name: Install Google API Python Client
         run: pip3 install --upgrade google-api-python-client
       - name: Check out lingua-franca repository

--- a/.github/workflows/serialization-tests.yml
+++ b/.github/workflows/serialization-tests.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libprotobuf-c-dev protobuf-c-compiler protobuf-compiler libprotobuf-dev
+      - name: Install LinguaFrancaBase
+        run: pip3 install LinguaFrancaBase
       - name: Run serialization tests;
         run: |
           source /opt/ros/*/setup.bash

--- a/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
@@ -341,9 +341,9 @@ public class PythonGenerator extends CGenerator {
         // To avoid this, we force the linker to allow multiple definitions. Duplicate names would still be caught by the 
         // compiler.
         if (buildCmd.run(context.getCancelIndicator()) == 0) {
-            System.out.println("Successfully installed python extension.");
+            System.out.println("Successfully built Python extension.");
         } else {
-            errorReporter.reportError("Failed to install python extension due to the following errors:\n" +
+            errorReporter.reportError("Failed to build Python extension due to the following error(s):\n" +
                 buildCmd.getErrors());
         }
     }

--- a/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
@@ -284,8 +284,7 @@ public class PythonGenerator extends CGenerator {
             "",
             "linguafranca"+topLevelName+"module = Extension("+StringUtil.addDoubleQuotes(moduleName)+",",
             "                                            sources = ["+String.join(", ", sources)+"],",
-            "                                            define_macros=["+String.join(", ", macros)+"],",
-            "                                            extra_compile_args=[\"-Wno-unused-variable\"])",
+            "                                            define_macros=["+String.join(", ", macros)+"])",
             "",
             "setup(name="+StringUtil.addDoubleQuotes(moduleName)+", version=\"1.0\",",
             "        ext_modules = [linguafranca"+topLevelName+"module],",
@@ -325,7 +324,7 @@ public class PythonGenerator extends CGenerator {
     public void pythonCompileCode(LFGeneratorContext context) {
         // if we found the compile command, we will also find the install command
         LFCommand buildCmd = commandFactory.createCommand(
-            "python3", List.of("setup.py", "build_ext", "--inplace"), fileConfig.getSrcGenPath()
+            "python3", List.of("setup.py", "--quiet", "build_ext", "--inplace"), fileConfig.getSrcGenPath()
         );
 
         if (buildCmd == null) {
@@ -334,6 +333,7 @@ public class PythonGenerator extends CGenerator {
                     "Auto-compiling can be disabled using the \"no-compile: true\" target property.");
             return;
         }
+        buildCmd.setQuiet();
 
         // Set compile time environment variables
         buildCmd.setEnvironmentVariable("CC", targetConfig.compiler); // Use gcc as the compiler


### PR DESCRIPTION
It has been a long-time quirk of the Python target that it installs the generated Python C extension module system-wide, to ensure compatibility.

However, I think I have found a workaround, inspired by the issues @edwardalee was having with the [Pac-Man](https://github.com/lf-lang/experimental-lingua-franca/tree/main/Python/src/Pac-Man) game.

This fix should dramatically reduce the clutter in terms of installed packages in a user's local environment.

It should also make working with virtual environments easier. 