### PR TITLE
Avoid NPE in `CompileActionHandler`

### DIFF
--- a/org.lflang.ui/src/org/lflang/ui/actions/CompileActionHandler.java
+++ b/org.lflang.ui/src/org/lflang/ui/actions/CompileActionHandler.java
@@ -134,15 +134,18 @@ class CompileActionHandler extends AbstractHandler {
             var xtextEditor = EditorUtils.getActiveXtextEditor(event);
             if (xtextEditor != null) {
                 var xtextDocument = xtextEditor.getDocument();
+                var resource = xtextEditor.getResource();
                 if (xtextDocument != null) {
                     // Save editor
                     if (xtextEditor.isDirty()) {
                         xtextEditor.doSave(new NullProgressMonitor());
+                    } else if (resource != null) {
+                        // Load the resource of this editor based on its associated file (collect).
+                        // This does not retrieve the model resource from the editor directly but creates a new one. 
+                        // => workaround for issue #746.
+                        lfFiles.addAll(collect((IFile) resource));
                     }
-                    // Load the resource of this editor based on its associated file (collect).
-                    // This does not retrieve the model resource from the editor directly but creates a new one. 
-                    // => workaround for issue #746.
-                    lfFiles.addAll(collect((IFile) xtextEditor.getResource()));
+                    
                 }
             }
         } else if (selection instanceof IStructuredSelection) { // Invoked from context menu in project explorer

--- a/org.lflang.ui/src/org/lflang/ui/actions/CompileActionHandler.java
+++ b/org.lflang.ui/src/org/lflang/ui/actions/CompileActionHandler.java
@@ -139,7 +139,8 @@ class CompileActionHandler extends AbstractHandler {
                     // Save editor
                     if (xtextEditor.isDirty()) {
                         xtextEditor.doSave(new NullProgressMonitor());
-                    } else if (resource != null) {
+                    }
+                    if (resource != null) {
                         // Load the resource of this editor based on its associated file (collect).
                         // This does not retrieve the model resource from the editor directly but creates a new one. 
                         // => workaround for issue #746.


### PR DESCRIPTION
This patch is meant to fix #1263, but I am puzzled as to why the resource associated with the Xtext editor would ever be `null`.

Closes #1263