### PR TITLE
Fix rust setup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     
   # Run the Rust integration tests.
   rs-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/rs-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/rs-tests.yml@ci-rust-fix
     needs: cancel
 
   # Run the Rust benchmark tests.

--- a/.github/workflows/rs-tests.yml
+++ b/.github/workflows/rs-tests.yml
@@ -26,6 +26,13 @@ jobs:
           ref: ${{ inputs.compiler-ref }}
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
+      - name: Check out specific ref of reactor-rs
+        uses: actions/checkout@v3
+        with:
+          repository: lf-lang/reactor-rs
+          path: org.lflang/src/lib/rs/reactor-rs
+          ref: ${{ inputs.runtime-ref }}
+        if: ${{ inputs.runtime-ref }}
       - name: Setup Rust
         id: rustup
         uses: ATiltedTree/setup-rust@v1
@@ -42,10 +49,6 @@ jobs:
         with:
           rust-version: ${{ matrix.rust }}
           components: clippy
-      - name: Set rust runtime version
-        run: |
-            echo ${{ inputs.runtime-ref }} > org.lflang/src/org/lflang/generator/rust/rust-runtime-version.txt
-        if: ${{ inputs.runtime-ref }}  
       - name: Run Rust tests
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.RustTest.*

--- a/.github/workflows/rs-tests.yml
+++ b/.github/workflows/rs-tests.yml
@@ -27,6 +27,17 @@ jobs:
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Setup Rust
+        id: rustup
+        uses: ATiltedTree/setup-rust@v1
+        with:
+          rust-version: ${{ matrix.rust }}
+          components: clippy
+        continue-on-error: true
+      - name: Delete rustup cache
+        run: rm -rf ~/.rustup
+        if: ${{ steps.rustup.outcome }} != "success"
+      - name: Setup Rust (again)
+        if: ${{ steps.rustup.outcome }} != "success"
         uses: ATiltedTree/setup-rust@v1
         with:
           rust-version: ${{ matrix.rust }}


### PR DESCRIPTION
This PR solves two issues:
1. It adds a workaround for a problem in the action that we are using for setting up rust (https://github.com/ATiltedTree/setup-rust/issues/157). This problem currently causes test failures on master (https://github.com/lf-lang/lingua-franca/runs/7951505913?check_suite_focus=true). It is caused by some internal bug of rustup and can be worked around by deleting its cache (https://github.com/rust-lang/rustup/issues/2417). This change implements this such that if setting up rusts fails, we manually delete the cache and then try again.
2. Since #1296 the rust runtime is included as a submodule. However, we forgot to update the CI setup for rust accordingly. This PR fixes the setup and correctly checks out the specified ref of the submodule