### PR TITLE
Use `toOriginalText` in `org.lflang.diagram`.

### DIFF
--- a/org.lflang.diagram/src/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/org.lflang.diagram/src/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -954,7 +954,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
                     if (connection != null) {
                         KEdge edge = createIODependencyEdge(connection, (leftPort.isMultiport() || rightPort.isMultiport()));
                         if (connection.getDelay() != null) {
-                            KLabel delayLabel = _kLabelExtensions.addCenterEdgeLabel(edge, ASTUtils.toText(connection.getDelay()));
+                            KLabel delayLabel = _kLabelExtensions.addCenterEdgeLabel(edge, ASTUtils.toOriginalText(connection.getDelay()));
                             associateWith(delayLabel, connection.getDelay());
                             if (connection.isPhysical()) {
                                 _linguaFrancaStyleExtensions.applyOnEdgePysicalDelayStyle(delayLabel, 
@@ -1121,13 +1121,13 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
             b.append("\u2219 ");
         }
         b.append(param.getName());
-        String t = param.type.toText();
+        String t = param.type.toOriginalText();
         if (!StringExtensions.isNullOrEmpty(t)) {
             b.append(":").append(t);
         }
         if (!IterableExtensions.isNullOrEmpty(param.getInitialValue())) {
             b.append("(");
-            b.append(IterableExtensions.join(param.getInitialValue(), ", ", ASTUtils::toText));
+            b.append(IterableExtensions.join(param.getInitialValue(), ", ", ASTUtils::toOriginalText));
             b.append(")");
         }
         return b.toString();
@@ -1159,11 +1159,11 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
         b.append(variable.getName());
         if (variable.getType() != null) {
             var t = InferredType.fromAST(variable.getType());
-            b.append(":").append(t.toText());
+            b.append(":").append(t.toOriginalText());
         }
         if (!IterableExtensions.isNullOrEmpty(variable.getInit())) {
             b.append("(");
-            b.append(IterableExtensions.join(variable.getInit(), ", ", ASTUtils::toText));
+            b.append(IterableExtensions.join(variable.getInit(), ", ", ASTUtils::toOriginalText));
             b.append(")");
         }
         return b.toString();

--- a/org.lflang.diagram/src/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
+++ b/org.lflang.diagram/src/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
@@ -176,7 +176,7 @@ public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
             if (reactorInstance.reactorDefinition.getHost() != null && 
                     getBooleanValue(LinguaFrancaSynthesis.SHOW_REACTOR_HOST)) {
                 KText hostNameText = _kContainerRenderingExtensions.addText(childContainer, 
-                        ASTUtils.toText(reactorInstance.reactorDefinition.getHost()));
+                        ASTUtils.toOriginalText(reactorInstance.reactorDefinition.getHost()));
                 DiagramSyntheses.suppressSelectability(hostNameText);
                 _linguaFrancaStyleExtensions.underlineSelectionStyle(hostNameText);
                 setGridPlacementDataFromPointToPoint(hostNameText,
@@ -246,7 +246,7 @@ public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
             
             if (getBooleanValue(LinguaFrancaSynthesis.SHOW_REACTOR_HOST)) {
                 KText reactorHostText = _kContainerRenderingExtensions.addText(childContainer, 
-                        ASTUtils.toText(reactorInstance.getDefinition().getHost()));
+                        ASTUtils.toOriginalText(reactorInstance.getDefinition().getHost()));
                 DiagramSyntheses.suppressSelectability(reactorHostText);
                 _linguaFrancaStyleExtensions.underlineSelectionStyle(reactorHostText);
                 setGridPlacementDataFromPointToPoint(reactorHostText,

--- a/org.lflang/src/org/lflang/InferredType.java
+++ b/org.lflang/src/org/lflang/InferredType.java
@@ -25,6 +25,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package org.lflang;
 
+import java.util.function.Function;
+import org.eclipse.emf.ecore.EObject;
+
 import org.lflang.lf.Type;
 
 /**
@@ -95,11 +98,20 @@ public class InferredType {
     }
 
     /**
-     * Convert the inferred type to its textual representation as it would appear in LF code.
+     * Convert the inferred type to its textual representation as it would appear in LF code,
+     * with CodeMap tags inserted.
      */
-    public String toText() {
+    public String toText() { return toTextHelper(ASTUtils::toText); }
+
+    /**
+     * Convert the inferred type to its textual representation as it would appear in LF code,
+     * without CodeMap tags inserted.
+     */
+    public String toOriginalText() { return toTextHelper(ASTUtils::toOriginalText); }
+
+    private String toTextHelper(Function<EObject, String> toText) {
         if (astType != null) {
-            return ASTUtils.toText(astType);
+            return toText.apply(astType);
         } else if (isTime) {
             if (isFixedSizeList) {
                 return "time[" + listSize + "]";


### PR DESCRIPTION
Some days ago I renamed a function in `ASTUtils` but forgot to update the function name in the `diagram` package. This amends that.