### PR TITLE
Do not minimize the shadow jar

### DIFF
--- a/org.lflang.lfc/build.gradle
+++ b/org.lflang.lfc/build.gradle
@@ -35,11 +35,6 @@ task buildLfc() {
 
     shadowJar {
         exclude 'test/*'
-        minimize() {
-            exclude(dependency('log4j:log4j:.*'))
-            exclude(dependency('com.google.inject:guice:.*'))
-            exclude(dependency('org.lflang:org.lflang:.*'))
-        }
         transform(com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer){
             resource = 'plugin.properties'
         }

--- a/org.lflang.lfc/build.gradle
+++ b/org.lflang.lfc/build.gradle
@@ -38,6 +38,11 @@ task buildLfc() {
         transform(com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer){
             resource = 'plugin.properties'
         }
+        // We should use minimize() here to reduce the size of the JAR, but it causes problems
+        // with regard to our Kotlin classes. Since we don't use imports to load them but load
+        // the classes manually, minimize does not see the dependency. While we can add an exclude
+        // rule, this does not seem to work very well and causes problems when compiling for a
+        // second time. Also see https://github.com/lf-lang/lingua-franca/pull/1285
     }
 }
 


### PR DESCRIPTION
Issue #1284 was caused by the mimization step of the shadowJar gradle plugin. The main problem is, that we don't import kotlin classes directly, but load them manually in order to work around the build problems in Eclipse... Hence, the minimizer thinks it can exclude the Kotlin classes. While in principle it is possible to add particular excludes, this does not work properly when we compile a second time. The reason for this is unclear, but we might as well disable the minimization. This slightly increases the jar size from 23 MB to 28 MB.

Closes #1284