### PR TITLE
Support passthrough connections in the C++ target

### DIFF
--- a/test/Cpp/src/multiport/IndexIntoMultiportInput.lf
+++ b/test/Cpp/src/multiport/IndexIntoMultiportInput.lf
@@ -38,15 +38,9 @@ main reactor IndexIntoMultiportInput {
 
     splitter.out -> receiver.in
 
-    reaction(startup) -> splitter.in0 {=
-        splitter.in0.set(0);
-    =}
+    reaction(startup) -> splitter.in0 {= splitter.in0.set(0); =}
 
-    reaction(startup) -> splitter.in1 {=
-        splitter.in1.set(1);
-    =}
+    reaction(startup) -> splitter.in1 {= splitter.in1.set(1); =}
 
-    reaction(startup) -> splitter.in2 {=
-        splitter.in2.set(2);
-    =}
+    reaction(startup) -> splitter.in2 {= splitter.in2.set(2); =}
 }

--- a/test/Cpp/src/multiport/IndexIntoMultiportInput.lf
+++ b/test/Cpp/src/multiport/IndexIntoMultiportInput.lf
@@ -1,3 +1,11 @@
+/**
+ * This test was first described by Peter Donovan in
+ * https://github.com/lf-lang/lingua-franca/issues/1321
+ *
+ * It simply tests if passthrough connections work as expected in the C++
+ * target. Such a connection directly connects an input to an output of the same
+ * reactor, without any reactions in between.
+ */
 target Cpp
 
 reactor ReactorWithMultiport {

--- a/test/Cpp/src/multiport/IndexIntoMultiportInput.lf
+++ b/test/Cpp/src/multiport/IndexIntoMultiportInput.lf
@@ -1,0 +1,52 @@
+target Cpp
+
+reactor ReactorWithMultiport {
+    input[3] in: int
+
+    reaction(startup, in) {=
+        bool error{false};
+        for (size_t i{0}; i < in.size(); i++) {
+            if (in[i].is_present()) {
+                if (*in[i].get() != i) {
+                    reactor::log::Error() << "received wrong input on port " << i;
+                }
+            } else {
+                error = true;
+                reactor::log::Error() << "input " << i << " is not present";
+            }
+        }
+        if (error) {
+            exit(1);
+        }
+        reactor::log::Info() << "success";
+    =}
+}
+
+reactor MultiportSplitter {
+    output[3] out: int
+
+    input in0: int
+    input in1: int
+    input in2: int
+
+    in0, in1, in2 -> out
+}
+
+main reactor IndexIntoMultiportInput {
+    splitter = new MultiportSplitter()
+    receiver = new ReactorWithMultiport()
+
+    splitter.out -> receiver.in
+
+    reaction(startup) -> splitter.in0 {=
+        splitter.in0.set(0);
+    =}
+
+    reaction(startup) -> splitter.in1 {=
+        splitter.in1.set(1);
+    =}
+
+    reaction(startup) -> splitter.in2 {=
+        splitter.in2.set(2);
+    =}
+}

--- a/test/Cpp/src/multiport/IndexIntoMultiportOutput.lf
+++ b/test/Cpp/src/multiport/IndexIntoMultiportOutput.lf
@@ -44,7 +44,7 @@ main reactor IndexIntoMultiportOutput {
             reactor::log::Error() << "expeced 1";
             exit(1);
         }
-    =} 
+    =}
 
     reaction(splitter.out2) {=
         received2 = true;

--- a/test/Cpp/src/multiport/IndexIntoMultiportOutput.lf
+++ b/test/Cpp/src/multiport/IndexIntoMultiportOutput.lf
@@ -1,0 +1,64 @@
+target Cpp
+
+reactor ReactorWithMultiport(width: size_t(3)) {
+    output[width] out: int
+
+    reaction(startup) -> out {=
+        for (size_t i{0}; i < width; i++) {
+            out[i].set(i);
+        }
+    =}
+}
+
+reactor MultiportSplitter(width: size_t(3)) {
+    input[width] in: int
+
+    output out0: int
+    output out1: int
+    output out2: int
+
+    in -> out0, out1, out2
+}
+
+main reactor IndexIntoMultiportOutput {
+    source = new ReactorWithMultiport()
+    splitter = new MultiportSplitter()
+
+    source.out -> splitter.in
+
+    state received0: bool{false}
+    state received1: bool{false}
+    state received2: bool{false}
+
+    reaction(splitter.out0) {=
+        received0 = true;
+        if (*splitter.out0.get() != 0) {
+            reactor::log::Error() << "expeced 0";
+            exit(1);
+        }
+    =}
+
+    reaction(splitter.out1) {=
+        received1 = true;
+        if (*splitter.out1.get() != 1) {
+            reactor::log::Error() << "expeced 1";
+            exit(1);
+        }
+    =} 
+
+    reaction(splitter.out2) {=
+        received2 = true;
+        if (*splitter.out2.get() != 2) {
+            reactor::log::Error() << "expeced 2";
+            exit(1);
+        }
+    =}
+
+    reaction(shutdown) {=
+        if (!received0 || !received1 || !received2) {
+            reactor::log::Error() << "missed a message";
+        } else {
+            reactor::log::Info() << "success";
+        }
+    =}
+}

--- a/test/Cpp/src/multiport/IndexIntoMultiportOutput.lf
+++ b/test/Cpp/src/multiport/IndexIntoMultiportOutput.lf
@@ -1,3 +1,11 @@
+/**
+ * This test was first described by Peter Donovan in
+ * https://github.com/lf-lang/lingua-franca/issues/1321
+ *
+ * It simply tests if passthrough connections work as expected in the C++
+ * target. Such a connection directly connects an input to an output of the same
+ * reactor, without any reactions in between.
+ */
 target Cpp
 
 reactor ReactorWithMultiport(width: size_t(3)) {


### PR DESCRIPTION
This pulls in https://github.com/lf-lang/reactor-cpp/pull/29 and addresses the problem in the C++ target described in https://github.com/lf-lang/lingua-franca/issues/1321. It also adds the two programs written by @petervdonovan as tests.