### PR TITLE
Exclude reactor runtime module from the Rust test modules

### DIFF
--- a/test/Rust/src-gen/Cargo.toml
+++ b/test/Rust/src-gen/Cargo.toml
@@ -16,7 +16,7 @@
 # If it causes problems, we can throw it away or hide it.
 [workspace]
 members = ["*"]
-exclude = ["concurrent", "target", "multiport", "generics"]
+exclude = ["concurrent", "target", "multiport", "generics", "reactor-rs"]
 
 [profile.release-with-min-size] # use `build-type: MinSizeRel`
 inherits = "release"


### PR DESCRIPTION
Including it causes version conflicts when one develops with a local copy of the runtime (using the env var LOCAL_RUST_REACTOR_RT env var). This problem was introduced when lfc started unpacking the runtime into src-gen.

For reference, here's an example failure caused by this:

```
error: package collision in the lockfile: packages reactor_rt v0.1.0 (/home/clem/Documents/LF/lingua-franca/test/Rust/src-gen/reactor-rs) and reactor_rt v0.1.0 (/home/clem/Documents/LF/reactor-rs) are different, but only one can be written to lockfile unambiguously
```
