### PR TITLE
Repair ability to execute commands with Bash in case command is not found on path

### DIFF
--- a/org.lflang/src/org/lflang/util/LFCommand.java
+++ b/org.lflang/src/org/lflang/util/LFCommand.java
@@ -325,7 +325,7 @@ public class LFCommand {
         } else if (findCommand(cmd) != null) {
             builder = new ProcessBuilder(cmdList);
         } else if (checkIfCommandIsExecutableWithBash(cmd, dir)) {
-            builder = new ProcessBuilder("bash", "--login", "-c", String.join(" ", cmdList));
+            builder = new ProcessBuilder("bash", "--login", "-c", String.format("\"%s\"", String.join(" ", cmdList)));
         }
 
         if (builder != null) {


### PR DESCRIPTION
This repairs the "execute" command that for scripts that use Node. I believe that Node is unusual in the way it is added to `$PATH` -- it only is present in the shell environment, which might be why we have to invoke it in this special way.

Issue reported [here](https://github.com/lf-lang/vscode-lingua-franca/issues/64).