### PR TITLE
diagram: Add categories explicitly to the synthesis options.

### DIFF
--- a/org.lflang.diagram/src/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/org.lflang.diagram/src/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -215,6 +215,8 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
             SHOW_ALL_REACTORS,
             MemorizingExpandCollapseAction.MEMORIZE_EXPANSION_STATES,
             CYCLE_DETECTION,
+            APPEARANCE,
+            ModeDiagrams.MODES_CATEGORY,
             ModeDiagrams.SHOW_TRANSITION_LABELS,
             ModeDiagrams.INITIALLY_COLLAPSE_MODES,
             SHOW_USER_LABELS,


### PR DESCRIPTION
Since the LSP does not allow sending cyclic structures via JSON the
category of a synthesis option is only retrievable by its id. If the
category is not also added as a synthesis option, klighd-vscode omits all

options for which the category is not retrievable. Adding the categories
explicitly solves this.
Bad:

![Screenshot from 2022-04-28 12-59-08](https://user-images.githubusercontent.com/6419799/165738064-4d2a361a-1626-43f4-9a13-06ac76dc7e1c.png)
Good:
![Screenshot from 2022-04-28 13-00-03](https://user-images.githubusercontent.com/6419799/165738101-47188adc-2749-473c-8b4f-9fcd857d4eaf.png)

