### PR TITLE
Reduction of output in formatter tests

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/compiler/RoundTripTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/RoundTripTests.java
@@ -46,31 +46,30 @@ public class RoundTripTests {
 
     private void run(Path file) throws Exception {
         Model originalModel = parse(file);
-        System.out.printf("Running formatter on %s...%n", file);
         Assertions.assertTrue(originalModel.eResource().getErrors().isEmpty());
         // TODO: Check that the output is a fixed point
         final int smallLineLength = 20;
-        String squishedTestCase = FormattingUtils.render(originalModel, smallLineLength);
-        System.out.printf(
-            "The following is what %s looks like after applying formatting with the preferred line "
-                + "length set to %d columns:%n%s%n%n",
-            file.getFileName(),
-            smallLineLength,
-            squishedTestCase
-        );
-        Model resultingModel = getResultingModel(file, squishedTestCase);
+        final String squishedTestCase = FormattingUtils.render(originalModel, smallLineLength);
+        final Model resultingModel = getResultingModel(file, squishedTestCase);
         Assertions.assertNotNull(resultingModel);
         if (!resultingModel.eResource().getErrors().isEmpty()) {
             resultingModel.eResource().getErrors().forEach(System.err::println);
             Assertions.assertTrue(resultingModel.eResource().getErrors().isEmpty());
         }
-        Assertions.assertTrue(new IsEqual(originalModel).doSwitch(resultingModel));
-        String normalTestCase = FormattingUtils.render(originalModel);
-        System.out.printf(
-            "The following is what %s looks like after applying formatting normally:%n%s%n%n",
-            file.getFileName(),
-            normalTestCase
-        );
+        if (!new IsEqual(originalModel).doSwitch(resultingModel)) {
+            System.out.printf(
+                "The following is what %s looks like after applying formatting with the preferred line "
+                    + "length set to %d columns:%n%s%n%n",
+                file.getFileName(),
+                smallLineLength,
+                squishedTestCase
+            );
+            throw new junit.framework.AssertionFailedError(String.format(
+                "The reformatted version of %s was not equivalent to the original file.",
+                file.getFileName()
+            ));
+        }
+        final String normalTestCase = FormattingUtils.render(originalModel);
         try {
             Assertions.assertEquals(
                 Files.readString(file).replaceAll("\\r\\n?", "\n"),
@@ -83,6 +82,11 @@ public class RoundTripTests {
                     + "formatter provided with the VS Code extension.%n",
                 file.getFileName(),
                 file.getFileName()
+            );
+            System.out.printf(
+                "The following is what %s looks like after applying formatting normally:%n%s%n%n",
+                file.getFileName(),
+                normalTestCase
             );
             throw e;
         }

--- a/org.lflang.tests/src/org/lflang/tests/lsp/LspTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/lsp/LspTests.java
@@ -99,7 +99,12 @@ class LspTests {
                         System.out.println(" Success.");
                     } else {
                         System.out.println(" but the expected error could not be found.");
-                        System.out.println("The following test failed:\n" + TestBase.THIN_LINE);
+                        System.out.printf(
+                            "%s failed. Content of altered version of %s:%n%s%n",
+                            alteredTest.getPath().getFileName(),
+                            alteredTest.getPath().getFileName(),
+                            TestBase.THIN_LINE
+                        );
                         System.out.println(alteredTest + "\n" + TestBase.THIN_LINE);
                     }
                     return result;


### PR DESCRIPTION
Fixes #1354.

This silences the formatter test except when there is an assertion failure, in which case the relevant information is printed.