### PR TITLE
New keyword for history transitions

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -2369,6 +2369,25 @@ public class LinguaFrancaValidationTest {
             "The state variable can not be automatically reset without an initial value.");
     }
 
+    @Test
+    public void testUnspecifiedTransitionType() throws Exception {
+        String testCase = """
+            target C;
+            main reactor {
+                initial mode IM {
+                    reaction(startup) -> M {==}
+                }
+                mode M {
+                    reset state s:int(0);
+                }
+            }
+        """;
+        validator.assertWarning(parseWithoutError(testCase), LfPackage.eINSTANCE.getReaction(), null,
+                "You should specifiy a transition type! "
+                + "Reset and history transitions have different effects on this target mode. "
+                + "Currently, a reset type is implicitly assumed.");
+    }
+
 }
 
 

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -457,7 +457,7 @@ enum BuiltinTrigger:
     STARTUP='startup' | SHUTDOWN='shutdown' | RESET='reset';
 
 enum ModeTransition:
-    RESET='reset' | HISTORY='continue';
+    RESET='reset' | HISTORY='history';
 
 // Note: time units are not keywords, otherwise it would reserve
 // a lot of useful identifiers (like 's' or 'd').
@@ -481,7 +481,7 @@ Token:
     'mutable' | 'input' | 'output' | 'timer' | 'action' | 'reaction' | 
     'startup' | 'shutdown' | 'after' | 'deadline' | 'mutation' | 'preamble' |
     'new' | 'federated' | 'at' | 'as' | 'from' | 'widthof' | 'const' | 'method' |
-    'interleaved' | 'mode' | 'initial' | 'reset' | 'continue' |
+    'interleaved' | 'mode' | 'initial' | 'reset' | 'history' |
     // Other terminals
     NEGINT | TRUE | FALSE |
     // Action origins

--- a/test/C/src/modal_models/ConvertCaseTest.lf
+++ b/test/C/src/modal_models/ConvertCaseTest.lf
@@ -20,7 +20,7 @@ reactor ResetProcessor {
         character -> converter.raw;
         converter.converted -> converted;
 
-        reaction(discard) -> Discarding {=
+        reaction(discard) -> reset(Discarding) {=
             lf_set_mode(Discarding);
         =}
     }
@@ -30,7 +30,7 @@ reactor ResetProcessor {
             lf_set(converted, '_');
         =}
 
-        reaction(character) -> Converting {=
+        reaction(character) -> reset(Converting) {=
             lf_set_mode(Converting);
         =}
     }
@@ -46,7 +46,7 @@ reactor HistoryProcessor {
         character -> converter.raw;
         converter.converted -> converted;
 
-        reaction(discard) -> Discarding {=
+        reaction(discard) -> reset(Discarding) {=
             lf_set_mode(Discarding);
         =}
     }

--- a/test/C/src/modal_models/ConvertCaseTest.lf
+++ b/test/C/src/modal_models/ConvertCaseTest.lf
@@ -56,7 +56,7 @@ reactor HistoryProcessor {
             lf_set(converted, '_');
         =}
 
-        reaction(character) -> continue(Converting) {=
+        reaction(character) -> history(Converting) {=
             lf_set_mode(Converting);
         =}
     }

--- a/test/C/src/modal_models/ModalActions.lf
+++ b/test/C/src/modal_models/ModalActions.lf
@@ -52,7 +52,7 @@ reactor Modal {
             lf_set(action2_exec, 1);
         =}
 
-        reaction(next) -> continue(One), mode_switch {=
+        reaction(next) -> history(One), mode_switch {=
             printf("Transitioning to mode One (continue)\n");
             lf_set(mode_switch, 1);
             lf_set_mode(One);

--- a/test/C/src/modal_models/ModalAfter.lf
+++ b/test/C/src/modal_models/ModalAfter.lf
@@ -38,7 +38,7 @@ reactor Modal {
         producer2.product -> consumer2.product after 500msec;
         consumer2.report -> consumed2;
 
-        reaction(next) -> continue(One), mode_switch {=
+        reaction(next) -> history(One), mode_switch {=
             printf("Transitioning to mode One (continue)\n");
             lf_set(mode_switch, 1);
             lf_set_mode(One);

--- a/test/C/src/modal_models/ModalCycleBreaker.lf
+++ b/test/C/src/modal_models/ModalCycleBreaker.lf
@@ -32,7 +32,7 @@ reactor Modal {
             lf_set(out, in1->value);
         =}
 
-        reaction(in1) -> Two {=
+        reaction(in1) -> reset(Two) {=
             if (in1->value % 5 == 4) {
                 lf_set_mode(Two);
                 printf("Switching to mode Two\n");

--- a/test/C/src/modal_models/ModalStateReset.lf
+++ b/test/C/src/modal_models/ModalStateReset.lf
@@ -56,7 +56,7 @@ reactor Modal {
             lf_set(count2, self->counter2++);
         =}
 
-        reaction(next) -> continue(One), mode_switch {=
+        reaction(next) -> history(One), mode_switch {=
             printf("Transitioning to mode One (continue)\n");
             lf_set(mode_switch, 1);
             lf_set_mode(One);

--- a/test/C/src/modal_models/ModalStateResetAuto.lf
+++ b/test/C/src/modal_models/ModalStateResetAuto.lf
@@ -9,7 +9,7 @@ target C {
 
 import TraceTesting from "util/TraceTesting.lf"
 
-reactor Modal {
+reactor Modal (test:int(0)){
     input next:bool;
     
     output mode_switch:int
@@ -18,6 +18,7 @@ reactor Modal {
     output count2:int;
     
     state counter0:int(0);
+    reset state counter4:int(0);
     
     reaction(next) -> count0 {=
         printf("Counter0: %d\n", self->counter0);
@@ -48,7 +49,7 @@ reactor Modal {
             lf_set(count2, self->counter2++);
         =}
         
-        reaction(next) -> continue(One), mode_switch {=
+        reaction(next) -> history(One), mode_switch {=
             printf("Transitioning to mode One (continue)\n");
             lf_set(mode_switch, 1);
             lf_set_mode(One);

--- a/test/C/src/modal_models/ModalStateResetAuto.lf
+++ b/test/C/src/modal_models/ModalStateResetAuto.lf
@@ -9,7 +9,7 @@ target C {
 
 import TraceTesting from "util/TraceTesting.lf"
 
-reactor Modal (test:int(0)){
+reactor Modal {
     input next:bool;
     
     output mode_switch:int
@@ -18,7 +18,6 @@ reactor Modal (test:int(0)){
     output count2:int;
     
     state counter0:int(0);
-    reset state counter4:int(0);
     
     reaction(next) -> count0 {=
         printf("Counter0: %d\n", self->counter0);

--- a/test/C/src/modal_models/ModalTimers.lf
+++ b/test/C/src/modal_models/ModalTimers.lf
@@ -38,7 +38,7 @@ reactor Modal {
             lf_set(timer2, 1);
         =}
 
-        reaction(next) -> continue(One), mode_switch {=
+        reaction(next) -> history(One), mode_switch {=
             printf("Transitioning to mode One (continue)\n");
             lf_set(mode_switch, 1);
             lf_set_mode(One);

--- a/test/C/src/modal_models/MultipleOutputFeeder_2Connections.lf
+++ b/test/C/src/modal_models/MultipleOutputFeeder_2Connections.lf
@@ -18,7 +18,7 @@ reactor Modal {
         counter1 = new Counter(period=250msec);
         counter1.value -> count;
 
-        reaction(next) -> Two {=
+        reaction(next) -> reset(Two) {=
             lf_set_mode(Two);
         =}
     }

--- a/test/C/src/modal_models/MultipleOutputFeeder_2Connections.lf
+++ b/test/C/src/modal_models/MultipleOutputFeeder_2Connections.lf
@@ -26,7 +26,7 @@ reactor Modal {
         counter2 = new Counter(period=100msec);
         counter2.value -> count;
 
-        reaction(next) -> continue(One) {=
+        reaction(next) -> history(One) {=
             lf_set_mode(One);
         =}
     }

--- a/test/C/src/modal_models/MultipleOutputFeeder_ReactionConnections.lf
+++ b/test/C/src/modal_models/MultipleOutputFeeder_ReactionConnections.lf
@@ -29,7 +29,7 @@ reactor Modal {
             lf_set(count, counter2.value->value * 10);
         =}
 
-        reaction(next) -> continue(One) {=
+        reaction(next) -> history(One) {=
             lf_set_mode(One);
         =}
     }

--- a/test/C/src/modal_models/MultipleOutputFeeder_ReactionConnections.lf
+++ b/test/C/src/modal_models/MultipleOutputFeeder_ReactionConnections.lf
@@ -18,7 +18,7 @@ reactor Modal {
         counter1 = new Counter(period=250msec);
         counter1.value -> count;
 
-        reaction(next) -> Two {=
+        reaction(next) -> reset(Two) {=
             lf_set_mode(Two);
         =}
     }

--- a/test/Python/src/modal_models/ConvertCaseTest.lf
+++ b/test/Python/src/modal_models/ConvertCaseTest.lf
@@ -19,7 +19,7 @@ reactor ResetProcessor {
         character -> converter.raw
         converter.converted -> converted
 
-        reaction(discard) -> Discarding {=
+        reaction(discard) -> reset(Discarding) {=
             Discarding.set()
         =}
     }
@@ -29,7 +29,7 @@ reactor ResetProcessor {
             converted.set('_')
         =}
 
-        reaction(character) -> Converting {=
+        reaction(character) -> reset(Converting) {=
             Converting.set()
         =}
     }
@@ -45,7 +45,7 @@ reactor HistoryProcessor {
         character -> converter.raw
         converter.converted -> converted
 
-        reaction(discard) -> Discarding {=
+        reaction(discard) -> reset(Discarding) {=
             Discarding.set()
         =}
     }

--- a/test/Python/src/modal_models/ConvertCaseTest.lf
+++ b/test/Python/src/modal_models/ConvertCaseTest.lf
@@ -55,7 +55,7 @@ reactor HistoryProcessor {
             converted.set('_')
         =}
 
-        reaction(character) -> continue(Converting) {=
+        reaction(character) -> history(Converting) {=
             Converting.set()
         =}
     }

--- a/test/Python/src/modal_models/ModalActions.lf
+++ b/test/Python/src/modal_models/ModalActions.lf
@@ -52,7 +52,7 @@ reactor Modal {
             action2_exec.set(1)
         =}
 
-        reaction(next) -> continue(One), mode_switch {=
+        reaction(next) -> history(One), mode_switch {=
             print("Transitioning to mode One (continue)")
             mode_switch.set(1)
             One.set()

--- a/test/Python/src/modal_models/ModalAfter.lf
+++ b/test/Python/src/modal_models/ModalAfter.lf
@@ -38,7 +38,7 @@ reactor Modal {
         producer2.product -> consumer2.product after 500msec
         consumer2.report -> consumed2
 
-        reaction(next) -> continue(One), mode_switch {=
+        reaction(next) -> history(One), mode_switch {=
             print("Transitioning to mode One (continue)")
             mode_switch.set(1)
             One.set()

--- a/test/Python/src/modal_models/ModalCycleBreaker.lf
+++ b/test/Python/src/modal_models/ModalCycleBreaker.lf
@@ -31,7 +31,7 @@ reactor Modal {
             out.set(in1.value)
         =}
 
-        reaction(in1) -> Two {=
+        reaction(in1) -> reset(Two) {=
             if in1.value % 5 == 4:
                 Two.set()
                 print("Switching to mode Two")

--- a/test/Python/src/modal_models/ModalStateReset.lf
+++ b/test/Python/src/modal_models/ModalStateReset.lf
@@ -59,7 +59,7 @@ reactor Modal {
             self.counter2 += 1
         =}
 
-        reaction(next) -> continue(One), mode_switch {=
+        reaction(next) -> history(One), mode_switch {=
             print("Transitioning to mode One (continue)")
             mode_switch.set(1)
             One.set()

--- a/test/Python/src/modal_models/ModalTimers.lf
+++ b/test/Python/src/modal_models/ModalTimers.lf
@@ -38,7 +38,7 @@ reactor Modal {
             timer2.set(1)
         =}
 
-        reaction(next) -> continue(One), mode_switch {=
+        reaction(next) -> history(One), mode_switch {=
             print("Transitioning to mode One (continue)")
             mode_switch.set(1)
             One.set()

--- a/test/Python/src/modal_models/MultipleOutputFeeder_2Connections.lf
+++ b/test/Python/src/modal_models/MultipleOutputFeeder_2Connections.lf
@@ -18,7 +18,7 @@ reactor Modal {
         counter1 = new Counter(period=250msec)
         counter1.value -> count
 
-        reaction(next) -> Two {=
+        reaction(next) -> reset(Two) {=
             Two.set()
         =}
     }

--- a/test/Python/src/modal_models/MultipleOutputFeeder_2Connections.lf
+++ b/test/Python/src/modal_models/MultipleOutputFeeder_2Connections.lf
@@ -26,7 +26,7 @@ reactor Modal {
         counter2 = new Counter(period=100msec)
         counter2.value -> count
 
-        reaction(next) -> continue(One) {=
+        reaction(next) -> history(One) {=
             One.set()
         =}
     }

--- a/test/Python/src/modal_models/MultipleOutputFeeder_ReactionConnections.lf
+++ b/test/Python/src/modal_models/MultipleOutputFeeder_ReactionConnections.lf
@@ -18,7 +18,7 @@ reactor Modal {
         counter1 = new Counter(period=250msec)
         counter1.value -> count
 
-        reaction(next) -> Two {=
+        reaction(next) -> reset(Two) {=
             Two.set()
         =}
     }

--- a/test/Python/src/modal_models/MultipleOutputFeeder_ReactionConnections.lf
+++ b/test/Python/src/modal_models/MultipleOutputFeeder_ReactionConnections.lf
@@ -29,7 +29,7 @@ reactor Modal {
             count.set(counter2.value.value * 10)
         =}
 
-        reaction(next) -> continue(One) {=
+        reaction(next) -> history(One) {=
             One.set()
         =}
     }


### PR DESCRIPTION
Changes keyword for history transitions from `continue` to `history`.
The documentation is updated by [website PR #87](https://github.com/lf-lang/website-lingua-franca/pull/87).
Update of the syntax highlighting for VSCode in [vscode PR #62](https://github.com/lf-lang/vscode-lingua-franca/pull/62).

Also adds warning if the user does not specify a transition type but the types would actually have different effects on the target mode.

Closes #1220