### PR TITLE
drop PermSize and MaxPermSize options as they are not supported by java 17

### DIFF
--- a/org.lflang.rca/lflang.product
+++ b/org.lflang.rca/lflang.product
@@ -25,8 +25,6 @@ Copyright © 2019-2021, Lingua Franca contributors. All rights reserved.
 -Xms512m
 -Xmn256m
 -Xmx1024m 
--XX:PermSize=128m
--XX:MaxPermSize=256m
 --add-modules=ALL-SYSTEM
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread


### PR DESCRIPTION
Java 17 does not support the PermSize and MaxPermSize options anymore. This PR simply drops the options so that Epoch can be run with Java 17.