### PR TITLE
A possible stub for publishing the LF internal model/AST to Github Pak.

### DIFF
--- a/.github/workflows/publish-model-2-packages.yml
+++ b/.github/workflows/publish-model-2-packages.yml
@@ -1,0 +1,21 @@
+name: Publish org.lflang to GitHub Packages
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare build environment
+        uses: ./.github/actions/prepare-build-env
+      - name: Publish package
+        uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
+        with:
+          arguments: org.lflang:publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,8 @@ subprojects {
     repositories {
         mavenCentral()
     }
-    
+
+    apply plugin: 'java'
     apply plugin: 'kotlin'
     compileKotlin {
         destinationDir = compileJava.destinationDir

--- a/org.lflang/build.gradle
+++ b/org.lflang/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'maven-publish'
+}
+
 dependencies {
     implementation "org.eclipse.xtext:org.eclipse.xtext:${xtextVersion}"
     implementation "org.eclipse.xtext:org.eclipse.xtext.xbase.lib:${xtextVersion}"
@@ -69,3 +73,18 @@ generateXtext.dependsOn(generateXtextLanguage)
 clean.dependsOn(cleanGenerateXtextLanguage)
 eclipse.classpath.plusConfigurations += [configurations.mwe2]
 
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = "https://maven.pkg.github.com/lf-lang/lingua-franca"
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}
+
+publish.dependsOn(generateXtextLanguage)
+publish.dependsOn(jar)


### PR DESCRIPTION
This is a small stub to help a bit with the issue opened in #937 . I am fairly certain that if any necessary jars/modules are published in Github Packages, the outcome is just as good as doing it for Maven central. Plus, it seems like Github Packages requires less setting up than maven central (e.g. no need for given GPG key).

Since I am not an expert on the infrastructure surrounding LF, I've tried my best to use GH's stub publishing along the other GH actions I saw in the repo. Hopefully it does not destroy anything but gives an _almost correct_ workflow to publish the model/AST jars to GH's packages.

The tests still all passed, minus the repo_token one. I could not find a proper branch to try to merge in to, so I leave master for now. If this is inappropriate, I can change the request. 