### PR TITLE
Use more portable way to suppress unused variable warnings

### DIFF
--- a/org.lflang/src/org/lflang/generator/CodeBuilder.java
+++ b/org.lflang/src/org/lflang/generator/CodeBuilder.java
@@ -328,8 +328,11 @@ public class CodeBuilder {
             indent();
             pr(String.join("\n", 
                 "int "+ri+" = mixed_radix_parent(&range_mr, "+nestedLevel+"); // Runtime index.",
+                "SUPPRESS_UNUSED_WARNING("+ri+");",
                 "int "+ci+" = range_mr.digits[0]; // Channel index.",
-                "int "+bi+" = "+(sizeMR <= 1 ? "0" : "range_mr.digits[1]")+"; // Bank index."
+                "SUPPRESS_UNUSED_WARNING("+ci+");",
+                "int "+bi+" = "+(sizeMR <= 1 ? "0" : "range_mr.digits[1]")+"; // Bank index.",
+                "SUPPRESS_UNUSED_WARNING("+bi+");"
             ));
             if (isFederated) {
                 if (restrict) {
@@ -358,10 +361,10 @@ public class CodeBuilder {
                 }
             }
             pr(String.join("\n", 
-                "int "+ri+" = "+riValue+"; // Runtime index.",
-                "int "+ci+" = "+ciValue+"; // Channel index.",
-                "int "+bi+" = "+biValue+"; // Bank index.",
-                "int range_count = 0;"
+                "int "+ri+" = "+riValue+"; SUPPRESS_UNUSED_WARNING("+ri+"); // Runtime index.",
+                "int "+ci+" = "+ciValue+"; SUPPRESS_UNUSED_WARNING("+ci+"); // Channel index.",
+                "int "+bi+" = "+biValue+"; SUPPRESS_UNUSED_WARNING("+bi+"); // Bank index.",
+                "int range_count = 0; SUPPRESS_UNUSED_WARNING(range_count);"
             ));
         }
     }
@@ -437,8 +440,11 @@ public class CodeBuilder {
             var riValue = srcRangeMR.get(srcNestedLevel);
             pr(String.join("\n", 
                 "int "+sr+" = "+riValue+"; // Runtime index.",
+                "SUPPRESS_UNUSED_WARNING("+sr+");",
                 "int "+sc+" = "+ciValue+"; // Channel index.",
-                "int "+sb+" = "+biValue+"; // Bank index."
+                "SUPPRESS_UNUSED_WARNING("+sc+");",
+                "int "+sb+" = "+biValue+"; // Bank index.",
+                "SUPPRESS_UNUSED_WARNING("+sb+");"
             ));
         }
         
@@ -447,8 +453,11 @@ public class CodeBuilder {
         if (srcRange.width > 1) {
             pr(String.join("\n", 
                 "int "+sr+" = mixed_radix_parent(&src_range_mr, "+srcNestedLevel+"); // Runtime index.",
+                "SUPPRESS_UNUSED_WARNING("+sr+");",
                 "int "+sc+" = src_range_mr.digits[0]; // Channel index.",
-                "int "+sb+" = "+(srcSizeMR <= 1 ? "0" : "src_range_mr.digits[1]")+"; // Bank index."
+                "SUPPRESS_UNUSED_WARNING("+sc+");",
+                "int "+sb+" = "+(srcSizeMR <= 1 ? "0" : "src_range_mr.digits[1]")+"; // Bank index.",
+                "SUPPRESS_UNUSED_WARNING("+sb+");"
             ));
         }
         

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -727,11 +727,17 @@ public class CGenerator extends GeneratorBase {
         if (main != null) {
             initializeTriggerObjects.pr(String.join("\n",
                 "int _lf_startup_reactions_count = 0;",
+                "SUPPRESS_UNUSED_WARNING(_lf_startup_reactions_count);",
                 "int _lf_shutdown_reactions_count = 0;",
+                "SUPPRESS_UNUSED_WARNING(_lf_shutdown_reactions_count);",
                 "int _lf_reset_reactions_count = 0;",
+                "SUPPRESS_UNUSED_WARNING(_lf_reset_reactions_count);",
                 "int _lf_timer_triggers_count = 0;",
+                "SUPPRESS_UNUSED_WARNING(_lf_timer_triggers_count);",
                 "int _lf_tokens_with_ref_count_count = 0;",
-                "int bank_index;"
+                "SUPPRESS_UNUSED_WARNING(_lf_tokens_with_ref_count_count);",
+                "int bank_index;",
+                "SUPPRESS_UNUSED_WARNING(bank_index);"
             ));
             // Add counters for modal initialization
             initializeTriggerObjects.pr(CModesGenerator.generateModalInitalizationCounters(hasModalReactors));
@@ -1678,7 +1684,7 @@ public class CGenerator extends GeneratorBase {
                                 // The port belongs to contained reactor, so we also have
                                 // iterate over the instance bank members.
                                 temp.startScopedBlock();
-                                temp.pr("int count = 0;");
+                                temp.pr("int count = 0; SUPPRESS_UNUSED_WARNING(count);");
                                 temp.startScopedBlock(instance, currentFederate, isFederated, true);
                                 temp.startScopedBankChannelIteration(port, currentFederate, null, isFederated);
                             } else {
@@ -1765,7 +1771,7 @@ public class CGenerator extends GeneratorBase {
             if (currentFederate.contains(child) && child.outputs.size() > 0) {
 
                 temp.startScopedBlock();
-                temp.pr("int count = 0;");
+                temp.pr("int count = 0; SUPPRESS_UNUSED_WARNING(count);");
                 temp.startScopedBlock(child, currentFederate, isFederated, true);
 
                 var channelCount = 0;

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -730,7 +730,8 @@ public class CGenerator extends GeneratorBase {
                 "int _lf_shutdown_reactions_count = 0;",
                 "int _lf_reset_reactions_count = 0;",
                 "int _lf_timer_triggers_count = 0;",
-                "int _lf_tokens_with_ref_count_count = 0;"
+                "int _lf_tokens_with_ref_count_count = 0;",
+                "int bank_index;"
             ));
             // Add counters for modal initialization
             initializeTriggerObjects.pr(CModesGenerator.generateModalInitalizationCounters(hasModalReactors));
@@ -2111,8 +2112,9 @@ public class CGenerator extends GeneratorBase {
      */
     protected void generateParameterInitialization(ReactorInstance instance) {
         var selfRef = CUtil.reactorRef(instance);
-        // Declare a local bank_index variable so that initializers can use it.
-        initializeTriggerObjects.pr("int bank_index = "+CUtil.bankIndex(instance)+";");
+        // Set the local bank_index variable so that initializers can use it.
+        initializeTriggerObjects.pr("bank_index = "+CUtil.bankIndex(instance)+";"
+                + " SUPPRESS_UNUSED_WARNING(bank_index);");
         for (ParameterInstance parameter : instance.parameters) {
             // NOTE: we now use the resolved literal value. For better efficiency, we could
             // store constants in a global array and refer to its elements to avoid duplicate

--- a/org.lflang/src/org/lflang/generator/c/CMethodGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CMethodGenerator.java
@@ -72,9 +72,8 @@ public class CMethodGenerator {
         // or anything else. No need to declare it.
         if (structType != null) {
              code.pr(String.join("\n",
-                 "#pragma GCC diagnostic push",
-                 "#pragma GCC diagnostic ignored \"-Wunused-variable\"",
                  structType+"* self = ("+structType+"*)instance_args;"
+                         + " SUPPRESS_UNUSED_WARNING(self);"
              ));
         }
         

--- a/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
@@ -69,16 +69,13 @@ public class CReactionGenerator {
         // or anything else. No need to declare it.
         if (structType != null) {
              code.pr(String.join("\n",
-                 "#pragma GCC diagnostic push",
-                 "#pragma GCC diagnostic ignored \"-Wunused-variable\"",
-                 structType+"* self = ("+structType+"*)instance_args;"
+                 structType+"* self = ("+structType+"*)instance_args; SUPPRESS_UNUSED_WARNING(self);"
              ));
         }
 
         // Do not generate the initialization code if the body is marked
         // to not generate it.
         if (body.startsWith(DISABLE_REACTION_INITIALIZATION_MARKER)) {
-             code.pr("#pragma GCC diagnostic pop");
             return code.toString();
         }
 
@@ -226,7 +223,6 @@ public class CReactionGenerator {
         }
         // Next generate all the collected setup code.
         code.pr(reactionInitialization.toString());
-        code.pr("#pragma GCC diagnostic pop");
         
         return code.toString();
     }

--- a/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
@@ -635,7 +635,7 @@ public class CReactionGenerator {
         // Set the _width variable for all cases. This will be -1
         // for a variable-width multiport, which is not currently supported.
         // It will be -2 if it is not multiport.
-        builder.pr("int "+inputWidth+" = self->_lf_"+inputWidth+";");
+        builder.pr("int "+inputWidth+" = self->_lf_"+inputWidth+"; SUPPRESS_UNUSED_WARNING("+inputWidth+");");
         return builder.toString();
     }
 
@@ -672,7 +672,7 @@ public class CReactionGenerator {
                 // Output port is a multiport.
                 // Set the _width variable.
                 return String.join("\n",
-                    "int "+outputWidth+" = self->_lf_"+outputWidth+";",
+                    "int "+outputWidth+" = self->_lf_"+outputWidth+"; SUPPRESS_UNUSED_WARNING("+outputWidth+");",
                     outputStructType+"** "+outputName+" = self->_lf_"+outputName+"_pointers;"
                 );
 

--- a/org.lflang/src/org/lflang/generator/c/CTriggerObjectsGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CTriggerObjectsGenerator.java
@@ -999,7 +999,7 @@ public class CTriggerObjectsGenerator {
         var init = new CodeBuilder();
 
         init.startScopedBlock();
-        init.pr("int count = 0;");
+        init.pr("int count = 0; SUPPRESS_UNUSED_WARNING(count);");
         for (PortInstance effect : Iterables.filter(reaction.effects, PortInstance.class)) {
             // Create the entry in the output_produced array for this port.
             // If the port is a multiport, then we need to create an entry for each

--- a/test/C/src/concurrent/Tracing.lf
+++ b/test/C/src/concurrent/Tracing.lf
@@ -19,12 +19,12 @@ reactor TakeTime(
 ) {
     input in:int;
     output out:int;
-    state event:string("No ID");
+    state event:char*("No ID");
     reaction(startup) {=
         // Construct an id string for a user trace event.
         const char* format = "Count completed by reactor %d.";
         size_t length = strlen(format) + 2;
-        self->event = (string)malloc(sizeof(char) * (length + 1));
+        self->event = (char*)malloc(sizeof(char) * (length + 1));
         snprintf(self->event, length, format, self->bank_index);
 
         // Register the user trace event.


### PR DESCRIPTION
This goes with the fewer-warnings PR at https://github.com/lf-lang/reactor-c/pull/98, which should be merged first.