### PR TITLE
String-based line-wrapping for formatter

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/compiler/RoundTripTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/RoundTripTests.java
@@ -58,6 +58,7 @@ public class RoundTripTests {
         Model originalModel = parse(file);
         System.out.printf("Running formatter on %s%n", file);
         Assertions.assertTrue(originalModel.eResource().getErrors().isEmpty());
+        ToLf.instance.setLineWrap(30);
         String reformattedTestCase = ToLf.instance.doSwitch(originalModel);
         System.out.printf("Reformatted test case:%n%s%n%n", reformattedTestCase);
         Model resultingModel = getResultingModel(file, reformattedTestCase);

--- a/org.lflang/src/org/lflang/ast/ToLf.java
+++ b/org.lflang/src/org/lflang/ast/ToLf.java
@@ -712,7 +712,7 @@ public class ToLf extends LfSwitch<String> {
     }
     
     /**
-     * Wraps a multi-line String based on the current state of lineWrap and indentLvl.
+     * Wrap a multi-line String based on the current state of lineWrap and indentLvl.
      * If lineWrap is 0, returns orgString. Otherwise, breaks lines such that if possible, each line has less than
      * (lineWrap - (indentLvl * INDENTATION) % lineWrap) characters, only breaking at spaces.
      * @param orgString The String to wrap.
@@ -724,7 +724,7 @@ public class ToLf extends LfSwitch<String> {
     }
     
     /**
-     * Wraps a single line of String based on the current state of lineWrap and indentLvl. See wrapLines().
+     * Wrap a single line of String based on the current state of lineWrap and indentLvl. See wrapLines().
      * @param line The line to wrap.
      * @return The wrapped line.
      */


### PR DESCRIPTION
This is a basic implementation for line-wrapping LF code. The formatter takes into account the current level of indentation when breaking lines for line-wrapping, but will always break at spaces (violating the line-wrap limit if it cannot find a space before the limit). Set the line-wrap limit with ToLf.instance.setLineWrap().
Part of #1227.