### PR TITLE
Do not include in cycles downstream reactions

### DIFF
--- a/org.lflang/src/org/lflang/generator/ReactionInstanceGraph.java
+++ b/org.lflang/src/org/lflang/generator/ReactionInstanceGraph.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.lflang.generator.ReactionInstance.Runtime;
-import org.lflang.graph.DirectedGraph;
+import org.lflang.graph.PrecedenceGraph;
 import org.lflang.lf.Variable;
 
 /**
@@ -54,7 +54,7 @@ import org.lflang.lf.Variable;
  * @author{Marten Lohstroh <marten@berkeley.edu>}
  * @author{Edward A. Lee <eal@berkeley.edu>}
  */
-public class ReactionInstanceGraph extends DirectedGraph<ReactionInstance.Runtime> {
+public class ReactionInstanceGraph extends PrecedenceGraph<ReactionInstance.Runtime> {
     
     /**
      * Create a new graph by traversing the maps in the named instances 


### PR DESCRIPTION
This PR addresses issue #1213. Before this PR, when a causality cycle was detected, reactions that were downstream of the cycle but not part of the cycle were reported to be part of the cycle.  This PR fixes it so that only the reactions in the cycle are highlighted.