### PR TITLE
Fix to ensure the ordering of reactions relative to modes is correct

### DIFF
--- a/org.lflang/src/org/lflang/ASTUtils.java
+++ b/org.lflang/src/org/lflang/ASTUtils.java
@@ -726,7 +726,7 @@ public class ASTUtils {
      * @param <T> The type of elements to collect (e.g., Port, Timer, etc.)
      * @return A list of all elements of type T found
      */
-    public static <T> List<T> collectElements(Reactor definition, EStructuralFeature feature) {
+    public static <T extends EObject> List<T> collectElements(Reactor definition, EStructuralFeature feature) {
         return ASTUtils.collectElements(definition, feature, true, true);
     }
     
@@ -741,7 +741,7 @@ public class ASTUtils {
      * @return A list of all elements of type T found
      */
     @SuppressWarnings("unchecked")
-    public static <T> List<T> collectElements(Reactor definition, EStructuralFeature feature, boolean includeSuperClasses, boolean includeModes) {
+    public static <T extends EObject> List<T> collectElements(Reactor definition, EStructuralFeature feature, boolean includeSuperClasses, boolean includeModes) {
         List<T> result = new ArrayList<>();
         
         if (includeSuperClasses) {
@@ -761,11 +761,63 @@ public class ASTUtils {
             var modeFeature = reactorModeFeatureMap.get(feature);
             // Add elements of elements defined in modes.
             for (Mode mode : includeSuperClasses ? allModes(definition) : definition.getModes()) {
-                result.addAll((EList<T>) mode.eGet(modeFeature));
+                insertModeElementsAtTextualPosition(result, (EList<T>) mode.eGet(modeFeature), mode);
             }
         }
         
         return result;
+    }
+    
+    /**
+     * Adds the elements into the given list at a location matching to their textual position.
+     * 
+     * When creating a flat view onto reactor elements including modes, the final list must be ordered according
+     * to the textual positions.
+     * 
+     * Example:
+     * reactor R {
+     *   reaction // -> is R.reactions[0]
+     *   mode M {
+     *      reaction // -> is R.mode[0].reactions[0]
+     *      reaction // -> is R.mode[0].reactions[1]
+     *   }
+     *   reaction // -> is R.reactions[1]
+     * }
+     * In this example, it is important that the reactions in the mode are inserted between the top-level 
+     * reactions to retain the correct global reaction ordering, which will be derived from this flattened view.
+     * 
+     * @param list The list to add the elements into.
+     * @param elements The elements to add.
+     * @param mode The mode containing the elements.
+     * @param <T> The type of elements to add (e.g., Port, Timer, etc.)
+     */
+    private static <T extends EObject> void insertModeElementsAtTextualPosition(List<T> list, List<T> elements, Mode mode) {
+        if (elements.isEmpty()) {
+            return; // Nothing to add
+        }
+        
+        var idx = list.size();
+        if (idx > 0) {
+            // If there are elements in the list, first check if the last element has the same container as the mode.
+            // I.e. we don't want to compare textual positions of different reactors (super classes)
+            if (mode.eContainer() == list.get(list.size() - 1).eContainer()) {
+                var modeAstNode = NodeModelUtils.getNode(mode);
+                if (modeAstNode != null) {
+                    var modePos = modeAstNode.getOffset();
+                    // Now move the insertion index from the last element forward as long as this element has a textual
+                    // position after the mode.
+                    do {
+                        var astNode = NodeModelUtils.getNode(list.get(idx - 1));
+                        if (astNode != null && astNode.getOffset() > modePos) {
+                            idx--;
+                        } else {
+                            break; // Insertion index is ok.
+                        }
+                    } while (idx > 0);
+                }
+            }
+        }
+        list.addAll(idx, elements);
     }
 
     ////////////////////////////////

--- a/test/C/src/modal_models/MixedReactions.lf
+++ b/test/C/src/modal_models/MixedReactions.lf
@@ -1,0 +1,54 @@
+/*
+ * Modal Reactor Test.
+ * Tests reactions that are defined between modes and should be ordered accordingly.
+ */
+target C {
+    fast: true,
+    timeout: 110 msec
+};
+
+main reactor {
+    state x:int(0);
+    state first:bool(true);
+    
+    timer t(0, 100msec)
+    
+    reaction(t) {=
+        self->x = self->x * 10 + 1;
+    =}
+    
+    reaction(t) {=
+        self->x = self->x * 10 + 2;
+    =}
+    
+    initial mode A {
+      reaction(t) -> B {=
+        self->x = self->x * 10 + 3;
+        lf_set_mode(B);
+      =}
+    }
+    
+    reaction(t) {=
+        self->x = self->x * 10 + 4;
+    =}
+    
+    mode B {
+      reaction(t) {=
+        self->x = self->x * 10 + 5;
+      =}
+    }
+    
+    reaction(t) {=
+        printf("%d\n", self->x);
+        if (self->first) {
+          if (self->x != 1234) {
+            printf("ERROR: Wrong reaction order.\n");
+            exit(1);
+          }
+          self->first = false;
+        } else if (self->x != 12341245) {
+            printf("ERROR: Wrong reaction order.\n");
+            exit(2);
+        }
+    =}
+}

--- a/test/C/src/modal_models/MixedReactions.lf
+++ b/test/C/src/modal_models/MixedReactions.lf
@@ -1,6 +1,6 @@
 /*
  * Modal Reactor Test.
- * Tests reactions that are defined between modes and should be ordered accordingly.
+ * Tests reactions that are defined between and after modes and should be ordered accordingly.
  */
 target C {
     fast: true,


### PR DESCRIPTION
Fixes ordering of reactions if placed between or after modes.

Closes #1301