### PR TITLE
Add Spotless Gradle plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Build and package lfc (nightly build)

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -30,6 +30,7 @@ jobs:
           repository: lf-lang/lingua-franca
           submodules: true
           ref: ${{ inputs.compiler-ref }}
+          fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Check out specific ref of reactor-c
@@ -55,7 +56,7 @@ jobs:
           wget "https://downloads.arduino.cc/arduino-1.8.19-linux32.tar.xz"
           tar -xvf arduino-1.8.19-linux32.tar.xz
           cd arduino-1.8.19/
-          sudo ./install.sh 
+          sudo ./install.sh
         if: ${{ runner.os == 'Linux' }}
       - name: Build RTI docker image
         uses: ./.github/actions/build-rti-docker
@@ -67,7 +68,7 @@ jobs:
       - name: Perform tests for C target with specified scheduler (no LSP tests)
         run: |
           echo "Specified scheduler: ${{ inputs.scheduler }}"
-          ./gradlew test --tests org.lflang.tests.runtime.CSchedulerTest.* -Dscheduler=${{ inputs.scheduler }} 
+          ./gradlew test --tests org.lflang.tests.runtime.CSchedulerTest.* -Dscheduler=${{ inputs.scheduler }}
         if: ${{ !inputs.use-cpp && inputs.scheduler }}
       - name: Perform tests for CCpp target with default scheduler
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,93 +18,93 @@ env:
 jobs:
   # Cancel previous workflow runs.
   cancel:
-    uses: lf-lang/lingua-franca/.github/workflows/cancel.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/cancel.yml@formatting-for-dev-workflow
 
   # Test the Maven build.
   build:
-    uses: lf-lang/lingua-franca/.github/workflows/build.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/build.yml@formatting-for-dev-workflow
     needs: cancel
 
   # Run the unit tests.
   unit-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/unit-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/unit-tests.yml@formatting-for-dev-workflow
     needs: cancel
-  
+
   # Run tests for the standalone compiler.
   # TODO: Change this back to master branch once merged!
   cli-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/cli-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/cli-tests.yml@formatting-for-dev-workflow
     needs: cancel
 
-  # Run the C benchmark tests. 
+  # Run the C benchmark tests.
   c-benchmark-tests:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
+    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@fetch-depth-0
     with:
       target: 'C'
     needs: cancel
 
   # Run tests for Eclipse.
   eclipse-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/eclipse-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/eclipse-tests.yml@formatting-for-dev-workflow
     needs: cancel
 
   # Run language server tests.
   lsp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@formatting-for-dev-workflow
     needs: cancel
 
   # Run the C integration tests.
   c-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@formatting-for-dev-workflow
     needs: cancel
-  
+
   # Run the CCpp integration tests.
   ccpp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@formatting-for-dev-workflow
     with:
       use-cpp: true
     needs: cancel
-  
+
   # Run the C++ benchmark tests.
   cpp-benchmark-tests:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
+    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@fetch-depth-0
     with:
       target: 'Cpp'
     needs: cancel
-  
+
   # Run the C++ integration tests.
   cpp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/cpp-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/cpp-tests.yml@formatting-for-dev-workflow
     needs: cancel
-  
+
   # Run the C++ integration tests on ROS2.
   cpp-ros2-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/cpp-ros2-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/cpp-ros2-tests.yml@formatting-for-dev-workflow
     needs: cancel
-  
+
   # Run the Python integration tests.
   py-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/py-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/py-tests.yml@formatting-for-dev-workflow
     needs: cancel
-    
+
   # Run the Rust integration tests.
   rs-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/rs-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/rs-tests.yml@formatting-for-dev-workflow
     needs: cancel
 
   # Run the Rust benchmark tests.
   rs-benchmark-tests:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
+    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@fetch-depth-0
     with:
       target: 'Rust'
     needs: cancel
-   
+
   # Run the TypeScript integration tests.
   ts-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@formatting-for-dev-workflow
     needs: cancel
 
   # Run the serialization tests
   serialization-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/serialization-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/serialization-tests.yml@formatting-for-dev-workflow
     needs: cancel

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+          fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Run standalone cli tests

--- a/.github/workflows/cpp-ros2-tests.yml
+++ b/.github/workflows/cpp-ros2-tests.yml
@@ -19,6 +19,7 @@ jobs:
           repository: lf-lang/lingua-franca
           submodules: true
           ref: ${{ inputs.compiler-ref }}
+          fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Check out specific ref of reactor-cpp

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -22,6 +22,7 @@ jobs:
           repository: lf-lang/lingua-franca
           submodules: true
           ref: ${{ inputs.compiler-ref }}
+          fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Install Dependencies OS X
@@ -38,7 +39,7 @@ jobs:
           repository: lf-lang/reactor-cpp
           path: org.lflang/src/lib/cpp/reactor-cpp
           ref: ${{ inputs.runtime-ref }}
-        if: ${{ inputs.runtime-ref }} 
+        if: ${{ inputs.runtime-ref }}
       - name: Run C++ tests;
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.CppTest.*

--- a/.github/workflows/eclipse-tests.yml
+++ b/.github/workflows/eclipse-tests.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+          fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Setup Node.js environment

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -19,6 +19,7 @@ jobs:
           repository: lf-lang/lingua-franca
           submodules: true
           ref: ${{ inputs.compiler-ref }}
+          fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Uninstall packages Ubuntu

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -26,6 +26,7 @@ jobs:
           repository: lf-lang/lingua-franca
           submodules: true
           ref: ${{ inputs.compiler-ref }}
+          fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Setup Python

--- a/.github/workflows/rs-tests.yml
+++ b/.github/workflows/rs-tests.yml
@@ -24,6 +24,7 @@ jobs:
           repository: lf-lang/lingua-franca
           submodules: true
           ref: ${{ inputs.compiler-ref }}
+          fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Check out specific ref of reactor-rs

--- a/.github/workflows/serialization-tests.yml
+++ b/.github/workflows/serialization-tests.yml
@@ -17,6 +17,7 @@ jobs:
           repository: lf-lang/lingua-franca
           submodules: true
           ref: ${{ inputs.compiler-ref }}
+          fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Setup ROS2

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -23,6 +23,7 @@ jobs:
           repository: lf-lang/lingua-franca
           submodules: true
           ref: ${{ inputs.compiler-ref }}
+          fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Setup Node.js environment

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Run compiler tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing to LF
+
+#### Formatting
+
+We require Lingua Franca tests to be formatted as prescribed by `lff`.
+- To check that modified tests are formatted correctly, run `./gradlew spotlessCheck`.
+- To apply the changes recommended by the formatter, run `./gradlew spotlessApply`.

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import com.diffplug.gradle.spotless.SpotlessTask
+import lfformat.LfFormatStep
+
 buildscript {
     repositories {
         mavenCentral()
@@ -12,13 +15,14 @@ plugins {
     id "com.github.johnrengelman.shadow" version "${shadowJarVersion}"
     id 'java'
     id 'jacoco'
+    id "com.diffplug.spotless" version "6.11.0"
 }
 
 subprojects {
     repositories {
         mavenCentral()
     }
-    
+
     apply plugin: 'kotlin'
     compileKotlin {
         destinationDir = compileJava.destinationDir
@@ -74,3 +78,38 @@ gradle.projectsEvaluated {
         }
     }
 }
+
+
+spotless {
+    repositories {
+        mavenCentral()
+    }
+    // optional: limit format enforcement to just the files changed by this feature branch
+    ratchetFrom 'origin/master'
+
+    format 'misc', {
+        // define the files to apply `misc` to
+        target '*.gradle', '*.md', '.gitignore'
+
+        // define the steps to apply to those files
+        trimTrailingWhitespace()
+        indentWithSpaces() // or spaces. Takes an integer argument if you don't like 4
+        endWithNewline()
+    }
+
+    format 'linguaFranca', {
+        addStep(LfFormatStep.create())
+        target 'test/*/src/**/*.lf' // you have to set the target manually
+        targetExclude 'test/**/failing/**'
+    }
+
+    java {
+        target 'org.lflang*/src/**/*.java', 'buildSrc/**/*.java'
+        // The following is quoted from https://github.com/google/google-java-format
+        // "Note: There is no configurability as to the formatter's algorithm for formatting.
+        // This is a deliberate design decision to unify our code formatting on a single format."
+        googleJavaFormat('1.15.0').aosp().reflowLongStrings()
+        formatAnnotations()
+    }
+}
+tasks.withType(SpotlessTask) { it.dependsOn(":org.lflang.cli:jarLff") }

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ spotless {
     }
 
     format 'linguaFranca', {
-        addStep(LfFormatStep.create())
+        addStep(LfFormatStep.create(project.projectDir))
         target 'test/*/src/**/*.lf' // you have to set the target manually
         targetExclude 'test/**/failing/**'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ spotless {
         // The following is quoted from https://github.com/google/google-java-format
         // "Note: There is no configurability as to the formatter's algorithm for formatting.
         // This is a deliberate design decision to unify our code formatting on a single format."
-        googleJavaFormat('1.15.0').aosp().reflowLongStrings()
+        googleJavaFormat('1.15.0').reflowLongStrings()
         formatAnnotations()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id "com.github.johnrengelman.shadow" version "${shadowJarVersion}"
     id 'java'
     id 'jacoco'
-    id "com.diffplug.spotless" version "6.11.0"
+    id "com.diffplug.spotless" version "${spotlessVersion}"
 }
 
 subprojects {
@@ -108,7 +108,7 @@ spotless {
         // The following is quoted from https://github.com/google/google-java-format
         // "Note: There is no configurability as to the formatter's algorithm for formatting.
         // This is a deliberate design decision to unify our code formatting on a single format."
-        googleJavaFormat('1.15.0').reflowLongStrings()
+        googleJavaFormat(googleJavaFormatVersion).reflowLongStrings()
         formatAnnotations()
     }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,9 @@
+repositories {
+    mavenCentral()
+    dependencies {
+        // https://mvnrepository.com/artifact/com.diffplug.spotless/spotless-lib
+        implementation group: 'com.diffplug.spotless', name: 'spotless-lib', version: '2.30.0'
+        // https://mvnrepository.com/artifact/com.diffplug.spotless/spotless-lib-extra
+        implementation group: 'com.diffplug.spotless', name: 'spotless-lib-extra', version: '2.30.0'
+    }
+}

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,8 +2,8 @@ repositories {
     mavenCentral()
     dependencies {
         // https://mvnrepository.com/artifact/com.diffplug.spotless/spotless-lib
-        implementation group: 'com.diffplug.spotless', name: 'spotless-lib', version: '2.30.0'
+        implementation group: 'com.diffplug.spotless', name: 'spotless-lib', version: spotlessLibVersion
         // https://mvnrepository.com/artifact/com.diffplug.spotless/spotless-lib-extra
-        implementation group: 'com.diffplug.spotless', name: 'spotless-lib-extra', version: '2.30.0'
+        implementation group: 'com.diffplug.spotless', name: 'spotless-lib-extra', version: spotlessLibVersion
     }
 }

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,0 +1,2 @@
+[versions]
+spotlessLibVersion=2.30.0

--- a/buildSrc/src/main/java/lfformat/LfFormatStep.java
+++ b/buildSrc/src/main/java/lfformat/LfFormatStep.java
@@ -5,34 +5,59 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Serializable;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
 
+/**
+ * {@code LfFormatStep} is used by the Spotless Gradle plugin as a custom formatting step for
+ * formatting LF code.
+ */
 public final class LfFormatStep {
     private LfFormatStep() {}
 
-    public static FormatterStep create() {
+    /** Return a {@code FormatterStep} for LF code. */
+    public static FormatterStep create(File projectRoot) {
+        Step.projectRoot = projectRoot.toPath();
         return new Step();
     }
 
-    private static final class Step implements FormatterStep {
+    /** Implement LF-specific formatting functionality. */
+    public static class Step implements FormatterStep, Serializable {
+        // The use of the static keyword here is a workaround for serialization difficulties.
+        /** The path to the lingua-franca repository. */
+        private static Path projectRoot;
+
         @Override
         public String format(@SuppressWarnings("NullableProblems") String rawUnix, File file)
                 throws IOException, InterruptedException {
-            // It looks stupid to invoke Java from Java, but it is necessary in
+            // It looks silly to invoke Java from Java, but it is necessary in
             // order to break the circularity of needing the program to be built
             // in order for it to be built.
+            final Path resourcePath =
+                    projectRoot.resolve(Path.of("org.lflang", "src", "org", "lflang"));
+            final ResourceBundle properties =
+                    ResourceBundle.getBundle(
+                            "StringsBundle",
+                            Locale.getDefault(),
+                            new URLClassLoader(new URL[] {resourcePath.toUri().toURL()}));
+            final Path lffPath =
+                    Path.of(
+                            "org.lflang.cli",
+                            "build",
+                            "libs",
+                            String.format(
+                                    "org.lflang.cli-%s-lff.jar", properties.getString("VERSION")));
             Process p =
                     new ProcessBuilder(
                                     List.of(
                                             "java",
                                             "-jar",
-                                            Path.of(
-                                                            "org.lflang.cli",
-                                                            "build",
-                                                            "libs",
-                                                            "org.lflang.cli-0.3.1-SNAPSHOT-lff.jar")
-                                                    .toString(),
+                                            lffPath.toString(),
                                             "--dry-run",
                                             file.getAbsoluteFile().toString()))
                             .start();
@@ -40,12 +65,18 @@ public final class LfFormatStep {
             BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
             String line;
             while ((line = in.readLine()) != null) {
-                if (!output.isEmpty()) output.append("\n");
+                if (!output.isEmpty()) {
+                    output.append("\n");
+                }
                 // Filtering by "lff: " is yet another string-processing hack that is not airtight!
-                if (!line.startsWith("lff: ")) output.append(line);
+                if (!line.startsWith("lff: ")) {
+                    output.append(line);
+                }
             }
             int returnCode = p.waitFor();
-            if (returnCode != 0) throw new RuntimeException("Failed to reformat file.");
+            if (returnCode != 0) {
+                throw new RuntimeException("Failed to reformat file.");
+            }
             return output.toString().stripTrailing() + "\n"; // Not sure why this is necessary
         }
 

--- a/buildSrc/src/main/java/lfformat/LfFormatStep.java
+++ b/buildSrc/src/main/java/lfformat/LfFormatStep.java
@@ -51,6 +51,7 @@ public final class LfFormatStep {
             return output.toString();
         }
 
+        /** Run the formatter on the given file and return the resulting process handle. */
         private Process runFormatter(File file) throws IOException {
             final Path resourcePath =
                     projectRoot.resolve(Path.of("org.lflang", "src", "org", "lflang"));

--- a/buildSrc/src/main/java/lfformat/LfFormatStep.java
+++ b/buildSrc/src/main/java/lfformat/LfFormatStep.java
@@ -1,0 +1,58 @@
+package lfformat;
+
+import com.diffplug.spotless.FormatterStep;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.List;
+
+public final class LfFormatStep {
+    private LfFormatStep() {}
+
+    public static FormatterStep create() {
+        return new Step();
+    }
+
+    private static final class Step implements FormatterStep {
+        @Override
+        public String format(@SuppressWarnings("NullableProblems") String rawUnix, File file)
+                throws IOException, InterruptedException {
+            // It looks stupid to invoke Java from Java, but it is necessary in
+            // order to break the circularity of needing the program to be built
+            // in order for it to be built.
+            Process p =
+                    new ProcessBuilder(
+                                    List.of(
+                                            "java",
+                                            "-jar",
+                                            Path.of(
+                                                            "org.lflang.cli",
+                                                            "build",
+                                                            "libs",
+                                                            "org.lflang.cli-0.3.1-SNAPSHOT-lff.jar")
+                                                    .toString(),
+                                            "--dry-run",
+                                            file.getAbsoluteFile().toString()))
+                            .start();
+            StringBuilder output = new StringBuilder();
+            BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            String line;
+            while ((line = in.readLine()) != null) {
+                if (!output.isEmpty()) output.append("\n");
+                // Filtering by "lff: " is yet another string-processing hack that is not airtight!
+                if (!line.startsWith("lff: ")) output.append(line);
+            }
+            int returnCode = p.waitFor();
+            if (returnCode != 0) throw new RuntimeException("Failed to reformat file.");
+            return output.toString().stripTrailing() + "\n"; // Not sure why this is necessary
+        }
+
+        @SuppressWarnings("NullableProblems")
+        @Override
+        public String getName() {
+            return "Lingua Franca formatting step";
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ version=0.3.1-SNAPSHOT
 
 [versions]
 commonsCliVersion=1.4
+googleJavaFormatVersion=1.8
 guiceVersion=5.1.0
 jacocoVersion=0.8.7
 jupiterVersion=5.8.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version=0.3.1-SNAPSHOT
 
 [versions]
 commonsCliVersion=1.4
-googleJavaFormatVersion=1.8
+googleJavaFormatVersion=1.15.0
 guiceVersion=5.1.0
 jacocoVersion=0.8.7
 jupiterVersion=5.8.2
@@ -17,6 +17,7 @@ mwe2LaunchVersion=2.12.2
 openTest4jVersion=1.2.0
 resourcesVersion=3.16.0
 shadowJarVersion=7.1.2
+spotlessVersion=6.11.0
 xtextGradleVersion=3.0.0
 xtextVersion=2.28.0
 

--- a/org.lflang.cli/src/org/lflang/cli/Lff.java
+++ b/org.lflang.cli/src/org/lflang/cli/Lff.java
@@ -32,259 +32,252 @@ import org.lflang.util.FileUtil;
  */
 public class Lff extends CliBase {
 
+  /**
+   * Supported CLI options.
+   *
+   * <p>Stores an Apache Commons CLI Option for each entry, sets it to be required if so specified,
+   * and stores whether to pass the option to the code generator.
+   *
+   * @author Marten Lohstroh <marten@berkeley.edu>
+   * @author {Billy Bao <billybao@berkeley.edu>}
+   */
+  enum CLIOption {
+    HELP("h", "help", false, false, "Display this information."),
+    DRY_RUN(
+        "d",
+        "dry-run",
+        false,
+        false,
+        "Send the formatted file contents to stdout without writing to the file system."),
+    LINE_WRAP(
+        "w",
+        "wrap",
+        true,
+        false,
+        "Causes the formatter to line wrap the files to a specified length."),
+    NO_RECURSE(
+        null,
+        "no-recurse",
+        false,
+        false,
+        "Do not format files in subdirectories of the specified paths."),
+    OUTPUT_PATH(
+        "o",
+        "output-path",
+        true,
+        false,
+        "If specified, outputs all formatted files into this directory instead of"
+            + " overwriting the original files. Subdirectory structure will be preserved."),
+    VERBOSE("v", "verbose", false, false, "Print more details on files affected."),
+    VERSION(null, "version", false, false, "Print version information.");
+
+    /** The corresponding Apache CLI Option object. */
+    public final Option option;
+
     /**
-     * Supported CLI options.
+     * Construct a new CLIOption.
      *
-     * <p>Stores an Apache Commons CLI Option for each entry, sets it to be required if so
-     * specified, and stores whether to pass the option to the code generator.
-     *
-     * @author Marten Lohstroh <marten@berkeley.edu>
-     * @author {Billy Bao <billybao@berkeley.edu>}
+     * @param opt The short option name. E.g.: "f" denotes a flag "-f".
+     * @param longOpt The long option name. E.g.: "foo" denotes a flag "--foo".
+     * @param hasArg Whether or not this option has an argument. E.g.: "--foo bar" where "bar" is
+     *     the argument value.
+     * @param isReq Whether or not this option is required. If it is required but not specified a
+     *     menu is shown.
+     * @param description The description used in the menu.
      */
-    enum CLIOption {
-        HELP("h", "help", false, false, "Display this information."),
-        DRY_RUN(
-                "d",
-                "dry-run",
-                false,
-                false,
-                "Send the formatted file contents to stdout without writing to the file system."),
-        LINE_WRAP(
-                "w",
-                "wrap",
-                true,
-                false,
-                "Causes the formatter to line wrap the files to a specified length."),
-        NO_RECURSE(
-                null,
-                "no-recurse",
-                false,
-                false,
-                "Do not format files in subdirectories of the specified paths."),
-        OUTPUT_PATH(
-                "o",
-                "output-path",
-                true,
-                false,
-                "If specified, outputs all formatted files into this directory instead of"
-                    + " overwriting the original files. Subdirectory structure will be preserved."),
-        VERBOSE("v", "verbose", false, false, "Print more details on files affected."),
-        VERSION(null, "version", false, false, "Print version information.");
-
-        /** The corresponding Apache CLI Option object. */
-        public final Option option;
-
-        /**
-         * Construct a new CLIOption.
-         *
-         * @param opt The short option name. E.g.: "f" denotes a flag "-f".
-         * @param longOpt The long option name. E.g.: "foo" denotes a flag "--foo".
-         * @param hasArg Whether or not this option has an argument. E.g.: "--foo bar" where "bar"
-         *     is the argument value.
-         * @param isReq Whether or not this option is required. If it is required but not specified
-         *     a menu is shown.
-         * @param description The description used in the menu.
-         */
-        CLIOption(String opt, String longOpt, boolean hasArg, boolean isReq, String description) {
-            this.option = new Option(opt, longOpt, hasArg, description);
-            option.setRequired(isReq);
-        }
-
-        /**
-         * Create an Apache Commons CLI Options object and add all the options.
-         *
-         * @return Options object that includes all the options in this enum.
-         */
-        public static Options getOptions() {
-            Options opts = new Options();
-            Arrays.asList(CLIOption.values()).forEach(o -> opts.addOption(o.option));
-            return opts;
-        }
+    CLIOption(String opt, String longOpt, boolean hasArg, boolean isReq, String description) {
+      this.option = new Option(opt, longOpt, hasArg, description);
+      option.setRequired(isReq);
     }
 
     /**
-     * Main function of the stand-alone compiler.
+     * Create an Apache Commons CLI Options object and add all the options.
      *
-     * @param args CLI arguments
+     * @return Options object that includes all the options in this enum.
      */
-    public static void main(final String[] args) {
-        final ReportingBackend reporter = new ReportingBackend(new Io(), "lff: ");
+    public static Options getOptions() {
+      Options opts = new Options();
+      Arrays.asList(CLIOption.values()).forEach(o -> opts.addOption(o.option));
+      return opts;
+    }
+  }
 
-        // Injector used to obtain Main instance.
-        final Injector injector =
-                new LFStandaloneSetup(new LFRuntimeModule(), new LFStandaloneModule(reporter))
-                        .createInjectorAndDoEMFRegistration();
-        // Main instance.
-        final Lff main = injector.getInstance(Lff.class);
-        // Apache Commons Options object configured according to available CLI arguments.
-        Options options = CLIOption.getOptions();
-        // CLI arguments parser.
-        CommandLineParser parser = new DefaultParser();
-        // Helper object for printing "help" menu.
-        HelpFormatter formatter = new HelpFormatter();
+  /**
+   * Main function of the stand-alone compiler.
+   *
+   * @param args CLI arguments
+   */
+  public static void main(final String[] args) {
+    final ReportingBackend reporter = new ReportingBackend(new Io(), "lff: ");
 
-        try {
-            main.cmd = parser.parse(options, args, true);
+    // Injector used to obtain Main instance.
+    final Injector injector =
+        new LFStandaloneSetup(new LFRuntimeModule(), new LFStandaloneModule(reporter))
+            .createInjectorAndDoEMFRegistration();
+    // Main instance.
+    final Lff main = injector.getInstance(Lff.class);
+    // Apache Commons Options object configured according to available CLI arguments.
+    Options options = CLIOption.getOptions();
+    // CLI arguments parser.
+    CommandLineParser parser = new DefaultParser();
+    // Helper object for printing "help" menu.
+    HelpFormatter formatter = new HelpFormatter();
 
-            // If requested, print help and abort
-            if (main.cmd.hasOption(CLIOption.HELP.option.getOpt())) {
-                formatter.printHelp("lff", options);
-                System.exit(0);
-            }
+    try {
+      main.cmd = parser.parse(options, args, true);
 
-            // If requested, print version and abort
-            if (main.cmd.hasOption(CLIOption.VERSION.option.getLongOpt())) {
-                System.out.println("lff " + LocalStrings.VERSION);
-                System.exit(0);
-            }
+      // If requested, print help and abort
+      if (main.cmd.hasOption(CLIOption.HELP.option.getOpt())) {
+        formatter.printHelp("lff", options);
+        System.exit(0);
+      }
 
-            List<String> files = main.cmd.getArgList();
+      // If requested, print version and abort
+      if (main.cmd.hasOption(CLIOption.VERSION.option.getLongOpt())) {
+        System.out.println("lff " + LocalStrings.VERSION);
+        System.exit(0);
+      }
 
-            if (files.size() < 1) {
-                reporter.printFatalErrorAndExit("No input files.");
-            }
-            try {
-                List<Path> paths = files.stream().map(Paths::get).collect(Collectors.toList());
-                main.runFormatter(paths);
-            } catch (RuntimeException e) {
-                reporter.printFatalErrorAndExit("An unexpected error occurred:", e);
-            }
-        } catch (ParseException e) {
-            reporter.printFatalError(
-                    "Unable to parse commandline arguments. Reason: " + e.getMessage());
-            formatter.printHelp("lff", options);
-            System.exit(1);
-        }
+      List<String> files = main.cmd.getArgList();
+
+      if (files.size() < 1) {
+        reporter.printFatalErrorAndExit("No input files.");
+      }
+      try {
+        List<Path> paths = files.stream().map(Paths::get).collect(Collectors.toList());
+        main.runFormatter(paths);
+      } catch (RuntimeException e) {
+        reporter.printFatalErrorAndExit("An unexpected error occurred:", e);
+      }
+    } catch (ParseException e) {
+      reporter.printFatalError("Unable to parse commandline arguments. Reason: " + e.getMessage());
+      formatter.printHelp("lff", options);
+      System.exit(1);
+    }
+  }
+
+  /**
+   * Check all given input paths and the output path, then invokes the formatter on all files given.
+   */
+  private void runFormatter(List<Path> files) {
+    String pathOption = CLIOption.OUTPUT_PATH.option.getOpt();
+    Path outputRoot = null;
+    if (cmd.hasOption(pathOption)) {
+      outputRoot = Paths.get(cmd.getOptionValue(pathOption)).toAbsolutePath().normalize();
+      if (!Files.exists(outputRoot)) {
+        reporter.printFatalErrorAndExit("Output location '" + outputRoot + "' does not exist.");
+      }
+      if (!Files.isDirectory(outputRoot)) {
+        reporter.printFatalErrorAndExit("Output location '" + outputRoot + "' is not a directory.");
+      }
     }
 
-    /**
-     * Check all given input paths and the output path, then invokes the formatter on all files
-     * given.
-     */
-    private void runFormatter(List<Path> files) {
-        String pathOption = CLIOption.OUTPUT_PATH.option.getOpt();
-        Path outputRoot = null;
-        if (cmd.hasOption(pathOption)) {
-            outputRoot = Paths.get(cmd.getOptionValue(pathOption)).toAbsolutePath().normalize();
-            if (!Files.exists(outputRoot)) {
-                reporter.printFatalErrorAndExit(
-                        "Output location '" + outputRoot + "' does not exist.");
-            }
-            if (!Files.isDirectory(outputRoot)) {
-                reporter.printFatalErrorAndExit(
-                        "Output location '" + outputRoot + "' is not a directory.");
-            }
-        }
-
-        for (Path path : files) {
-            if (!Files.exists(path)) {
-                reporter.printFatalErrorAndExit(path + ": No such file or directory");
-            }
-        }
-
-        final int lineLength =
-                !cmd.hasOption(CLIOption.LINE_WRAP.option.getOpt())
-                        ? FormattingUtils.DEFAULT_LINE_LENGTH
-                        : Integer.parseInt(cmd.getOptionValue(CLIOption.LINE_WRAP.option.getOpt()));
-
-        final boolean dryRun = cmd.hasOption(CLIOption.DRY_RUN.option.getOpt());
-
-        for (Path path : files) {
-            if (verbose()) {
-                reporter.printInfo("Formatting " + path + ":");
-            }
-            path = path.toAbsolutePath();
-            if (Files.isDirectory(path)
-                    && !cmd.hasOption(CLIOption.NO_RECURSE.option.getLongOpt())) {
-                formatRecursive(Paths.get("."), path, outputRoot, lineLength, dryRun);
-            } else {
-                if (outputRoot == null) {
-                    formatSingleFile(path, path, lineLength, dryRun);
-                } else {
-                    formatSingleFile(
-                            path, outputRoot.resolve(path.getFileName()), lineLength, dryRun);
-                }
-            }
-        }
-        if (!dryRun || verbose()) reporter.printInfo("Done formatting.");
+    for (Path path : files) {
+      if (!Files.exists(path)) {
+        reporter.printFatalErrorAndExit(path + ": No such file or directory");
+      }
     }
 
-    /**
-     * Invoke the formatter on all files in a directory recursively.
-     *
-     * @param curPath Current relative path from inputRoot.
-     * @param inputRoot Root directory of input files.
-     * @param outputRoot Root output directory.
-     * @param lineLength The preferred maximum number of columns per line.
-     */
-    private void formatRecursive(
-            Path curPath, Path inputRoot, Path outputRoot, int lineLength, boolean dryRun) {
-        Path curDir = inputRoot.resolve(curPath);
-        try (var dirStream = Files.newDirectoryStream(curDir)) {
-            for (Path path : dirStream) {
-                Path newPath = curPath.resolve(path.getFileName());
-                if (Files.isDirectory(path)) {
-                    formatRecursive(newPath, inputRoot, outputRoot, lineLength, dryRun);
-                } else {
-                    if (outputRoot == null) {
-                        formatSingleFile(path, path, lineLength, dryRun);
-                    } else {
-                        formatSingleFile(path, outputRoot.resolve(newPath), lineLength, dryRun);
-                    }
-                }
-            }
-        } catch (IOException e) {
-            reporter.printError("Error reading directory " + curDir + ": " + e.getMessage());
-        }
-    }
+    final int lineLength =
+        !cmd.hasOption(CLIOption.LINE_WRAP.option.getOpt())
+            ? FormattingUtils.DEFAULT_LINE_LENGTH
+            : Integer.parseInt(cmd.getOptionValue(CLIOption.LINE_WRAP.option.getOpt()));
 
-    /** Load and validate a single file, then format it and output to the given outputPath. */
-    private void formatSingleFile(Path file, Path outputPath, int lineLength, boolean dryRun) {
-        file = file.normalize();
-        outputPath = outputPath.normalize();
-        final Resource resource = getResource(file);
-        if (resource == null) {
-            if (verbose()) {
-                reporter.printInfo("Skipped " + file + ": not an LF file");
-            }
-            return; // not an LF file, nothing to do here
-        }
-        validateResource(resource);
+    final boolean dryRun = cmd.hasOption(CLIOption.DRY_RUN.option.getOpt());
 
-        exitIfCollectedErrors();
-        final String formattedFileContents =
-                FormattingUtils.render(resource.getContents().get(0), lineLength);
-
-        if (dryRun) {
-            System.out.print(formattedFileContents);
+    for (Path path : files) {
+      if (verbose()) {
+        reporter.printInfo("Formatting " + path + ":");
+      }
+      path = path.toAbsolutePath();
+      if (Files.isDirectory(path) && !cmd.hasOption(CLIOption.NO_RECURSE.option.getLongOpt())) {
+        formatRecursive(Paths.get("."), path, outputRoot, lineLength, dryRun);
+      } else {
+        if (outputRoot == null) {
+          formatSingleFile(path, path, lineLength, dryRun);
         } else {
-            try {
-                FileUtil.writeToFile(formattedFileContents, outputPath, true);
-            } catch (IOException e) {
-                if (e instanceof FileAlreadyExistsException) {
-                    // only happens if a subdirectory is named with ".lf" at the end
-                    reporter.printFatalErrorAndExit(
-                            "Error writing to "
-                                    + outputPath
-                                    + ": file already exists. Make sure that no file or directory"
-                                    + " within provided input paths have the same relative paths.");
-                }
-                reporter.printFatalErrorAndExit(
-                        "Error writing to " + outputPath + ": " + e.getMessage());
-            }
+          formatSingleFile(path, outputRoot.resolve(path.getFileName()), lineLength, dryRun);
         }
+      }
+    }
+    if (!dryRun || verbose()) reporter.printInfo("Done formatting.");
+  }
 
-        exitIfCollectedErrors();
-        issueCollector.getAllIssues().forEach(reporter::printIssue);
-        if (verbose()) {
-            String msg = "Formatted " + file;
-            if (file != outputPath) msg += " -> " + outputPath;
-            reporter.printInfo(msg);
+  /**
+   * Invoke the formatter on all files in a directory recursively.
+   *
+   * @param curPath Current relative path from inputRoot.
+   * @param inputRoot Root directory of input files.
+   * @param outputRoot Root output directory.
+   * @param lineLength The preferred maximum number of columns per line.
+   */
+  private void formatRecursive(
+      Path curPath, Path inputRoot, Path outputRoot, int lineLength, boolean dryRun) {
+    Path curDir = inputRoot.resolve(curPath);
+    try (var dirStream = Files.newDirectoryStream(curDir)) {
+      for (Path path : dirStream) {
+        Path newPath = curPath.resolve(path.getFileName());
+        if (Files.isDirectory(path)) {
+          formatRecursive(newPath, inputRoot, outputRoot, lineLength, dryRun);
+        } else {
+          if (outputRoot == null) {
+            formatSingleFile(path, path, lineLength, dryRun);
+          } else {
+            formatSingleFile(path, outputRoot.resolve(newPath), lineLength, dryRun);
+          }
         }
+      }
+    } catch (IOException e) {
+      reporter.printError("Error reading directory " + curDir + ": " + e.getMessage());
+    }
+  }
+
+  /** Load and validate a single file, then format it and output to the given outputPath. */
+  private void formatSingleFile(Path file, Path outputPath, int lineLength, boolean dryRun) {
+    file = file.normalize();
+    outputPath = outputPath.normalize();
+    final Resource resource = getResource(file);
+    if (resource == null) {
+      if (verbose()) {
+        reporter.printInfo("Skipped " + file + ": not an LF file");
+      }
+      return; // not an LF file, nothing to do here
+    }
+    validateResource(resource);
+
+    exitIfCollectedErrors();
+    final String formattedFileContents =
+        FormattingUtils.render(resource.getContents().get(0), lineLength);
+
+    if (dryRun) {
+      System.out.print(formattedFileContents);
+    } else {
+      try {
+        FileUtil.writeToFile(formattedFileContents, outputPath, true);
+      } catch (IOException e) {
+        if (e instanceof FileAlreadyExistsException) {
+          // only happens if a subdirectory is named with ".lf" at the end
+          reporter.printFatalErrorAndExit(
+              "Error writing to "
+                  + outputPath
+                  + ": file already exists. Make sure that no file or directory"
+                  + " within provided input paths have the same relative paths.");
+        }
+        reporter.printFatalErrorAndExit("Error writing to " + outputPath + ": " + e.getMessage());
+      }
     }
 
-    /** Return whether the "verbose" flag has been set. */
-    private boolean verbose() {
-        return cmd.hasOption(CLIOption.VERBOSE.option.getOpt());
+    exitIfCollectedErrors();
+    issueCollector.getAllIssues().forEach(reporter::printIssue);
+    if (verbose()) {
+      String msg = "Formatted " + file;
+      if (file != outputPath) msg += " -> " + outputPath;
+      reporter.printInfo(msg);
     }
+  }
+
+  /** Return whether the "verbose" flag has been set. */
+  private boolean verbose() {
+    return cmd.hasOption(CLIOption.VERBOSE.option.getOpt());
+  }
 }

--- a/org.lflang.cli/src/org/lflang/cli/Lff.java
+++ b/org.lflang.cli/src/org/lflang/cli/Lff.java
@@ -1,9 +1,7 @@
-/**
- * Stand-alone version of the Lingua Franca formatter (lff).
- */
-
+/** Stand-alone version of the Lingua Franca formatter (lff). */
 package org.lflang.cli;
 
+import com.google.inject.Injector;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -12,7 +10,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -20,18 +17,14 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.emf.ecore.resource.Resource;
-
 import org.lflang.LFRuntimeModule;
 import org.lflang.LFStandaloneSetup;
 import org.lflang.LocalStrings;
 import org.lflang.ast.FormattingUtils;
 import org.lflang.util.FileUtil;
 
-import com.google.inject.Injector;
-
 /**
- * Standalone version of the Lingua Franca formatter (lff).
- * Based on lfc.
+ * Standalone version of the Lingua Franca formatter (lff). Based on lfc.
  *
  * @author {Marten Lohstroh <marten@berkeley.edu>}
  * @author {Christian Menard <christian.menard@tu-dresden.de>}
@@ -41,10 +34,9 @@ public class Lff extends CliBase {
 
     /**
      * Supported CLI options.
-     * <p>
-     * Stores an Apache Commons CLI Option for each entry, sets it to be
-     * required if so specified, and stores whether to pass the
-     * option to the code generator.
+     *
+     * <p>Stores an Apache Commons CLI Option for each entry, sets it to be required if so
+     * specified, and stores whether to pass the option to the code generator.
      *
      * @author Marten Lohstroh <marten@berkeley.edu>
      * @author {Billy Bao <billybao@berkeley.edu>}
@@ -52,53 +44,45 @@ public class Lff extends CliBase {
     enum CLIOption {
         HELP("h", "help", false, false, "Display this information."),
         DRY_RUN(
-            "d",
-            "dry-run",
-            false,
-            false,
-            "Send the formatted file contents to stdout without writing to the file system."
-        ),
+                "d",
+                "dry-run",
+                false,
+                false,
+                "Send the formatted file contents to stdout without writing to the file system."),
         LINE_WRAP(
-            "w",
-            "wrap",
-            true,
-            false,
-            "Causes the formatter to line wrap the files to a specified length."
-        ),
+                "w",
+                "wrap",
+                true,
+                false,
+                "Causes the formatter to line wrap the files to a specified length."),
         NO_RECURSE(
-            null,
-            "no-recurse",
-            false,
-            false,
-            "Do not format files in subdirectories of the specified paths."
-        ),
+                null,
+                "no-recurse",
+                false,
+                false,
+                "Do not format files in subdirectories of the specified paths."),
         OUTPUT_PATH(
-            "o",
-            "output-path",
-            true,
-            false,
-            "If specified, outputs all formatted files into this directory instead "
-                + "of overwriting the original files. Subdirectory structure will be preserved."
-        ),
+                "o",
+                "output-path",
+                true,
+                false,
+                "If specified, outputs all formatted files into this directory instead of"
+                    + " overwriting the original files. Subdirectory structure will be preserved."),
         VERBOSE("v", "verbose", false, false, "Print more details on files affected."),
         VERSION(null, "version", false, false, "Print version information.");
 
-        /**
-         * The corresponding Apache CLI Option object.
-         */
+        /** The corresponding Apache CLI Option object. */
         public final Option option;
 
         /**
          * Construct a new CLIOption.
          *
-         * @param opt         The short option name. E.g.: "f" denotes a flag
-         *                    "-f".
-         * @param longOpt     The long option name. E.g.: "foo" denotes a flag
-         *                    "--foo".
-         * @param hasArg      Whether or not this option has an argument. E.g.:
-         *                    "--foo bar" where "bar" is the argument value.
-         * @param isReq       Whether or not this option is required. If it is
-         *                    required but not specified a menu is shown.
+         * @param opt The short option name. E.g.: "f" denotes a flag "-f".
+         * @param longOpt The long option name. E.g.: "foo" denotes a flag "--foo".
+         * @param hasArg Whether or not this option has an argument. E.g.: "--foo bar" where "bar"
+         *     is the argument value.
+         * @param isReq Whether or not this option is required. If it is required but not specified
+         *     a menu is shown.
          * @param description The description used in the menu.
          */
         CLIOption(String opt, String longOpt, boolean hasArg, boolean isReq, String description) {
@@ -127,10 +111,9 @@ public class Lff extends CliBase {
         final ReportingBackend reporter = new ReportingBackend(new Io(), "lff: ");
 
         // Injector used to obtain Main instance.
-        final Injector injector = new LFStandaloneSetup(
-            new LFRuntimeModule(),
-            new LFStandaloneModule(reporter)
-        ).createInjectorAndDoEMFRegistration();
+        final Injector injector =
+                new LFStandaloneSetup(new LFRuntimeModule(), new LFStandaloneModule(reporter))
+                        .createInjectorAndDoEMFRegistration();
         // Main instance.
         final Lff main = injector.getInstance(Lff.class);
         // Apache Commons Options object configured according to available CLI arguments.
@@ -168,8 +151,7 @@ public class Lff extends CliBase {
             }
         } catch (ParseException e) {
             reporter.printFatalError(
-                "Unable to parse commandline arguments. Reason: " + e.getMessage()
-            );
+                    "Unable to parse commandline arguments. Reason: " + e.getMessage());
             formatter.printHelp("lff", options);
             System.exit(1);
         }
@@ -186,13 +168,11 @@ public class Lff extends CliBase {
             outputRoot = Paths.get(cmd.getOptionValue(pathOption)).toAbsolutePath().normalize();
             if (!Files.exists(outputRoot)) {
                 reporter.printFatalErrorAndExit(
-                    "Output location '" + outputRoot + "' does not exist."
-                );
+                        "Output location '" + outputRoot + "' does not exist.");
             }
             if (!Files.isDirectory(outputRoot)) {
                 reporter.printFatalErrorAndExit(
-                    "Output location '" + outputRoot + "' is not a directory."
-                );
+                        "Output location '" + outputRoot + "' is not a directory.");
             }
         }
 
@@ -202,9 +182,10 @@ public class Lff extends CliBase {
             }
         }
 
-        final int lineLength = !cmd.hasOption(CLIOption.LINE_WRAP.option.getOpt()) ?
-            FormattingUtils.DEFAULT_LINE_LENGTH
-            : Integer.parseInt(cmd.getOptionValue(CLIOption.LINE_WRAP.option.getOpt()));
+        final int lineLength =
+                !cmd.hasOption(CLIOption.LINE_WRAP.option.getOpt())
+                        ? FormattingUtils.DEFAULT_LINE_LENGTH
+                        : Integer.parseInt(cmd.getOptionValue(CLIOption.LINE_WRAP.option.getOpt()));
 
         final boolean dryRun = cmd.hasOption(CLIOption.DRY_RUN.option.getOpt());
 
@@ -213,20 +194,15 @@ public class Lff extends CliBase {
                 reporter.printInfo("Formatting " + path + ":");
             }
             path = path.toAbsolutePath();
-            if (
-                Files.isDirectory(path)&& !cmd.hasOption(CLIOption.NO_RECURSE.option.getLongOpt())
-            ) {
+            if (Files.isDirectory(path)
+                    && !cmd.hasOption(CLIOption.NO_RECURSE.option.getLongOpt())) {
                 formatRecursive(Paths.get("."), path, outputRoot, lineLength, dryRun);
             } else {
                 if (outputRoot == null) {
                     formatSingleFile(path, path, lineLength, dryRun);
                 } else {
                     formatSingleFile(
-                        path,
-                        outputRoot.resolve(path.getFileName()),
-                        lineLength,
-                        dryRun
-                    );
+                            path, outputRoot.resolve(path.getFileName()), lineLength, dryRun);
                 }
             }
         }
@@ -235,18 +211,14 @@ public class Lff extends CliBase {
 
     /**
      * Invoke the formatter on all files in a directory recursively.
+     *
      * @param curPath Current relative path from inputRoot.
      * @param inputRoot Root directory of input files.
      * @param outputRoot Root output directory.
      * @param lineLength The preferred maximum number of columns per line.
      */
     private void formatRecursive(
-        Path curPath,
-        Path inputRoot,
-        Path outputRoot,
-        int lineLength,
-        boolean dryRun
-    ) {
+            Path curPath, Path inputRoot, Path outputRoot, int lineLength, boolean dryRun) {
         Path curDir = inputRoot.resolve(curPath);
         try (var dirStream = Files.newDirectoryStream(curDir)) {
             for (Path path : dirStream) {
@@ -266,9 +238,7 @@ public class Lff extends CliBase {
         }
     }
 
-    /**
-     * Load and validate a single file, then format it and output to the given outputPath.
-     */
+    /** Load and validate a single file, then format it and output to the given outputPath. */
     private void formatSingleFile(Path file, Path outputPath, int lineLength, boolean dryRun) {
         file = file.normalize();
         outputPath = outputPath.normalize();
@@ -282,10 +252,8 @@ public class Lff extends CliBase {
         validateResource(resource);
 
         exitIfCollectedErrors();
-        final String formattedFileContents = FormattingUtils.render(
-            resource.getContents().get(0),
-            lineLength
-        );
+        final String formattedFileContents =
+                FormattingUtils.render(resource.getContents().get(0), lineLength);
 
         if (dryRun) {
             System.out.print(formattedFileContents);
@@ -296,14 +264,13 @@ public class Lff extends CliBase {
                 if (e instanceof FileAlreadyExistsException) {
                     // only happens if a subdirectory is named with ".lf" at the end
                     reporter.printFatalErrorAndExit(
-                        "Error writing to " + outputPath
-                            + ": file already exists. Make sure that no "
-                            + "file or directory within provided input paths have the same relative "
-                            + "paths.");
+                            "Error writing to "
+                                    + outputPath
+                                    + ": file already exists. Make sure that no file or directory"
+                                    + " within provided input paths have the same relative paths.");
                 }
                 reporter.printFatalErrorAndExit(
-                    "Error writing to " + outputPath + ": " + e.getMessage()
-                );
+                        "Error writing to " + outputPath + ": " + e.getMessage());
             }
         }
 

--- a/org.lflang.cli/src/org/lflang/cli/Lff.java
+++ b/org.lflang.cli/src/org/lflang/cli/Lff.java
@@ -283,6 +283,7 @@ public class Lff extends CliBase {
         }
     }
 
+    /** Return whether the "verbose" flag has been set. */
     private boolean verbose() {
         return cmd.hasOption(CLIOption.VERBOSE.option.getOpt());
     }

--- a/org.lflang.cli/src/org/lflang/cli/Lff.java
+++ b/org.lflang.cli/src/org/lflang/cli/Lff.java
@@ -209,7 +209,7 @@ public class Lff extends CliBase {
         final boolean dryRun = cmd.hasOption(CLIOption.DRY_RUN.option.getOpt());
 
         for (Path path : files) {
-            if (cmd.hasOption(CLIOption.VERBOSE.option.getOpt())) {
+            if (verbose()) {
                 reporter.printInfo("Formatting " + path + ":");
             }
             path = path.toAbsolutePath();
@@ -230,7 +230,7 @@ public class Lff extends CliBase {
                 }
             }
         }
-        reporter.printInfo("Done formatting.");
+        if (!dryRun || verbose()) reporter.printInfo("Done formatting.");
     }
 
     /**
@@ -274,7 +274,7 @@ public class Lff extends CliBase {
         outputPath = outputPath.normalize();
         final Resource resource = getResource(file);
         if (resource == null) {
-            if (cmd.hasOption(CLIOption.VERBOSE.option.getOpt())) {
+            if (verbose()) {
                 reporter.printInfo("Skipped " + file + ": not an LF file");
             }
             return; // not an LF file, nothing to do here
@@ -288,7 +288,7 @@ public class Lff extends CliBase {
         );
 
         if (dryRun) {
-            System.out.println(formattedFileContents);
+            System.out.print(formattedFileContents);
         } else {
             try {
                 FileUtil.writeToFile(formattedFileContents, outputPath, true);
@@ -309,10 +309,14 @@ public class Lff extends CliBase {
 
         exitIfCollectedErrors();
         issueCollector.getAllIssues().forEach(reporter::printIssue);
-        if (cmd.hasOption(CLIOption.VERBOSE.option.getOpt())) {
+        if (verbose()) {
             String msg = "Formatted " + file;
             if (file != outputPath) msg += " -> " + outputPath;
             reporter.printInfo(msg);
         }
+    }
+
+    private boolean verbose() {
+        return cmd.hasOption(CLIOption.VERBOSE.option.getOpt());
     }
 }


### PR DESCRIPTION
I have gotten feedback from multiple people that the requirement that LF tests be formatted has the potential to be annoying if it is not documented properly (and perhaps automated or hooked into some established workflow).

Unfortunately, using client-side Git hooks for the formatter seems like it would require each person to manually add the Git hook (for some reason, client-side Git hooks apparently cannot be tracked). If we were to use a server-side Git hook, then people would find out about formatting problems after they have already pushed their work, which can be annoying.

Because there has already been plenty of talk about adding Spotless to our regular workflow (#1052), it seems to me like the overhead of dealing with formatting tools can be minimized by just using the Spotless Gradle plugin for both LF formatting and Java formatting.

If we cannot quickly reach consensus about Java formatting, I propose to comment Java formatting out of this PR so that we at least have an established way of invoking `lff`. Otherwise, people would have to get used to directly invoking the `runLff` task, and then when we have a Java formatter or linter, they would have to get used to that again. Additionally, Spotless has advantages over direct invocation of the formatter. For example, it only runs the formatter on files that have changed.

Development of a comprehensive `CONTRIBUTING.md` file and building of consensus around coding standards have already been started in #478; therefore, they are both non-goals of this PR.