### PR TITLE
[Federated] Fix segfault for internally disconnected output ports

### DIFF
--- a/org.lflang/src/org/lflang/generator/c/CNetworkGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CNetworkGenerator.java
@@ -350,7 +350,11 @@ public class CNetworkGenerator {
             "LF_PRINT_LOG(\"Contemplating whether to send port \"",
             "          \"absent for port %d to federate %d.\", ",
             "          "+portID+", "+receivingFederateID+");",
-            "if (!"+sendRef+"->is_present) {",
+            "if ("+sendRef+" != NULL) { // Check that the output port is not NULL",
+            "    if (!"+sendRef+"->is_present) {",
+            "        send_port_absent_to_federate("+additionalDelayString+", "+portID+", "+receivingFederateID+");",
+            "    }",
+            "} else { // Unblock the downstream federate",
             "    send_port_absent_to_federate("+additionalDelayString+", "+portID+", "+receivingFederateID+");",
             "}"
         ));

--- a/org.lflang/src/org/lflang/generator/c/CNetworkGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CNetworkGenerator.java
@@ -350,11 +350,8 @@ public class CNetworkGenerator {
             "LF_PRINT_LOG(\"Contemplating whether to send port \"",
             "          \"absent for port %d to federate %d.\", ",
             "          "+portID+", "+receivingFederateID+");",
-            "if ("+sendRef+" != NULL) { // Check that the output port is not NULL",
-            "    if (!"+sendRef+"->is_present) {",
-            "        send_port_absent_to_federate("+additionalDelayString+", "+portID+", "+receivingFederateID+");",
-            "    }",
-            "} else { // Unblock the downstream federate",
+            "if ("+sendRef+" == NULL || !"+sendRef+"->is_present) {",
+            "    // The output port is NULL or it is not present.",
             "    send_port_absent_to_federate("+additionalDelayString+", "+portID+", "+receivingFederateID+");",
             "}"
         ));

--- a/test/C/src/federated/SimpleFederated.lf
+++ b/test/C/src/federated/SimpleFederated.lf
@@ -1,0 +1,12 @@
+target C;
+reactor Fed {
+    input in:int;
+    output out:int;
+}
+federated reactor {
+    fed1 = new Fed();
+    fed2 = new Fed();
+    
+    fed1.out -> fed2.in;
+    fed2.out -> fed1.in;
+}

--- a/test/C/src/federated/SimpleFederated.lf
+++ b/test/C/src/federated/SimpleFederated.lf
@@ -1,4 +1,7 @@
-target C;
+target C {
+    timeout: 2 secs,
+    build-type: RelWithDebInfo
+};
 reactor Fed {
     input in:int;
     output out:int;


### PR DESCRIPTION
This fixes a segmentation fault that arose whenever a federate had an output port that was not internally connected (e.g., it did not appear as an effect in any reaction). In the CGenerator, such an output port will be NULL, but the output control reactions were attempting to check the `->is_present` field of these ports. 

This PR adds an extra check for this. 