### PR TITLE
Removal of error reporting markers from parameter types

### DIFF
--- a/org.lflang/src/org/lflang/generator/TargetTypes.java
+++ b/org.lflang/src/org/lflang/generator/TargetTypes.java
@@ -163,7 +163,7 @@ public interface TargetTypes {
         } else if (type.isVariableSizeList) {
             return getTargetVariableSizeListType(type.baseType());
         }
-        return type.toText();
+        return type.toOriginalText();
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/ts/TSParameterPreambleGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSParameterPreambleGenerator.kt
@@ -126,7 +126,7 @@ class TSParameterPreambleGenerator(
             var customArgType: String? = null
             var customTypeLabel: String? = null
 
-            val paramType = getTargetType(parameter)
+            val paramType = parameter.type.id
             if (paramType == "string") {
                 mainParameters.add(parameter)
                 customArgType = "String";

--- a/org.lflang/src/org/lflang/generator/ts/TSParameterPreambleGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSParameterPreambleGenerator.kt
@@ -126,7 +126,7 @@ class TSParameterPreambleGenerator(
             var customArgType: String? = null
             var customTypeLabel: String? = null
 
-            val paramType = parameter.type.id
+            val paramType = getTargetType(parameter)
             if (paramType == "string") {
                 mainParameters.add(parameter)
                 customArgType = "String";


### PR DESCRIPTION
The string returned by <code>getTargetType</code> included error reporting markers, which it shouldn't.

Before this change:
![image](https://user-images.githubusercontent.com/88364973/181696238-f8eff038-17a9-491e-b90b-f02aabeba399.png)

After this change:
![image](https://user-images.githubusercontent.com/88364973/181695731-2d2aaa4e-d0e2-4a9e-b8bb-f0129c930e03.png)
