### PR TITLE
Use HTTPS for Rust reactor runtime submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/lf-lang/reactor-cpp
 [submodule "org.lflang/src/lib/rs/reactor-rs"]
 	path = org.lflang/src/lib/rs/reactor-rs
-	url = git@github.com:lf-lang/reactor-rs.git
+	url = https://github.com/lf-lang/reactor-rs


### PR DESCRIPTION
Use HTTPS for consistency. Also for practical purposes, because Github denies access via SSH for those who don't have access rights.