### PR TITLE
Allow bank_index in initializers.

### DIFF
--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -2231,6 +2231,8 @@ public class CGenerator extends GeneratorBase {
      */
     public void generateParameterInitialization(ReactorInstance instance) {
         var selfRef = CUtil.reactorRef(instance);
+        // Declare a local bank_index variable so that initializers can use it.
+        initializeTriggerObjects.pr("int bank_index = "+CUtil.bankIndex(instance)+";");
         for (ParameterInstance parameter : instance.parameters) {
             // NOTE: we now use the resolved literal value. For better efficiency, we could
             // store constants in a global array and refer to its elements to avoid duplicate

--- a/org.lflang/src/org/lflang/generator/python/PythonReactorGenerator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonReactorGenerator.java
@@ -147,6 +147,9 @@ public class PythonReactorGenerator {
                 "for "+PyUtil.bankIndexName(instance)+" in range("+instance.getWidth()+"):"
             ));
             code.indent();
+            // Define a bank_index local variable so that it can be used while
+            // setting parameter values.
+            code.pr("bank_index = "+PyUtil.bankIndexName(instance));
             code.pr(generatePythonClassInstantiation(instance, className));
         }
 

--- a/test/C/src/multiport/BankIndexInitializer.lf
+++ b/test/C/src/multiport/BankIndexInitializer.lf
@@ -1,0 +1,43 @@
+// Test bank of reactors to multiport input with id parameter in the bank.
+target C;
+
+preamble {=
+    int table[] = {4, 3, 2, 1};
+=}
+
+reactor Source(
+    bank_index:int(0),
+    value:int(0)
+) {
+    output out:int;
+    reaction (startup) -> out {=
+        SET(out, self->value);
+    =}
+}
+
+reactor Sink(width:int(4)) {
+    input[width] in:int;
+    state received:bool(false);
+    
+    reaction (in) {=
+        for (int idx = 0; idx < in_width; idx++) {
+            if (in[idx]->is_present) {
+                printf("Received on channel %d: %d\n", idx, in[idx]->value);
+                self->received = true;
+                if (in[idx]->value != 4 - idx) {
+                    error_print_and_exit("Expected %d.", 4 - idx);
+                }
+            }
+        }
+    =}
+    reaction(shutdown) {=
+        if (!self->received) {
+            error_print_and_exit("Sink received no data.");
+        }
+    =}
+}
+main reactor(width:int(4)) {
+    source = new[width] Source(value = {= table[bank_index] =});
+    sink = new Sink(width = width);
+    source.out -> sink.in;
+}

--- a/test/Python/src/multiport/BankIndexInitializer.lf
+++ b/test/Python/src/multiport/BankIndexInitializer.lf
@@ -1,0 +1,41 @@
+// Test bank of reactors to multiport input with id parameter in the bank.
+target Python;
+
+preamble {=
+    table = [4, 3, 2, 1]
+=}
+
+reactor Source(
+    bank_index(0),
+    value(0)
+) {
+    output out;
+    reaction (startup) -> out {=
+        out.set(self.value)
+    =}
+}
+
+reactor Sink(width(4)) {
+    input[width] _in;
+    state received(false);
+    
+    reaction (_in) {=
+        for (idx, port) in enumerate(_in):
+            if port.is_present is True:
+                print("Received on channel {:d}: {:d}".format(idx, port.value))
+                self.received = True
+                if port.value != 4 - idx:
+                    sys.stderr.write("ERROR: expected {:d}\n".format(4 - idx))
+                    exit(1)
+    =}
+    reaction(shutdown) {=
+        if self.received is False:
+            sys.stderr.write("ERROR: Sink received no data\n")
+            exit(1)
+    =}
+}
+main reactor(width(4)) {
+    source = new[width] Source(value = {= table[bank_index] =});
+    sink = new Sink(width = width);
+    source.out -> sink._in;
+}


### PR DESCRIPTION
A common problem with banks is that members of the bank may need to each have its own set of parameter values. The only mechanism we currently offer requires modifying the reactor class itself, which needs to set state variables (rather than parameters) from a global table. This means that the reactor can only be used in a bank and must be written to work in bank.

This PR adds to the C and Python targets the ability to initialize parameters using a table lookup and the `bank_index` variable. Here is an example:

```
target C;
preamble {=
    int table[] = {4, 3, 2, 1};
=}
reactor Source(bank_index:int(0), value:int(0)) {
    output out:int;
    reaction (startup) -> out {=
        SET(out, self->value);
    =}
}
main reactor {
    source = new[4] Source(value = {= table[bank_index] =});
}
```

The `table` defined in the preamble determines the parameter values to use for each bank member.

This change was motivated by @Soroosh129's PacMan game example, where I have made the ghosts into a bank rather than four individual reactor instances.