### PR TITLE
Check for Java 17 in lfc scripts and properly exit on error

### DIFF
--- a/bin/lfc.ps1
+++ b/bin/lfc.ps1
@@ -42,8 +42,8 @@ if (-not (Test-Path $java_cmd)) {
 
 # check for correct java version
 $java_version = (Get-Command java | Select-Object -ExpandProperty Version).toString()
-if ([version]$java_version -lt [version]"11.0") {
-    throw "JRE $java_version found but 11.0 or greater is required."
+if ([version]$java_version -lt [version]"17.0") {
+    throw "JRE $java_version found but 17.0 or greater is required."
 }
 
 # invoke lfc

--- a/lib/scripts/include.sh
+++ b/lib/scripts/include.sh
@@ -87,8 +87,8 @@ function get_java_cmd {
         java_version=$(echo "$semantic_version" | awk -F. '{printf("%03d%03d",$1,$2);}')
         #echo Semantic version: "$semantic_version"
         #echo Java version: "$java_version"
-        if [ $java_version -lt 011000 ]; then
-            fatal_error "JRE $semantic_version found but 1.11 or greater is required."
+        if [ $java_version -lt 017000 ]; then
+            fatal_error "JRE $semantic_version found but 1.17 or greater is required."
         fi
         echo ${java_cmd}
     fi
@@ -104,6 +104,7 @@ function run_lfc_with_args {
     fi
 
     # Launch the compiler.
-    "$(get_java_cmd)" -jar "${jar_path}" "$@";
+    java_cmd="$(get_java_cmd)"
+    "${java_cmd}" -jar "${jar_path}" "$@";
     exit $?
 }


### PR DESCRIPTION
This updates the build and launch lfc scripts to check for a Java 17 runtime (instead of 11). Also it introduces a small fix that let's the script exit gracefully if no Java 17 runtime was found.