### PR TITLE
Machine-applicable refactorings

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaDependencyAnalysisTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaDependencyAnalysisTest.java
@@ -154,36 +154,20 @@ class LinguaFrancaDependencyAnalysisTest {
      */
     @Test
     public void circularInstantiation() throws Exception {
-// Java 17:
-//         String testCase = """
-//             target C;
-//             
-//             reactor X {
-//                 reaction() {=
-//                 //
-//                 =}
-//                 p = new Y();
-//             }
-//             
-//             reactor Y {
-//                 q = new X();
-//             }
-//         """
-// Java 11:
-        String testCase = String.join(System.getProperty("line.separator"),
-            "target C;",
-            "",
-            "reactor X {",
-            "    reaction() {=",
-            "    //",
-            "    =}",
-            "    p = new Y();",
-            "}",
-            "",
-            "reactor Y {",
-            "    q = new X();",
-            "}"
-        );
+        String testCase = """
+             target C;
+
+             reactor X {
+                 reaction() {=
+                 //
+                 =}
+                 p = new Y();
+             }
+
+             reactor Y {
+                 q = new X();
+             }
+         """;
         Model model = parser.parse(testCase);
         
         Assertions.assertNotNull(model);

--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaScopingTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaScopingTest.java
@@ -123,40 +123,21 @@ public class LinguaFrancaScopingTest {
      */
     @Test
     public void unresolvedHierarchicalPortReference() throws Exception {
-// Java 17:
-//        Model model = """
-//            target C;
-//            reactor From {
-//                output y:int;
-//            }
-//            reactor To {
-//                input x:int;
-//            }
-//            
-//            main reactor {
-//                a = new From();
-//                d = new To();
-//                a.x -> d.y;
-//            }
-//        """;
-// Java 11:
-        
-        Model model = parser.parse(String.join(
-            System.getProperty("line.separator"),
-            "target C;", 
-            "reactor From {",
-            "    output y:int;",
-            "}",
-            "reactor To {",
-            "    input x:int;",
-            "}",
-            "main reactor {",
-            "    a = new From();",
-            "    d = new To();",
-            "    a.x -> d.y;",
-            "}"
-        ));
-              
+        Model model = parser.parse("""
+            target C;
+            reactor From {
+                output y:int;
+            }
+            reactor To {
+                input x:int;
+            }
+
+            main reactor {
+                a = new From();
+                d = new To();
+                a.x -> d.y;
+            }
+        """);
         
         Assertions.assertNotNull(model);
         Assertions.assertTrue(model.eResource().getErrors().isEmpty(),
@@ -171,21 +152,12 @@ public class LinguaFrancaScopingTest {
 
     @Test
     public void unresolvedReferenceInTriggerClause() throws Exception {
-// Java 17:
-//        Model model = """
-//            target C;
-//            main reactor {
-//                reaction(unknown) {==}
-//            }
-//        """
-// Java 11:
-        Model model = parser.parse(String.join(
-        System.getProperty("line.separator"),
-            "target C;", 
-            "main reactor {",
-            "    reaction(unknown) {==}",
-            "}"
-        ));
+        Model model = parser.parse("""
+            target C;
+            main reactor {
+                reaction(unknown) {==}
+            }
+        """);
         
     validator.assertError(model, LfPackage.eINSTANCE.getVarRef(),
             XtextLinkingDiagnostic.LINKING_DIAGNOSTIC,
@@ -194,21 +166,12 @@ public class LinguaFrancaScopingTest {
 
     @Test
     public void unresolvedReferenceInUseClause() throws Exception {
-// Java 17:
-//        Model model = """
-//            target C;
-//            main reactor {
-//                reaction() unknown {==}
-//            }
-//        """
-// Java 11:
-        Model model = parser.parse(String.join(
-        System.getProperty("line.separator"),
-            "target C;", 
-            "main reactor {",
-            "    reaction() unknown {==}",
-            "}"
-        ));
+        Model model = parser.parse("""
+            target C;
+            main reactor {
+                reaction() unknown {==}
+            }
+        """);
         
         
         validator.assertError(model, LfPackage.eINSTANCE.getVarRef(),
@@ -218,24 +181,13 @@ public class LinguaFrancaScopingTest {
 
     @Test
     public void unresolvedReferenceInEffectsClause() throws Exception {
-// Java 17:
-//        Model model = """
-//            target C;
-//            main reactor {
-//                reaction() -> unknown {==}
-//            }
-//        """
-// Java 11:        
-        
-        Model model = parser.parse(String.join(
-        System.getProperty("line.separator"),
-            "target C;", 
-            "main reactor {",
-            "    reaction() -> unknown {==}",
-            "}"
-        ));
+        Model model = parser.parse("""
+            target C;
+            main reactor {
+                reaction() -> unknown {==}
+            }
+        """);
 
-        
         validator.assertError(model, LfPackage.eINSTANCE.getVarRef(),
             XtextLinkingDiagnostic.LINKING_DIAGNOSTIC,
             "Couldn't resolve reference to Variable 'unknown'.");

--- a/org.lflang/src/org/lflang/generator/GeneratorBase.java
+++ b/org.lflang/src/org/lflang/generator/GeneratorBase.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -102,7 +101,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
      */
     public ReactorInstance main;
 
-    /** A error reporter for reporting any errors or warnings during the code generation */
+    /** An error reporter for reporting any errors or warnings during the code generation */
     public ErrorReporter errorReporter;
 
     ////////////////////////////////////////////
@@ -248,7 +247,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
 
     /**
      * Store the given reactor in the collection of generated delay classes
-     * and insert it in the AST under the top-level reactors node.
+     * and insert it in the AST under the top-level reactor's node.
      */
     public void addDelayClass(Reactor generatedDelay) {
         // Record this class, so it can be reused.
@@ -275,7 +274,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
         Iterable<EObject> nodes = IteratorExtensions.toIterable(fileConfig.resource.getAllContents());
         for (Reactor reactor : Iterables.filter(nodes, Reactor.class)) {
             if (reactor.isMain() || reactor.isFederated()) {
-                // Creating an definition for the main reactor because there isn't one.
+                // Creating a definition for the main reactor because there isn't one.
                 this.mainDef = LfFactory.eINSTANCE.createInstantiation();
                 this.mainDef.setName(reactor.getName());
                 this.mainDef.setReactorClass(reactor);
@@ -289,7 +288,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
      * This is the main entry point for code generation. This base class finds all
      * reactor class definitions, including any reactors defined in imported .lf files
      * (except any main reactors in those imported files), and adds them to the
-     * {@link #GeneratorBase.reactors reactors} list. If errors occur during
+     * {@link GeneratorBase#reactors reactors} list. If errors occur during
      * generation, then a subsequent call to errorsOccurred() will return true.
      * @param resource The resource containing the source code.
      * @param context Context relating to invocation of the code generator.
@@ -346,7 +345,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
         resources.addAll(allResources.stream()  // FIXME: This filter reproduces the behavior of the method it replaces. But why must it be so complicated? Why are we worried about weird corner cases like this?
             .filter(it -> !Objects.equal(it, fileConfig.resource) || mainDef != null && it == mainDef.getReactorClass().eResource())
             .map(it -> GeneratorUtils.getLFResource(it, fileConfig.getSrcGenBasePath(), context, errorReporter))
-            .collect(Collectors.toList())
+            .toList()
         );
         GeneratorUtils.accommodatePhysicalActionsIfPresent(
             allResources,
@@ -457,16 +456,16 @@ public abstract class GeneratorBase extends AbstractLFValidator {
     /**
      * Generate code for the body of a reaction that takes an input and
      * schedules an action with the value of that input.
-     * @param the action to schedule
-     * @param the port to read from
+     * @param action the action to schedule
+     * @param port the port to read from
      */
     public abstract String generateDelayBody(Action action, VarRef port);
 
     /**
      * Generate code for the body of a reaction that is triggered by the
      * given action and writes its value to the given port.
-     * @param the action that triggers the reaction
-     * @param the port to write to
+     * @param action the action that triggers the reaction
+     * @param port the port to write to
      */
     public abstract String generateForwardBody(Action action, VarRef port);
 
@@ -489,7 +488,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
      * @return True if the reaction has been marked unordered.
      */
     public boolean isUnordered(Reaction reaction) {
-        return unorderedReactions != null ? unorderedReactions.contains(reaction) : false;
+        return unorderedReactions != null && unorderedReactions.contains(reaction);
     }
 
     /**
@@ -506,7 +505,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
      */
     public void makeUnordered(Reaction reaction) {
         if (unorderedReactions == null) {
-            unorderedReactions = new LinkedHashSet<Reaction>();
+            unorderedReactions = new LinkedHashSet<>();
         }
         unorderedReactions.add(reaction);
     }
@@ -517,7 +516,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
      * a specific bank index as an effect or trigger. Reactions that
      * send messages between federates, including absent messages,
      * need to be specific to a bank member.
-     * @param The reaction.
+     * @param reaction The reaction.
      * @param bankIndex The bank index, or -1 if there is no bank.
      */
     public void setReactionBankIndex(Reaction reaction, int bankIndex) {
@@ -525,15 +524,15 @@ public abstract class GeneratorBase extends AbstractLFValidator {
             return;
         }
         if (reactionBankIndices == null) {
-            reactionBankIndices = new LinkedHashMap<Reaction,Integer>();
+            reactionBankIndices = new LinkedHashMap<>();
         }
         reactionBankIndices.put(reaction, bankIndex);
     }
 
     /**
      * Return the reaction bank index.
-     * @see setReactionBankIndex(Reaction reaction, int bankIndex)
-     * @param The reaction.
+     * @see #setReactionBankIndex(Reaction reaction, int bankIndex)
+     * @param reaction The reaction.
      * @return The reaction bank index, if one has been set, and -1 otherwise.
      */
     public int getReactionBankIndex(Reaction reaction) {
@@ -565,7 +564,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
     }
 
     // note that this is moved out by #544
-    public static final String cMacroName(TimeUnit unit) {
+    public static String cMacroName(TimeUnit unit) {
         return unit.getCanonicalName().toUpperCase();
     }
 
@@ -626,7 +625,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
      * Return target code for forwarding reactions iff the connections have the
      * same destination as other connections or reaction in mutually exclusive modes.
      *
-     * This methods needs to be overridden in target specific code generators that
+     * This method needs to be overridden in target specific code generators that
      * support modal reactors.
      */
     protected String getConflictingConnectionsInModalReactorsBody(String source, String dest) {
@@ -711,7 +710,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
      * Generate code for the body of a reaction that waits long enough so that the status
      * of the trigger for the given port becomes known for the current logical time.
      *
-     * @param port The port to generate the control reaction for
+     * @param receivingPortID port The port to generate the control reaction for
      * @param maxSTP The maximum value of STP is assigned to reactions (if any)
      *  that have port as their trigger or source
      */
@@ -961,7 +960,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
      * Set the RTI hostname, port and username if given as compiler arguments
      */
     private void setFederationRTIProperties(LFGeneratorContext context) {
-        String rtiAddr = context.getArgs().getProperty("rti").toString();
+        String rtiAddr = context.getArgs().getProperty("rti");
         Pattern pattern = Pattern.compile("([a-zA-Z0-9]+@)?([a-zA-Z0-9]+\\.?[a-z]{2,}|[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+):?([0-9]+)?");
         Matcher matcher = pattern.matcher(rtiAddr);
 
@@ -1075,15 +1074,15 @@ public abstract class GeneratorBase extends AbstractLFValidator {
                          * federateInstance.dir = instantiation.getHost().dir
                          */
                         if (federateInstance.host != null &&
-                            federateInstance.host != "localhost" &&
-                            federateInstance.host != "0.0.0.0"
+                            !federateInstance.host.equals("localhost") &&
+                            !federateInstance.host.equals("0.0.0.0")
                         ) {
                             federateInstance.isRemote = true;
                         }
                     }
                 }
                 if (federatesByInstantiation == null) {
-                    federatesByInstantiation = new LinkedHashMap<Instantiation, List<FederateInstance>>();
+                    federatesByInstantiation = new LinkedHashMap<>();
                 }
                 federatesByInstantiation.put(instantiation, federateInstances);
             }
@@ -1131,7 +1130,6 @@ public abstract class GeneratorBase extends AbstractLFValidator {
     /**
      * Replace the connections from the specified output port for the specified federate reactor.
      * @param output The output port instance.
-     * @param srcFederate The federate for which this port is an output.
      * @param federateReactor The reactor instance for that federate.
      * @param mainInstance The main reactor instance.
      */
@@ -1168,16 +1166,15 @@ public abstract class GeneratorBase extends AbstractLFValidator {
                         errorReporter.reportError(output.definition,
                                 "Unexpected error. Cannot find output connection for port");
                     } else {
-                        if (!connection.isPhysical()
-                            && targetConfig.coordination != CoordinationType.DECENTRALIZED) {
+                        if (
+                            !connection.isPhysical()
+                            && targetConfig.coordination != CoordinationType.DECENTRALIZED
+                        ) {
                             // Map the delays on connections between federates.
-                            // First see if the cache has been created.
-                            Set<Expression> dependsOnDelays = dstFederate.dependsOn.get(srcFederate);
-                            if (dependsOnDelays == null) {
-                                // If not, create it.
-                                dependsOnDelays = new LinkedHashSet<Expression>();
-                                dstFederate.dependsOn.put(srcFederate, dependsOnDelays);
-                            }
+                            Set<Expression> dependsOnDelays = dstFederate.dependsOn.computeIfAbsent(
+                                srcFederate,
+                                k -> new LinkedHashSet<>()
+                            );
                             // Put the delay on the cache.
                             if (connection.getDelay() != null) {
                                 dependsOnDelays.add(connection.getDelay());
@@ -1186,11 +1183,10 @@ public abstract class GeneratorBase extends AbstractLFValidator {
                                 dependsOnDelays.add(null);
                             }
                             // Map the connections between federates.
-                            Set<Expression> sendsToDelays = srcFederate.sendsTo.get(dstFederate);
-                            if (sendsToDelays == null) {
-                                sendsToDelays = new LinkedHashSet<Expression>();
-                                srcFederate.sendsTo.put(dstFederate, sendsToDelays);
-                            }
+                            Set<Expression> sendsToDelays = srcFederate.sendsTo.computeIfAbsent(
+                                dstFederate,
+                                k -> new LinkedHashSet<>()
+                            );
                             if (connection.getDelay() != null) {
                                 sendsToDelays.add(connection.getDelay());
                             } else {
@@ -1238,7 +1234,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
      * Indicates whether delay banks generated from after delays should have a variable length width.
      *
      * If this is true, any delay reactors that are inserted for after delays on multiport connections
-     * will have a unspecified variable length width. The code generator is then responsible for inferring the
+     * will have an unspecified variable length width. The code generator is then responsible for inferring the
      * correct width of the delay bank, which is only possible if the precise connection width is known at compile time.
      *
      * If this is false, the width specification of the generated bank will list all the ports listed on the right

--- a/org.lflang/src/org/lflang/generator/ReactionInstance.java
+++ b/org.lflang/src/org/lflang/generator/ReactionInstance.java
@@ -50,7 +50,7 @@ import org.lflang.lf.Variable;
  * is a bank of reactors, then there will be more than one runtime instance
  * corresponding to this compile-time instance.  The {@link #getRuntimeInstances()}
  * method returns a list of these runtime instances, each an instance of the
- * inner class {@link #Runtime}.  Each runtime instance has a "level", which is
+ * inner class {@link ReactionInstance.Runtime}.  Each runtime instance has a "level", which is
  * its depth an acyclic precedence graph representing the dependencies between
  * reactions at a tag.
  *  
@@ -207,18 +207,16 @@ public class ReactionInstance extends NamedInstance<Reaction> {
     /**
      * The ports or actions that this reaction may write to.
      */
-    public Set<TriggerInstance<? extends Variable>> effects 
-            = new LinkedHashSet<TriggerInstance<? extends Variable>>();
+    public Set<TriggerInstance<? extends Variable>> effects = new LinkedHashSet<>();
 
     /**
      * The ports, actions, or timers that this reaction is triggered by or uses.
      */
-    public Set<TriggerInstance<? extends Variable>> sources 
-            = new LinkedHashSet<TriggerInstance<? extends Variable>>();
+    public Set<TriggerInstance<? extends Variable>> sources = new LinkedHashSet<>();
     // FIXME: Above sources is misnamed because in the grammar,
     // "sources" are only the inputs a reaction reads without being
     // triggered by them. The name "reads" used here would be a better
-    // choice in the grammer.
+    // choice in the grammar.
     
     /**
      * Deadline for this reaction instance, if declared.
@@ -253,15 +251,13 @@ public class ReactionInstance extends NamedInstance<Reaction> {
     /**
      * The ports that this reaction reads but that do not trigger it.
      */
-    public Set<TriggerInstance<? extends Variable>> reads
-            = new LinkedHashSet<TriggerInstance<? extends Variable>>();
+    public Set<TriggerInstance<? extends Variable>> reads = new LinkedHashSet<>();
 
     /**
      * The trigger instances (input ports, timers, and actions
      * that trigger reactions) that trigger this reaction.
      */
-    public Set<TriggerInstance<? extends Variable>> triggers
-            = new LinkedHashSet<TriggerInstance<? extends Variable>>();
+    public Set<TriggerInstance<? extends Variable>> triggers = new LinkedHashSet<>();
 
     //////////////////////////////////////////////////////
     //// Public methods.
@@ -282,14 +278,14 @@ public class ReactionInstance extends NamedInstance<Reaction> {
     
     /**
      * Return the set of immediate downstream reactions, which are reactions
-     * that receive data produced produced by this reaction plus
+     * that receive data produced by this reaction plus
      * at most one reaction in the same reactor whose definition
      * lexically follows this one (unless this reaction is unordered).
      */
     public Set<ReactionInstance> dependentReactions() {
         // Cache the result.
         if (dependentReactionsCache != null) return dependentReactionsCache;
-        dependentReactionsCache = new LinkedHashSet<ReactionInstance>();
+        dependentReactionsCache = new LinkedHashSet<>();
         
         // First, add the next lexical reaction, if appropriate.
         if (!isUnordered && parent.reactions.size() > index + 1) {
@@ -322,7 +318,7 @@ public class ReactionInstance extends NamedInstance<Reaction> {
     public Set<ReactionInstance> dependsOnReactions() {
         // Cache the result.
         if (dependsOnReactionsCache != null) return dependsOnReactionsCache;
-        dependsOnReactionsCache = new LinkedHashSet<ReactionInstance>();
+        dependsOnReactionsCache = new LinkedHashSet<>();
         
         // First, add the previous lexical reaction, if appropriate.
         if (!isUnordered && index > 0) {
@@ -358,7 +354,7 @@ public class ReactionInstance extends NamedInstance<Reaction> {
      * a bank and its dependencies on other reactions pass through multiports.
      */
     public Set<Integer> getLevels() {
-        Set<Integer> result = new LinkedHashSet<Integer>();
+        Set<Integer> result = new LinkedHashSet<>();
         // Force calculation of levels if it has not been done.
         parent.assignLevels();
         for (Runtime runtime : runtimeInstances) {
@@ -374,7 +370,7 @@ public class ReactionInstance extends NamedInstance<Reaction> {
      * a bank and its dependencies on other reactions pass through multiports.
      */
     public List<Integer> getLevelsList() {
-        List<Integer> result = new LinkedList<Integer>();
+        List<Integer> result = new LinkedList<>();
         // Force calculation of levels if it has not been done.
         parent.assignLevels();
         for (Runtime runtime : runtimeInstances) {
@@ -418,7 +414,7 @@ public class ReactionInstance extends NamedInstance<Reaction> {
         int size = parent.getTotalWidth();
         // If the width cannot be determined, assume there is only one instance.
         if (size < 0) size = 1;
-        runtimeInstances = new ArrayList<Runtime>(size);
+        runtimeInstances = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             Runtime r = new Runtime();
             r.id = i;
@@ -492,10 +488,9 @@ public class ReactionInstance extends NamedInstance<Reaction> {
         }
         @Override
         public String toString() {
-            String result = ReactionInstance.this.toString() 
-                    + "(level: " + level;
+            String result = ReactionInstance.this + "(level: " + level;
             if (deadline != null && deadline != TimeValue.MAX_VALUE) {
-               result += ", deadline: " + deadline.toString();
+               result += ", deadline: " + deadline;
             }
             if (dominating != null) {
                 result += ", dominating: " + dominating.getReaction();

--- a/org.lflang/src/org/lflang/generator/ReactionInstanceGraph.java
+++ b/org.lflang/src/org/lflang/generator/ReactionInstanceGraph.java
@@ -243,8 +243,7 @@ public class ReactionInstanceGraph extends DirectedGraph<ReactionInstance.Runtim
      * Number of reactions per level, represented as a list of 
      * integers where the indices are the levels.
      */
-    private List<Integer> numReactionsPerLevel = new ArrayList<>(
-            List.of(Integer.valueOf(0)));
+    private List<Integer> numReactionsPerLevel = new ArrayList<>(List.of(0));
 
     ///////////////////////////////////////////////////////////
     //// Private methods
@@ -260,7 +259,7 @@ public class ReactionInstanceGraph extends DirectedGraph<ReactionInstance.Runtim
      * the levels of the reactions it depends on.
      */
     private void assignLevels() {
-        List<ReactionInstance.Runtime> start = new ArrayList<ReactionInstance.Runtime>(rootNodes());
+        List<ReactionInstance.Runtime> start = new ArrayList<>(rootNodes());
         
         // All root nodes start with level 0.
         for (Runtime origin : start) {
@@ -271,7 +270,7 @@ public class ReactionInstanceGraph extends DirectedGraph<ReactionInstance.Runtim
         // the graph must be cyclic.
         while (!start.isEmpty()) {
             Runtime origin = start.remove(0);
-            Set<Runtime> toRemove = new LinkedHashSet<Runtime>();
+            Set<Runtime> toRemove = new LinkedHashSet<>();
             Set<Runtime> downstreamAdjacentNodes = getDownstreamAdjacentNodes(origin);
 
             // Visit effect nodes.

--- a/org.lflang/src/org/lflang/generator/ReactorInstance.java
+++ b/org.lflang/src/org/lflang/generator/ReactorInstance.java
@@ -54,9 +54,7 @@ import org.lflang.lf.Port;
 import org.lflang.lf.Reaction;
 import org.lflang.lf.Reactor;
 import org.lflang.lf.ReactorDecl;
-import org.lflang.lf.Time;
 import org.lflang.lf.Timer;
-import org.lflang.lf.TriggerRef;
 import org.lflang.lf.VarRef;
 import org.lflang.lf.Variable;
 import org.lflang.lf.WidthSpec;
@@ -246,13 +244,13 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
     public Set<NamedInstance<?>> getCycles() {
         if (depth != 0) return root().getCycles();
         if (cachedCycles != null) return cachedCycles;
-        Set<ReactionInstance> reactions = new LinkedHashSet<ReactionInstance>();
+        Set<ReactionInstance> reactions = new LinkedHashSet<>();
         
         ReactionInstanceGraph reactionRuntimes = assignLevels();
         for (ReactionInstance.Runtime runtime : reactionRuntimes.nodes()) {
             reactions.add(runtime.getReaction());
         }
-        Set<PortInstance> ports = new LinkedHashSet<PortInstance>();
+        Set<PortInstance> ports = new LinkedHashSet<>();
         // Need to figure out which ports are involved in the cycles.
         // It may not be all ports that depend on this reaction.
         for (ReactionInstance r : reactions) {
@@ -263,7 +261,7 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
             }
         }
         
-        cachedCycles = new LinkedHashSet<NamedInstance<?>>();
+        cachedCycles = new LinkedHashSet<>();
         cachedCycles.addAll(reactions);
         cachedCycles.addAll(ports);
         return cachedCycles;
@@ -400,7 +398,7 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
      * Return true if the top-level parent of this reactor has causality cycles.
      */
     public boolean hasCycles() {
-        return (assignLevels().nodeCount() != 0);
+        return assignLevels().nodeCount() != 0;
     }
     
     /**
@@ -467,7 +465,7 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
      * @return true if a reactor is a bank, false otherwise
      */
     public boolean isBank() {
-        return (definition.getWidthSpec() != null);
+        return definition.getWidthSpec() != null;
     }
 
     /**
@@ -995,8 +993,8 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
     private List<RuntimeRange<PortInstance>> listPortInstances(
             List<VarRef> references, Connection connection
     ) {
-        List<RuntimeRange<PortInstance>> result = new ArrayList<RuntimeRange<PortInstance>>();
-        List<RuntimeRange<PortInstance>> tails = new LinkedList<RuntimeRange<PortInstance>>();
+        List<RuntimeRange<PortInstance>> result = new ArrayList<>();
+        List<RuntimeRange<PortInstance>> tails = new LinkedList<>();
         int count = 0;
         for (VarRef portRef : references) {
             // Simple error checking first.
@@ -1017,7 +1015,7 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
                 PortInstance portInstance = reactor.lookupPortInstance(
                         (Port) portRef.getVariable());
                 
-                Set<ReactorInstance> interleaved = new LinkedHashSet<ReactorInstance>();
+                Set<ReactorInstance> interleaved = new LinkedHashSet<>();
                 if (portRef.isInterleaved()) {
                     // NOTE: Here, we are assuming that the interleaved()
                     // keyword is only allowed on the multiports contained by
@@ -1059,7 +1057,7 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
         }
         // Iterate over the tails.
         while(tails.size() > 0) {
-            List<RuntimeRange<PortInstance>> moreTails = new LinkedList<RuntimeRange<PortInstance>>();
+            List<RuntimeRange<PortInstance>> moreTails = new LinkedList<>();
             count = 0;
             for (RuntimeRange<PortInstance> tail : tails) {
                 if (count < tails.size() - 1) {

--- a/org.lflang/src/org/lflang/generator/RuntimeRange.java
+++ b/org.lflang/src/org/lflang/generator/RuntimeRange.java
@@ -47,7 +47,7 @@ import java.util.Set;
  * in the graphical rendition). Equivalently, each CIG node has a unique
  * full name, even though it may represent many runtime instances.
  * The CIG is represented by
- * {@link NamedInstance<T extends EObject>} and its derived classes.
+ * {@link NamedInstance} and its derived classes.
  * In the RIG, each bank is expanded so each bank member and
  * each port channel is represented.
  * 
@@ -251,13 +251,7 @@ public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<Runt
         if (start < o.start) {
             return -1;
         } else if (start == o.start) {
-            if (width < o.width) {
-                return -1;
-            } else if (width == o.width) {
-                return 0;
-            } else {
-                return 1;
-            }
+            return Integer.compare(width, o.width);
         } else {
             return 1;
         }
@@ -274,7 +268,7 @@ public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<Runt
     public RuntimeRange<T> head(int newWidth) {
         if (newWidth >= width) return this;
         if (newWidth <= 0) return null;
-        return new RuntimeRange<T>(instance, start, newWidth, _interleaved);
+        return new RuntimeRange<>(instance, start, newWidth, _interleaved);
     }
     
     /**
@@ -288,7 +282,7 @@ public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<Runt
      * in which the runtime instances should be iterated.
      */
     public List<Integer> instances() {
-        List<Integer> result = new ArrayList<Integer>(width);
+        List<Integer> result = new ArrayList<>(width);
         MixedRadixInt mr = startMR();
         int count = 0;
         while (count++ < width) {
@@ -309,7 +303,7 @@ public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<Runt
      * shallower).
      */
     public List<NamedInstance<?>> iterationOrder() {
-        ArrayList<NamedInstance<?>> result = new ArrayList<NamedInstance<?>>();
+        ArrayList<NamedInstance<?>> result = new ArrayList<>();
         result.add(instance);
         ReactorInstance parent = instance.parent;
         while (parent.depth > 0) {
@@ -341,7 +335,7 @@ public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<Runt
      */
     public boolean overlaps(RuntimeRange<?> range) {
         if (!instance.equals(range.instance)) return false;
-        return (start < range.start + range.width && start + width > range.start);
+        return start < range.start + range.width && start + width > range.start;
     }
     
     /**
@@ -373,7 +367,7 @@ public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<Runt
      *   
      * * The remaining digits will be bank indices of containers up to but not
      *   including the top-level reactor (there is no point in including the top-level
-     *   reactor because it is never a bank.
+     *   reactor because it is never a bank).
      *   
      * Each index that is returned can be used as an index into an array of
      * runtime instances that is assumed to be in a **natural order**.
@@ -382,7 +376,7 @@ public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<Runt
      *  less than the depth of this RuntimeRange's instance or an exception will be thrown.
      */
     public Set<Integer> parentInstances(int n) {
-        Set<Integer> result = new LinkedHashSet<Integer>(width);        
+        Set<Integer> result = new LinkedHashSet<>(width);
         MixedRadixInt mr = startMR();
         int count = 0;
         while (count++ < width) {
@@ -411,7 +405,7 @@ public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<Runt
      * be incremented.
      */
     public List<Integer> permutation() {
-        List<Integer> result = new ArrayList<Integer>(instance.depth);
+        List<Integer> result = new ArrayList<>(instance.depth);
         // Populate the result with default zeros.
         for (int i = 0; i < instance.depth; i++) {
             result.add(0);
@@ -429,7 +423,7 @@ public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<Runt
      * has radix 1 and value 0.
      */
     public List<Integer> radixes() {
-        List<Integer> result = new ArrayList<Integer>(instance.depth);
+        List<Integer> result = new ArrayList<>(instance.depth);
         int width = instance.width;
         // If the width cannot be determined, assume 1.
         if (width < 0) width = 1;
@@ -466,7 +460,7 @@ public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<Runt
     public RuntimeRange<T> tail(int offset) {
         if (offset == 0) return this;
         if (offset >= width) return null;
-        return new RuntimeRange<T>(instance, start + offset, width - offset, _interleaved);
+        return new RuntimeRange<>(instance, start + offset, width - offset, _interleaved);
     }
     
     /**
@@ -477,13 +471,13 @@ public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<Runt
      * @param reactor The parent reactor at which to toggle interleaving.
      */
     public RuntimeRange<T> toggleInterleaved(ReactorInstance reactor) {
-        Set<ReactorInstance> newInterleaved = new HashSet<ReactorInstance>(_interleaved);
+        Set<ReactorInstance> newInterleaved = new HashSet<>(_interleaved);
         if (_interleaved.contains(reactor)) {
             newInterleaved.remove(reactor);
         } else {
             newInterleaved.add(reactor);
         }
-        return new RuntimeRange<T>(instance, start, width, newInterleaved);
+        return new RuntimeRange<>(instance, start, width, newInterleaved);
     }
         
     @Override
@@ -495,7 +489,7 @@ public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<Runt
     //// Protected variables
     
     /** Record of which levels are interleaved. */
-    Set<ReactorInstance> _interleaved = new HashSet<ReactorInstance>();
+    Set<ReactorInstance> _interleaved = new HashSet<>();
     
     //////////////////////////////////////////////////////////
     //// Public inner classes

--- a/org.lflang/src/org/lflang/generator/SendRange.java
+++ b/org.lflang/src/org/lflang/generator/SendRange.java
@@ -96,8 +96,7 @@ public class SendRange extends RuntimeRange.Port {
     public final Connection connection;
     
     /** The list of destination ranges to which this broadcasts. */
-    public final List<RuntimeRange<PortInstance>> destinations 
-            = new ArrayList<RuntimeRange<PortInstance>>();
+    public final List<RuntimeRange<PortInstance>> destinations = new ArrayList<>();
 
     //////////////////////////////////////////////////////////
     //// Public methods
@@ -148,7 +147,7 @@ public class SendRange extends RuntimeRange.Port {
         if (_numberOfDestinationReactors < 0) {
             // Has not been calculated before. Calculate now.
             _numberOfDestinationReactors = 0;
-            Map<ReactorInstance, Set<Integer>> result = new HashMap<ReactorInstance, Set<Integer>>();
+            Map<ReactorInstance, Set<Integer>> result = new HashMap<>();
             for (RuntimeRange<PortInstance> destination : this.destinations) {
                 // The following set contains unique identifiers the parent reactors
                 // of destination ports.
@@ -251,7 +250,7 @@ public class SendRange extends RuntimeRange.Port {
         StringBuilder result = new StringBuilder();
         result.append(super.toString());
         result.append("->[");
-        List<String> dsts = new LinkedList<String>();
+        List<String> dsts = new LinkedList<>();
         for (RuntimeRange<PortInstance> dst : destinations) {
             dsts.add(dst.toString());
         }
@@ -291,7 +290,7 @@ public class SendRange extends RuntimeRange.Port {
                 // then assume srcRange is multicasting via this.
                 int newWidth = Math.min(width,  srcRange.width);
                 // The interleaving of the result is the union of the two interleavings.
-                Set<ReactorInstance> interleaving = new LinkedHashSet<ReactorInstance>();
+                Set<ReactorInstance> interleaving = new LinkedHashSet<>();
                 interleaving.addAll(_interleaved);
                 interleaving.addAll(srcRange._interleaved);
                 SendRange result = new SendRange(
@@ -307,8 +306,8 @@ public class SendRange extends RuntimeRange.Port {
             }
         }
         throw new IllegalArgumentException(
-                "Expected this SendRange " + this.toString()
-                + " to be completely contained by a destination of " + srcRange.toString());
+                "Expected this SendRange " + this
+                + " to be completely contained by a destination of " + srcRange);
     }
 
     //////////////////////////////////////////////////////////

--- a/org.lflang/src/org/lflang/generator/c/CActionGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CActionGenerator.java
@@ -174,7 +174,7 @@ public class CActionGenerator {
         }
         // Do not convert to lf_token_t* using lfTypeToTokenType because there
         // will be a separate field pointing to the token.
-        return action.getType() == null && target.requiresTypes == true ?
+        return action.getType() == null && target.requiresTypes ?
                "" :
                types.getTargetType(action) + " value;";
     }

--- a/org.lflang/src/org/lflang/generator/c/CCmakeCompiler.java
+++ b/org.lflang/src/org/lflang/generator/c/CCmakeCompiler.java
@@ -187,15 +187,15 @@ public class CCmakeCompiler extends CCompiler {
         // Set the build directory to be "build"
         Path buildPath = fileConfig.getSrcGenPath().resolve("build");
 
-        List<String> arguments =  new ArrayList<String>();
-        arguments.addAll(List.of("-DCMAKE_INSTALL_PREFIX="+ FileUtil.toUnixString(fileConfig.getOutPath()),
-                                 "-DCMAKE_INSTALL_BINDIR="+ FileUtil.toUnixString(
-                        fileConfig.getOutPath().relativize(
-                                fileConfig.binPath
-                                )
-                        ),
-                                 FileUtil.toUnixString(fileConfig.getSrcGenPath())
-            ));
+        List<String> arguments = new ArrayList<>(List.of(
+            "-DCMAKE_INSTALL_PREFIX=" + FileUtil.toUnixString(fileConfig.getOutPath()),
+            "-DCMAKE_INSTALL_BINDIR=" + FileUtil.toUnixString(
+                fileConfig.getOutPath().relativize(
+                    fileConfig.binPath
+                )
+            ),
+            FileUtil.toUnixString(fileConfig.getSrcGenPath())
+        ));
 
         if (GeneratorUtils.isHostWindows()) {
             arguments.add("-DCMAKE_SYSTEM_VERSION=\"10.0\"");

--- a/org.lflang/src/org/lflang/generator/c/CCmakeGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CCmakeGenerator.java
@@ -81,7 +81,7 @@ class CCmakeGenerator {
             String cMakeExtras) {
         CodeBuilder cMakeCode = new CodeBuilder();
 
-        List<String> additionalSources = new ArrayList<String>();
+        List<String> additionalSources = new ArrayList<>();
         for (String file: targetConfig.compileAdditionalSources) {
             var relativePath = fileConfig.getSrcGenPath().relativize(
                 fileConfig.getSrcGenPath().resolve(Paths.get(file)));
@@ -139,15 +139,15 @@ class CCmakeGenerator {
         }
         cMakeCode.indent();
         cMakeCode.pr("${LF_MAIN_TARGET}");
-        sources.forEach(source -> {cMakeCode.pr(source);});
+        sources.forEach(cMakeCode::pr);
         cMakeCode.pr("${CoreLib}/platform/${LF_PLATFORM_FILE}");
-        additionalSources.forEach(source -> {cMakeCode.pr(source);});
+        additionalSources.forEach(cMakeCode::pr);
         cMakeCode.unindent();
         cMakeCode.pr(")");
         cMakeCode.newLine();
 
         if (targetConfig.threading || targetConfig.tracing != null) {
-            // If threaded computation is requested, add a the threads option.
+            // If threaded computation is requested, add the threads option.
             cMakeCode.pr("# Find threads and link to it");
             cMakeCode.pr("find_package(Threads REQUIRED)");
             cMakeCode.pr("target_link_libraries( ${LF_MAIN_TARGET} Threads::Threads)");
@@ -203,9 +203,10 @@ class CCmakeGenerator {
                 case "-lprotobuf-c":
                     cMakeCode.pr("include(FindPackageHandleStandardArgs)");
                     cMakeCode.pr("FIND_PATH( PROTOBUF_INCLUDE_DIR protobuf-c/protobuf-c.h)");
-                    cMakeCode.pr("find_library(PROTOBUF_LIBRARY \n"+
-                                     "NAMES libprotobuf-c.a libprotobuf-c.so libprotobuf-c.dylib protobuf-c.lib protobuf-c.dll\n"+
-                                     ")");
+                    cMakeCode.pr("""
+                                     find_library(PROTOBUF_LIBRARY\s
+                                     NAMES libprotobuf-c.a libprotobuf-c.so libprotobuf-c.dylib protobuf-c.lib protobuf-c.dll
+                                     )""");
                     cMakeCode.pr("find_package_handle_standard_args(libprotobuf-c DEFAULT_MSG PROTOBUF_INCLUDE_DIR PROTOBUF_LIBRARY)");
                     cMakeCode.pr("target_include_directories( ${LF_MAIN_TARGET} PUBLIC ${PROTOBUF_INCLUDE_DIR} )");
                     cMakeCode.pr("target_link_libraries( ${LF_MAIN_TARGET} ${PROTOBUF_LIBRARY})");

--- a/org.lflang/src/org/lflang/generator/c/CCompiler.java
+++ b/org.lflang/src/org/lflang/generator/c/CCompiler.java
@@ -143,7 +143,7 @@ public class CCompiler {
             System.out.println("SUCCESS: Compiling generated code for "+ fileConfig.name +" finished with no errors.");
         }
 
-        return (returnCode == 0);
+        return returnCode == 0;
     }
 
     /**
@@ -176,7 +176,7 @@ public class CCompiler {
             relBinPathString += ".o";
         }
 
-        ArrayList<String> compileArgs = new ArrayList<String>();
+        ArrayList<String> compileArgs = new ArrayList<>();
         compileArgs.add(relSrcPathString);
         for (String file: targetConfig.compileAdditionalSources) {
             var relativePath = fileConfig.getOutPath().relativize(

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -475,7 +475,7 @@ public class CGenerator extends GeneratorBase {
                 //  Visual Studio compiler is extensive.
                 return false;
             }
-            if (targetConfig.useCmake == false) {
+            if (!targetConfig.useCmake) {
                 errorReporter.reportError(
                     "Only CMake is supported as the build system on Windows. "+
                     "Use `cmake: true` in the target properties. Exiting code generation."
@@ -834,7 +834,7 @@ public class CGenerator extends GeneratorBase {
             ));
 
             if (isFederated) {
-                code.pr(CFederateGenerator.generateFederateNeighborStructure(currentFederate).toString());
+                code.pr(CFederateGenerator.generateFederateNeighborStructure(currentFederate));
             }
 
             // Generate function to schedule shutdown reactions if any
@@ -947,7 +947,7 @@ public class CGenerator extends GeneratorBase {
             }
             // Extract the contents of the imported file for the preambles
             var contents = toDefinition(reactor).eResource().getContents();
-            var model = (Model) contents.get(0);;
+            var model = (Model) contents.get(0);
             // Add the preambles from the imported .lf file
             toDefinition(reactor).getPreambles().addAll(model.getPreambles());
         }
@@ -1081,19 +1081,19 @@ public class CGenerator extends GeneratorBase {
     private void pickCompilePlatform() {
         var OS = System.getProperty("os.name").toLowerCase();
         // FIXME: allow for cross-compiling
-        if ((OS.indexOf("mac") >= 0) || (OS.indexOf("darwin") >= 0)) {
+        if (OS.contains("mac") || OS.contains("darwin")) {
             if (mainDef != null && !targetConfig.useCmake) {
                 targetConfig.compileAdditionalSources.add(
                      "core" + File.separator + "platform" + File.separator + "lf_macos_support.c"
                 );
             }
-        } else if (OS.indexOf("win") >= 0) {
+        } else if (OS.contains("win")) {
             if (mainDef != null && !targetConfig.useCmake) {
                 targetConfig.compileAdditionalSources.add(
                     "core" + File.separator + "platform" + File.separator + "lf_windows_support.c"
                 );
             }
-        } else if (OS.indexOf("nux") >= 0) {
+        } else if (OS.contains("nux")) {
             if (mainDef != null && !targetConfig.useCmake) {
                 targetConfig.compileAdditionalSources.add(
                     "core" + File.separator + "platform" + File.separator + "lf_linux_support.c"
@@ -1104,12 +1104,7 @@ public class CGenerator extends GeneratorBase {
         }
     }
 
-    /**
-     * Create a launcher script that executes all the federates and the RTI.
-     *
-     * @param coreFiles The files from the core directory that must be
-     *  copied to the remote machines.
-     */
+    /** Create a launcher script that executes all the federates and the RTI. */
     public void createFederatedLauncher() throws IOException{
         var launcher = new FedCLauncher(
             targetConfig,
@@ -1132,7 +1127,7 @@ public class CGenerator extends GeneratorBase {
      * Initialize clock synchronization (if enabled) and its related options for a given federate.
      *
      * Clock synchronization can be enabled using the clock-sync target property.
-     * @see https://github.com/icyphy/lingua-franca/wiki/Distributed-Execution#clock-synchronization
+     * @see <a href="https://github.com/icyphy/lingua-franca/wiki/Distributed-Execution#clock-synchronization">Documentation</a>
      */
     protected void initializeClockSynchronization() {
         // Check if clock synchronization should be enabled for this federate in the first place
@@ -1251,7 +1246,7 @@ public class CGenerator extends GeneratorBase {
     /**
      * Generate the struct type definitions for inputs, outputs, and
      * actions of the specified reactor.
-     * @param reactor The parsed reactor data structure.
+     * @param decl The parsed reactor data structure.
      */
     protected void generateAuxiliaryStructs(ReactorDecl decl) {
         var reactor = ASTUtils.toDefinition(decl);
@@ -1311,7 +1306,7 @@ public class CGenerator extends GeneratorBase {
     /**
      * Generate the self struct type definition for the specified reactor
      * in the specified federate.
-     * @param reactor The parsed reactor data structure.
+     * @param decl The parsed reactor data structure.
      * @param constructorCode Place to put lines of code that need to
      *  go into the constructor.
      */
@@ -1523,7 +1518,7 @@ public class CGenerator extends GeneratorBase {
      *  These functions have a single argument that is a void* pointing to
      *  a struct that contains parameters, state variables, inputs (triggering or not),
      *  actions (triggering or produced), and outputs.
-     *  @param reactor The reactor.
+     *  @param decl The reactor.
      *  @param federate The federate, or null if this is not
      *   federated or not the main reactor and reactions should be
      *   unconditionally generated.
@@ -1546,7 +1541,7 @@ public class CGenerator extends GeneratorBase {
      *  a struct that contains parameters, state variables, inputs (triggering or not),
      *  actions (triggering or produced), and outputs.
      *  @param reaction The reaction.
-     *  @param reactor The reactor.
+     *  @param decl The reactor.
      *  @param reactionIndex The position of the reaction within the reactor.
      */
     public void generateReaction(Reaction reaction, ReactorDecl decl, int reactionIndex) {
@@ -1844,7 +1839,7 @@ public class CGenerator extends GeneratorBase {
      * Construct a unique type for the struct of the specified
      * typed variable (port or action) of the specified reactor class.
      * This is required to be the same as the type name returned by
-     * {@link variableStructType(TriggerInstance<?>)}.
+     * {@link #variableStructType(TriggerInstance)}.
      * @param variable The variable.
      * @param reactor The reactor class.
      * @return The name of the self struct.
@@ -1857,7 +1852,7 @@ public class CGenerator extends GeneratorBase {
      * Construct a unique type for the struct of the specified
      * instance (port or action).
      * This is required to be the same as the type name returned by
-     * {@link variableStructType(Variable, ReactorDecl)}.
+     * {@link #variableStructType(Variable, ReactorDecl)}.
      * @param portOrAction The port or action instance.
      * @return The name of the self struct.
      */
@@ -1901,8 +1896,6 @@ public class CGenerator extends GeneratorBase {
      * Generate code to instantiate the specified reactor instance and
      * initialize it.
      * @param instance A reactor instance.
-     * @param federate A federate instance to conditionally generate code by
-     *  contained reactors or null if there are no federates.
      */
     public void generateReactorInstance(ReactorInstance instance) {
         var reactorClass = instance.getDefinition().getReactorClass();
@@ -1966,7 +1959,7 @@ public class CGenerator extends GeneratorBase {
                 if (targetConfig.coordinationOptions.advance_message_interval == null) {
                     errorReporter.reportWarning(outputFound, String.join("\n",
                         "Found a path from a physical action to output for reactor "+addDoubleQuotes(instance.getName())+". ",
-                        "The amount of delay is "+minDelay.toString()+".",
+                        "The amount of delay is "+minDelay+".",
                         "With centralized coordination, this can result in a large number of messages to the RTI.",
                         "Consider refactoring the code so that the output does not depend on the physical action,",
                         "or consider using decentralized coordination. To silence this warning, set the target",
@@ -2037,7 +2030,6 @@ public class CGenerator extends GeneratorBase {
      * but for the top-level of a federate, will be a subset of reactions that
      * is relevant to the federate.
      * @param instance The reactor instance.
-     * @param reactions The reactions of this instance.
      */
     public void generateReactorInstanceExtension(ReactorInstance instance) {
         // Do nothing
@@ -2048,7 +2040,6 @@ public class CGenerator extends GeneratorBase {
      * Unlike parameters, state variables are uniformly initialized for all instances
      * of the same reactor.
      * @param instance The reactor class instance
-     * @return Initialization code fore state variables of instance
      */
     public void generateStateVariableInitializations(ReactorInstance instance) {
         var reactorClass = instance.getDefinition().getReactorClass();
@@ -2059,7 +2050,7 @@ public class CGenerator extends GeneratorBase {
                     instance.lookupModeInstance((Mode) stateVar.eContainer()) :
                     instance.getMode(false);
                 // In the current concept state variables are not automatically reset.
-                // Instead they need to be manually reset using a reset triggered reaction or marked as reset.
+                // Instead, they need to be manually reset using a reset triggered reaction or marked as reset.
                 if (!stateVar.isReset()) {
                     mode = null; // Treat as if outside of mode
                 }
@@ -2450,7 +2441,7 @@ public class CGenerator extends GeneratorBase {
      * input port "port" or has it in its sources. If there are only connections to contained
      * reactors, in the top-level reactor.
      *
-     * @param port The port to generate the control reaction for
+     * @param receivingPortID The port to generate the control reaction for
      * @param maxSTP The maximum value of STP is assigned to reactions (if any)
      *  that have port as their trigger or source
      */
@@ -2531,7 +2522,7 @@ public class CGenerator extends GeneratorBase {
                             "To use the ROS 2 serializer, please use the CCpp target."
                             );
                     }
-                    if (targetConfig.useCmake == false) {
+                    if (!targetConfig.useCmake) {
                         throw new UnsupportedOperationException(
                             "Invalid target property \"cmake: false\"" +
                             "To use the ROS 2 serializer, please use the CMake build system (default)"

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -1079,28 +1079,28 @@ public class CGenerator extends GeneratorBase {
      * will detect and use the appropriate platform file based on the platform that cmake is invoked on.
      */
     private void pickCompilePlatform() {
-        var OS = System.getProperty("os.name").toLowerCase();
+        var osName = System.getProperty("os.name").toLowerCase();
         // FIXME: allow for cross-compiling
-        if (OS.contains("mac") || OS.contains("darwin")) {
+        if (osName.contains("mac") || osName.contains("darwin")) {
             if (mainDef != null && !targetConfig.useCmake) {
                 targetConfig.compileAdditionalSources.add(
                      "core" + File.separator + "platform" + File.separator + "lf_macos_support.c"
                 );
             }
-        } else if (OS.contains("win")) {
+        } else if (osName.contains("win")) {
             if (mainDef != null && !targetConfig.useCmake) {
                 targetConfig.compileAdditionalSources.add(
                     "core" + File.separator + "platform" + File.separator + "lf_windows_support.c"
                 );
             }
-        } else if (OS.contains("nux")) {
+        } else if (osName.contains("nux")) {
             if (mainDef != null && !targetConfig.useCmake) {
                 targetConfig.compileAdditionalSources.add(
                     "core" + File.separator + "platform" + File.separator + "lf_linux_support.c"
                 );
             }
         } else {
-            errorReporter.reportError("Platform " + OS + " is not supported");
+            errorReporter.reportError("Platform " + osName + " is not supported");
         }
     }
 

--- a/org.lflang/src/org/lflang/generator/c/CMethodGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CMethodGenerator.java
@@ -10,7 +10,7 @@ import org.lflang.lf.Reactor;
 import org.lflang.lf.ReactorDecl;
 
 /**
- * Collection of functios to generate C code to declare methods.
+ * Collection of functions to generate C code to declare methods.
  *
  * @author {Edward A. Lee <eal@berkeley.edu>}
  */
@@ -89,7 +89,7 @@ public class CMethodGenerator {
      * Generate method functions definition for a reactor.
      * These functions have a first argument that is a void* pointing to
      * the self struct.
-     * @param reactor The reactor.
+     * @param decl The reactor.
      * @param code The place to put the code.
      * @param types The C-specific type conversion functions.
      */

--- a/org.lflang/src/org/lflang/generator/c/CNetworkGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CNetworkGenerator.java
@@ -291,7 +291,7 @@ public class CNetworkGenerator {
      * input port "port" or has it in its sources. If there are only connections to contained
      * reactors, in the top-level reactor.
      *
-     * @param port The port to generate the control reaction for
+     * @param receivingPortID The port to generate the control reaction for
      * @param maxSTP The maximum value of STP is assigned to reactions (if any)
      *  that have port as their trigger or source
      */

--- a/org.lflang/src/org/lflang/generator/c/CParameterGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CParameterGenerator.java
@@ -78,7 +78,6 @@ public class CParameterGenerator {
      * Generate code for parameters variables of a reactor in the form "parameter.type parameter.name;"
      * @param reactor The reactor
      * @param types A helper class for types
-     * @return
      */
     public static String generateDeclarations(Reactor reactor, CTypes types) {
         CodeBuilder code = new CodeBuilder();

--- a/org.lflang/src/org/lflang/generator/c/CPortGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CPortGenerator.java
@@ -187,7 +187,7 @@ public class CPortGenerator {
         ErrorReporter errorReporter,
         CTypes types
     ) {
-        if (port.getType() == null && target.requiresTypes == true) {
+        if (port.getType() == null && target.requiresTypes) {
             // This should have been caught by the validator.
             errorReporter.reportError(port, "Port is required to have a type: " + port.getName());
             return "";

--- a/org.lflang/src/org/lflang/generator/c/CPreambleGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CPreambleGenerator.java
@@ -127,18 +127,17 @@ public class CPreambleGenerator {
      * Initialize clock synchronization (if enabled) and its related options for a given federate.
      *
      * Clock synchronization can be enabled using the clock-sync target property.
-     * @see https://github.com/icyphy/lingua-franca/wiki/Distributed-Execution#clock-synchronization
+     * @see <a href="https://github.com/icyphy/lingua-franca/wiki/Distributed-Execution#clock-synchronization">Documentation</a>
      */
     private static String generateClockSyncDefineDirective(
         ClockSyncMode mode,
         ClockSyncOptions options
     ) {
-        List<String> code = new ArrayList<>();
-        code.addAll(List.of(
+        List<String> code = new ArrayList<>(List.of(
             "#define _LF_CLOCK_SYNC_INITIAL",
-            "#define _LF_CLOCK_SYNC_PERIOD_NS "+GeneratorBase.timeInTargetLanguage(options.period),
-            "#define _LF_CLOCK_SYNC_EXCHANGES_PER_INTERVAL "+options.trials,
-            "#define _LF_CLOCK_SYNC_ATTENUATION "+options.attenuation
+            "#define _LF_CLOCK_SYNC_PERIOD_NS " + GeneratorBase.timeInTargetLanguage(options.period),
+            "#define _LF_CLOCK_SYNC_EXCHANGES_PER_INTERVAL " + options.trials,
+            "#define _LF_CLOCK_SYNC_ATTENUATION " + options.attenuation
         ));
         if (mode == ClockSyncMode.ON) {
             code.add("#define _LF_CLOCK_SYNC_ON");

--- a/org.lflang/src/org/lflang/generator/c/CStateGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CStateGenerator.java
@@ -17,7 +17,6 @@ public class CStateGenerator {
      * Generate code for state variables of a reactor in the form "stateVar.type stateVar.name;"
      * @param reactor The reactor
      * @param types A helper object for types
-     * @return
      */
     public static String generateDeclarations(Reactor reactor, CTypes types) {
         CodeBuilder code = new CodeBuilder();

--- a/org.lflang/src/org/lflang/generator/c/CTimerGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CTimerGenerator.java
@@ -57,15 +57,14 @@ public class CTimerGenerator {
     public static String generateLfInitializeTimer(int timerCount) {
         return String.join("\n",
             "void _lf_initialize_timers() {",
-            (timerCount > 0 ?
-            String.join("\n",
-            "    for (int i = 0; i < _lf_timer_triggers_size; i++) {",
-            "        if (_lf_timer_triggers[i] != NULL) {",
-            "            _lf_initialize_timer(_lf_timer_triggers[i]);",
-            "        }",
-            "    }"
-            ) :
-            ""),
+            timerCount > 0 ?
+            """
+                for (int i = 0; i < _lf_timer_triggers_size; i++) {
+                    if (_lf_timer_triggers[i] != NULL) {
+                        _lf_initialize_timer(_lf_timer_triggers[i]);
+                    }
+                }""".indent(4) :
+            "",
             "}"
         );
     }

--- a/org.lflang/src/org/lflang/generator/c/CTriggerObjectsGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CTriggerObjectsGenerator.java
@@ -363,7 +363,7 @@ public class CTriggerObjectsGenerator {
         }
 
         var temp = new CodeBuilder();
-        temp.pr("// Set reaction priorities for " + reactor.toString());
+        temp.pr("// Set reaction priorities for " + reactor);
         temp.startScopedBlock(reactor, currentFederate, isFederated, true);
         for (ReactionInstance r : reactor.reactions) {
             if (currentFederate.contains(r.getDefinition())) {
@@ -454,7 +454,7 @@ public class CTriggerObjectsGenerator {
      * to by a reaction belonging to the parent of the port's parent.
      * If it is an output, then it is being written to by a reaction belonging
      * to the port's parent.
-     * @param port A port that is written to by reactions.
+     * @param src A port that is written to by reactions.
      */
     private static String connectPortToEventualDestinations(
         FederateInstance currentFederate,
@@ -474,7 +474,7 @@ public class CTriggerObjectsGenerator {
                 // really necessary.
                 if (currentFederate.contains(dst.getParent())) {
                     var mod = (dst.isMultiport() || (src.isInput() && src.isMultiport()))? "" : "&";
-                    code.pr("// Connect "+srcRange.toString()+" to port "+dstRange.toString());
+                    code.pr("// Connect "+srcRange+" to port "+dstRange);
                     code.startScopedRangeBlock(currentFederate, srcRange, dstRange, isFederated);
                     if (src.isInput()) {
                         // Source port is written to by reaction in port's parent's parent
@@ -500,7 +500,7 @@ public class CTriggerObjectsGenerator {
      * to the single dominating upstream reaction if there is one, or to be
      * NULL if there is none.
      *
-     * @param reactor The reactor.
+     * @param r The reactor.
      */
     private static String deferredOptimizeForSingleDominatingReaction(
         FederateInstance currentFederate,
@@ -870,7 +870,7 @@ public class CTriggerObjectsGenerator {
      * so each function it calls must handle its own iteration
      * over all runtime instance.
      * @param reactor The container.
-     * @param federate The federate (used to determine whether a
+     * @param currentFederate The federate (used to determine whether a
      *  reaction belongs to the federate).
      */
     private static String deferredInitializeNonNested(
@@ -929,7 +929,7 @@ public class CTriggerObjectsGenerator {
     /**
      * For each output of the specified reactor that has a token type
      * (type* or type[]), create a default token and put it on the self struct.
-     * @param parent The reactor.
+     * @param reactor The reactor.
      */
     private static String deferredCreateDefaultTokens(
         ReactorInstance reactor,
@@ -961,7 +961,7 @@ public class CTriggerObjectsGenerator {
      * produced.  The port may be an output of the reaction's parent
      * or an input to a reactor contained by the parent.
      *
-     * @param The reaction instance.
+     * @param reaction The reaction instance.
      */
     private static String deferredReactionOutputs(
         FederateInstance currentFederate,
@@ -1034,7 +1034,7 @@ public class CTriggerObjectsGenerator {
         init.endScopedBlock();
         code.pr(String.join("\n",
             "// Total number of outputs (single ports and multiport channels)",
-            "// produced by "+reaction.toString()+".",
+            "// produced by "+reaction+".",
             CUtil.reactionRef(reaction)+".num_outputs = "+outputCount+";"
         ));
         if (outputCount > 0) {
@@ -1170,7 +1170,7 @@ public class CTriggerObjectsGenerator {
      * all reactor runtime instances have been created.
      * This function creates nested loops over nested banks.
      * @param reactor The container.
-     * @param federate The federate (used to determine whether a
+     * @param currentFederate The federate (used to determine whether a
      *  reaction belongs to the federate).
      */
     private static String deferredInitialize(

--- a/org.lflang/src/org/lflang/generator/c/CTypes.java
+++ b/org.lflang/src/org/lflang/generator/c/CTypes.java
@@ -65,7 +65,7 @@ public class CTypes implements TargetTypes {
      * as a type, and {@code int*} must be used instead, except when initializing
      * a variable using a static initializer, as in {@code int[] foo = {1, 2, 3};}.
      * When initializing a variable using a static initializer, use
-     * {@link #getVariableDeclaration(InferredType, String)} instead.
+     * {@link #getVariableDeclaration(InferredType, String, boolean)} instead.
      * @param type The type.
      */
     @Override

--- a/org.lflang/src/org/lflang/generator/c/CUtil.java
+++ b/org.lflang/src/org/lflang/generator/c/CUtil.java
@@ -90,7 +90,7 @@ public class CUtil {
      * If the instance is not a bank, return "0".
      * @param instance A reactor instance.
      */
-    static public String bankIndex(ReactorInstance instance) {
+    public static String bankIndex(ReactorInstance instance) {
         if (!instance.isBank()) return "0";
         return bankIndexName(instance);
     }
@@ -102,19 +102,18 @@ public class CUtil {
      * from the ID of any other instance in the program.
      * @param instance A reactor instance.
      */
-    static public String bankIndexName(ReactorInstance instance) {
+    public static String bankIndexName(ReactorInstance instance) {
         return instance.uniqueID() + "_i";
     }
 
     /**
      * Return a default name of a variable to refer to the channel index of a port
-     * in a bank. This is has the form uniqueID_c where uniqueID
+     * in a bank. This has the form uniqueID_c where uniqueID
      * is an identifier for the instance that is guaranteed to be different
      * from the ID of any other instance in the program.
      * If the port is not a multiport, then return the string "0".
-     * @param instance A reactor instance.
      */
-    static public String channelIndex(PortInstance port) {
+    public static String channelIndex(PortInstance port) {
         if (!port.isMultiport()) return "0";
         return channelIndexName(port);
     }
@@ -124,9 +123,8 @@ public class CUtil {
      * in a bank. This is has the form uniqueID_c where uniqueID
      * is an identifier for the instance that is guaranteed to be different
      * from the ID of any other instance in the program.
-     * @param instance A reactor instance.
      */
-    static public String channelIndexName(PortInstance port) {
+    public static String channelIndexName(PortInstance port) {
         return port.uniqueID() + "_c";
     }
 
@@ -163,7 +161,7 @@ public class CUtil {
      * @param channelIndex A variable name to use to index the channel or null to
      *  use the default, the string returned by {@link CUtil#channelIndex(PortInstance)}.
      */
-    static public String portRef(
+    public static String portRef(
             PortInstance port,
             boolean isNested,
             boolean includeChannelIndex,
@@ -192,7 +190,7 @@ public class CUtil {
      * This is equivalent to calling `portRef(port, false, true, null, null)`.
      * @param port An instance of the port to be referenced.
      */
-    static public String portRef(PortInstance port) {
+    public static String portRef(PortInstance port) {
         return portRef(port, false, true, null, null, null);
     }
 
@@ -211,7 +209,7 @@ public class CUtil {
      * @param channelIndex A variable name to use to index the channel or null to
      *  use the default, the string returned by {@link CUtil#channelIndex(PortInstance)}.
      */
-    static public String portRef(
+    public static String portRef(
             PortInstance port, String runtimeIndex, String bankIndex, String channelIndex
     ) {
         return portRef(port, false, true, runtimeIndex, bankIndex, channelIndex);
@@ -222,7 +220,7 @@ public class CUtil {
      * This is useful for deriving a reference to the _width variable.
      * @param port An instance of the port to be referenced.
      */
-    static public String portRefName(PortInstance port) {
+    public static String portRefName(PortInstance port) {
         return portRef(port, false, false, null, null, null);
     }
 
@@ -238,7 +236,7 @@ public class CUtil {
      * @param channelIndex A variable name to use to index the channel or null to
      *  use the default, the string returned by {@link CUtil#channelIndex(PortInstance)}.
      */
-    static public String portRefName(
+    public static String portRefName(
             PortInstance port, String runtimeIndex, String bankIndex, String channelIndex
     ) {
         return portRef(port, false, false, runtimeIndex, bankIndex, channelIndex);
@@ -254,7 +252,7 @@ public class CUtil {
      *
      * @param port The port.
      */
-    static public String portRefNested(PortInstance port) {
+    public static String portRefNested(PortInstance port) {
         return portRef(port, true, true, null, null, null);
     }
 
@@ -274,7 +272,7 @@ public class CUtil {
      * @param channelIndex A variable name to use to index the channel or null to
      *  use the default, the string returned by {@link CUtil#channelIndex(PortInstance)}.
      */
-    static public String portRefNested(
+    public static String portRefNested(
             PortInstance port, String runtimeIndex, String bankIndex, String channelIndex
     ) {
         return portRef(port, true, true, runtimeIndex, bankIndex, channelIndex);
@@ -291,7 +289,7 @@ public class CUtil {
      *
      * @param port The port.
      */
-    static public String portRefNestedName(PortInstance port) {
+    public static String portRefNestedName(PortInstance port) {
         return portRef(port, true, false, null, null, null);
     }
 
@@ -312,7 +310,7 @@ public class CUtil {
      * @param channelIndex A variable name to use to index the channel or null to
      *  use the default, the string returned by {@link CUtil#channelIndex(PortInstance)}.
      */
-    static public String portRefNestedName(
+    public static String portRefNestedName(
             PortInstance port, String runtimeIndex, String bankIndex, String channelIndex
     ) {
         return portRef(port, true, false, runtimeIndex, bankIndex, channelIndex);
@@ -350,7 +348,7 @@ public class CUtil {
      * of the parent of the specified reaction.
      * @param reaction The reaction.
      */
-    static public String reactionRef(ReactionInstance reaction) {
+    public static String reactionRef(ReactionInstance reaction) {
         return reactionRef(reaction, null);
     }
 
@@ -360,7 +358,7 @@ public class CUtil {
      * @param reaction The reaction.
      * @param runtimeIndex An index into the array of self structs for the parent.
      */
-    static public String reactionRef(ReactionInstance reaction, String runtimeIndex) {
+    public static String reactionRef(ReactionInstance reaction, String runtimeIndex) {
         return reactorRef(reaction.getParent(), runtimeIndex)
                 + "->_lf__reaction_" + reaction.index;
     }
@@ -373,7 +371,7 @@ public class CUtil {
      * by {@link #runtimeIndex(ReactorInstance)} or 0 if there are no banks.
      * @param instance The reactor instance.
      */
-    static public String reactorRef(ReactorInstance instance) {
+    public static String reactorRef(ReactorInstance instance) {
         return reactorRef(instance, null);
     }
 
@@ -383,7 +381,7 @@ public class CUtil {
      * except that it does not index into the array.
      * @param instance The reactor instance.
      */
-    static public String reactorRefName(ReactorInstance instance) {
+    public static String reactorRefName(ReactorInstance instance) {
         return instance.uniqueID() + "_self";
     }
 
@@ -393,13 +391,13 @@ public class CUtil {
      * self[runtimeIndex], where self is the name of the array of self structs
      * for this reactor instance. If runtimeIndex is null, then it is replaced by
      * the expression returned
-     * by {@link runtimeIndex(ReactorInstance)} or 0 if there are no banks.
+     * by {@link #runtimeIndex(ReactorInstance)} or 0 if there are no banks.
      * @param instance The reactor instance.
      * @param runtimeIndex An optional expression to use to address bank members.
      *  If this is null, the expression used will be that returned  by
      *  {@link #runtimeIndex(ReactorInstance)}.
      */
-    static public String reactorRef(ReactorInstance instance, String runtimeIndex) {
+    public static String reactorRef(ReactorInstance instance, String runtimeIndex) {
         if (runtimeIndex == null) runtimeIndex = runtimeIndex(instance);
         return reactorRefName(instance) + "[" + runtimeIndex + "]";
     }
@@ -412,11 +410,11 @@ public class CUtil {
      * a struct with fields corresponding to those inputs and outputs.
      * This method returns a reference to that struct or array of structs.
      * Note that the returned reference is not to the self struct of the
-     * contained reactor. Use {@link reactorRef(ReactorInstance)} for that.
+     * contained reactor. Use {@link #reactorRef(ReactorInstance)} for that.
      *
      * @param reactor The contained reactor.
      */
-    static public String reactorRefNested(ReactorInstance reactor) {
+    public static String reactorRefNested(ReactorInstance reactor) {
         return reactorRefNested(reactor, null, null);
     }
 
@@ -436,7 +434,7 @@ public class CUtil {
      * @param bankIndex A variable name to use to index the bank or null to use the
      *  default, the string returned by {@link CUtil#bankIndex(ReactorInstance)}.
      */
-    static public String reactorRefNested(ReactorInstance reactor, String runtimeIndex, String bankIndex) {
+    public static String reactorRefNested(ReactorInstance reactor, String runtimeIndex, String bankIndex) {
         String result = reactorRef(reactor.getParent(), runtimeIndex) + "->_lf_" + reactor.getName();
         if (reactor.isBank()) {
             // Need the bank index not the runtimeIndex.
@@ -463,7 +461,7 @@ public class CUtil {
      *
      * @param reactor The reactor.
      */
-    static public String runtimeIndex(ReactorInstance reactor) {
+    public static String runtimeIndex(ReactorInstance reactor) {
         StringBuilder result = new StringBuilder();
         int width = 0;
         int parens = 0;
@@ -491,17 +489,12 @@ public class CUtil {
      * @param reactor The reactor class.
      * @return The type of a self struct for the specified reactor class.
      */
-    static public String selfType(ReactorDecl reactor) {
+    public static String selfType(ReactorDecl reactor) {
         return reactor.getName().toLowerCase() + "_self_t";
     }
 
-    /**
-     * Construct a unique type for the "self" struct of the specified
-     * reactor class from the reactor class.
-     * @param reactor The reactor class.
-     * @return The name of the self struct.
-     */
-    static public String selfType(ReactorInstance instance) {
+    /** Construct a unique type for the "self" struct of the class of the given reactor. */
+    public static String selfType(ReactorInstance instance) {
         return selfType(instance.getDefinition().getReactorClass());
     }
 
@@ -511,7 +504,7 @@ public class CUtil {
      * is on the self struct.
      * @param instance The port or action instance.
      */
-    static public String triggerRef(TriggerInstance<? extends Variable> instance) {
+    public static String triggerRef(TriggerInstance<? extends Variable> instance) {
         return triggerRef(instance, null);
     }
 
@@ -522,7 +515,7 @@ public class CUtil {
      * @param instance The port or action instance.
      * @param runtimeIndex An optional index variable name to use to address runtime instances.
      */
-    static public String triggerRef(TriggerInstance<? extends Variable> instance, String runtimeIndex) {
+    public static String triggerRef(TriggerInstance<? extends Variable> instance, String runtimeIndex) {
         return reactorRef(instance.getParent(), runtimeIndex)
                 + "->_lf__"
                 + instance.getName();
@@ -533,7 +526,7 @@ public class CUtil {
      * port of a contained reactor.
      * @param port The output port of a contained reactor.
      */
-    static public String triggerRefNested(PortInstance port) {
+    public static String triggerRefNested(PortInstance port) {
         return triggerRefNested(port, null, null);
     }
 
@@ -548,7 +541,7 @@ public class CUtil {
      *  the the bank of the port's parent, or null to get the default returned by
      *  {@link CUtil#bankIndex(ReactorInstance)}.
      */
-    static public String triggerRefNested(PortInstance port, String runtimeIndex, String bankIndex) {
+    public static String triggerRefNested(PortInstance port, String runtimeIndex, String bankIndex) {
         return reactorRefNested(port.getParent(), runtimeIndex, bankIndex) + "." + port.getName() + "_trigger";
     }
 
@@ -735,8 +728,7 @@ public class CUtil {
         String[] files = fileConfig.binPath.toFile().list();
         List<String> federateNames = new LinkedList<>(); // FIXME: put this in ASTUtils?
         fileConfig.resource.getAllContents().forEachRemaining(node -> {
-            if (node instanceof Reactor) {
-                Reactor r = (Reactor) node;
+            if (node instanceof Reactor r) {
                 if (r.isFederated()) {
                     r.getInstantiations().forEach(inst -> federateNames
                         .add(inst.getName()));

--- a/org.lflang/src/org/lflang/generator/c/InteractingContainedReactors.java
+++ b/org.lflang/src/org/lflang/generator/c/InteractingContainedReactors.java
@@ -34,9 +34,6 @@ public class InteractingContainedReactors {
      * For each port, this provides a list of reaction indices that
      * are triggered by the port, or an empty list if there are no
      * reactions triggered by the port.
-     * @param reactor The container.
-     * @param federate The federate (used to determine whether a
-     *  reaction belongs to the federate).
      */
     // This horrible data structure is a collection, indexed by instantiation
     // of a contained reactor, of lists, indexed by ports of the contained reactor
@@ -72,10 +69,9 @@ public class InteractingContainedReactors {
                 // Second, handle reactions that are triggered by outputs
                 // of contained reactors.
                 for (TriggerRef trigger : ASTUtils.convertToEmptyListIfNull(reaction.getTriggers())) {
-                    if (trigger instanceof VarRef) {
+                    if (trigger instanceof VarRef triggerAsVarRef) {
                         // If an trigger is an output, then it must be an output
                         // of a contained reactor.
-                        VarRef triggerAsVarRef = (VarRef) trigger;
                         if (triggerAsVarRef.getVariable() instanceof Output) {
                             var list = addPort(triggerAsVarRef.getContainer(), (Output) triggerAsVarRef.getVariable());
                             list.add(reactionCount);
@@ -108,18 +104,12 @@ public class InteractingContainedReactors {
      */
     private List<Integer> addPort(Instantiation containedReactor, Port port) {
         // Get or create the entry for the containedReactor.
-        var containedReactorEntry = portsByContainedReactor.get(containedReactor);
-        if (containedReactorEntry == null) {
-            containedReactorEntry = new LinkedHashMap<>();
-            portsByContainedReactor.put(containedReactor, containedReactorEntry);
-        }
+        var containedReactorEntry = portsByContainedReactor.computeIfAbsent(
+            containedReactor,
+            k -> new LinkedHashMap<>()
+        );
         // Get or create the entry for the port.
-        var portEntry = containedReactorEntry.get(port);
-        if (portEntry == null) {
-            portEntry = new LinkedList<>();
-            containedReactorEntry.put(port, portEntry);
-        }
-        return portEntry;
+        return containedReactorEntry.computeIfAbsent(port, k -> new LinkedList<>());
     }
 
     /**


### PR DESCRIPTION
I did a quick (< 2 hour) pass through some files related to the C generator because the warnings appearing in the IDE were distracting. The only changes that should make any semantic difference to our code are replacement of `==` with `.equals` to compare strings.

In the interest of minimizing conflicts (and of avoiding controversy), I tried to do this quickly and neglected many more potential issues that IntelliJ flagged. Maybe some more "code health" passes of this sort should happen if we think it's a good idea.

Changes include:
* Replacing redundant type arguments with diamond types
* Removing redundant `toString()` calls in string concatenation
* Using pattern matching to avoid casting (after using `instanceof`)
* Fixing broken references in Javadoc comments
* Deleting or updating outdated method documentation
* **Replacing usages of == and != to compare strings!** This seems like a real bug, and it surprises me that it was not caught in CI.

Changes do not include:
* Removing unnecessary parentheses
* Always surrounding + with spaces when used for string concatenation
* Making members final
* Deleting unused class variables
* Deleting unused methods
* Deleting unused parameters
* Deleting useless local variables
* Addressing warnings that point to logical errors in the control flow of methods
* Addressing "wrong tag" warnings for comments of the form "@author{Name Surname <email.address@university.edu>}" that make "@author{Name" look like all one JavaDoc tag
* Refactoring "pseudo functional style code" that causes side effects, even though it uses APIs designed for functional programming