### PR TITLE
Quick fix to adjust upstreamFedDelays as never tag

### DIFF
--- a/org.lflang/src/org/lflang/generator/ts/TSConstructorGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSConstructorGenerator.kt
@@ -126,8 +126,8 @@ class TSConstructorGenerator (
         val federateConfigurations = LinkedList<String>()
         if (reactor.isFederated) {
             for ((key, _) in federate.dependsOn) {
-                // FIXME: Get delay properly considering the unit instead of hardcoded BigInt(0).
-                federateConfigurations.add("this.addUpstreamFederate(${key.id}, BigInt(0));")
+                // FIXME: Get delay properly considering the unit instead of hardcoded TimeValue.NEVER().
+                federateConfigurations.add("this.addUpstreamFederate(${key.id}, TimeValue.NEVER());")
             }
             for ((key, _) in federate.sendsTo) {
                 federateConfigurations.add("this.addDownstreamFederate(${key.id});")


### PR DESCRIPTION
Relevant issue: https://github.com/lf-lang/reactor-ts/issues/118

Relevant reactor-ts PR: [lf-lang/reactor-ts#120](https://github.com/lf-lang/reactor-ts/pull/120)

This is not a fundamental solution to solve the issue above. 
But it makes the federated execution in TypeScript more properly compared to before.