### PR TITLE
Fixed LET inference and added test

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/compiler/LetInferenceTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LetInferenceTests.java
@@ -1,0 +1,156 @@
+package org.lflang.tests.compiler;/* Parsing unit tests. */
+
+/*************
+ Copyright (c) 2019, The University of California at Berkeley.
+
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ***************/
+
+import static org.lflang.ASTUtils.isInitialized;
+import static org.lflang.util.IteratorUtil.asStream;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+
+import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.eclipse.xtext.testing.util.ParseHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.lflang.ASTUtils;
+import org.lflang.DefaultErrorReporter;
+import org.lflang.TimeUnit;
+import org.lflang.TimeValue;
+import org.lflang.generator.GeneratorBase;
+import org.lflang.generator.GeneratorUtils;
+import org.lflang.generator.LFResource;
+import org.lflang.generator.ReactionInstance;
+import org.lflang.generator.ReactorInstance;
+import org.lflang.lf.Instantiation;
+import org.lflang.lf.LfFactory;
+import org.lflang.lf.LfPackage;
+import org.lflang.lf.Literal;
+import org.lflang.lf.Model;
+import org.lflang.lf.Parameter;
+import org.lflang.lf.Reactor;
+import org.lflang.lf.StateVar;
+import org.lflang.tests.LFInjectorProvider;
+import static org.lflang.ASTUtils.*;
+
+import com.google.common.base.Objects;
+
+@ExtendWith(InjectionExtension.class)
+@InjectWith(LFInjectorProvider.class)
+
+/**
+ * Test for getting minimum delay in reactions.
+ * Checking the actions and port's delay,then get the minimum reaction delay.
+ */
+class LetInferenceTest  {
+
+    @Inject
+    ParseHelper<Model> parser;
+
+
+    @Test
+    public void testLet() throws Exception {
+        Model model = parser.parse(String.join(
+            System.getProperty("line.separator"),
+            "target C;",
+            "main reactor {",
+            "    ramp = new Ramp();",
+            "    print = new Print();",
+            "    print2 = new Print();",
+            "    ramp.y -> print.x after 20 msec;",
+            "    ramp.y -> print2.x after 30 msec;",
+            "}",
+            "reactor Ramp {",
+            "    logical action a(60 msec):int;",
+            "    logical action b(100 msec):int;",
+            "    input x:int;",
+            "    output y:int;",
+            "    output z:int;",
+            "    reaction(startup) -> y, z, a, b{=",
+            "    =}",
+            "}",
+            "reactor Print {",
+            "    input x:int;",
+            "    output z:int;",
+            "    reaction(x) -> z {=",
+            "    =}",
+            "}"
+        ));
+
+        Assertions.assertNotNull(model);
+        Assertions.assertTrue(model.eResource().getErrors().isEmpty(),
+                              "Encountered unexpected error while parsing: " +
+                                  model.eResource().getErrors());
+
+        Instantiation mainDef = null;
+
+        TreeIterator<EObject> it = model.eResource().getAllContents();
+        while (it.hasNext()) {
+            EObject obj = it.next();
+            if (!(obj instanceof Reactor)) {
+                continue;
+            }
+            Reactor reactor = (Reactor) obj;
+            if (reactor.isMain()) {
+                mainDef = LfFactory.eINSTANCE.createInstantiation();
+                mainDef.setName(reactor.getName());
+                mainDef.setReactorClass(reactor);
+            }
+        }
+
+        ReactorInstance mainI = new ReactorInstance(toDefinition(mainDef.getReactorClass()), new DefaultErrorReporter());
+        for (Reactor r : model.getReactors()) {
+            System.out.println(r.getName());
+        }
+
+        for (ReactorInstance reactorInstance : mainI.children) {
+            System.out.println("reactor: " + reactorInstance.getName());
+            for (ReactionInstance reactionInstance : reactorInstance.reactions) {
+                System.out.println(reactionInstance.getLogicalExecutionTime().toString());
+            }
+            if (reactorInstance.isGeneratedDelay()) {
+                for (ReactionInstance reactionInstance : reactorInstance.reactions) {
+                    Assertions.assertEquals(reactionInstance.getLogicalExecutionTime(), TimeValue.ZERO);
+                }
+            } else if (reactorInstance.getName().contains("ramp")) {
+                for (ReactionInstance reactionInstance : reactorInstance.reactions) {
+
+                    Assertions.assertEquals(reactionInstance.getLogicalExecutionTime(),
+                                            new TimeValue(10, TimeUnit.NANO));
+                }
+            }
+        }
+    }
+}

--- a/org.lflang/src/org/lflang/TimeValue.java
+++ b/org.lflang/src/org/lflang/TimeValue.java
@@ -74,6 +74,13 @@ public final class TimeValue implements Comparable<TimeValue> {
         this.unit = unit;
     }
 
+    @Override
+    public boolean equals(Object t1) {
+        if (t1 instanceof TimeValue) {
+            return this.compareTo((TimeValue) t1) == 0;
+        }
+        return false;
+    }
     
     public static int compare(TimeValue t1, TimeValue t2) {
         if (t1.isEarlierThan(t2)) {

--- a/org.lflang/src/org/lflang/generator/ReactionInstance.java
+++ b/org.lflang/src/org/lflang/generator/ReactionInstance.java
@@ -452,7 +452,11 @@ public class ReactionInstance extends NamedInstance<Reaction> {
         if (this.let != null) {
             return this.let;
         }
-     
+
+        if (this.parent.isGeneratedDelay()) {
+            return this.let = TimeValue.ZERO;
+        }
+
         TimeValue let = null;
 
         // Iterate over effect and find minimum delay.
@@ -460,7 +464,8 @@ public class ReactionInstance extends NamedInstance<Reaction> {
             if (effect instanceof PortInstance) {
                 var afters = this.parent.getParent().children.stream().filter(c -> {
                     if (c.isGeneratedDelay()) {
-                        return c.inputs.iterator().next().equals((PortInstance) effect);
+                        return c.inputs.iterator().next().getDependsOnPorts().iterator().next().instance
+                                       .equals((PortInstance) effect);
                     }
                     return false;
                 }).map(c -> c.actions.iterator().next().getMinDelay())

--- a/org.lflang/src/org/lflang/generator/ReactorInstance.java
+++ b/org.lflang/src/org/lflang/generator/ReactorInstance.java
@@ -1158,7 +1158,7 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
      * @return True if this is a generated delay, false otherwise.
      */
     public boolean isGeneratedDelay() {
-        if (this.definition.getName().contains("delay")) {
+        if (this.definition.getReactorClass().getName().contains(GeneratorBase.GEN_DELAY_CLASS_NAME)) {
             return true;
         }
         return false;

--- a/org.lflang/src/org/lflang/generator/ReactorInstance.java
+++ b/org.lflang/src/org/lflang/generator/ReactorInstance.java
@@ -1158,7 +1158,7 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
      * @return True if this is a generated delay, false otherwise.
      */
     public boolean isGeneratedDelay() {
-        if (this.definition.getName().contains(GeneratorBase.GEN_DELAY_CLASS_NAME)) {
+        if (this.definition.getName().contains("delay")) {
             return true;
         }
         return false;

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -1931,7 +1931,6 @@ public class CGenerator extends GeneratorBase {
         initializeOutputMultiports(instance);
         initializeInputMultiports(instance);
         recordBuiltinTriggers(instance);
-        assignLetToReaction(instance);
 
         // Next, initialize the "self" struct with state variables.
         // These values may be expressions that refer to the parameter values defined above.

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -1615,6 +1615,12 @@ public class CGenerator extends GeneratorBase {
         }
     }
 
+    private void assignLetToReaction(ReactorInstance instance) {
+        for (ReactionInstance reaction : instance.reactions) {
+            reaction.getLogicalExecutionTime();
+        }
+    }
+
 
 
     /**
@@ -1925,6 +1931,7 @@ public class CGenerator extends GeneratorBase {
         initializeOutputMultiports(instance);
         initializeInputMultiports(instance);
         recordBuiltinTriggers(instance);
+        assignLetToReaction(instance);
 
         // Next, initialize the "self" struct with state variables.
         // These values may be expressions that refer to the parameter values defined above.


### PR DESCRIPTION
1. Set delay reactor's let is zero.
2. Checking if delay reaction's ```DependsOnPort``` is same as effect or not.
3. In``` isGeneratedDelay()```, the function checks if the reactor's name match "delay."
4. Add ```assignLetToReaction``` function in the Generator after ```recordBuiltinTriggers```.