### PR TITLE
Only record tests in test/*/src

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/TestRegistry.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestRegistry.java
@@ -6,6 +6,7 @@ import static java.nio.file.FileVisitResult.SKIP_SUBTREE;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -214,9 +215,9 @@ public class TestRegistry {
 
             // Walk the tree.
             try {
-                Path dir = LF_TEST_PATH.resolve(target.toString());
+                Path dir = LF_TEST_PATH.resolve(target.getDirectoryName()).resolve("src");
                 if (Files.exists(dir)) {
-                    Files.walkFileTree(dir, new TestDirVisitor(rs, target));
+                    new TestDirVisitor(rs, target, dir).walk();
                 } else {
                     System.out.println("WARNING: No test directory for target " + target + "\n");
                 }
@@ -330,16 +331,18 @@ public class TestRegistry {
         protected ResourceSet rs;
 
         protected Path srcBasePath;
-        
+
         /**
          * Create a new file visitor based on a given target.
+         *
          * @param target The target that all encountered tests belong to.
+         * @param srcBasePath The test sources directory
          */
-        public TestDirVisitor(ResourceSet rs, Target target) {
+        public TestDirVisitor(ResourceSet rs, Target target, Path srcBasePath) {
             stack.push(TestCategory.GENERIC);
             this.rs = rs;
             this.target = target;
-            this.srcBasePath = LF_TEST_PATH.resolve(target.toString()).resolve("src");
+            this.srcBasePath = srcBasePath;
         }
         
         /**
@@ -412,6 +415,10 @@ public class TestRegistry {
                 registered.getTests(this.target, this.stack.peek()).add(test);
             }
             return CONTINUE;
+        }
+
+        public void walk() throws IOException {
+            Files.walkFileTree(srcBasePath, this);
         }
     }
 }

--- a/org.lflang.tests/src/org/lflang/tests/compiler/RoundTripTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/RoundTripTests.java
@@ -60,7 +60,7 @@ public class RoundTripTests {
             System.out.printf(
                 "The following is what %s looks like after applying formatting with the preferred line "
                     + "length set to %d columns:%n%s%n%n",
-                file.getFileName(),
+                file,
                 smallLineLength,
                 squishedTestCase
             );
@@ -80,7 +80,7 @@ public class RoundTripTests {
                 "An assertion failed while checking that the content of %s is the same before and "
                     + "after formatting. Check that %s is formatted according to lff and the "
                     + "formatter provided with the VS Code extension.%n",
-                file.getFileName(),
+                file,
                 file.getFileName()
             );
             System.out.printf(


### PR DESCRIPTION
The current implementation also walked into src-gen. This causes problems with my setup because the Rust runtime repo has some LF files, and since it is copied into src-gen, these were registered as tests and caused failures eg of the formatter tests.