### PR TITLE
Prefix print functions with `lf_`

### DIFF
--- a/org.lflang/src/org/lflang/generator/c/CCoreFilesUtils.java
+++ b/org.lflang/src/org/lflang/generator/c/CCoreFilesUtils.java
@@ -1,4 +1,5 @@
 package org.lflang.generator.c;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import org.lflang.TargetProperty.SchedulerOption;
@@ -25,18 +26,9 @@ public class CCoreFilesUtils {
         coreFiles.addAll(getThreadSupportFiles(threading, scheduler));
         return coreFiles;
     }
-
-    public static List<String> getCTargetHeaders() {
-        return List.of(
-            "ctarget_schedule.h",
-            "ctarget_set.h",
-            "ctarget_set_undef.h"
-        );
-    }
-
     public static List<String> getCTargetSrc() {
         return List.of(
-            "ctarget_schedule.c"
+            "ctarget" + File.separator + "schedule.c"
         );
     }
 

--- a/org.lflang/src/org/lflang/generator/c/CCoreFilesUtils.java
+++ b/org.lflang/src/org/lflang/generator/c/CCoreFilesUtils.java
@@ -28,7 +28,8 @@ public class CCoreFilesUtils {
     }
     public static List<String> getCTargetSrc() {
         return List.of(
-            "ctarget" + File.separator + "schedule.c"
+            "ctarget/schedule.c",
+            "ctarget/util.c"
         );
     }
 

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -611,8 +611,8 @@ public class CGenerator extends GeneratorBase {
                         targetConfig.schedulerType
                     )
                 );
-                // Copy the header files
-                copyTargetHeaderFile();
+                // Copy the C target files
+                copyTargetFiles();
             } catch (IOException e) {
                 Exceptions.sneakyThrow(e);
             }
@@ -1273,16 +1273,16 @@ public class CGenerator extends GeneratorBase {
     /**
      * Copy target-specific header file to the src-gen directory.
      */
-    public void copyTargetHeaderFile() throws IOException{
-        FileUtil.copyFilesFromClassPath(
+    public void copyTargetFiles() throws IOException{
+        FileUtil.copyDirectoryFromClassPath(
             "/lib/c/reactor-c/include", 
             fileConfig.getSrcGenPath(),
-            CCoreFilesUtils.getCTargetHeaders()
+            false
         );
-        FileUtil.copyFilesFromClassPath(
+        FileUtil.copyDirectoryFromClassPath(
             "/lib/c/reactor-c/lib", 
             fileConfig.getSrcGenPath(),
-            CCoreFilesUtils.getCTargetSrc()
+            false
         );
     }
 

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -1273,7 +1273,7 @@ public class CGenerator extends GeneratorBase {
     /**
      * Copy target-specific header file to the src-gen directory.
      */
-    public void copyTargetFiles() throws IOException{
+    private void copyTargetFiles() throws IOException{
         FileUtil.copyDirectoryFromClassPath(
             "/lib/c/reactor-c/include", 
             fileConfig.getSrcGenPath(),

--- a/org.lflang/src/org/lflang/generator/c/CNetworkGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CNetworkGenerator.java
@@ -341,7 +341,7 @@ public class CNetworkGenerator {
         result.pr(String.join("\n", 
             "// If the output port has not been SET for the current logical time,",
             "// send an ABSENT message to the receiving federate            ",
-            "LOG_PRINT(\"Contemplating whether to send port \"",
+            "LF_PRINT_LOG(\"Contemplating whether to send port \"",
             "          \"absent for port %d to federate %d.\", ",
             "          "+portID+", "+receivingFederateID+");",
             "if (!"+sendRef+"->is_present) {",

--- a/org.lflang/src/org/lflang/generator/c/CPreambleGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CPreambleGenerator.java
@@ -36,6 +36,7 @@ public class CPreambleGenerator {
         var tracing = targetConfig.tracing;
         CodeBuilder code = new CodeBuilder();
         code.pr("#include \"ctarget/schedule.h\"");
+        code.pr("#include \"ctarget/util.h\"");
         if (targetConfig.threading) {
             code.pr("#include \"core/threaded/reactor_threaded.c\"");
             code.pr("#include \"core/threaded/scheduler.h\"");

--- a/org.lflang/src/org/lflang/generator/c/CPreambleGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CPreambleGenerator.java
@@ -35,8 +35,7 @@ public class CPreambleGenerator {
     ) {
         var tracing = targetConfig.tracing;
         CodeBuilder code = new CodeBuilder();
-        code.pr("#include \"ctarget/schedule.h\"");
-        code.pr("#include \"ctarget/util.h\"");
+        code.pr("#include \"ctarget/ctarget.h\"");
         if (targetConfig.threading) {
             code.pr("#include \"core/threaded/reactor_threaded.c\"");
             code.pr("#include \"core/threaded/scheduler.h\"");

--- a/org.lflang/src/org/lflang/generator/c/CPreambleGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CPreambleGenerator.java
@@ -35,7 +35,7 @@ public class CPreambleGenerator {
     ) {
         var tracing = targetConfig.tracing;
         CodeBuilder code = new CodeBuilder();
-        code.pr("#include \"ctarget_schedule.h\"");
+        code.pr("#include \"ctarget/schedule.h\"");
         if (targetConfig.threading) {
             code.pr("#include \"core/threaded/reactor_threaded.c\"");
             code.pr("#include \"core/threaded/scheduler.h\"");

--- a/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
@@ -1187,7 +1187,7 @@ public class CReactionGenerator {
                         types, errorReporter, mainDef, 
                         isFederatedAndDecentralized, 
                         requiresType);
-        code.pr("#include \"ctarget_set.h\"");
+        code.pr("#include \"ctarget/set.h\"");
         code.pr(generateFunction(
             generateReactionFunctionHeader(decl, reactionIndex),
             init, reaction.getCode()
@@ -1208,7 +1208,7 @@ public class CReactionGenerator {
                 generateDeadlineFunctionHeader(decl, reactionIndex), 
                 init, reaction.getDeadline().getCode()));
         }
-        code.pr("#include \"ctarget_set_undef.h\"");
+        code.pr("#include \"ctarget/set_undef.h\"");
         return code.toString();
     }
 

--- a/org.lflang/src/org/lflang/generator/python/PyUtil.java
+++ b/org.lflang/src/org/lflang/generator/python/PyUtil.java
@@ -169,24 +169,4 @@ public class PyUtil extends CUtil {
 
         return returnValue;
     }
-
-
-    /**
-     * Copy Python specific target code to the src-gen directory
-     */
-    public static void copyTargetFiles(FileConfig fileConfig) throws IOException {
-        // Copy the required target language files into the target file system.
-        // This will also overwrite previous versions.
-        final Path srcGen = fileConfig.getSrcGenPath();
-        FileUtil.copyDirectoryFromClassPath(
-            "/lib/py/reactor-c-py/include",
-             srcGen,
-             false
-        );
-        FileUtil.copyDirectoryFromClassPath(
-            "/lib/py/reactor-c-py/lib",
-             srcGen,
-             false
-        );
-    }
 }

--- a/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
@@ -648,7 +648,7 @@ public class PythonGenerator extends CGenerator {
                 try {
                     Map<Path, CodeMap> codeMapsForFederate = generatePythonFiles(federate);
                     codeMaps.putAll(codeMapsForFederate);
-                    PyUtil.copyTargetFiles(fileConfig);
+                    copyTargetFiles();
                     if (!targetConfig.noCompile) {
                         compilingFederatesContext.reportProgress(
                             String.format("Validating %d/%d sets of generated files...", federateCount, federates.size()),
@@ -872,5 +872,23 @@ public class PythonGenerator extends CGenerator {
 
     private static String generateMacroEntry(String key, String val) {
         return "(" + StringUtil.addDoubleQuotes(key) + ", " + StringUtil.addDoubleQuotes(val) + ")";
+    }
+
+    /**
+     * Copy Python specific target code to the src-gen directory
+     */
+    private void copyTargetFiles() throws IOException {
+        // Copy the required target language files into the target file system.
+        // This will also overwrite previous versions.
+        FileUtil.copyDirectoryFromClassPath(
+            "/lib/py/reactor-c-py/include",
+            fileConfig.getSrcGenPath(),
+            false
+        );
+        FileUtil.copyDirectoryFromClassPath(
+            "/lib/py/reactor-c-py/lib",
+            fileConfig.getSrcGenPath(),
+            false
+        );
     }
 }

--- a/org.lflang/src/org/lflang/generator/python/PythonReactionGenerator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonReactionGenerator.java
@@ -129,7 +129,7 @@ public class PythonReactionGenerator {
                                                 types, errorReporter, mainDef, 
                                                 isFederatedAndDecentralized, 
                                                 Target.Python.requiresTypes);
-        code.pr("#include \"ctarget_set.h\"");
+        code.pr("#include \"ctarget/set.h\"");
         code.pr(generateFunction(
                     CReactionGenerator.generateReactionFunctionHeader(decl, reactionIndex), 
                     cInit, reaction.getCode(), 
@@ -144,7 +144,7 @@ public class PythonReactionGenerator {
                 generateCPythonDeadlineCaller(decl, reactionIndex, pyObjects)
             ));
         }
-        code.pr("#include \"ctarget_set_undef.h\"");
+        code.pr("#include \"ctarget/set_undef.h\"");
         return code.toString();
     }
 

--- a/org.lflang/src/org/lflang/generator/python/PythonReactionGenerator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonReactionGenerator.java
@@ -77,7 +77,7 @@ public class PythonReactionGenerator {
         code.pr(PyUtil.generateGILAcquireCode());
         code.pr(inits);
         code.pr(String.join("\n", 
-                "DEBUG_PRINT(\"Calling reaction function "+reactorDeclName+"."+pythonFunctionName+"\");",
+                "LF_PRINT_DEBUG(\"Calling reaction function "+reactorDeclName+"."+pythonFunctionName+"\");",
                 "PyObject *rValue = PyObject_CallObject(",
                 "    self->"+cpythonFunctionName+", ",
                 "    Py_BuildValue(\"("+"O".repeat(pyObjects.size())+")\""+pyObjectsJoined+")",

--- a/test/C/src/Alignment.lf
+++ b/test/C/src/Alignment.lf
@@ -26,7 +26,7 @@ reactor Sieve {
     reaction(in) -> out {=
         // Reject inputs that are out of bounds.
         if (in->value <= 0 || in->value > 10000) {
-            warning_print("Sieve: Input value out of range: %d.", in->value);
+            lf_print_warning("Sieve: Input value out of range: %d.", in->value);
         }
         // Primes 1 and 2 are not on the list.
         if (in->value == 1 || in->value == 2) {
@@ -52,7 +52,7 @@ reactor Sieve {
             if (prime) {
                 self->last_prime++;
                 self->primes[self->last_prime] = candidate;
-                info_print("Sieve: Found prime: %d.", candidate);
+                lf_print("Sieve: Found prime: %d.", candidate);
             }
         }
         // We are now assured that the input is less than or
@@ -74,13 +74,13 @@ reactor Destination {
     state last_invoked:tag_t({= NEVER_TAG_INITIALIZER =});
     reaction(ok, in) {=
         if (ok->is_present && in->is_present) {
-            info_print("Destination: Input %d is prime at tag (%lld, %d).", 
+            lf_print("Destination: Input %d is prime at tag (%lld, %d).", 
                 in->value,
                 current_tag.time - start_time, current_tag.microstep
             );
         }
         if (lf_tag_compare(current_tag, self->last_invoked) <= 0) {
-            error_print_and_exit("Invoked at tag (%lld, %d), "
+            lf_print_error_and_exit("Invoked at tag (%lld, %d), "
                 "but previously invoked at tag (%lld, %d).",
                 current_tag.time - start_time, current_tag.microstep,
                 self->last_invoked.time - start_time, self->last_invoked.microstep

--- a/test/C/src/FloatLiteral.lf
+++ b/test/C/src/FloatLiteral.lf
@@ -13,9 +13,9 @@ main reactor {
     reaction(startup) {=
         double F = - self->N * self->charge;
         if (fabs(F - self->expected) < fabs(self->minus_epsilon)) {
-            info_print("The Faraday constant is roughly %f.", F);
+            lf_print("The Faraday constant is roughly %f.", F);
         } else {
-            error_print_and_exit(
+            lf_print_error_and_exit(
                 "ERROR: Expected %f but computed %f.",
                 self->expected, F
             );

--- a/test/C/src/GetMicroStep.lf
+++ b/test/C/src/GetMicroStep.lf
@@ -11,7 +11,7 @@ main reactor GetMicroStep {
     reaction(l) -> l {=
         microstep_t microstep = lf_tag().microstep;
         if (microstep != self->s) {
-            error_print_and_exit("expected microstep %d, got %d instead.", self->s, microstep);
+            lf_print_error_and_exit("expected microstep %d, got %d instead.", self->s, microstep);
         }
         self->s += 1;
         if (self->s < 10) {

--- a/test/C/src/MultipleContained.lf
+++ b/test/C/src/MultipleContained.lf
@@ -27,7 +27,7 @@ reactor Contained {
     =}
     reaction(shutdown) {=
         if (self->count != 2) {
-            error_print_and_exit("FAILED: Expected two inputs!");
+            lf_print_error_and_exit("FAILED: Expected two inputs!");
         }
     =}
 }

--- a/test/C/src/ParameterHierarchy.lf
+++ b/test/C/src/ParameterHierarchy.lf
@@ -3,9 +3,9 @@ target C;
 reactor Deep(p:int(0)) {
     reaction(startup) {=
         if (self->p != 42) {
-            error_print_and_exit("Parameter value is %d. Should have been 42.");
+            lf_print_error_and_exit("Parameter value is %d. Should have been 42.");
         } else {
-            info_print("Success.");
+            lf_print("Success.");
         }
     =}
 }

--- a/test/C/src/RequestStop.lf
+++ b/test/C/src/RequestStop.lf
@@ -3,7 +3,7 @@ target C;
 main reactor {
     reaction(shutdown) {=
         tag_t current_time = lf_tag();
-        info_print("Shutdown invoked at tag (%lld, %d). Calling request_stop(), which should have no effect.",
+        lf_print("Shutdown invoked at tag (%lld, %d). Calling request_stop(), which should have no effect.",
             current_tag.time - lf_time_start(), current_tag.microstep
         );
         request_stop();

--- a/test/C/src/SetCopyConstructor.lf
+++ b/test/C/src/SetCopyConstructor.lf
@@ -23,9 +23,9 @@ reactor Destination {
     mutable input in:int_array_t*;
     reaction(in) {=
         if (in->value->data[0] != 42 || in->value->data[1] != 24) {
-            error_print_and_exit("ERROR: Input data does not match expected data");
+            lf_print_error_and_exit("ERROR: Input data does not match expected data");
         } else {
-            info_print("SUCCESS");
+            lf_print("SUCCESS");
         }
         in->value->data[0] = ~0;
         in->value->data[1] = ~0;

--- a/test/C/src/SetDestructor.lf
+++ b/test/C/src/SetDestructor.lf
@@ -10,7 +10,7 @@ preamble {=
 reactor Source {
     output out:int_array_t*;
     reaction(startup) -> out {=
-        info_print("%d", out->destructor);
+        lf_print("%d", out->destructor);
         lf_set_destructor(out, int_array_destructor);
         int_array_t* array =  int_array_constructor(2);
         for (size_t i = 0; i < array->length; i++) {

--- a/test/C/src/TimeLimit.lf
+++ b/test/C/src/TimeLimit.lf
@@ -39,7 +39,7 @@ reactor Destination {
             fprintf(stderr, "ERROR: Expected 10000002 but got %d.\n", self->s);
             exit(1);
         }
-        info_print("Approx. time per reaction: %lldns", lf_time_physical_elapsed()/(self->s+1));
+        lf_print("Approx. time per reaction: %lldns", lf_time_physical_elapsed()/(self->s+1));
     =}
 }
 main reactor TimeLimit(period:time(1 usec)) {

--- a/test/C/src/ToReactionNested.lf
+++ b/test/C/src/ToReactionNested.lf
@@ -18,9 +18,9 @@ main reactor {
      
     reaction(s.out) {=
         if (s.out->is_present) {
-            info_print("Received %d.", s.out->value);
+            lf_print("Received %d.", s.out->value);
             if (self->count != s.out->value) {
-                error_print_and_exit("Expected %d.", self->count);
+                lf_print_error_and_exit("Expected %d.", self->count);
             }
             self->received = true;
         } 
@@ -28,7 +28,7 @@ main reactor {
     =}
     reaction(shutdown) {=
         if (!self->received) {
-            error_print_and_exit("No inputs present.");
+            lf_print_error_and_exit("No inputs present.");
         }
     =}
 }

--- a/test/C/src/concurrent/StopThreaded.lf
+++ b/test/C/src/concurrent/StopThreaded.lf
@@ -22,12 +22,12 @@ reactor Consumer {
             // The reaction should not have been called at tags larger than (10
             // msec, 9)
             char time[255];
-            error_print_and_exit("Invoked reaction(in) at tag (%llu, %d) which is bigger than shutdown.", 
+            lf_print_error_and_exit("Invoked reaction(in) at tag (%llu, %d) which is bigger than shutdown.", 
                 current_tag.time - lf_time_start(), current_tag.microstep);
         } else if (lf_tag_compare(current_tag,
                          (tag_t) { .time = MSEC(10) + lf_time_start(), .microstep = 8}) == 0) {
             // Call request_stop() at relative tag (10 msec, 8)
-            info_print("Requesting stop.");
+            lf_print("Requesting stop.");
             request_stop();
         } else if (lf_tag_compare(current_tag,
                          (tag_t) { .time = MSEC(10) + lf_time_start(), .microstep = 9}) == 0) {
@@ -39,19 +39,19 @@ reactor Consumer {
     
     reaction(shutdown) {=
         tag_t current_tag = lf_tag();
-        info_print("Shutdown invoked at tag (%lld, %u).", current_tag.time - lf_time_start(), current_tag.microstep);
+        lf_print("Shutdown invoked at tag (%lld, %u).", current_tag.time - lf_time_start(), current_tag.microstep);
         // Check to see if shutdown is called at relative tag (10 msec, 9)
         if (lf_tag_compare(current_tag,
             (tag_t) { .time = MSEC(10) + lf_time_start(), .microstep = 9}) == 0 && 
             self->reaction_invoked_correctly == true) {
-            info_print("SUCCESS: successfully enforced stop.");
+            lf_print("SUCCESS: successfully enforced stop.");
         } else if(lf_tag_compare(current_tag,
             (tag_t) { .time = MSEC(10) + lf_time_start(), .microstep = 9}) > 0) {
-                error_print_and_exit("Shutdown invoked at tag (%llu, %d). Failed to enforce timeout.",
+                lf_print_error_and_exit("Shutdown invoked at tag (%llu, %d). Failed to enforce timeout.",
                             current_tag.time - lf_time_start(), current_tag.microstep);
         } else if (self->reaction_invoked_correctly == false) {
             // Check to see if reactions were called correctly
-        	error_print_and_exit("Failed to invoke reaction(in) at tag (%llu, %d).",
+        	lf_print_error_and_exit("Failed to invoke reaction(in) at tag (%llu, %d).",
                             current_tag.time - lf_time_start(), current_tag.microstep);
         }
     =}

--- a/test/C/src/concurrent/TimeLimitThreaded.lf
+++ b/test/C/src/concurrent/TimeLimitThreaded.lf
@@ -34,7 +34,7 @@ reactor Destination {
             fprintf(stderr, "ERROR: Expected 10000002 but got %d.\n", self->s);
             exit(1);
         }
-        info_print("Approx. time per reaction: %lldns", lf_time_physical_elapsed()/(self->s+1));
+        lf_print("Approx. time per reaction: %lldns", lf_time_physical_elapsed()/(self->s+1));
     =}
 }
 main reactor (period:time(1 usec)) {

--- a/test/C/src/concurrent/Workers.lf
+++ b/test/C/src/concurrent/Workers.lf
@@ -2,9 +2,9 @@ target C { workers: 16 };
 main reactor {
     reaction(startup) {=
         if (NUMBER_OF_WORKERS != 16) {
-            error_print_and_exit("Expected to have 16 workers.");
+            lf_print_error_and_exit("Expected to have 16 workers.");
         } else {
-            info_print("Using 16 workers.");
+            lf_print("Using 16 workers.");
         }
     =}
 }

--- a/test/C/src/federated/BroadcastFeedback.lf
+++ b/test/C/src/federated/BroadcastFeedback.lf
@@ -15,13 +15,13 @@ reactor SenderAndReceiver {
     =}
     reaction(in) {=
         if (in[0]->is_present && in[1]->is_present && in[0]->value == 42 && in[1]->value == 42) {
-            info_print("SUCCESS");
+            lf_print("SUCCESS");
             self->received = true;
         }
     =}
     reaction(shutdown) {=
         if (!self->received == true) {
-            error_print_and_exit("Failed to receive broadcast");
+            lf_print_error_and_exit("Failed to receive broadcast");
         }
     =}
 }

--- a/test/C/src/federated/BroadcastFeedbackWithHierarchy.lf
+++ b/test/C/src/federated/BroadcastFeedbackWithHierarchy.lf
@@ -22,13 +22,13 @@ reactor Receiver {
     
     reaction(in) {=
         if (in[0]->is_present && in[1]->is_present && in[0]->value == 42 && in[1]->value == 42) {
-            info_print("SUCCESS");
+            lf_print("SUCCESS");
             self->received = true;
         }
     =}
     reaction(shutdown) {=
         if (!self->received == true) {
-            error_print_and_exit("Failed to receive broadcast");
+            lf_print_error_and_exit("Failed to receive broadcast");
         }
     =}
 }

--- a/test/C/src/federated/ClockSync.lf
+++ b/test/C/src/federated/ClockSync.lf
@@ -46,19 +46,19 @@ reactor Printer {
 
     reaction(startup) {=
         interval_t offset = _lf_time_physical_clock_offset + _lf_time_test_physical_clock_offset;
-        info_print("Clock sync error at startup is %lld ns.", offset);
+        lf_print("Clock sync error at startup is %lld ns.", offset);
     =}
         
     reaction(in) {=
-        info_print("Received %d.", in->value);
+        lf_print("Received %d.", in->value);
     =}
     
     reaction(shutdown) {=
         interval_t offset = _lf_time_physical_clock_offset + _lf_time_test_physical_clock_offset;
-        info_print("Clock sync error at shutdown is %lld ns.", offset);
+        lf_print("Clock sync error at shutdown is %lld ns.", offset);
         // Error out if the offset is bigger than 100 msec.
         if (offset > MSEC(100)) {
-            error_print("Offset exceeds test threshold of 100 msec.");
+            lf_print_error("Offset exceeds test threshold of 100 msec.");
             exit(1);
         }
     =}

--- a/test/C/src/federated/CycleDetection.lf
+++ b/test/C/src/federated/CycleDetection.lf
@@ -36,14 +36,14 @@ reactor UserInput {
     =}
     reaction(balance) {=
         if (balance->value != 200) {
-            error_print_and_exit("Did not receive the expected balance. Expected: 200. Got: %d.", balance->value);
+            lf_print_error_and_exit("Did not receive the expected balance. Expected: 200. Got: %d.", balance->value);
         }
-        info_print("Balance: %d", balance->value);
+        lf_print("Balance: %d", balance->value);
         request_stop();
     =}
     
     reaction(shutdown) {=
-        info_print("Test passed!");
+        lf_print("Test passed!");
     =}
 }
 

--- a/test/C/src/federated/DecentralizedP2PComm.lf
+++ b/test/C/src/federated/DecentralizedP2PComm.lf
@@ -15,26 +15,26 @@ reactor Platform(start:int(0), expected_start:int(0), stp_offset_param:time(0)) 
         lf_set(out, self->count++);
     =}
     reaction(in) {=
-        info_print("Received %d.", in->value);
+        lf_print("Received %d.", in->value);
         if (in->value != self->expected_start++) {
-            error_print_and_exit("Expected %d but got %d.", 
+            lf_print_error_and_exit("Expected %d but got %d.", 
                 self->expected_start - 1,
                 in->value
             );
         }
     =} STP (stp_offset_param) {=
-        info_print("Received %d late.", in->value);
+        lf_print("Received %d late.", in->value);
         tag_t current_tag = lf_tag();
         self->expected_start++;
-        error_print("STP offset was violated by (%lld, %u).",
+        lf_print_error("STP offset was violated by (%lld, %u).",
             current_tag.time - in->intended_tag.time,
             current_tag.microstep - in->intended_tag.microstep
         );
     =}
     reaction(shutdown) {=
-        info_print("Shutdown invoked.");
+        lf_print("Shutdown invoked.");
         if (self->expected == self->expected_start) {
-            error_print_and_exit("Did not receive anything.");
+            lf_print_error_and_exit("Did not receive anything.");
         }
     =}
 }

--- a/test/C/src/federated/DecentralizedP2PUnbalancedTimeout.lf
+++ b/test/C/src/federated/DecentralizedP2PUnbalancedTimeout.lf
@@ -16,29 +16,29 @@ reactor Clock(offset:time(0), period:time(1 sec)) {
     state count:int(0);
     reaction(t) -> y {=
         (self->count)++;
-        info_print("Sending %d.", self->count);
+        lf_print("Sending %d.", self->count);
         lf_set(y, self->count);
     =}
     reaction(shutdown) {=
-        info_print("SUCCESS: the source exited successfully.");
+        lf_print("SUCCESS: the source exited successfully.");
     =}
 }
 reactor Destination {
     input x:int;
     state s:int(1);
     reaction(x) {=
-        info_print("Received %d", x->value);
+        lf_print("Received %d", x->value);
         tag_t current_tag = lf_tag();
         if (x->value != self->s) {
-            error_print_and_exit("At tag (%lld, %u) expected %d and got %d.", 
+            lf_print_error_and_exit("At tag (%lld, %u) expected %d and got %d.", 
                 current_tag.time - start_time, current_tag.microstep, self->s, x->value
             );
         }
         self->s++;
     =}
     reaction(shutdown) {=
-        info_print("**** shutdown reaction invoked.");
-        info_print("Approx. time per reaction: %lldns", lf_time_physical_elapsed()/(self->s+1));
+        lf_print("**** shutdown reaction invoked.");
+        lf_print("Approx. time per reaction: %lldns", lf_time_physical_elapsed()/(self->s+1));
     =}
 }
 federated reactor (period:time(10 usec)) {

--- a/test/C/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
+++ b/test/C/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
@@ -21,7 +21,7 @@ reactor Clock(offset:time(0), period:time(1 sec)) {
         lf_set(y, self->count);
     =}
     reaction(shutdown) {=
-        info_print("SUCCESS: the source exited successfully.");
+        lf_print("SUCCESS: the source exited successfully.");
     =}
 }
 reactor Destination {
@@ -30,13 +30,13 @@ reactor Destination {
     reaction(x) {=
         // printf("%d\n", x->value);
         if (x->value != self->s) {
-            error_print_and_exit("Expected %d and got %d.", self->s, x->value);
+            lf_print_error_and_exit("Expected %d and got %d.", self->s, x->value);
         }
         self->s++;
     =}
     reaction(shutdown) {=
-        info_print("**** shutdown reaction invoked.");
-        info_print("Approx. time per reaction: %lldns", lf_time_physical_elapsed()/(self->s+1));
+        lf_print("**** shutdown reaction invoked.");
+        lf_print("Approx. time per reaction: %lldns", lf_time_physical_elapsed()/(self->s+1));
     =}
 }
 federated reactor (period:time(10 usec)) {

--- a/test/C/src/federated/DistributedBank.lf
+++ b/test/C/src/federated/DistributedBank.lf
@@ -8,11 +8,11 @@ reactor Node {
     timer t(0, 100 msec);
     state count:int(0);
     reaction(t) {=
-        info_print("Hello world %d.", self->count++);
+        lf_print("Hello world %d.", self->count++);
     =}
     reaction(shutdown) {=
         if (self->count == 0) {
-            error_print_and_exit("Timer reactions did not execute.");
+            lf_print_error_and_exit("Timer reactions did not execute.");
         }
     =}
 }

--- a/test/C/src/federated/DistributedBankToMultiport.lf
+++ b/test/C/src/federated/DistributedBankToMultiport.lf
@@ -10,16 +10,16 @@ reactor Destination {
     state count:int(1);
     reaction(in) {=
         for (int i = 0; i < in_width; i++) {
-        	info_print("Received %d.", in[i]->value);  
+        	lf_print("Received %d.", in[i]->value);  
         	if (self->count != in[i]->value) {
-            	error_print_and_exit("Expected %d.", self->count);
+            	lf_print_error_and_exit("Expected %d.", self->count);
         	}   
       	}  
         self->count++;         
     =}
     reaction(shutdown) {=
         if (self->count == 0) {
-            error_print_and_exit("No data received.");
+            lf_print_error_and_exit("No data received.");
         }
     =}
 }

--- a/test/C/src/federated/DistributedCount.lf
+++ b/test/C/src/federated/DistributedCount.lf
@@ -17,18 +17,18 @@ reactor Print {
     state c:int(1);
     reaction(in) {=
         interval_t elapsed_time = lf_time_logical_elapsed();
-        info_print("At time %lld, received %d", elapsed_time, in->value);
+        lf_print("At time %lld, received %d", elapsed_time, in->value);
         if (in->value != self->c) {
-            error_print_and_exit("Expected to receive %d.", self->c);
+            lf_print_error_and_exit("Expected to receive %d.", self->c);
         }
         if (elapsed_time != MSEC(200) + SEC(1) * (self->c - 1) ) {
-            error_print_and_exit("Expected received time to be %lld.", MSEC(200) * self->c);
+            lf_print_error_and_exit("Expected received time to be %lld.", MSEC(200) * self->c);
         }
         self->c++;
     =}
     reaction(shutdown) {=
         if (self->c != 6) {
-            error_print_and_exit("Expected to receive 5 items.");
+            lf_print_error_and_exit("Expected to receive 5 items.");
         }
     =}
 }

--- a/test/C/src/federated/DistributedCountDecentralizedLateDownstream.lf
+++ b/test/C/src/federated/DistributedCountDecentralizedLateDownstream.lf
@@ -34,7 +34,7 @@ reactor ImportantActuator {
     state c:int(0);
     reaction(in) {=
         tag_t current_tag = lf_tag();
-        info_print("ImportantActuator: At tag (%lld, %u) received %d. Intended tag is (%lld, %u).",
+        lf_print("ImportantActuator: At tag (%lld, %u) received %d. Intended tag is (%lld, %u).",
             lf_time_logical_elapsed(),
             lf_tag().microstep,
             in->value,
@@ -44,12 +44,12 @@ reactor ImportantActuator {
                          (tag_t){.time=SEC(1) *  self->c, .microstep=0}) == 0) {
             self->success++; // Message was on-time
         } else {
-            error_print_and_exit("Normal reaction was invoked, but current tag doesn't match expected tag.");
+            lf_print_error_and_exit("Normal reaction was invoked, but current tag doesn't match expected tag.");
         }
         self->c++;
     =} STP (0) {=
         tag_t current_tag = lf_tag();
-        info_print("ImportantActuator: At tag (%lld, %u), message has violated the STP offset by (%lld, %u).",
+        lf_print("ImportantActuator: At tag (%lld, %u), message has violated the STP offset by (%lld, %u).",
                 current_tag.time - start_time, current_tag.microstep,
                 current_tag.time - in->intended_tag.time,
                 current_tag.microstep - in->intended_tag.microstep);
@@ -62,9 +62,9 @@ reactor ImportantActuator {
     
     reaction(shutdown) {=
         if ((self->success +  self->success_stp_violation) != 2) {
-            error_print_and_exit("Failed to detect STP violation in messages.");
+            lf_print_error_and_exit("Failed to detect STP violation in messages.");
         } else {
-            info_print("Successfully detected STP violations (%d violations, %d on-time).", self->success_stp_violation, self->success);
+            lf_print("Successfully detected STP violations (%d violations, %d on-time).", self->success_stp_violation, self->success);
         }
     =}
 }
@@ -73,7 +73,7 @@ reactor Print {
     input in:int;
     reaction(in) {=
         tag_t current_tag = lf_tag();  
-        info_print("Print reactor: at tag (%lld, %u) received %d. Intended tag is (%lld, %u).",
+        lf_print("Print reactor: at tag (%lld, %u) received %d. Intended tag is (%lld, %u).",
                current_tag.time - lf_time_start(),
                current_tag.microstep,
                in->value,

--- a/test/C/src/federated/DistributedDoublePort.lf
+++ b/test/C/src/federated/DistributedDoublePort.lf
@@ -34,14 +34,14 @@ reactor Print {
     input in2:int;
     reaction(in, in2) {=
         interval_t elapsed_time = lf_time_logical_elapsed();
-        info_print("At tag (%lld, %u), received in = %d and in2 = %d.", elapsed_time, lf_tag().microstep, in->value, in2->value);
+        lf_print("At tag (%lld, %u), received in = %d and in2 = %d.", elapsed_time, lf_tag().microstep, in->value, in2->value);
         if (in->is_present && in2->is_present) {
-            error_print_and_exit("ERROR: invalid logical simultaneity.");
+            lf_print_error_and_exit("ERROR: invalid logical simultaneity.");
         }
     =}
     
     reaction(shutdown) {=
-        info_print("SUCCESS: messages were at least one microstep apart.");
+        lf_print("SUCCESS: messages were at least one microstep apart.");
     =}
 }
 

--- a/test/C/src/federated/DistributedLoopedActionDecentralized.lf
+++ b/test/C/src/federated/DistributedLoopedActionDecentralized.lf
@@ -34,7 +34,7 @@ reactor Receiver(take_a_break_after:int(10), break_interval:time(400 msec)) {
     state breaks:int(0);
     reaction(in) {=
         tag_t current_tag = lf_tag();
-        info_print("At tag (%lld, %u) received value %d with STP violation (%lld, %u).",
+        lf_print("At tag (%lld, %u) received value %d with STP violation (%lld, %u).",
             current_tag.time - lf_time_start(),
             current_tag.microstep,
             in->value,
@@ -43,7 +43,7 @@ reactor Receiver(take_a_break_after:int(10), break_interval:time(400 msec)) {
         );
         self->total_received_messages++;
         if (in->value != lf_tag().microstep) {
-            warning_print("Received incorrect value %d. Expected %d.", in->value, lf_tag().microstep);
+            lf_print_warning("Received incorrect value %d. Expected %d.", in->value, lf_tag().microstep);
             // exit(1); // The receiver should tolerate this type of error
                         // in this test because messages on the network can
                         // arrive late. Note that with an accurate STP offset,
@@ -51,7 +51,7 @@ reactor Receiver(take_a_break_after:int(10), break_interval:time(400 msec)) {
                         
         }
         if (in->value != self->received_messages) {
-            warning_print("Skipped expected value %d. Received value %d.", self->received_messages, in->value);
+            lf_print_warning("Skipped expected value %d. Received value %d.", self->received_messages, in->value);
             self->received_messages = in->value;
             // exit(1); // The receiver should tolerate this type of error
                         // in this test because multiple messages arriving 
@@ -76,9 +76,9 @@ reactor Receiver(take_a_break_after:int(10), break_interval:time(400 msec)) {
         if (self->breaks != 3 ||
             (self->total_received_messages != ((SEC(1)/self->break_interval)+1) * self->take_a_break_after)
         ) {
-            error_print_and_exit("Test failed. Breaks: %d, Messages: %d.", self->breaks, self->total_received_messages);
+            lf_print_error_and_exit("Test failed. Breaks: %d, Messages: %d.", self->breaks, self->total_received_messages);
         }
-        info_print("SUCCESS: Successfully received all messages from the sender. Breaks: %d, Messages: %d.", self->breaks, self->total_received_messages);
+        lf_print("SUCCESS: Successfully received all messages from the sender. Breaks: %d, Messages: %d.", self->breaks, self->total_received_messages);
     =}
 }
 
@@ -89,19 +89,19 @@ reactor STPReceiver(take_a_break_after:int(10), break_interval:time(400 msec), s
     timer t (0, 1 msec); // Force advancement of logical time
     
     reaction (in) -> receiver.in {=
-        info_print("Received %d.", in->value);
+        lf_print("Received %d.", in->value);
         lf_set(receiver.in, in->value);
     =} STP (stp_offset) {=
-        info_print("Received %d late.", in->value);
+        lf_print("Received %d late.", in->value);
         tag_t current_tag = lf_tag();
-        info_print("STP violation of (%lld, %u) perceived on the input.",              
+        lf_print("STP violation of (%lld, %u) perceived on the input.",              
                current_tag.time - in->intended_tag.time,
                current_tag.microstep - in->intended_tag.microstep);
         lf_set(receiver.in, in->value);
         // Only update the STP offset once per
         // time step.
         if (current_tag.time != self->last_time_updated_stp) {
-            info_print("Raising the STP offset by %lld.", MSEC(10));
+            lf_print("Raising the STP offset by %lld.", MSEC(10));
 	        self->stp_offset += MSEC(10);
 	        set_stp_offset(MSEC(10));
 	        self->last_time_updated_stp = current_tag.time;

--- a/test/C/src/federated/DistributedLoopedPhysicalAction.lf
+++ b/test/C/src/federated/DistributedLoopedPhysicalAction.lf
@@ -45,13 +45,13 @@ reactor Receiver(take_a_break_after:int(10), break_interval:time(550 msec)) {
                         // log output.
     reaction(in) {=
         tag_t current_tag = lf_tag();  
-        info_print("At tag (%lld, %u) received %d.",
+        lf_print("At tag (%lld, %u) received %d.",
                current_tag.time - lf_time_start(),
                current_tag.microstep,
                in->value);
         self->total_received_messages++;
         if (in->value != self->received_messages++) {
-            error_print_and_exit("Expected %d.", self->received_messages - 1);
+            lf_print_error_and_exit("Expected %d.", self->received_messages - 1);
         }
 
         if (self->received_messages == self->take_a_break_after) {
@@ -69,9 +69,9 @@ reactor Receiver(take_a_break_after:int(10), break_interval:time(550 msec)) {
         if (self->breaks != 2 ||
             (self->total_received_messages != ((SEC(1)/self->break_interval)+1) * self->take_a_break_after)
         ) {
-            error_print_and_exit("Test failed. Breaks: %d, Messages: %d.", self->breaks, self->total_received_messages);
+            lf_print_error_and_exit("Test failed. Breaks: %d, Messages: %d.", self->breaks, self->total_received_messages);
         }
-        info_print("SUCCESS: Successfully received all messages from the sender.");
+        lf_print("SUCCESS: Successfully received all messages from the sender.");
     =}
 }
 

--- a/test/C/src/federated/DistributedMultiport.lf
+++ b/test/C/src/federated/DistributedMultiport.lf
@@ -21,16 +21,16 @@ reactor Destination {
     reaction(in) {=
         for (int i = 0; i < in_width; i++) {
             if (in[i]->is_present) {
-                info_print("Received %d.", in[i]->value);
+                lf_print("Received %d.", in[i]->value);
                 if (in[i]->value != self->count++) {
-                    error_print_and_exit("Expected %d.", self->count - 1);
+                    lf_print_error_and_exit("Expected %d.", self->count - 1);
                 }            
             }
         }
     =}
     reaction(shutdown) {=
         if (self->count == 0) {
-            error_print_and_exit("No data received.");
+            lf_print_error_and_exit("No data received.");
         }
     =}
 }

--- a/test/C/src/federated/DistributedMultiportToBank.lf
+++ b/test/C/src/federated/DistributedMultiportToBank.lf
@@ -19,14 +19,14 @@ reactor Destination {
     input in:int;
     state count:int(0);
     reaction(in) {=
-        info_print("Received %d.", in->value);  
+        lf_print("Received %d.", in->value);  
         if (self->count++ != in->value) {
-            error_print_and_exit("Expected %d.", self->count - 1);
+            lf_print_error_and_exit("Expected %d.", self->count - 1);
         }              
     =}
     reaction(shutdown) {=
         if (self->count == 0) {
-            error_print_and_exit("No data received.");
+            lf_print_error_and_exit("No data received.");
         }
     =}
 }

--- a/test/C/src/federated/DistributedMultiportToken.lf
+++ b/test/C/src/federated/DistributedMultiportToken.lf
@@ -18,7 +18,7 @@ reactor Source {
             SET_NEW_ARRAY(out[i], length);
             // Populate the output string and increment the count.
             snprintf(out[i]->value, length, "Hello %d", self->count++);
-            info_print("MessageGenerator: At time %lld, send message: %s.",
+            lf_print("MessageGenerator: At time %lld, send message: %s.",
                 lf_time_logical_elapsed(),
                 out[i]->value
             );
@@ -31,7 +31,7 @@ reactor Destination {
     reaction(in) {=
         for (int i = 0; i < in_width; i++) {
             if (in[i]->is_present) {
-                info_print("Received %s.", in[i]->value);                
+                lf_print("Received %s.", in[i]->value);                
             }
         }
     =}

--- a/test/C/src/federated/DistributedStop.lf
+++ b/test/C/src/federated/DistributedStop.lf
@@ -11,7 +11,7 @@ reactor Sender {
     logical action act;
     state reaction_invoked_correctly:bool(false);
     reaction(t, act) -> out, act {=
-        info_print("Sending 42 at (%lld, %u).",
+        lf_print("Sending 42 at (%lld, %u).",
                      lf_time_logical_elapsed(),
                      lf_tag().microstep);
         lf_set(out, 42);
@@ -25,7 +25,7 @@ reactor Sender {
         if (lf_time_logical_elapsed() == USEC(1)) {
             // Call request_stop() both at (1 usec, 0) and
             // (1 usec, 1)
-            info_print("Requesting stop at (%lld, %u).",
+            lf_print("Requesting stop at (%lld, %u).",
                      lf_time_logical_elapsed(),
                      lf_tag().microstep);
             request_stop();
@@ -37,24 +37,24 @@ reactor Sender {
 		    self->reaction_invoked_correctly = true;
         } else if (lf_tag_compare(lf_tag(), _1usec1) > 0) {
             // The reaction should not have been invoked at tags larger than (1 usec, 1)
-            error_print_and_exit("ERROR: Invoked reaction(t, act) at tag bigger than shutdown.");
+            lf_print_error_and_exit("ERROR: Invoked reaction(t, act) at tag bigger than shutdown.");
         }
     =}
     
     reaction(shutdown) {=
         if (lf_time_logical_elapsed() != USEC(1) ||
             lf_tag().microstep != 1) {
-            error_print_and_exit("ERROR: Sender failed to stop the federation in time. "
+            lf_print_error_and_exit("ERROR: Sender failed to stop the federation in time. "
                     "Stopping at (%lld, %u).",
                      lf_time_logical_elapsed(),
                      lf_tag().microstep);
         } else if (self->reaction_invoked_correctly == false) {
-            error_print_and_exit("ERROR: Sender reaction(t, act) was not invoked at (1 usec, 1). "
+            lf_print_error_and_exit("ERROR: Sender reaction(t, act) was not invoked at (1 usec, 1). "
                     "Stopping at (%lld, %u).",
                      lf_time_logical_elapsed(),
                      lf_tag().microstep);
         }
-        info_print("SUCCESS: Successfully stopped the federation at (%lld, %u).",
+        lf_print("SUCCESS: Successfully stopped the federation at (%lld, %u).",
                      lf_time_logical_elapsed(),
                      lf_tag().microstep);
     =}
@@ -66,12 +66,12 @@ reactor Receiver (
     input in:int;
     state reaction_invoked_correctly:bool(false);
     reaction(in) {=
-        info_print("Received %d at (%lld, %u).",
+        lf_print("Received %d at (%lld, %u).",
                      in->value,
                      lf_time_logical_elapsed(),
                      lf_tag().microstep);
         if (lf_time_logical_elapsed() == USEC(1)) {
-            info_print("Requesting stop at (%lld, %u).",
+            lf_print("Requesting stop at (%lld, %u).",
                      lf_time_logical_elapsed(),
                      lf_tag().microstep);
         	request_stop();
@@ -92,17 +92,17 @@ reactor Receiver (
         // receiver.
         if (lf_time_logical_elapsed() != USEC(1) ||
             lf_tag().microstep != 1) {
-            error_print_and_exit("Receiver failed to stop the federation at the right time. "
+            lf_print_error_and_exit("Receiver failed to stop the federation at the right time. "
                     "Stopping at (%lld, %u).",
                      lf_time_logical_elapsed(),
                      lf_tag().microstep);
         } else if (self->reaction_invoked_correctly == false) {            
-            error_print_and_exit("Receiver reaction(in) was not invoked the correct number of times. "
+            lf_print_error_and_exit("Receiver reaction(in) was not invoked the correct number of times. "
                     "Stopping at (%lld, %u).",
                      lf_time_logical_elapsed(),
                      lf_tag().microstep);
         }
-        info_print("SUCCESS: Successfully stopped the federation at (%lld, %u).",
+        lf_print("SUCCESS: Successfully stopped the federation at (%lld, %u).",
                      lf_time_logical_elapsed(),
                      lf_tag().microstep);
     =}

--- a/test/C/src/federated/HelloDistributed.lf
+++ b/test/C/src/federated/HelloDistributed.lf
@@ -9,7 +9,7 @@ target C;
 reactor Source {
     output out:string;
     reaction(startup) -> out {=
-        info_print("Sending 'Hello World!' message from source federate.");
+        lf_print("Sending 'Hello World!' message from source federate.");
         lf_set(out, "Hello World!");
         request_stop();
     =}
@@ -18,10 +18,10 @@ reactor Destination {
     input in:string;
     state received:bool(false);
     reaction(startup) {=
-        info_print("Destination started.");
+        lf_print("Destination started.");
     =}
     reaction(in) {=
-        info_print("At logical time %lld, destination received: %s", lf_time_logical_elapsed(), in->value);
+        lf_print("At logical time %lld, destination received: %s", lf_time_logical_elapsed(), in->value);
         if (strcmp(in->value, "Hello World!") != 0) {
             fprintf(stderr, "ERROR: Expected to receive 'Hello World!'\n");
             exit(1);
@@ -29,16 +29,16 @@ reactor Destination {
         self->received = true;
     =}
     reaction(shutdown) {=
-        info_print("Shutdown invoked.");
+        lf_print("Shutdown invoked.");
         if (!self->received) {
-            error_print_and_exit("Destination did not receive the message.");
+            lf_print_error_and_exit("Destination did not receive the message.");
         }
     =}
 }
 
 federated reactor HelloDistributed at localhost {
     reaction(startup) {=
-        info_print("Printing something in top-level federated reactor.");
+        lf_print("Printing something in top-level federated reactor.");
     =}
     s = new Source();      // Reactor s is in federate Source
     d = new Destination(); // Reactor d is in federate Destination

--- a/test/C/src/federated/LoopDistributedCentralized.lf
+++ b/test/C/src/federated/LoopDistributedCentralized.lf
@@ -16,7 +16,7 @@ preamble {=
     // Thread to trigger an action once every second.
     void* ping(void* actionref) {
         while(!stop) {
-            info_print("Scheduling action.");
+            lf_print("Scheduling action.");
             lf_schedule(actionref, 0);
             sleep(1);
         }
@@ -32,7 +32,7 @@ reactor Looper(incr:int(1), delay:time(0 msec)) {
     reaction(startup) -> a {=
         // Start the thread that listens for Enter or Return.
         lf_thread_t thread_id;
-        info_print("Starting thread.");
+        lf_print("Starting thread.");
         lf_thread_create(&thread_id, &ping, a);        
     =}
     reaction(a) -> out {=
@@ -43,14 +43,14 @@ reactor Looper(incr:int(1), delay:time(0 msec)) {
         instant_t time_lag = lf_time_physical() - lf_time_logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         lf_comma_separated_time(time_buffer, time_lag);
-        info_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
     =}
     reaction(shutdown) {=
-        info_print("******* Shutdown invoked.");
+        lf_print("******* Shutdown invoked.");
         // Stop the thread that is scheduling actions.
         stop = true;
         if (self->count != 5 * self->incr) {
-            error_print_and_exit("Failed to receive all five expected inputs.");
+            lf_print_error_and_exit("Failed to receive all five expected inputs.");
         }
     =}
 }

--- a/test/C/src/federated/LoopDistributedCentralizedPrecedence.lf
+++ b/test/C/src/federated/LoopDistributedCentralizedPrecedence.lf
@@ -26,18 +26,18 @@ reactor Looper(incr:int(1), delay:time(0 msec)) {
         instant_t time_lag = lf_time_physical() - lf_time_logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         lf_comma_separated_time(time_buffer, time_lag);
-        info_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
         self->received_count = self->count;
     =}
     reaction(t) {=
         if (self->received_count != self->count) {
-            error_print_and_exit("reaction(t) was invoked before reaction(in). Precedence order was not kept.");
+            lf_print_error_and_exit("reaction(t) was invoked before reaction(in). Precedence order was not kept.");
         }
     =}
     reaction(shutdown) {=
-        info_print("******* Shutdown invoked.");
+        lf_print("******* Shutdown invoked.");
         if (self->count != 6 * self->incr) {
-            error_print_and_exit("Failed to receive all six expected inputs.");
+            lf_print_error_and_exit("Failed to receive all six expected inputs.");
         }
     =}
 }

--- a/test/C/src/federated/LoopDistributedCentralizedPrecedenceHierarchy.lf
+++ b/test/C/src/federated/LoopDistributedCentralizedPrecedenceHierarchy.lf
@@ -25,7 +25,7 @@ reactor Contained (incr:int(1)) {
     =}
     reaction(t) {=
         if (self->received_count != self->count) {
-            error_print_and_exit("reaction(t) was invoked before reaction(in). Precedence order was not kept.");
+            lf_print_error_and_exit("reaction(t) was invoked before reaction(in). Precedence order was not kept.");
         }
     =}
 }
@@ -39,7 +39,7 @@ reactor Looper(incr:int(1), delay:time(0 msec)) {
     c = new Contained(incr = incr);
     
     reaction(t) -> out {=
-        info_print("Sending network output %d", self->count); 
+        lf_print("Sending network output %d", self->count); 
         lf_set(out, self->count);
         self->count += self->incr;
     =}
@@ -47,13 +47,13 @@ reactor Looper(incr:int(1), delay:time(0 msec)) {
         instant_t time_lag = lf_time_physical() - lf_time_logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         lf_comma_separated_time(time_buffer, time_lag);
-        info_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
     =}
     in->c.in;
     reaction(shutdown) {=
-        info_print("******* Shutdown invoked.");
+        lf_print("******* Shutdown invoked.");
         if (self->count != 6 * self->incr) {
-            error_print_and_exit("Failed to receive all six expected inputs.");
+            lf_print_error_and_exit("Failed to receive all six expected inputs.");
         }
     =}
 }

--- a/test/C/src/federated/LoopDistributedDecentralized.lf
+++ b/test/C/src/federated/LoopDistributedDecentralized.lf
@@ -14,7 +14,7 @@ preamble {=
     // Thread to trigger an action once every second.
     void* ping(void* actionref) {
         while(!stop) {
-            info_print("Scheduling action.");
+            lf_print("Scheduling action.");
             lf_schedule(actionref, 0);
             sleep(1);
         }
@@ -30,11 +30,11 @@ reactor Looper(incr:int(1), delay:time(0 msec), stp_offset:time(0)) {
     reaction(startup) -> a {=
         // Start the thread that listens for Enter or Return.
         lf_thread_t thread_id;
-        info_print("Starting thread.");
+        lf_print("Starting thread.");
         lf_thread_create(&thread_id, &ping, a);        
     =}
     reaction(a) -> out {=
-        info_print("Setting out.");
+        lf_print("Setting out.");
         lf_set(out, self->count);
         self->count += self->incr;
     =}
@@ -42,24 +42,24 @@ reactor Looper(incr:int(1), delay:time(0 msec), stp_offset:time(0)) {
         instant_t time_lag = lf_time_physical() - lf_time_logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         lf_comma_separated_time(time_buffer, time_lag);
-        info_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
     =} STP (stp_offset) {=
         instant_t time_lag = lf_time_physical() - lf_time_logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         lf_comma_separated_time(time_buffer, time_lag);
-        info_print("STP offset was violated. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);        
+        lf_print("STP offset was violated. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);        
     =} deadline (10 msec) {=
         instant_t time_lag = lf_time_physical() - lf_time_logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         lf_comma_separated_time(time_buffer, time_lag);
-        info_print("Deadline miss. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("Deadline miss. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
     =}
     reaction(shutdown) {=
-        info_print("******* Shutdown invoked.");
+        lf_print("******* Shutdown invoked.");
         // Stop the thread that is scheduling actions.
         stop = true;
         if (self->count != 5 * self->incr) {
-            error_print_and_exit("Failed to receive all five expected inputs.");
+            lf_print_error_and_exit("Failed to receive all five expected inputs.");
         }
     =}
 }

--- a/test/C/src/federated/LoopDistributedDouble.lf
+++ b/test/C/src/federated/LoopDistributedDouble.lf
@@ -16,7 +16,7 @@ preamble {=
     // Thread to trigger an action once every second.
     void* ping(void* actionref) {
         while(!stop) {
-            info_print("Scheduling action.");
+            lf_print("Scheduling action.");
             lf_schedule(actionref, 0);
             sleep(1);
         }
@@ -35,7 +35,7 @@ reactor Looper(incr:int(1), delay:time(0 msec)) {
     reaction(startup) -> a {=
         // Start the thread that listens for Enter or Return.
         lf_thread_t thread_id;
-        info_print("Starting thread.");
+        lf_print("Starting thread.");
         lf_thread_create(&thread_id, &ping, a);        
     =}
     reaction(a) -> out, out2 {=
@@ -47,28 +47,28 @@ reactor Looper(incr:int(1), delay:time(0 msec)) {
         self->count += self->incr;
     =}
     reaction(in) {=
-        info_print("Received %d at logical time (%lld, %d).",
+        lf_print("Received %d at logical time (%lld, %d).",
             in->value,
             current_tag.time - start_time, current_tag.microstep
         );
     =}
     reaction(in2) {=
-        info_print("Received %d on in2 at logical time (%lld, %d).",
+        lf_print("Received %d on in2 at logical time (%lld, %d).",
             in2->value,
             current_tag.time - start_time, current_tag.microstep
         );
     =}
     reaction(t) {=
-        info_print("Timer triggered at logical time (%lld, %d).",
+        lf_print("Timer triggered at logical time (%lld, %d).",
             current_tag.time - start_time, current_tag.microstep
         );
     =}
     reaction(shutdown) {=
-        info_print("******* Shutdown invoked.");
+        lf_print("******* Shutdown invoked.");
         // Stop the thread that is scheduling actions.
         stop = true;
         if (self->count != 5 * self->incr) {
-            error_print_and_exit("Failed to receive all five expected inputs.");
+            lf_print_error_and_exit("Failed to receive all five expected inputs.");
         }
     =}
 }

--- a/test/C/src/federated/PhysicalSTP.lf
+++ b/test/C/src/federated/PhysicalSTP.lf
@@ -14,26 +14,26 @@ reactor Print (STP_offset_param:time(0)) {
     state c:int(1);
     reaction(in) {=
         interval_t elapsed_time = lf_time_logical_elapsed();
-        info_print("At time %lld, received %d", elapsed_time, in->value);
-        // info_print("Physical time of arrival is %lld.", in->physical_time_of_arrival - start_time);
+        lf_print("At time %lld, received %d", elapsed_time, in->value);
+        // lf_print("Physical time of arrival is %lld.", in->physical_time_of_arrival - start_time);
         if (in->value != self->c) {
-            error_print_and_exit("Expected to receive %d.", self->c);
+            lf_print_error_and_exit("Expected to receive %d.", self->c);
         }
         instant_t STP_discrepency = lf_time_logical() + self->STP_offset_param - in->physical_time_of_arrival;
         if (STP_discrepency < 0) {
-            info_print("The message has violated the STP offset by %lld in physical time.", -1 * STP_discrepency);
+            lf_print("The message has violated the STP offset by %lld in physical time.", -1 * STP_discrepency);
         	self->c++;
         } else {
-            error_print_and_exit("Message arrived %lld early.", STP_discrepency);
+            lf_print_error_and_exit("Message arrived %lld early.", STP_discrepency);
         }
     =} STP (STP_offset_param) {=
         // This STP handler should never be invoked because the only source of event
         // for Print is the Count reactor.
-        error_print_and_exit("Logical STP violation was detected. Only physical STP violations are possible.");
+        lf_print_error_and_exit("Logical STP violation was detected. Only physical STP violations are possible.");
     =}
     reaction(shutdown) {=
         if (self->c != 3) {
-    		error_print_and_exit("Expected to receive 2 items but got %d.", self->c);
+    		lf_print_error_and_exit("Expected to receive 2 items but got %d.", self->c);
     	}
     =}
 }

--- a/test/C/src/federated/StopAtShutdown.lf
+++ b/test/C/src/federated/StopAtShutdown.lf
@@ -13,11 +13,11 @@ target C {
 reactor A {
     input in:int;
     reaction(startup) {=
-        info_print("Hello World!");
+        lf_print("Hello World!");
     =}
      
     reaction(in) {=
-        info_print("Got it");
+        lf_print("Got it");
     =}
     
     reaction(shutdown) {=

--- a/test/C/src/federated/TopLevelArtifacts.lf
+++ b/test/C/src/federated/TopLevelArtifacts.lf
@@ -35,8 +35,8 @@
     
     reaction (shutdown) {=
         if (self->successes != 3) {
-            error_print_and_exit("Failed to properly execute top-level reactions");
+            lf_print_error_and_exit("Failed to properly execute top-level reactions");
         }
-        info_print("SUCCESS!");
+        lf_print("SUCCESS!");
     =}
 }

--- a/test/C/src/federated/failing/DistributedDoublePortLooped.lf
+++ b/test/C/src/federated/failing/DistributedDoublePortLooped.lf
@@ -65,9 +65,9 @@ reactor Print {
     timer t(0,2 msec);
     reaction(in1, in2, in3, t) -> out {=
         interval_t elapsed_time = lf_time_logical_elapsed();
-        info_print("At tag (%lld, %u), received in = %d and in2 = %d.", elapsed_time, lf_tag().microstep, in1->value, in2->value);
+        lf_print("At tag (%lld, %u), received in = %d and in2 = %d.", elapsed_time, lf_tag().microstep, in1->value, in2->value);
         if (in1->is_present && in2->is_present) {
-            error_print_and_exit("ERROR: invalid logical simultaneity.");
+            lf_print_error_and_exit("ERROR: invalid logical simultaneity.");
         }
         lf_set(out, in1->value);
     =}

--- a/test/C/src/federated/failing/DistributedDoublePortLooped2.lf
+++ b/test/C/src/federated/failing/DistributedDoublePortLooped2.lf
@@ -19,12 +19,12 @@ reactor Count {
     output out:int;
     timer t(0, 1 msec);
     reaction(t) -> out {=
-        info_print("Count sends %d.", self->count);
+        lf_print("Count sends %d.", self->count);
         lf_set(out, self->count++);
     =}
     
     reaction(in) {=
-        info_print("Count received %d.", in->value);
+        lf_print("Count received %d.", in->value);
     =}
 }
 
@@ -50,13 +50,13 @@ reactor Print {
     reaction(in, in2) -> out {=
         interval_t elapsed_time = lf_time_logical_elapsed();
         if (in->is_present) {
-        	info_print("At tag (%lld, %u), received in = %d.", elapsed_time, lf_tag().microstep, in->value);
+        	lf_print("At tag (%lld, %u), received in = %d.", elapsed_time, lf_tag().microstep, in->value);
         }
         if (in2->is_present) {
-            info_print("At tag (%lld, %u), received in2 = %d.", elapsed_time, lf_tag().microstep, in2->value);
+            lf_print("At tag (%lld, %u), received in2 = %d.", elapsed_time, lf_tag().microstep, in2->value);
         }
         if (in->is_present && in2->is_present) {
-            error_print_and_exit("ERROR: invalid logical simultaneity.");
+            lf_print_error_and_exit("ERROR: invalid logical simultaneity.");
         }
         lf_set(out, in->value);
     =}
@@ -64,7 +64,7 @@ reactor Print {
         // Do nothing
     =}
     reaction(shutdown) {=
-        info_print("SUCCESS: messages were at least one microstep apart.");
+        lf_print("SUCCESS: messages were at least one microstep apart.");
     =}
 }
 

--- a/test/C/src/federated/failing/LoopDistributedDecentralizedPrecedence.lf
+++ b/test/C/src/federated/failing/LoopDistributedDecentralizedPrecedence.lf
@@ -25,30 +25,30 @@ reactor Looper(incr:int(1), delay:time(0 msec), stp_offset:time(0)) {
         instant_t time_lag = lf_time_physical() - lf_time_logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         readable_time(time_buffer, time_lag);
-        info_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
         self->received_count = self->count;
     =} STP (stp_offset) {=
         instant_t time_lag = lf_time_physical() - lf_time_logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         readable_time(time_buffer, time_lag);
-        info_print("STP offset was violated. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer); 
+        lf_print("STP offset was violated. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer); 
         self->received_count = self->count;       
     =} deadline (10 msec) {=
         instant_t time_lag = lf_time_physical() - lf_time_logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         readable_time(time_buffer, time_lag);
-        info_print("Deadline miss. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("Deadline miss. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
         self->received_count = self->count;
     =}
     reaction(t) {=
         if (self->received_count != self->count) {
-            error_print_and_exit("reaction(t) was invoked before reaction(in). Precedence order was not kept.");
+            lf_print_error_and_exit("reaction(t) was invoked before reaction(in). Precedence order was not kept.");
         }
     =}
     reaction(shutdown) {=
-        info_print("******* Shutdown invoked.");
+        lf_print("******* Shutdown invoked.");
         if (self->count != 5 * self->incr) {
-            error_print_and_exit("Failed to receive all five expected inputs.");
+            lf_print_error_and_exit("Failed to receive all five expected inputs.");
         }
     =}
 }

--- a/test/C/src/federated/failing/LoopDistributedDecentralizedPrecedenceHierarchy.lf
+++ b/test/C/src/federated/failing/LoopDistributedDecentralizedPrecedenceHierarchy.lf
@@ -29,23 +29,23 @@ reactor Looper(incr:int(1), delay:time(0 msec), stp_offset:time(0)) {
         instant_t time_lag = lf_time_physical() - lf_time_logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         readable_time(time_buffer, time_lag);
-        info_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
     =} STP (stp_offset) {=
         instant_t time_lag = lf_time_physical() - lf_time_logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         readable_time(time_buffer, time_lag);
-        info_print("STP offset was violated. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("STP offset was violated. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
     =} deadline (10 msec) {=
         instant_t time_lag = lf_time_physical() - lf_time_logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         readable_time(time_buffer, time_lag);
-        info_print("Deadline miss. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("Deadline miss. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
     =}
     in->c.in;
     reaction(shutdown) {=
-        info_print("******* Shutdown invoked.");
+        lf_print("******* Shutdown invoked.");
         if (self->count != 5 * self->incr) {
-            error_print_and_exit("Failed to receive all five expected inputs.");
+            lf_print_error_and_exit("Failed to receive all five expected inputs.");
         }
     =}
 }

--- a/test/C/src/lib/TestCount.lf
+++ b/test/C/src/lib/TestCount.lf
@@ -13,17 +13,17 @@ reactor TestCount(start:int(1), stride:int(1), num_inputs:int(1)) {
     state inputs_received:int(0);
     input in:int;
     reaction(in) {=
-        info_print("Received %d.", in->value);
+        lf_print("Received %d.", in->value);
         if (in->value != self->count) {
-            error_print_and_exit("Expected %d.", self->count);
+            lf_print_error_and_exit("Expected %d.", self->count);
         }
         self->count += self->stride;
         self->inputs_received++;
     =}
     reaction(shutdown) {=
-        info_print("Shutdown invoked.");
+        lf_print("Shutdown invoked.");
         if (self->inputs_received != self->num_inputs) {
-            error_print_and_exit("Expected to receive %d inputs, but got %d.",
+            lf_print_error_and_exit("Expected to receive %d inputs, but got %d.",
                 self->num_inputs,
                 self->inputs_received
             );

--- a/test/C/src/lib/TestCountMultiport.lf
+++ b/test/C/src/lib/TestCountMultiport.lf
@@ -17,20 +17,20 @@ reactor TestCountMultiport(start:int(1), stride:int(1), num_inputs:int(1), width
     reaction(in) {=
         for (int i = 0; i < in_width; i++) {
             if (!in[i]->is_present) {
-            	error_print_and_exit("No input on channel %d.", i);
+            	lf_print_error_and_exit("No input on channel %d.", i);
             }
-        	info_print("Received %d on channel %d.", in[i]->value, i);
+        	lf_print("Received %d on channel %d.", in[i]->value, i);
         	if (in[i]->value != self->count) {
-           	 	error_print_and_exit("Expected %d.", self->count);
+           	 	lf_print_error_and_exit("Expected %d.", self->count);
         	}
         	self->count += self->stride;
         }
         self->inputs_received++;
     =}
     reaction(shutdown) {=
-        info_print("Shutdown invoked.");
+        lf_print("Shutdown invoked.");
         if (self->inputs_received != self->num_inputs) {
-            error_print_and_exit("Expected to receive %d inputs, but only got %d.",
+            lf_print_error_and_exit("Expected to receive %d inputs, but only got %d.",
                 self->num_inputs,
                 self->inputs_received
             );

--- a/test/C/src/multiport/BankIndexInitializer.lf
+++ b/test/C/src/multiport/BankIndexInitializer.lf
@@ -25,14 +25,14 @@ reactor Sink(width:int(4)) {
                 printf("Received on channel %d: %d\n", idx, in[idx]->value);
                 self->received = true;
                 if (in[idx]->value != 4 - idx) {
-                    error_print_and_exit("Expected %d.", 4 - idx);
+                    lf_print_error_and_exit("Expected %d.", 4 - idx);
                 }
             }
         }
     =}
     reaction(shutdown) {=
         if (!self->received) {
-            error_print_and_exit("Sink received no data.");
+            lf_print_error_and_exit("Sink received no data.");
         }
     =}
 }

--- a/test/C/src/multiport/BankMultiportToReaction.lf
+++ b/test/C/src/multiport/BankMultiportToReaction.lf
@@ -21,9 +21,9 @@ main reactor {
         for (int i = 0; i < s_width; i++) {
             for (int j = 0; j < s[0].out_width; j++) {
                 if (s[i].out[j]->is_present) {
-                    info_print("Received %d.", s[i].out[j]->value);
+                    lf_print("Received %d.", s[i].out[j]->value);
                     if (self->count != s[i].out[j]->value) {
-                        error_print_and_exit("Expected %d.", self->count);
+                        lf_print_error_and_exit("Expected %d.", self->count);
                     }
                     self->received = true;
                 } 
@@ -33,7 +33,7 @@ main reactor {
     =}
     reaction(shutdown) {=
         if (!self->received) {
-            error_print_and_exit("No inputs present.");
+            lf_print_error_and_exit("No inputs present.");
         }
     =}
 }

--- a/test/C/src/multiport/BankReactionsInContainer.lf
+++ b/test/C/src/multiport/BankReactionsInContainer.lf
@@ -13,7 +13,7 @@ reactor R (bank_index:int(0)) {
         for (int i = 0; i < out_width; i++) {
             int value = self->bank_index * 2 + i;
             lf_set(out[i], value);
-            info_print("Inner sending %d to bank %d channel %d.", 
+            lf_print("Inner sending %d to bank %d channel %d.", 
                 value, self->bank_index, i
             );
         }
@@ -22,18 +22,18 @@ reactor R (bank_index:int(0)) {
     reaction(in) {=
         for (int i = 0; i < in_width; i++) {
             if (in[i]->is_present) {
-                info_print("Inner received %d in bank %d, channel %d", in[i]->value, self->bank_index, i);
+                lf_print("Inner received %d in bank %d, channel %d", in[i]->value, self->bank_index, i);
                 self->received = true;
                 if (in[i]->value != self->bank_index * 2 + i) {
-                    error_print_and_exit("Expected %d.", self->bank_index * 2 + i);
+                    lf_print_error_and_exit("Expected %d.", self->bank_index * 2 + i);
                 }
             }
         }
     =}
     reaction(shutdown) {=
-        info_print("Inner shutdown invoked.");
+        lf_print("Inner shutdown invoked.");
         if (!self->received) {
-            error_print_and_exit("Received no input.");
+            lf_print_error_and_exit("Received no input.");
         }
     =}
 }
@@ -45,7 +45,7 @@ main reactor {
         int count = 0;
         for (int i = 0; i < s_width; i++) {
             for (int j = 0; j < s[i].in_width; j++) {
-                info_print("Sending %d to bank %d channel %d.", count, i, j);
+                lf_print("Sending %d to bank %d channel %d.", count, i, j);
                 lf_set(s[i].in[j], count++);
             }
         }
@@ -54,19 +54,19 @@ main reactor {
         for (int j = 0; j < s_width; j++) {
             for (int i = 0; i < s[j].out_width; i++) {
                 if (s[j].out[i]->is_present) {
-                    info_print("Outer received %d on bank %d channel %d.", s[j].out[i]->value, j, i);
+                    lf_print("Outer received %d on bank %d channel %d.", s[j].out[i]->value, j, i);
                     self->received = true;
                     if (s[j].out[i]->value != j * 2 + i) {
-                        error_print_and_exit("Expected %d.", j * 2 + i);
+                        lf_print_error_and_exit("Expected %d.", j * 2 + i);
                     }
                 }
             }
         }
     =}
     reaction(shutdown) {=
-        info_print("Outer shutdown invoked.");
+        lf_print("Outer shutdown invoked.");
         if (!self->received) {
-            error_print_and_exit("Received no input.");
+            lf_print_error_and_exit("Received no input.");
         }
     =}
 }

--- a/test/C/src/multiport/BankSelfBroadcast.lf
+++ b/test/C/src/multiport/BankSelfBroadcast.lf
@@ -19,26 +19,26 @@ reactor A (
     reaction(in) {=
         for (int i = 0; i < in_width; i++) {
             if (in[i]->is_present) {
-        		info_print(
+        		lf_print(
         			"Reactor %d received %d on channel %d.",
                     self->bank_index, in[i]->value, i
                 );
                 if (in[i]->value != i) {
-                    error_print_and_exit("Expected %d.", i);
+                    lf_print_error_and_exit("Expected %d.", i);
                 }
                 self->received = true;
        		} else {
-        		info_print(
+        		lf_print(
         			"Reactor %d channel %d is absent.",
                     self->bank_index, i
                 );
-                error_print_and_exit("Expected %d.", i);
+                lf_print_error_and_exit("Expected %d.", i);
             }
       	}
     =}
     reaction(shutdown) {=
         if (!self->received) {
-            error_print_and_exit("No inputs received.");
+            lf_print_error_and_exit("No inputs received.");
         }
     =}
 }

--- a/test/C/src/multiport/BankToReaction.lf
+++ b/test/C/src/multiport/BankToReaction.lf
@@ -11,9 +11,9 @@ main reactor {
     
     reaction(s.out) {=
         for (int i = 0; i < s_width; i++) {
-        	info_print("Received %d.", s[i].out->value);  
+        	lf_print("Received %d.", s[i].out->value);  
         	if (self->count != s[i].out->value) {
-            	error_print_and_exit("Expected %d.", self->count);
+            	lf_print_error_and_exit("Expected %d.", self->count);
         	}   
       	}  
         self->count++;         

--- a/test/C/src/multiport/FullyConnected.lf
+++ b/test/C/src/multiport/FullyConnected.lf
@@ -10,7 +10,7 @@ reactor Node(
     state received: bool(false);
     
     reaction (startup) -> out{=
-     	info_print("Hello from node %d!", self->bank_index);
+     	lf_print("Hello from node %d!", self->bank_index);
      	// broadcast my ID to everyone
      	lf_set(out, self->bank_index);    
     =}
@@ -27,12 +27,12 @@ reactor Node(
         }   
         printf("\n");
         if (count != self->num_nodes) {
-            error_print_and_exit("Received fewer messages than expected!"); 
+            lf_print_error_and_exit("Received fewer messages than expected!"); 
         }
     =}
     reaction (shutdown) {=
         if (!self->received) {
-            error_print_and_exit("Received no input!"); 
+            lf_print_error_and_exit("Received no input!"); 
         }
     =}
 }

--- a/test/C/src/multiport/FullyConnectedAddressable.lf
+++ b/test/C/src/multiport/FullyConnectedAddressable.lf
@@ -14,7 +14,7 @@ reactor Node(
     
     reaction (startup) -> out {=
         int outChannel = (self->bank_index + 1) % self->num_nodes;
-     	info_print("Node %d sending %d out on channel %d.",
+     	lf_print("Node %d sending %d out on channel %d.",
             self->bank_index, self->bank_index, outChannel
         );
      	// broadcast my ID to everyone
@@ -35,15 +35,15 @@ reactor Node(
         printf("\n");
         int expected = self->bank_index == 0 ? self->num_nodes - 1 : self->bank_index - 1;
         if (count != 1) {
-            error_print_and_exit("Received %d messages, but expecting only one!"); 
+            lf_print_error_and_exit("Received %d messages, but expecting only one!"); 
         }
         if (self->received != expected) {
-            error_print_and_exit("Received %d, but expected %d!", self->received, expected); 
+            lf_print_error_and_exit("Received %d, but expected %d!", self->received, expected); 
         }
     =}
     reaction (shutdown) {=
         if (!self->triggered) {
-            error_print_and_exit("Received no input!"); 
+            lf_print_error_and_exit("Received no input!"); 
         }
     =}
 }

--- a/test/C/src/multiport/NestedBanks.lf
+++ b/test/C/src/multiport/NestedBanks.lf
@@ -34,9 +34,9 @@ reactor D {
     input[2] u:int;
     reaction(u) {=
         for (int i = 0; i < u_width; i++) {
-            info_print("d.u[%d] received %d.", i, u[i]->value);
+            lf_print("d.u[%d] received %d.", i, u[i]->value);
             if (u[i]->value != 6 + i) {
-                error_print_and_exit("Expected %d but received %d.", 6 + i, u[i]->value);
+                lf_print_error_and_exit("Expected %d but received %d.", 6 + i, u[i]->value);
             }
         }
     =}
@@ -45,25 +45,25 @@ reactor E {
     input[8] t:int;
     reaction(t) {=
         for (int i = 0; i < t_width; i++) {
-            info_print("e.t[%d] received %d.", i, t[i]->value);
+            lf_print("e.t[%d] received %d.", i, t[i]->value);
         }
     =}
 }
 reactor F(c_bank_index:int(0)) {
     input w:int;
     reaction(w) {=
-        info_print("c[%d].f.w received %d.", self->c_bank_index, w->value);
+        lf_print("c[%d].f.w received %d.", self->c_bank_index, w->value);
         if (w->value != self->c_bank_index * 2) {
-            error_print_and_exit("Expected %d but received %d.", self->c_bank_index * 2, w->value);
+            lf_print_error_and_exit("Expected %d but received %d.", self->c_bank_index * 2, w->value);
         }
     =}
 }
 reactor G(c_bank_index:int(0)) {
     input s:int;
     reaction(s) {=
-        info_print("c[%d].g.s received %d.", self->c_bank_index, s->value);
+        lf_print("c[%d].g.s received %d.", self->c_bank_index, s->value);
         if (s->value != self->c_bank_index * 2 + 1) {
-            error_print_and_exit("Expected %d but received %d.", self->c_bank_index * 2 + 1, s->value);
+            lf_print_error_and_exit("Expected %d but received %d.", self->c_bank_index * 2 + 1, s->value);
         }
     =}
 }

--- a/test/C/src/multiport/NestedInterleavedBanks.lf
+++ b/test/C/src/multiport/NestedInterleavedBanks.lf
@@ -8,7 +8,7 @@ reactor A(bank_index:int(0), outer_bank_index:int(0)) {
     reaction(startup) -> p {=
         for (int i = 0; i < p_width; i++) {
             lf_set(p[i], self->outer_bank_index * 4 + self->bank_index * 2 + i + 1);
-            info_print("A sending %d.", p[i]->value);
+            lf_print("A sending %d.", p[i]->value);
         }
     =}
 }
@@ -22,9 +22,9 @@ reactor C {
     reaction(i) {=
         int expected[] = {1, 3, 2, 4, 5, 7, 6, 8};
         for(int j = 0; j < i_width; j++) {
-            info_print("C received %d.", i[j]->value);
+            lf_print("C received %d.", i[j]->value);
             if (i[j]->value != expected[j]) {
-                error_print_and_exit("Expected %d.", expected[j]);
+                lf_print_error_and_exit("Expected %d.", expected[j]);
             }
         }
     =}

--- a/test/C/src/multiport/ReactionsToNested.lf
+++ b/test/C/src/multiport/ReactionsToNested.lf
@@ -7,15 +7,15 @@ reactor T(expected:int(0)) {
     input z:int;
     state received:bool(false);
 	reaction(z) {=
-		info_print("T received %d", z->value);
+		lf_print("T received %d", z->value);
 		self->received = true;
 		if (z->value != self->expected) {
-            error_print_and_exit("Expected %d", self->expected);
+            lf_print_error_and_exit("Expected %d", self->expected);
         }
 	=}
 	reaction(shutdown) {=
         if (!self->received) {
-            error_print_and_exit("No input received");
+            lf_print_error_and_exit("No input received");
         }
     =}
 }

--- a/test/C/src/serialization/ROSBuiltInSerialization.lf
+++ b/test/C/src/serialization/ROSBuiltInSerialization.lf
@@ -53,12 +53,12 @@ reactor Receiver {
         
     reaction (in) {=        
         // Print the ROS2 message data
-        info_print(
+        lf_print(
             "Serialized integer after deserialization: %d", 
             in->value.data
         );
         if (in->value.data != self->count) {
-            error_print_and_exit("Expected %d.", self->count);
+            lf_print_error_and_exit("Expected %d.", self->count);
         }
         self->count++;
     =}

--- a/test/C/src/serialization/ROSBuiltInSerializationSharedPtr.lf
+++ b/test/C/src/serialization/ROSBuiltInSerializationSharedPtr.lf
@@ -53,12 +53,12 @@ reactor Receiver {
         
     reaction (in) {=        
         // Print the ROS2 message data
-        info_print(
+        lf_print(
             "Serialized integer after deserialization: %d", 
             in->value->data
         );
         if (in->value->data != self->count) {
-            error_print_and_exit("Expected %d.", self->count);
+            lf_print_error_and_exit("Expected %d.", self->count);
         }
         self->count++;
     =}

--- a/test/C/src/target/CMakeInclude.lf
+++ b/test/C/src/target/CMakeInclude.lf
@@ -15,7 +15,7 @@ reactor Foo {
         #include <math.h>
     =}
     reaction (startup) {=
-        info_print("Maximum of 4.20 and %.2f is %.2f", FOO, fmax(4.20, FOO));
+        lf_print("Maximum of 4.20 and %.2f is %.2f", FOO, fmax(4.20, FOO));
         
         // Check if BAR is defined, which is an error condition (@see federated/DistributedCMakeIncludeSeparateCompile.lf).
         #ifdef BAR

--- a/test/C/src/target/DistributedCMakeInclude.lf
+++ b/test/C/src/target/DistributedCMakeInclude.lf
@@ -14,7 +14,7 @@ reactor Bar {
         #include <math.h>
     =}
     reaction (startup) {=
-        info_print("Maximum of 4.20 and %.2f is %.2f", BAR, fmax(4.20, BAR));
+        lf_print("Maximum of 4.20 and %.2f is %.2f", BAR, fmax(4.20, BAR));
         
         // Check if FOO is defined, which is an error condition (@see DistributedCMakeIncludeSeparateCompile.lf).
         #ifdef FOO

--- a/test/C/src/target/Files.lf
+++ b/test/C/src/target/Files.lf
@@ -14,6 +14,6 @@ main reactor {
     reaction(startup) {=
         hello_t t;
         dummy_t d;
-        info_print("SUCCESS.");
+        lf_print("SUCCESS.");
     =}
 }

--- a/test/C/src/target/lib/ImportedCMakeInclude.lf
+++ b/test/C/src/target/lib/ImportedCMakeInclude.lf
@@ -7,7 +7,7 @@ reactor Baz {
         #include <math.h>
     =}
     reaction (startup) {=
-        info_print("Maximum of 4.20 and %.2f is %.2f", BAZ, fmax(4.20, BAZ));
+        lf_print("Maximum of 4.20 and %.2f is %.2f", BAZ, fmax(4.20, BAZ));
         
         // Check if FOO is defined, which is an error condition (@see DistributedCMakeIncludeSeparateCompile.lf).
         #ifdef FOO


### PR DESCRIPTION
This PR addresses the issue #1124 and prefixes print functions in the C target (ex. `info_print`, `debug_print`, ...) with `lf_`.

Here is a detailed list of changes:

`info_print` -> `lf_print`
`log_print` -> `lf_print_log`
`debug_print` -> `lf_print_debug`
`error_print` -> `lf_print_error`
`warning_print` -> `lf_print_warning`
`error_print_and_exit` -> `lf_print_error_and_exit`

The deprecated names are still available currently but will be removed in a future release.

