### PR TITLE
Improve model order layout configuration

### DIFF
--- a/org.lflang.diagram/src/org/lflang/diagram/synthesis/util/LayoutPostProcessing.java
+++ b/org.lflang.diagram/src/org/lflang/diagram/synthesis/util/LayoutPostProcessing.java
@@ -227,7 +227,7 @@ public class LayoutPostProcessing extends AbstractSynthesisExtensions {
                 // This requires that the list of nodes is not ordered by type, e.g. first all reactions, then all reactors, then all actions, ...
                 // but by their model order. In other approaches ordering actions between the reactions has no effect.
                 DiagramSyntheses.setLayoutOption(node, LayeredOptions.CROSSING_MINIMIZATION_STRATEGY, CrossingMinimizationStrategy.NONE);
-                DiagramSyntheses.setLayoutOption(node, LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.OFF);  
+                DiagramSyntheses.setLayoutOption(node, LayeredOptions.CROSSING_MINIMIZATION_GREEDY_SWITCH_TYPE, GreedySwitchType.ONE_SIDED);  
                 
                 break;
             default:


### PR DESCRIPTION
Full Control mode sometimes produces bad drawings that cannot be fully controlled since edges are not explicit in LF and many dummy nodes are created by fixed port sides.

LF needs a model order strategy that is strict during crossing minimization, which requires to set a model order for all elements (also actions), and less strict during crossing minimization.

![fullControlNeedsGreedySwitch](https://user-images.githubusercontent.com/6419799/187692095-75fb93a0-60f0-4b5c-99d1-d282982922f8.svg)
Here it would be better to activate the greedy switch heuristic to get a better drawing.
![fullControlNeedsGreedySwitch-OYES](https://user-images.githubusercontent.com/6419799/187692346-a9bfb750-d905-4427-8eeb-d147e22bf859.svg)
Here it is also not possible to route the edge below the nodes, but at least no crossings are created.

Example model:
```
target C

main reactor {
    reaction (startup) -> a {= =}
    logical action a:char*;
    reaction (a) -> b {= =}
    physical action b:char*;
    reaction (b) -> a {= =}
    
}
```