### PR TITLE
Use Node version 18 in CI

### DIFF
--- a/.github/workflows/eclipse-tests.yml
+++ b/.github/workflows/eclipse-tests.yml
@@ -16,7 +16,9 @@ jobs:
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Install pnpm
         run: npm i -g pnpm
       - name: Build lfc

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -34,7 +34,9 @@ jobs:
           del "C:\Program Files\LLVM\bin\clang++.exe"
         if: ${{ runner.os == 'Windows' }}
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Install pnpm
         run: npm i -g pnpm
       - name: Cache .pnpm-store

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Install pnpm
         run: npm i -g pnpm
       - name: Cache .pnpm-store


### PR DESCRIPTION
We should probably decide exactly what Node version(s) we support (e.g., [here](https://github.com/lf-lang/vscode-lingua-franca/blob/051579e8ea4752c1c095e779e78ce02099406722/src/config.ts#L34)), but that can be done later.

Probably the only lines of code that _actually_ caused the problem (of not recognizing optional chaining syntax) were the ones in reactor-ts that explicitly pinned our Node version to version 10.