### PR TITLE
Fix layout for error messsage node

### DIFF
--- a/org.lflang.diagram/src/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/org.lflang.diagram/src/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -259,6 +259,9 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
     @Override
     public KNode transform(final Model model) {
         KNode rootNode = _kNodeExtensions.createNode();
+        setLayoutOption(rootNode, CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+        setLayoutOption(rootNode, CoreOptions.DIRECTION, Direction.RIGHT);
+        setLayoutOption(rootNode, CoreOptions.PADDING, new ElkPadding(0));
 
         try {
             // Find main
@@ -301,6 +304,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
                         }
                         _kRenderingExtensions.addInvisibleContainerRendering(child);
                         setLayoutOption(child, CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
+                        setLayoutOption(child, CoreOptions.DIRECTION, Direction.RIGHT);
                         setLayoutOption(child, CoreOptions.PADDING, new ElkPadding(0));
                         // Legacy ordering option.
                         setLayoutOption(child, CoreOptions.PRIORITY, reactorNodes.size() - index); // Order!


### PR DESCRIPTION
Due to a change in the default layout direction in ELK, the error message node for detected cycles was place left of the reactor instead of top. This PR fixes that by making the assumed layout options explicit. 