### PR TITLE
Baremetal spike support

### DIFF
--- a/org.lflang/src/org/lflang/TargetProperty.java
+++ b/org.lflang/src/org/lflang/TargetProperty.java
@@ -1342,6 +1342,7 @@ public enum TargetProperty {
         ARDUINO("Arduino"),
         LINUX("Linux"),
         MAC("Darwin"),
+        SPIKE("Spike"),
         WINDOWS("Windows");
 
         String cMakeName;

--- a/org.lflang/src/org/lflang/generator/c/CCmakeGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CCmakeGenerator.java
@@ -146,6 +146,7 @@ class CCmakeGenerator {
         cMakeCode.pr("${LF_MAIN_TARGET}");
         sources.forEach(cMakeCode::pr);
         cMakeCode.pr("${CoreLib}/platform/${LF_PLATFORM_FILE}");
+        cMakeCode.pr("${LF_ADDITIONAL_SOURCES}");
         additionalSources.forEach(cMakeCode::pr);
         cMakeCode.unindent();
         cMakeCode.pr(")");

--- a/org.lflang/src/org/lflang/generator/c/CCoreFilesUtils.java
+++ b/org.lflang/src/org/lflang/generator/c/CCoreFilesUtils.java
@@ -23,6 +23,7 @@ public class CCoreFilesUtils {
         List<String> coreFiles = new ArrayList<>();
         coreFiles.addAll(getBaseCoreFiles());
         coreFiles.addAll(getPlatformFiles());
+        coreFiles.addAll(getSpikeFiles());
         if (isFederated) {
             coreFiles.addAll(getFederatedFiles());
         }
@@ -104,7 +105,19 @@ public class CCoreFilesUtils {
             "platform/lf_arduino_support.c",
             "platform/lf_arduino_support.h",
             "platform/lf_linux_support.c",
-            "platform/lf_linux_support.h"
+            "platform/lf_linux_support.h",
+            "platform/lf_spike_support.c",
+            "platform/lf_spike_support.h"
+        );
+    }
+
+    private static List<String> getSpikeFiles() {
+        return List.of(
+            "spike/common/crt.S",
+            "spike/common/encoding.h",
+            "spike/common/link.ld",
+            "spike/common/syscall.c",
+            "spike/common/util.h"
         );
     }
 

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -1121,6 +1121,12 @@ public class CGenerator extends GeneratorBase {
                     "core" + File.separator + "platform" + File.separator + "lf_linux_support.c"
                 );
             }
+        } else if (osName.indexOf("spike") >= 0) {
+            if (mainDef != null && !targetConfig.useCmake) {
+                targetConfig.compileAdditionalSources.add(
+                    "core" + File.separator + "platform" + File.separator + "lf_spike_support.c"
+                );
+            }
         } else {
             errorReporter.reportError("Platform " + osName + " is not supported");
         }


### PR DESCRIPTION
Add C support for the risc-v spike platform. Also comes with code generation support for any of the 4 platforms (mac, windows, linux, spike) by setting the "platform" flag.

Also, no longer pulls in every platform support file for all platforms, only pulls in the specific support files needed. Could be used in the future to facilitate cross-compilation and expand support to more platforms. In addition, this could be used to replace the OS macros in https://github.com/lf-lang/reactor-c/blob/main/core/platform.h, which would make custom platforms significantly easier.  