### PR TITLE
Added support for C methods

### DIFF
--- a/org.lflang/src/org/lflang/ASTUtils.java
+++ b/org.lflang/src/org/lflang/ASTUtils.java
@@ -55,7 +55,6 @@ import org.eclipse.xtext.util.Tuples;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.IteratorExtensions;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
-
 import org.lflang.ast.ToText;
 import org.lflang.generator.CodeMap;
 import org.lflang.generator.GeneratorBase;
@@ -73,6 +72,7 @@ import org.lflang.lf.Instantiation;
 import org.lflang.lf.LfFactory;
 import org.lflang.lf.LfPackage;
 import org.lflang.lf.Literal;
+import org.lflang.lf.Method;
 import org.lflang.lf.Mode;
 import org.lflang.lf.Model;
 import org.lflang.lf.Output;
@@ -635,6 +635,15 @@ public class ASTUtils {
         return ASTUtils.collectElements(definition, featurePackage.getReactor_Instantiations());
     }
     
+    /**
+     * Given a reactor class, return a list of all its methods,
+     * which includes methods of base classes that it extends.
+     * @param definition Reactor class definition.
+     */
+    public static List<Method> allMethods(Reactor definition) {
+        return ASTUtils.collectElements(definition, featurePackage.getReactor_Methods());
+    }
+
     /**
      * Given a reactor class, return a list of all its outputs,
      * which includes outputs of base classes that it extends.

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -27,7 +27,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.lflang.generator.c;
 import static org.lflang.ASTUtils.allActions;
 import static org.lflang.ASTUtils.allInputs;
-import static org.lflang.ASTUtils.allMethods;
 import static org.lflang.ASTUtils.allOutputs;
 import static org.lflang.ASTUtils.allReactions;
 import static org.lflang.ASTUtils.allStateVars;
@@ -90,7 +89,6 @@ import org.lflang.lf.ActionOrigin;
 import org.lflang.lf.Expression;
 import org.lflang.lf.Input;
 import org.lflang.lf.Instantiation;
-import org.lflang.lf.Method;
 import org.lflang.lf.Mode;
 import org.lflang.lf.Model;
 import org.lflang.lf.Output;
@@ -1196,7 +1194,7 @@ public class CGenerator extends GeneratorBase {
         var constructorCode = new CodeBuilder();
         generateAuxiliaryStructs(reactor);
         generateSelfStruct(reactor, constructorCode);
-        generateMethods(reactor);
+        CMethodGenerator.generateMethods(reactor, code, types);
         generateReactions(reactor, currentFederate);
         generateConstructor(reactor, currentFederate, constructorCode);
 
@@ -1347,9 +1345,6 @@ public class CGenerator extends GeneratorBase {
         // Next, generate fields for modes
         CModesGenerator.generateDeclarations(reactor, body, constructorCode);
         
-        // Finally, generate fields for methods.
-        CMethodGenerator.generateDeclarations(reactor, body, constructorCode, types);
-
         // The first field has to always be a pointer to the list of
         // of allocated memory that must be freed when the reactor is freed.
         // This means that the struct can be safely cast to self_base_t.
@@ -1491,18 +1486,6 @@ public class CGenerator extends GeneratorBase {
                 "} _lf_"+containedReactor.getName()+array+";",
                 "int _lf_"+containedReactor.getName()+"_width;"
             ));
-        }
-    }
-
-    /** Generate method functions definition for a reactor.
-     *  These functions have a first argument that is a void* pointing to
-     *  the self struct.
-     *  @param reactor The reactor.
-     */
-    public void generateMethods(ReactorDecl decl) {
-        var reactor = ASTUtils.toDefinition(decl);
-        for (Method method : allMethods(reactor)) {
-            code.pr(CMethodGenerator.generateMethod(method, decl, types));
         }
     }
 

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -25,6 +25,19 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***************/
 
 package org.lflang.generator.c;
+import static org.lflang.ASTUtils.allActions;
+import static org.lflang.ASTUtils.allInputs;
+import static org.lflang.ASTUtils.allMethods;
+import static org.lflang.ASTUtils.allOutputs;
+import static org.lflang.ASTUtils.allReactions;
+import static org.lflang.ASTUtils.allStateVars;
+import static org.lflang.ASTUtils.convertToEmptyListIfNull;
+import static org.lflang.ASTUtils.getInferredType;
+import static org.lflang.ASTUtils.isInitialized;
+import static org.lflang.ASTUtils.toDefinition;
+import static org.lflang.ASTUtils.toText;
+import static org.lflang.util.StringUtil.addDoubleQuotes;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -34,18 +47,17 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-import com.google.common.base.Objects;
-import com.google.common.collect.Iterables;
+
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.IteratorExtensions;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
+import org.lflang.ASTUtils;
 import org.lflang.ErrorReporter;
 import org.lflang.FileConfig;
 import org.lflang.InferredType;
-import org.lflang.ASTUtils;
 import org.lflang.Target;
 import org.lflang.TargetConfig;
 import org.lflang.TargetProperty;
@@ -60,10 +72,9 @@ import org.lflang.federated.serialization.SupportedSerializers;
 import org.lflang.generator.ActionInstance;
 import org.lflang.generator.CodeBuilder;
 import org.lflang.generator.GeneratorBase;
-import org.lflang.generator.DockerGeneratorBase;
 import org.lflang.generator.GeneratorResult;
-import org.lflang.generator.IntegratedBuilder;
 import org.lflang.generator.GeneratorUtils;
+import org.lflang.generator.IntegratedBuilder;
 import org.lflang.generator.LFGeneratorContext;
 import org.lflang.generator.LFResource;
 import org.lflang.generator.ParameterInstance;
@@ -79,6 +90,7 @@ import org.lflang.lf.ActionOrigin;
 import org.lflang.lf.Expression;
 import org.lflang.lf.Input;
 import org.lflang.lf.Instantiation;
+import org.lflang.lf.Method;
 import org.lflang.lf.Mode;
 import org.lflang.lf.Model;
 import org.lflang.lf.Output;
@@ -92,8 +104,9 @@ import org.lflang.lf.VarRef;
 import org.lflang.lf.Variable;
 import org.lflang.lf.WidthTerm;
 import org.lflang.util.FileUtil;
-import static org.lflang.ASTUtils.*;
-import static org.lflang.util.StringUtil.*;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Iterables;
 
 /**
  * Generator for C target. This class generates C code defining each reactor
@@ -1183,6 +1196,7 @@ public class CGenerator extends GeneratorBase {
         var constructorCode = new CodeBuilder();
         generateAuxiliaryStructs(reactor);
         generateSelfStruct(reactor, constructorCode);
+        generateMethods(reactor);
         generateReactions(reactor, currentFederate);
         generateConstructor(reactor, currentFederate, constructorCode);
 
@@ -1474,6 +1488,18 @@ public class CGenerator extends GeneratorBase {
                 "} _lf_"+containedReactor.getName()+array+";",
                 "int _lf_"+containedReactor.getName()+"_width;"
             ));
+        }
+    }
+
+    /** Generate method functions definition for a reactor.
+     *  These functions have a first argument that is a void* pointing to
+     *  the self struct.
+     *  @param reactor The reactor.
+     */
+    public void generateMethods(ReactorDecl decl) {
+        var reactor = ASTUtils.toDefinition(decl);
+        for (Method method : allMethods(reactor)) {
+            code.pr(CMethodGenerator.generateMethod(method, decl, types));
         }
     }
 

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -1346,6 +1346,9 @@ public class CGenerator extends GeneratorBase {
 
         // Next, generate fields for modes
         CModesGenerator.generateDeclarations(reactor, body, constructorCode);
+        
+        // Finally, generate fields for methods.
+        CMethodGenerator.generateDeclarations(reactor, body, constructorCode, types);
 
         // The first field has to always be a pointer to the list of
         // of allocated memory that must be freed when the reactor is freed.

--- a/org.lflang/src/org/lflang/generator/c/CMethodGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CMethodGenerator.java
@@ -10,54 +10,41 @@ import org.lflang.lf.Reactor;
 import org.lflang.lf.ReactorDecl;
 
 /**
- * Generates C code to declare and initialize methods.
+ * Collection of functios to generate C code to declare methods.
  *
  * @author {Edward A. Lee <eal@berkeley.edu>}
  */
 public class CMethodGenerator {
+    
     /**
-     * Generate fields in the self struct for method functions and
-     * initialize them in the constructor.
-     *
+     * Generate macro definitions for methods.
      * @param reactor The reactor.
-     * @param body The place to put the struct declarations.
-     * @param constructorCode The place to put the constructor code.
-     * @param types The C-specific type conversion functions.
+     * @param body The place to put the macro definitions.
      */
-    public static void generateDeclarations(
+    public static void generateMacrosForMethods(
         Reactor reactor,
-        CodeBuilder body,
-        CodeBuilder constructorCode,
-        CTypes types
+        CodeBuilder body
     ) {
         for (Method method : allMethods(reactor)) {
-            
             var functionName = methodFunctionName(reactor, method);
-            
-            // Construct function type signature.
-            StringBuilder typeSignature = new StringBuilder();
-            if (method.getReturn() != null) {
-                typeSignature.append(types.getTargetType(InferredType.fromAST(method.getReturn())));
-            } else {
-                typeSignature.append("void");
-            }
-            typeSignature.append("(*");
-            typeSignature.append(method.getName());
-            typeSignature.append(")(void*");
-            if (method.getArguments() != null) {
-                for (var arg : method.getArguments()) {
-                    typeSignature.append(", ");
-                    typeSignature.append(types.getTargetType(InferredType.fromAST(arg.getType())));
-                }
-            }
-            typeSignature.append(");");
-            body.pr(typeSignature);
-            
-            constructorCode.pr("self->"+method.getName()+" = "+functionName+";");
+            body.pr("#define "+method.getName()+"(...) "+functionName+"(self, ##__VA_ARGS__)");
         }
-
     }
-    
+
+    /**
+     * Generate macro undefinitions for methods.
+     * @param reactor The reactor.
+     * @param body The place to put the macro definitions.
+     */
+    public static void generateMacroUndefsForMethods(
+        Reactor reactor,
+        CodeBuilder body
+    ) {
+        for (Method method : allMethods(reactor)) {
+            body.pr("#undef "+method.getName());
+        }
+    }
+
     /** 
      * Generate a method function definition for a reactor.
      * This function will have a first argument that is a void* pointing to
@@ -73,29 +60,10 @@ public class CMethodGenerator {
     ) {
         var code = new CodeBuilder();
         var body = ASTUtils.toText(method.getCode());
-        var functionName = methodFunctionName(decl, method);
-        
-        StringBuilder header = new StringBuilder();
-        if (method.getReturn() != null) {
-            header.append(types.getTargetType(InferredType.fromAST(method.getReturn())));
-            header.append(" ");
-        } else {
-            header.append("void ");
-        }
-        header.append(functionName);
-        header.append("(void* instance_args");
-        if (method.getArguments() != null) {
-            for (var arg : method.getArguments()) {
-                header.append(", ");
-                header.append(types.getTargetType(InferredType.fromAST(arg.getType())));
-                header.append(" ");
-                header.append(arg.getName());
-            }
-        }
-        header.append(") {");
-        
+                
         code.prSourceLineNumber(method);
-        code.pr(header);
+        code.prComment("Implementation of method "+method.getName()+"()");
+        code.pr(generateMethodSignature(method, decl, types) + " {");
         code.indent();
         
         // Define the "self" struct.
@@ -117,6 +85,49 @@ public class CMethodGenerator {
         return code.toString();
     }
 
+    /** 
+     * Generate method functions definition for a reactor.
+     * These functions have a first argument that is a void* pointing to
+     * the self struct.
+     * @param reactor The reactor.
+     * @param code The place to put the code.
+     * @param types The C-specific type conversion functions.
+     */
+    public static void generateMethods(
+            ReactorDecl decl,
+            CodeBuilder code,
+            CTypes types
+    ) {
+        var reactor = ASTUtils.toDefinition(decl);
+        code.prComment("***** Start of method declarations.");
+        signatures(decl, code, types);
+        generateMacrosForMethods(reactor, code);
+        for (Method method : allMethods(reactor)) {
+            code.pr(CMethodGenerator.generateMethod(method, decl, types));
+        }
+        generateMacroUndefsForMethods(reactor, code);
+        code.prComment("***** End of method declarations.");
+    }
+
+    /**
+     * Generate function signatures for methods.
+     * This can be used to declare all the methods with signatures only
+     * before giving the full definition so that methods may call each other
+     * (and themselves) regardless of the order of definition.
+     * @param decl The reactor declaration.
+     * @param types The C-specific type conversion functions.
+     */
+    public static void signatures(
+        ReactorDecl decl,
+        CodeBuilder body,
+        CTypes types
+    ) {
+        Reactor reactor = ASTUtils.toDefinition(decl);
+        for (Method method : allMethods(reactor)) {
+            body.pr(generateMethodSignature(method, decl, types) + ";");
+        }
+    }
+
     /**
      * Return the function name for specified method of the specified reactor.
      * @param reactor The reactor
@@ -125,5 +136,41 @@ public class CMethodGenerator {
      */
     private static String methodFunctionName(ReactorDecl reactor, Method method) {
         return reactor.getName().toLowerCase() + "_method_" + method.getName();
+    }
+    
+    /** 
+     * Generate a method function signature for a reactor.
+     * This function will have a first argument that is a void* pointing to
+     * the self struct, followed by any arguments given in its definition.
+     * @param method The method.
+     * @param decl The reactor declaration.
+     * @param types The C-specific type conversion functions.
+     */
+    public static String generateMethodSignature(
+        Method method,
+        ReactorDecl decl,
+        CTypes types
+    ) {
+        var functionName = methodFunctionName(decl, method);
+        
+        StringBuilder result = new StringBuilder();
+        if (method.getReturn() != null) {
+            result.append(types.getTargetType(InferredType.fromAST(method.getReturn())));
+            result.append(" ");
+        } else {
+            result.append("void ");
+        }
+        result.append(functionName);
+        result.append("(void* instance_args");
+        if (method.getArguments() != null) {
+            for (var arg : method.getArguments()) {
+                result.append(", ");
+                result.append(types.getTargetType(InferredType.fromAST(arg.getType())));
+                result.append(" ");
+                result.append(arg.getName());
+            }
+        }
+        result.append(")");
+        return result.toString();
     }
 }

--- a/org.lflang/src/org/lflang/generator/c/CMethodGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CMethodGenerator.java
@@ -1,0 +1,72 @@
+package org.lflang.generator.c;
+
+import org.lflang.ASTUtils;
+import org.lflang.InferredType;
+import org.lflang.generator.CodeBuilder;
+import org.lflang.lf.Method;
+import org.lflang.lf.ReactorDecl;
+
+/**
+ * Generates C code to declare and initialize methods.
+ *
+ * @author {Edward A. Lee <eal@berkeley.edu>}
+ */
+public class CMethodGenerator {
+    /** 
+     * Generate a method function definition for a reactor.
+     * This function will have a first argument that is a void* pointing to
+     * the self struct, followed by any arguments given in its definition.
+     * @param method The method.
+     * @param decl The reactor declaration.
+     * @param types The C-specific type conversion functions.
+     */
+    public static String generateMethod(
+        Method method,
+        ReactorDecl decl,
+        CTypes types
+    ) {
+        var code = new CodeBuilder();
+        var body = ASTUtils.toText(method.getCode());
+        
+        StringBuilder header = new StringBuilder();
+        if (method.getReturn() != null) {
+            header.append(types.getTargetType(InferredType.fromAST(method.getReturn())));
+            header.append(" ");
+        } else {
+            header.append("void ");
+        }
+        header.append(method.getName());
+        header.append("(void* instance_args");
+        if (method.getArguments() != null) {
+            for (var arg : method.getArguments()) {
+                header.append(", ");
+                header.append(types.getTargetType(InferredType.fromAST(arg.getType())));
+                header.append(" ");
+                header.append(arg.getName());
+            }
+        }
+        header.append(") {");
+        
+        code.prSourceLineNumber(method);
+        code.pr(header);
+        code.indent();
+        
+        // Define the "self" struct.
+        String structType = CUtil.selfType(decl);
+        // A null structType means there are no inputs, state,
+        // or anything else. No need to declare it.
+        if (structType != null) {
+             code.pr(String.join("\n",
+                 "#pragma GCC diagnostic push",
+                 "#pragma GCC diagnostic ignored \"-Wunused-variable\"",
+                 structType+"* self = ("+structType+"*)instance_args;"
+             ));
+        }
+        
+        code.prSourceLineNumber(method.getCode());
+        code.pr(body);
+        code.unindent();
+        code.pr("}");
+        return code.toString();
+    }
+}

--- a/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
@@ -1,6 +1,7 @@
 package org.lflang.generator.c;
 
 import static org.lflang.generator.c.CUtil.generateWidthVariable;
+import static org.lflang.util.StringUtil.addDoubleQuotes;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -8,6 +9,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.lflang.ASTUtils;
 import org.lflang.ErrorReporter;
 import org.lflang.InferredType;
@@ -20,6 +22,7 @@ import org.lflang.lf.ActionOrigin;
 import org.lflang.lf.Code;
 import org.lflang.lf.Input;
 import org.lflang.lf.Instantiation;
+import org.lflang.lf.Method;
 import org.lflang.lf.Mode;
 import org.lflang.lf.Output;
 import org.lflang.lf.Port;
@@ -31,8 +34,6 @@ import org.lflang.lf.TriggerRef;
 import org.lflang.lf.VarRef;
 import org.lflang.lf.Variable;
 import org.lflang.util.StringUtil;
-
-import static org.lflang.util.StringUtil.addDoubleQuotes;
 
 public class CReactionGenerator {
     protected static String DISABLE_REACTION_INITIALIZATION_MARKER

--- a/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
@@ -22,7 +22,6 @@ import org.lflang.lf.ActionOrigin;
 import org.lflang.lf.Code;
 import org.lflang.lf.Input;
 import org.lflang.lf.Instantiation;
-import org.lflang.lf.Method;
 import org.lflang.lf.Mode;
 import org.lflang.lf.Output;
 import org.lflang.lf.Port;
@@ -1190,6 +1189,7 @@ public class CReactionGenerator {
         code.pr(
             "#include " + StringUtil.addDoubleQuotes(
                 CCoreFilesUtils.getCTargetSetHeader()));
+        CMethodGenerator.generateMacrosForMethods(ASTUtils.toDefinition(decl), code);
         code.pr(generateFunction(
             generateReactionFunctionHeader(decl, reactionIndex),
             init, reaction.getCode()
@@ -1210,6 +1210,7 @@ public class CReactionGenerator {
                 generateDeadlineFunctionHeader(decl, reactionIndex),
                 init, reaction.getDeadline().getCode()));
         }
+        CMethodGenerator.generateMacroUndefsForMethods(ASTUtils.toDefinition(decl), code);
         code.pr(
             "#include " + StringUtil.addDoubleQuotes(
                 CCoreFilesUtils.getCTargetSetUndefHeader()));

--- a/test/C/src/target/Methods.lf
+++ b/test/C/src/target/Methods.lf
@@ -13,13 +13,13 @@ main reactor {
     =}
 
     reaction(startup){=
-        lf_print("Foo is initialized to %d", self->getFoo(self));
-        if (self->getFoo(self) != 2) {
+        lf_print("Foo is initialized to %d", getFoo());
+        if (getFoo() != 2) {
             lf_print_error_and_exit("Expected 2!");
         }
 
-        self->add(self, 40);
-        int a = self->getFoo(self);
+        add(40);
+        int a = getFoo();
         lf_print("2 + 40 = %d", a);
         if (a != 42) {
             lf_print_error_and_exit("Expected 42!");

--- a/test/C/src/target/Methods.lf
+++ b/test/C/src/target/Methods.lf
@@ -1,0 +1,28 @@
+target C;
+
+main reactor {
+
+    state foo:int(2);
+
+    method getFoo(): int {=
+        return self->foo;
+    =}
+
+    method add(x:int) {=
+        self->foo += x;
+    =}
+
+    reaction(startup){=
+        lf_print("Foo is initialized to %d", getFoo(self));
+        if (getFoo(self) != 2) {
+            lf_print_error_and_exit("Expected 2!");
+        }
+
+        add(self, 40);
+        int a = getFoo(self);
+        lf_print("2 + 40 = %d", a);
+        if (a != 42) {
+            lf_print_error_and_exit("Expected 42!");
+        }
+    =}
+}

--- a/test/C/src/target/Methods.lf
+++ b/test/C/src/target/Methods.lf
@@ -13,13 +13,13 @@ main reactor {
     =}
 
     reaction(startup){=
-        lf_print("Foo is initialized to %d", getFoo(self));
-        if (getFoo(self) != 2) {
+        lf_print("Foo is initialized to %d", self->getFoo(self));
+        if (self->getFoo(self) != 2) {
             lf_print_error_and_exit("Expected 2!");
         }
 
-        add(self, 40);
-        int a = getFoo(self);
+        self->add(self, 40);
+        int a = self->getFoo(self);
         lf_print("2 + 40 = %d", a);
         if (a != 42) {
             lf_print_error_and_exit("Expected 42!");

--- a/test/C/src/target/MethodsRecursive.lf
+++ b/test/C/src/target/MethodsRecursive.lf
@@ -1,0 +1,23 @@
+// Test ability of methods to call each other and (recursively) themselves.
+target C;
+
+main reactor {
+
+    state foo:int(2);
+
+    // Return the n-th Fibonacci number.
+    method fib(n:int): int {=
+        if (n <= 1) return 1;
+        return add(fib(n-1), fib(n-2));
+    =}
+
+    method add(x:int, y:int): int {=
+        return x + y;
+    =}
+
+    reaction(startup){=
+        for (int n = 1; n < 10; n++) {
+            lf_print("%d-th Fibonacci number is %d", n, fib(n));
+        }
+    =}
+}

--- a/test/C/src/target/MethodsSameName.lf
+++ b/test/C/src/target/MethodsSameName.lf
@@ -10,7 +10,7 @@ reactor Foo {
     =}
 
     reaction(startup){=
-        self->add(self, 40);
+        add(40);
         lf_print("Foo: 2 + 40 = %d", self->foo);
         if (self->foo != 42) {
             lf_print_error_and_exit("Expected 42!");
@@ -29,7 +29,7 @@ main reactor {
     =}
 
     reaction(startup){=
-        self->add(self, 40);
+        add(40);
         lf_print("Main: 2 + 40 = %d", self->foo);
         if (self->foo != 42) {
             lf_print_error_and_exit("Expected 42!");

--- a/test/C/src/target/MethodsSameName.lf
+++ b/test/C/src/target/MethodsSameName.lf
@@ -1,0 +1,38 @@
+/** This tests that reactors can have methods with the same names. */
+target C;
+
+reactor Foo {
+
+    state foo:int(2);
+
+    method add(x:int) {=
+        self->foo += x;
+    =}
+
+    reaction(startup){=
+        self->add(self, 40);
+        lf_print("Foo: 2 + 40 = %d", self->foo);
+        if (self->foo != 42) {
+            lf_print_error_and_exit("Expected 42!");
+        }
+    =}
+}
+
+main reactor {
+
+    state foo:int(2);
+    
+    a = new Foo();
+
+    method add(x:int) {=
+        self->foo += x;
+    =}
+
+    reaction(startup){=
+        self->add(self, 40);
+        lf_print("Main: 2 + 40 = %d", self->foo);
+        if (self->foo != 42) {
+            lf_print_error_and_exit("Expected 42!");
+        }
+    =}
+}


### PR DESCRIPTION
I've added support for methods in C because I need this to implement LET.
The invocation of a method in target code is a bit awkward.
You have to do this:
```
    self->my_method(self, my_arguments);
```
But with this design, method names need not be unique across reactors.