### PR TITLE
Address LSP test failures.

### DIFF
--- a/org.lflang/src/org/lflang/generator/CodeBuilder.java
+++ b/org.lflang/src/org/lflang/generator/CodeBuilder.java
@@ -98,31 +98,11 @@ public class CodeBuilder {
     }
 
     /**
-     * Append the specified text plus a final newline to the specified
-     * code buffer. This also replaces tabs with four spaces.
-     * @param text The the object whose toString() method provides the text.
+     * Append the given text to the code buffer at the current indentation level.
      */
-    public void pr(Object text) {
-        String string = text.toString();
-        string = string.replaceAll("\t", "    ");
-        String[] split = string.split("\n");
-        int offset = Stream.of(split).skip(1)
-                           .mapToInt(line -> line.indexOf(line.trim()))
-                           .min()
-                           .orElse(0);
-        // Now make a pass for each line, replacing the offset leading
-        // spaces with the current indentation.
-        boolean firstLine = true;
-        for (String line : split) {
-            code.append(indentation);
-            // Do not trim the first line
-            if (firstLine) {
-                code.append(line);
-                firstLine = false;
-            } else {
-                code.append(line.substring(offset));
-            }
-            code.append("\n");
+    public void pr(CharSequence text) {
+        for (String line : (Iterable<? extends String>) () -> text.toString().lines().iterator()) {
+            code.append(indentation).append(line).append(System.lineSeparator());
         }
     }
 


### PR DESCRIPTION
This simplifies the `pr` method in `CodeBuilder.java`. The work ostensibly done by this method is, I think, taken care of elsewhere.

I believe that this fixes the test failure [here](https://github.com/lf-lang/lingua-franca/runs/6487050913?check_suite_focus=true). I was able to reproduce the failure by running the tests locally with the same random seed, and the failure was gone after I made this change.

After this change, the generated code still looks mostly the same to me as before.