### PR TITLE
Disable pylint `c-extension-no-member` warning

### DIFF
--- a/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
@@ -206,6 +206,7 @@ public class PythonGenerator extends CGenerator {
             "    get_start_time, port_capsule, request_stop, schedule_copy,",
             "    start",
             ")",
+            "# pylint: disable=c-extension-no-member", 
             "import LinguaFranca"+topLevelName+" as lf",
             "try:",
             "    from LinguaFrancaBase.constants import BILLION, FOREVER, NEVER, instant_t, interval_t",


### PR DESCRIPTION
After the API changes in the python target in #1116, the time API in the python target became `lf.time.<function_name>`.

Since `lf` is a c extension of python, pylint does not have python source code to reference the content of `lf` and complains about `Module 'lf' has no 'time' member`. 

A temporary fix is to disable `c-extension-no-member` warnings globally in the generated `.py` file.