### PR TITLE
Address`after` delay in Federated Execution of TypeScript

### DIFF
--- a/org.lflang/src/org/lflang/federated/extensions/TSExtension.java
+++ b/org.lflang/src/org/lflang/federated/extensions/TSExtension.java
@@ -12,7 +12,6 @@ import org.lflang.ASTUtils;
 import org.lflang.ErrorReporter;
 import org.lflang.InferredType;
 import org.lflang.TargetProperty.CoordinationType;
-import org.lflang.TimeUnit;
 import org.lflang.TimeValue;
 import org.lflang.federated.generator.FedASTUtils;
 import org.lflang.federated.generator.FedConnectionInstance;
@@ -23,11 +22,9 @@ import org.lflang.generator.ReactorInstance;
 import org.lflang.generator.ts.TSExtensionsKt;
 import org.lflang.lf.Action;
 import org.lflang.lf.Output;
-import org.lflang.lf.ParameterReference;
 import org.lflang.lf.VarRef;
 import org.lflang.lf.Variable;
 import org.lflang.lf.Expression;
-import org.lflang.lf.Time;
 
 public class TSExtension implements FedTargetExtension {
     @Override
@@ -51,7 +48,7 @@ public class TSExtension implements FedTargetExtension {
 
     @Override
     public String generateNetworkSenderBody(VarRef sendingPort, VarRef receivingPort, FedConnectionInstance connection, InferredType type, CoordinationType coordinationType, ErrorReporter errorReporter) {
-        String additionalDelayString = getNetworkDelayLiteral(connection.getDefinition().getDelay());
+        String additionalDelayString = TSExtensionsKt.getNetworkDelayLiteral(connection.getDefinition().getDelay());
         return"""
         if (%1$s.%2$s !== undefined) {
             this.util.sendRTITimedMessage(%1$s.%2$s, %3$s, %4$s, %5$s);
@@ -151,17 +148,18 @@ public class TSExtension implements FedTargetExtension {
                 // Unless silenced, issue a warning.
                 if (federate.targetConfig.coordinationOptions.advance_message_interval
                     == null) {
-                    errorReporter.reportWarning(outputFound, String.join("\n",
-                                                                         "Found a path from a physical action to output for reactor "
-                                                                             + addDoubleQuotes(instance.getName())
-                                                                             + ". ",
-                                                                         "The amount of delay is "
-                                                                             + minOutputDelay
-                                                                             + ".",
-                                                                         "With centralized coordination, this can result in a large number of messages to the RTI.",
-                                                                         "Consider refactoring the code so that the output does not depend on the physical action,",
-                                                                         "or consider using decentralized coordination. To silence this warning, set the target",
-                                                                         "parameter coordination-options with a value like {advance-message-interval: 10 msec}"
+                    errorReporter.reportWarning(outputFound, String.join(
+                        "\n",
+                        "Found a path from a physical action to output for reactor "
+                            + addDoubleQuotes(instance.getName())
+                            + ". ",
+                        "The amount of delay is "
+                            + minOutputDelay
+                            + ".",
+                        "With centralized coordination, this can result in a large number of messages to the RTI.",
+                        "Consider refactoring the code so that the output does not depend on the physical action,",
+                        "or consider using decentralized coordination. To silence this warning, set the target",
+                        "parameter coordination-options with a value like {advance-message-interval: 10 msec}"
                     ));
                 }
                 return minOutputDelay;
@@ -179,7 +177,7 @@ public class TSExtension implements FedTargetExtension {
                 int cnt = 0;
                 if (delays != null) {
                     for (Expression delay : delays) {
-                        element += getNetworkDelayLiteral(delay);
+                        element += TSExtensionsKt.getNetworkDelayLiteral(delay);
                         cnt++;
                         if (cnt != delays.size()) {
                             element += ", ";
@@ -194,23 +192,5 @@ public class TSExtension implements FedTargetExtension {
             }
         }
         return candidates;
-    }
-
-    /**
-     * Given a connection 'delay' predicate, return a string that represents the
-     * time value in TypeScript code.
-     */
-    private static String getNetworkDelayLiteral(Expression delay) {
-        String additionalDelayString = "TimeValue.NEVER()";
-        if (delay != null) {
-            if (delay instanceof Time) {
-                TSExtensionsKt.timeInTargetLanguage(ASTUtils.toTimeValue((Time) delay));
-            } else if (delay instanceof ParameterReference) {
-                // The delay is given as a parameter reference. Find its value.
-                final var param = ((ParameterReference)delay).getParameter();
-                additionalDelayString = TSExtensionsKt.timeInTargetLanguage(ASTUtils.getDefaultAsTimeValue(param));
-            }
-        }
-        return additionalDelayString;
     }
 }

--- a/org.lflang/src/org/lflang/federated/extensions/TSExtension.java
+++ b/org.lflang/src/org/lflang/federated/extensions/TSExtension.java
@@ -196,11 +196,6 @@ public class TSExtension implements FedTargetExtension {
         return candidates;
     }
 
-    private static String getTargetTime(Time t) {
-        TimeValue value = new TimeValue(t.getInterval(), TimeUnit.fromName(t.getUnit()));
-        return TSExtensionsKt.timeInTargetLanguage(value);
-    }
-
     /**
      * Given a connection 'delay' predicate, return a string that represents the
      * time value in TypeScript code.
@@ -209,7 +204,7 @@ public class TSExtension implements FedTargetExtension {
         String additionalDelayString = "TimeValue.NEVER()";
         if (delay != null) {
             if (delay instanceof Time) {
-                additionalDelayString = getTargetTime((Time) delay);
+                TSExtensionsKt.timeInTargetLanguage(ASTUtils.toTimeValue((Time) delay));
             } else if (delay instanceof ParameterReference) {
                 // The delay is given as a parameter reference. Find its value.
                 final var param = ((ParameterReference)delay).getParameter();

--- a/org.lflang/src/org/lflang/federated/extensions/TSExtension.java
+++ b/org.lflang/src/org/lflang/federated/extensions/TSExtension.java
@@ -174,25 +174,37 @@ public class TSExtension implements FedTargetExtension {
         List<String> candidates = new ArrayList<>();
         if (!federate.dependsOn.keySet().isEmpty()) {
             for (FederateInstance upstreamFederate: federate.dependsOn.keySet()) {
+                String element = "[";
                 var delays = federate.dependsOn.get(upstreamFederate);
+                int cnt = 0;
                 if (delays != null) {
                     for (Expression delay : delays) {
                         if (delay == null) {
-                            candidates.add("TimeValue.NEVER()");
+                            element += "TimeValue.NEVER()";
+                            //candidates.add("TimeValue.NEVER()");
                         } else {
                             //FIXME: Figure out how to get TimeValue from the delay and convert it to the string 
                             if (delay instanceof Time) {
-                                candidates.add(getTargetTime(((Time) delay)));
+                                element += getTargetTime((Time) delay);
+                                //candidates.add(getTargetTime(((Time) delay)));
                             } else if (delay instanceof ParameterReference) {
                                 // The delay is given as a parameter reference. Find its value.
                                 final var param = ((ParameterReference)delay).getParameter();
-                                candidates.add(TSExtensionsKt.timeInTargetLanguage(ASTUtils.getDefaultAsTimeValue(param)));
+                                //candidates.add(TSExtensionsKt.timeInTargetLanguage(ASTUtils.getDefaultAsTimeValue(param)));
+                                element += TSExtensionsKt.timeInTargetLanguage(ASTUtils.getDefaultAsTimeValue(param));
                             }
+                        }
+                        cnt++;
+                        if (cnt != delays.size()) {
+                            element += ", ";
                         }
                     }
                 } else {
-                    candidates.add("TimeValue.NEVER()");
+                    element += "TimeValue.NEVER()";
+                    //candidates.add("TimeValue.NEVER()");
                 }
+                element += "]";
+                candidates.add(element);
             }
         }
         return candidates;

--- a/org.lflang/src/org/lflang/federated/extensions/TSExtension.java
+++ b/org.lflang/src/org/lflang/federated/extensions/TSExtension.java
@@ -211,7 +211,6 @@ public class TSExtension implements FedTargetExtension {
             } else if (delay instanceof ParameterReference) {
                 // The delay is given as a parameter reference. Find its value.
                 final var param = ((ParameterReference)delay).getParameter();
-                //candidates.add(TSExtensionsKt.timeInTargetLanguage(ASTUtils.getDefaultAsTimeValue(param)));
                 additionalDelayString = TSExtensionsKt.timeInTargetLanguage(ASTUtils.getDefaultAsTimeValue(param));
             }
         }

--- a/org.lflang/src/org/lflang/generator/ts/TSExtensions.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSExtensions.kt
@@ -1,10 +1,13 @@
 package org.lflang.generator.ts
 
+import org.lflang.ASTUtils
 import org.lflang.TimeValue
 import org.lflang.isBank
 import org.lflang.isMultiport
 import org.lflang.lf.Action
+import org.lflang.lf.Expression
 import org.lflang.lf.Parameter
+import org.lflang.lf.ParameterReference
 import org.lflang.lf.Port
 import org.lflang.lf.Type
 import org.lflang.lf.WidthSpec
@@ -73,4 +76,23 @@ fun timeInTargetLanguage(value: TimeValue): String {
         // The value must be zero.
         "TimeValue.zero()"
     }
+}
+
+/**
+ * Given a connection 'delay' predicate, return a string that represents the
+ * time value in TypeScript code.
+ */
+fun getNetworkDelayLiteral(delay: Expression?): String {
+    var additionalDelayString = "TimeValue.NEVER()"
+    if (delay != null) {
+        val tv: TimeValue
+        tv = if (delay is ParameterReference) {
+            // The delay is given as a parameter reference. Find its value.
+            ASTUtils.getDefaultAsTimeValue(delay.parameter)
+        } else {
+            ASTUtils.getLiteralTimeValue(delay)
+        }
+        additionalDelayString = timeInTargetLanguage(tv)
+    }
+    return additionalDelayString
 }

--- a/org.lflang/src/org/lflang/generator/ts/TSParameterPreambleGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSParameterPreambleGenerator.kt
@@ -31,6 +31,8 @@ import org.lflang.TimeValue
 import org.lflang.generator.PrependOperator
 import org.lflang.lf.Parameter
 import org.lflang.lf.Reactor
+import org.lflang.lf.Instantiation
+import org.lflang.reactor
 import java.util.StringJoiner
 
 /**
@@ -167,6 +169,10 @@ class TSParameterPreambleGenerator(
 
         val customArgsList = "[\n$customArgs]"
         val clTypeExtensionDef = "{$clTypeExtension}"
+
+        if (tsGenerator.mainDef.reactor.attributes.stream().anyMatch{ it.attrName == "_fed_config" }) {
+            targetConfig.keepalive = true
+        }
 
         val codeText = with(PrependOperator) {"""
             |// ************* App Parameters

--- a/test/TypeScript/src/federated/DistributedCount.lf
+++ b/test/TypeScript/src/federated/DistributedCount.lf
@@ -22,7 +22,7 @@ reactor Print {
         if (inp !== c) {
             util.requestErrorStop("Expected to receive " + c + ".");
         }
-        if (elapsedTime.isEqualTo(TimeValue.msec(200).add(TimeValue.sec(c - 1)))) {
+        if (!elapsedTime.isEqualTo(TimeValue.msec(200).add(TimeValue.sec(c - 1)))) {
             util.requestErrorStop("Expected received time to be " + TimeValue.msec(200).add(TimeValue.sec(c - 1)) + ".");
         }
         c++;


### PR DESCRIPTION
Relevant reactor-ts PR: [`reactor-ts#125`](https://github.com/lf-lang/reactor-ts/pull/125)

This PR adds logic for handling `after` delay in federated execution.
`additionalDelay` is reflected when sending `taggedMessage`.

Some functions in TSExtension.kt are modified and added like getNetworkDelay() and getProcessDelay() etc.

The function names and locations might be modified for a semantic reason.