### PR TITLE
Removal of unnecessary build dependency to address security exceptions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,6 @@ lsp4jVersion=0.14.0
 mwe2LaunchVersion=2.12.2
 openTest4jVersion=1.2.0
 resourcesVersion=3.16.0
-runtimeVersion=3.25.0
 shadowJarVersion=7.1.2
 xtextGradleVersion=3.0.0
 xtextVersion=2.27.0

--- a/org.lflang/META-INF/MANIFEST.MF
+++ b/org.lflang/META-INF/MANIFEST.MF
@@ -20,8 +20,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.lsp4j;bundle-version="0.14.0",
  com.fasterxml.jackson.core.jackson-core,
  com.fasterxml.jackson.core.jackson-annotations,
- com.fasterxml.jackson.core.jackson-databind,
- org.eclipse.core.runtime;bundle-version="3.25.0"
+ com.fasterxml.jackson.core.jackson-databind
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.lflang,
  org.lflang.ast,

--- a/org.lflang/META-INF/MANIFEST.MF
+++ b/org.lflang/META-INF/MANIFEST.MF
@@ -39,6 +39,5 @@ Export-Package: org.lflang,
  org.lflang.util,
  org.lflang.validation,
  org.lflang.formatting2
-Import-Package: org.eclipse.core.resources,
- org.eclipse.core.runtime;version="3.5.0",
- org.apache.log4j
+Import-Package: org.apache.log4j,
+ org.eclipse.core.resources

--- a/org.lflang/build.gradle
+++ b/org.lflang/build.gradle
@@ -1,8 +1,6 @@
 dependencies {
     implementation "org.eclipse.xtext:org.eclipse.xtext:${xtextVersion}"
     implementation "org.eclipse.xtext:org.eclipse.xtext.xbase.lib:${xtextVersion}"
-    // https://mvnrepository.com/artifact/org.eclipse.platform/org.eclipse.core.runtime
-    implementation group: 'org.eclipse.platform', name: 'org.eclipse.core.runtime', version: "${runtimeVersion}"
     // https://mvnrepository.com/artifact/org.eclipse.platform/org.eclipse.core.resources
     implementation group: 'org.eclipse.platform', name: 'org.eclipse.core.resources', version: "${resourcesVersion}"
     // https://mvnrepository.com/artifact/org.eclipse.emf/org.eclipse.emf.mwe2.launch

--- a/org.lflang/pom.xml
+++ b/org.lflang/pom.xml
@@ -61,11 +61,6 @@
                         <version>${mwe2LaunchVersion}</version>
                     </dependency>
                     <dependency>
-                        <groupId>org.eclipse.platform</groupId>
-                        <artifactId>org.eclipse.core.runtime</artifactId>
-                        <version>${runtimeVersion}</version>
-                    </dependency>
-                    <dependency>
                         <groupId>org.eclipse.xtext</groupId>
                         <artifactId>org.eclipse.xtext.common.types</artifactId>
                         <version>${xtextVersion}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
 
         <!-- Eclipse specific components -->
         <!-- Important: Any version specified for these plugins must be available via the update sites listed in the target platform definition. If not, the Epoch build will fail! You can find the target platform definition in org.lflang.targetplatform/org.lflang.targetplatform.target. Changes to the target platform should also be transferred to the oomph setup (oomph/LinguaFranca.setup). -->
-        <runtimeVersion>3.25.0</runtimeVersion> <!-- This version reflects the actual Eclipse release (e.g. 3.25 -> 2022-06) -->
         <xtextVersion>2.27.0</xtextVersion>
         <lsp4jVersion>0.14.0</lsp4jVersion> <!-- This plugin is provided by Xtext -->
         <mwe2LaunchVersion>2.13.0</mwe2LaunchVersion> <!-- This plugin is provided by Eclipse, not Xtext -->


### PR DESCRIPTION
This fixes https://github.com/lf-lang/lingua-franca/issues/1363 (at least locally on my machine, let's wait for CI). I think the issue is that `org.eclipse.core.runtime` had a conflicting version. Interestingly, it seems to work fine if we just remove our own version specification and let gradle resolve the dependency from xtext.

I am not sure if we would also need to make a similar change in the Maven configuration.

This fixes https://github.com/lf-lang/lingua-franca/issues/1363