### PR TITLE
Support inline code arguments on main reactor for Rust target

### DIFF
--- a/org.lflang/src/org/lflang/generator/rust/RustCargoTomlEmitter.kt
+++ b/org.lflang/src/org/lflang/generator/rust/RustCargoTomlEmitter.kt
@@ -51,7 +51,7 @@ object RustCargoTomlEmitter : RustEmitterBase() {
             |[dependencies]
             |env_logger = "0.9"
             |log = { version = "0.4", features = ["release_max_level_info"] }
-            |clap = { version = "=3.0.0-beta.5", optional = true }
+            |clap = { version = "3.1.8", features = ["derive", "env"], optional = true }
 ${"         |"..crate.dependencies.asIterable().joinToString("\n") { (name, spec) -> name + " = " + spec.toToml() }}
             |
             |[[bin]]

--- a/org.lflang/src/org/lflang/generator/rust/RustMainFileEmitter.kt
+++ b/org.lflang/src/org/lflang/generator/rust/RustMainFileEmitter.kt
@@ -30,6 +30,7 @@ import org.lflang.generator.PrependOperator
 import org.lflang.generator.PrependOperator.rangeTo
 import org.lflang.generator.UnsupportedGeneratorFeatureException
 import org.lflang.joinWithCommasLn
+import org.lflang.withoutQuotes
 
 
 /**
@@ -243,7 +244,7 @@ ${"         |           "..mainReactor.ctorParams.joinWithCommasLn { "opts." + i
         if (defaultValueAsTimeValue != null)
             append("default_value=\"").append(defaultValueAsTimeValue).append("\", ")
         else if (defaultValue != null)
-            append("default_value=\"").append(defaultValue.removeSurrounding("\"")).append("\", ")
+            append("default_value_t=").append(defaultValue.withoutQuotes()).append(", ")
         else
             append("required=true, ")
 

--- a/test/Rust/src/MainReactorParam.lf
+++ b/test/Rust/src/MainReactorParam.lf
@@ -1,0 +1,9 @@
+target Rust;
+main reactor (one: u64(1152921504606846976), two: u64({= 1 << 60 =})) {
+    state one(one);
+    state two(two);
+
+    reaction(startup) {=
+        assert_eq!(self.one, self.two);
+    =}
+}


### PR DESCRIPTION
Previously inline arguments for the main reactor weren't handled in a way that was appropriate for clap, the CLI library used for Rust reactor programs. 
Basically, it couldn't handle arguments like this: `max_value: u64({= 1 << 60 =})`.

This PR upgrades to a stable version of clap and handles inline arguments correctly. This depends on #1098, so that should be merged first.

Ref: https://github.com/lf-lang/benchmarks-lingua-franca/issues/5