### PR TITLE
Use debug logging for all LF tests run in CI

### DIFF
--- a/org.lflang.cli/src/org/lflang/cli/Lfc.java
+++ b/org.lflang.cli/src/org/lflang/cli/Lfc.java
@@ -70,6 +70,7 @@ public class Lfc extends CliBase {
         EXTERNAL_RUNTIME_PATH(null, "external-runtime-path", true, false, "Specify an external runtime library to be used by the compiled binary.", true),
         FEDERATED("f", "federated", false, false, "Treat main reactor as federated.", false),
         HELP("h", "help", false, false, "Display this information.", true),
+        LOGGING(null, "logging", true, false, "The logging level to use by the generated binary", true),
         LINT("l", "lint", false, false, "Enable or disable linting of generated code.", true),
         NO_COMPILE("n", "no-compile", false, false, "Do not invoke target compiler.", true),
         OUTPUT_PATH("o", "output-path", true, false, "Specify the root output directory.", false),

--- a/org.lflang.tests/src/org/lflang/tests/LFTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/LFTest.java
@@ -193,7 +193,7 @@ public class LFTest implements Comparable<LFTest> {
          * String buffer used to record the standard output and error
          * streams from the input process.
          */
-        final StringBuffer buffer = new StringBuffer();
+        StringBuffer buffer = new StringBuffer();
 
         /**
          * Return a thread responsible for recording the standard output stream
@@ -238,6 +238,10 @@ public class LFTest implements Comparable<LFTest> {
         @Override
         public String toString() {
             return buffer.toString();
+        }
+
+        public void clear() {
+            buffer = null;
         }
     }
 }

--- a/org.lflang.tests/src/org/lflang/tests/LFTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/LFTest.java
@@ -126,9 +126,14 @@ public class LFTest implements Comparable<LFTest> {
     public void reportErrors() {
         if (this.hasFailed()) {
             System.out.println("+---------------------------------------------------------------------------+");
-            System.out.println("Failed: ");
+            System.out.println("Failed: " + this);
             System.out.println("-----------------------------------------------------------------------------");
             System.out.println("Reason: " + this.result.message + " Exit code: " + this.exitValue);
+            if (this.exitValue.equals("139")) {
+                // The java ProcessBuiler and Process interface does not allow us to reliably retrieve stderr and stdout
+                // from a process that segfaults. We can only print a message indicating that the putput is incomplete.
+                System.out.println("This exit code typically indicates a segfault. In this case, the execution output is likely missing or incomplete.");
+            }
             printIfNotEmpty("Reported issues", this.issues.toString());
             printIfNotEmpty("Compilation output", this.compilationLog.toString());
             printIfNotEmpty("Execution output", this.execLog.toString());

--- a/org.lflang.tests/src/org/lflang/tests/LFTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/LFTest.java
@@ -11,6 +11,8 @@ import java.io.StringWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.eclipse.xtext.util.RuntimeIOException;
+
 import org.lflang.FileConfig;
 import org.lflang.Target;
 import org.lflang.generator.LFGeneratorContext;
@@ -228,7 +230,7 @@ public class LFTest implements Comparable<LFTest> {
                         builder.append(buf, 0, len);
                     }
                 } catch (IOException e) {
-                    throw new RuntimeException("While reading from a stream, an I/O exception occurred:\n" + e);
+                    throw new RuntimeIOException(e);
                 }
             });
             t.start();

--- a/org.lflang.tests/src/org/lflang/tests/LFTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/LFTest.java
@@ -5,9 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.PrintWriter;
 import java.io.Reader;
-import java.io.StringWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 

--- a/org.lflang.tests/src/org/lflang/tests/LFTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/LFTest.java
@@ -5,7 +5,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.io.Reader;
+import java.io.StringWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -121,34 +123,29 @@ public class LFTest implements Comparable<LFTest> {
      * Compile a string that contains all collected errors and return it.
      * @return A string that contains all collected errors.
      */
-    public String reportErrors() {
+    public void reportErrors() {
         if (this.hasFailed()) {
-            StringBuilder sb = new StringBuilder(System.lineSeparator());
-            sb.append("+---------------------------------------------------------------------------+").append(System.lineSeparator());
-            sb.append("Failed: ").append(this.name).append(System.lineSeparator());
-            sb.append("-----------------------------------------------------------------------------").append(System.lineSeparator());
-            sb.append("Reason: ").append(this.result.message).append(" Exit code: ").append(this.exitValue).append(System.lineSeparator());
-            appendIfNotEmpty("Reported issues", this.issues.toString(), sb);
-            appendIfNotEmpty("Compilation output", this.compilationLog.toString(), sb);
-            appendIfNotEmpty("Execution output", this.execLog.toString(), sb);
-            sb.append("+---------------------------------------------------------------------------+\n");
-        return sb.toString();
-        } else {
-            return "";
+            System.out.println("+---------------------------------------------------------------------------+");
+            System.out.println("Failed: ");
+            System.out.println("-----------------------------------------------------------------------------");
+            System.out.println("Reason: " + this.result.message + " Exit code: " + this.exitValue);
+            printIfNotEmpty("Reported issues", this.issues.toString());
+            printIfNotEmpty("Compilation output", this.compilationLog.toString());
+            printIfNotEmpty("Execution output", this.execLog.toString());
+            System.out.println("+---------------------------------------------------------------------------+");
         }
     }
 
     /**
-     * Append the given header and message to the log, but only if the message is not empty.
+     * Print the message to the system output, but only if the message is not empty.
      *
-     * @param header Header for the message to append to the log.
-     * @param message The log message to add.
-     * @param log The log so far.
+     * @param header Header for the message to be printed.
+     * @param message The log message to print.
      */
-    private static void appendIfNotEmpty(String header, String message, StringBuilder log) {
+    private static void printIfNotEmpty(String header, String message) {
         if (!message.isEmpty()) {
-            log.append(header).append(":").append(System.lineSeparator());
-            log.append(message).append(System.lineSeparator());
+            System.out.println(header + ":");
+            System.out.println(message);
         }
     }
 

--- a/org.lflang.tests/src/org/lflang/tests/TestBase.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestBase.java
@@ -444,7 +444,7 @@ public abstract class TestBase {
      * Override to add some LFC arguments to all runs of this test class.
      */
     protected void addExtraLfcArgs(Properties args) {
-        // to be overridden
+        args.setProperty("logging", "Debug");
     }
 
 

--- a/org.lflang.tests/src/org/lflang/tests/TestBase.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestBase.java
@@ -498,6 +498,7 @@ public abstract class TestBase {
                     return;
                 } else {
                     if (stdoutException.get() != null || stderrException.get() != null) {
+                        test.result = Result.TEST_EXCEPTION;
                         test.execLog.buffer.setLength(0);
                         if (stdoutException.get() != null) {
                             test.execLog.buffer.append("Error during stdout handling:\n");
@@ -507,6 +508,7 @@ public abstract class TestBase {
                             test.execLog.buffer.append("Error during stderr handling:\n");
                             appendStackTrace(stderrException.get(), test.execLog.buffer);
                         }
+                        return;
                     }
                     if (p.exitValue() != 0) {
                         test.result = Result.TEST_FAIL;
@@ -522,6 +524,8 @@ public abstract class TestBase {
             return;
         }
         test.result = Result.TEST_PASS;
+        // clear the log if the test succeeded to free memory
+        test.execLog.clear();
     }
 
     static private void appendStackTrace(Throwable t, StringBuffer buffer) {

--- a/org.lflang.tests/src/org/lflang/tests/TestBase.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestBase.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
@@ -20,6 +21,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -481,6 +483,13 @@ public abstract class TestBase {
                 var p = pb.start();
                 var stdout = test.execLog.recordStdOut(p);
                 var stderr = test.execLog.recordStdErr(p);
+
+                AtomicReference<Throwable> stdoutException = null;
+                AtomicReference<Throwable> stderrException = null;
+
+                stdout.setUncaughtExceptionHandler((thread, throwable) -> stdoutException.set(throwable));
+                stderr.setUncaughtExceptionHandler((thread, throwable) -> stderrException.set(throwable));
+
                 if (!p.waitFor(MAX_EXECUTION_TIME_SECONDS, TimeUnit.SECONDS)) {
                     stdout.interrupt();
                     stderr.interrupt();
@@ -488,6 +497,17 @@ public abstract class TestBase {
                     test.result = Result.TEST_TIMEOUT;
                     return;
                 } else {
+                    if (stdoutException.get() != null || stderrException.get() != null) {
+                        test.execLog.buffer.setLength(0);
+                        if (stdoutException.get() == null) {
+                            test.execLog.buffer.append("Error during stdout handling:\n");
+                            appendStackTrace(stdoutException.get(), test.execLog.buffer);
+                        }
+                        if (stderrException.get() == null) {
+                            test.execLog.buffer.append("Error during stderr handling:\n");
+                            appendStackTrace(stderrException.get(), test.execLog.buffer);
+                        }
+                    }
                     if (p.exitValue() != 0) {
                         test.result = Result.TEST_FAIL;
                         test.exitValue = Integer.toString(p.exitValue());
@@ -498,13 +518,17 @@ public abstract class TestBase {
         } catch (Exception e) {
             test.result = Result.TEST_EXCEPTION;
             // Add the stack trace to the test output
-            StringWriter sw = new StringWriter();
-            PrintWriter pw = new PrintWriter(sw);
-            e.printStackTrace(pw);
-            test.execLog.buffer.append(sw);
+            appendStackTrace(e, test.execLog.buffer);
             return;
         }
         test.result = Result.TEST_PASS;
+    }
+
+    static private void appendStackTrace(Throwable t, StringBuffer buffer) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        t.printStackTrace(pw);
+        buffer.append(pw);
     }
 
     /**

--- a/org.lflang.tests/src/org/lflang/tests/TestBase.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestBase.java
@@ -499,11 +499,11 @@ public abstract class TestBase {
                 } else {
                     if (stdoutException.get() != null || stderrException.get() != null) {
                         test.execLog.buffer.setLength(0);
-                        if (stdoutException.get() == null) {
+                        if (stdoutException.get() != null) {
                             test.execLog.buffer.append("Error during stdout handling:\n");
                             appendStackTrace(stdoutException.get(), test.execLog.buffer);
                         }
-                        if (stderrException.get() == null) {
+                        if (stderrException.get() != null) {
                             test.execLog.buffer.append("Error during stderr handling:\n");
                             appendStackTrace(stderrException.get(), test.execLog.buffer);
                         }

--- a/org.lflang.tests/src/org/lflang/tests/TestBase.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestBase.java
@@ -362,7 +362,7 @@ public abstract class TestBase {
         System.out.print(THIN_LINE);
 
         for (var test : tests) {
-            System.out.print(test.reportErrors());
+            test.reportErrors();
         }
         for (LFTest lfTest : tests) {
             assertSame(Result.TEST_PASS, lfTest.result);
@@ -484,8 +484,8 @@ public abstract class TestBase {
                 var stdout = test.execLog.recordStdOut(p);
                 var stderr = test.execLog.recordStdErr(p);
 
-                AtomicReference<Throwable> stdoutException = null;
-                AtomicReference<Throwable> stderrException = null;
+                var stdoutException = new AtomicReference<Throwable>(null);
+                var stderrException = new AtomicReference<Throwable>(null);
 
                 stdout.setUncaughtExceptionHandler((thread, throwable) -> stdoutException.set(throwable));
                 stderr.setUncaughtExceptionHandler((thread, throwable) -> stderrException.set(throwable));
@@ -528,7 +528,7 @@ public abstract class TestBase {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
         t.printStackTrace(pw);
-        buffer.append(pw);
+        buffer.append(sw);
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/GeneratorUtils.java
+++ b/org.lflang/src/org/lflang/generator/GeneratorUtils.java
@@ -23,6 +23,7 @@ import org.lflang.ErrorReporter;
 import org.lflang.FileConfig;
 import org.lflang.Target;
 import org.lflang.TargetConfig;
+import org.lflang.TargetProperty.BuildType;
 import org.lflang.generator.LFGeneratorContext.Mode;
 import org.lflang.TargetProperty;
 import org.lflang.TargetProperty.SchedulerOption;
@@ -79,6 +80,9 @@ public class GeneratorUtils {
         }
         if (context.getArgs().containsKey("no-compile")) {
             targetConfig.noCompile = true;
+        }
+        if (context.getArgs().containsKey("logging")) {
+            targetConfig.logLevel = LogLevel.valueOf(context.getArgs().getProperty("logging").toUpperCase());
         }
         if (context.getArgs().containsKey("workers")) {
             targetConfig.workers = Integer.parseInt(context.getArgs().getProperty("workers"));

--- a/org.lflang/src/org/lflang/generator/GeneratorUtils.java
+++ b/org.lflang/src/org/lflang/generator/GeneratorUtils.java
@@ -24,6 +24,7 @@ import org.lflang.FileConfig;
 import org.lflang.Target;
 import org.lflang.TargetConfig;
 import org.lflang.TargetProperty.BuildType;
+import org.lflang.TargetProperty.LogLevel;
 import org.lflang.generator.LFGeneratorContext.Mode;
 import org.lflang.TargetProperty;
 import org.lflang.TargetProperty.SchedulerOption;

--- a/test/C/src/Deadline.lf
+++ b/test/C/src/Deadline.lf
@@ -14,11 +14,7 @@ reactor Source(period: time(3 sec)) {
         if (2 * (self->count / 2) != self->count) {
             // The count variable is odd.
             // Take time to cause a deadline violation.
-            // Do not use nanosleep() here because if this is threaded,
-            // it gets awakened right away.
-            interval_t sleep_time = MSEC(1500);
-            instant_t start_time = lf_time_physical();
-            while (lf_time_physical() < start_time + sleep_time) {};
+            lf_nanosleep(MSEC(1500));
         }
         printf("Source sends: %d.\n", self->count);
         lf_set(y, self->count);

--- a/test/C/src/DeadlineHandledAbove.lf
+++ b/test/C/src/DeadlineHandledAbove.lf
@@ -20,11 +20,7 @@ main reactor DeadlineHandledAbove {
     d = new Deadline(threshold = 10 msec)
 
     reaction(startup) -> d.x {=
-        // Do not use nanosleep() here because if this is threaded,
-        // it gets awakened right away.
-        interval_t sleep_time = MSEC(200);
-        instant_t start_time = lf_time_physical();
-        while (lf_time_physical() < start_time + sleep_time) {};
+        lf_nanosleep(MSEC(200));
         lf_set(d.x, 42);
     =}
 

--- a/test/C/src/TimeLimit.lf
+++ b/test/C/src/TimeLimit.lf
@@ -39,15 +39,15 @@ reactor Destination {
 
     reaction(shutdown) {=
         printf("**** shutdown reaction invoked.\n");
-        if (self->s != 10000002) {
-            fprintf(stderr, "ERROR: Expected 10000002 but got %d.\n", self->s);
+        if (self->s != 12) {
+            fprintf(stderr, "ERROR: Expected 12 but got %d.\n", self->s);
             exit(1);
         }
         lf_print("Approx. time per reaction: %lldns", lf_time_physical_elapsed()/(self->s+1));
     =}
 }
 
-main reactor TimeLimit(period: time(1 usec)) {
+main reactor TimeLimit(period: time(1 sec)) {
     timer stop(10 sec)
     c = new Clock(period = period)
     d = new Destination()

--- a/test/C/src/TimeLimit.lf
+++ b/test/C/src/TimeLimit.lf
@@ -1,14 +1,7 @@
 // Test that the stop function can be used to internally impose a a time limit.
-// This is also used to test performance (number of reactions per second). See
-// [Benchmarks wiki
-// page](https://github.com/icyphy/lingua-franca/wiki/Benchmarks). Correct
-// output for this 1, 2, 3, 4. Failure for this test is failing to halt or
-// getting the wrong data. On a 2.6 GHz Intel Core i7 running MacOS Mojave,
-// using a single core, this executes 10,000,000 cycles (two reactions in each
-// cycle) in 0.6 seconds, for over 32 million reactions per second. This
-// translates to 31 nanoseconds per reaction invocation.
+// Correct output for this 1, 2, 3, 4. Failure for this test is failing to halt
+// or getting the wrong data.
 target C {
-    flags: "-O2",
     fast: true
 }
 
@@ -43,7 +36,6 @@ reactor Destination {
             fprintf(stderr, "ERROR: Expected 12 but got %d.\n", self->s);
             exit(1);
         }
-        lf_print("Approx. time per reaction: %lldns", lf_time_physical_elapsed()/(self->s+1));
     =}
 }
 

--- a/test/C/src/concurrent/DeadlineHandledAboveThreaded.lf
+++ b/test/C/src/concurrent/DeadlineHandledAboveThreaded.lf
@@ -20,11 +20,7 @@ main reactor {
     d = new Deadline(threshold = 10 msec)
 
     reaction(startup) -> d.x {=
-        // Do not use nanosleep() here because if this is threaded,
-        // it gets awakened right away.
-        interval_t sleep_time = MSEC(200);
-        instant_t start_time = lf_time_physical();
-        while (lf_time_physical() < start_time + sleep_time) {};
+        lf_nanosleep(MSEC(200));
         lf_set(d.x, 42);
     =}
 

--- a/test/C/src/concurrent/DeadlineThreaded.lf
+++ b/test/C/src/concurrent/DeadlineThreaded.lf
@@ -14,11 +14,7 @@ reactor Source(period: time(1500 msec)) {
         if (2 * (self->count / 2) != self->count) {
             // The count variable is odd.
             // Take time to cause a deadline violation.
-            // Do not use nanosleep() here because if this is threaded,
-            // it gets awakened right away.
-            interval_t sleep_time = MSEC(400);
-            instant_t start_time = lf_time_physical();
-            while (lf_time_physical() < start_time + sleep_time) {};
+            lf_nanosleep(MSEC(400));
         }
         printf("Source sends: %d.\n", self->count);
         lf_set(y, self->count);

--- a/test/C/src/concurrent/TimeLimitThreaded.lf
+++ b/test/C/src/concurrent/TimeLimitThreaded.lf
@@ -34,15 +34,15 @@ reactor Destination {
 
     reaction(shutdown) {=
         printf("**** shutdown reaction invoked.\n");
-        if (self->s != 10000002) {
-            fprintf(stderr, "ERROR: Expected 10000002 but got %d.\n", self->s);
+        if (self->s != 12) {
+            fprintf(stderr, "ERROR: Expected 12 but got %d.\n", self->s);
             exit(1);
         }
         lf_print("Approx. time per reaction: %lldns", lf_time_physical_elapsed()/(self->s+1));
     =}
 }
 
-main reactor(period: time(1 usec)) {
+main reactor(period: time(1 sec)) {
     timer stop(10 sec)
     c = new Clock(period = period)
     d = new Destination()

--- a/test/C/src/concurrent/TimeLimitThreaded.lf
+++ b/test/C/src/concurrent/TimeLimitThreaded.lf
@@ -1,9 +1,6 @@
 // Test that the stop function can be used to internally impose a a time limit.
 // Correct output for this 1, 2, 3, 4. Failure for this test is failing to halt.
-// See [Benchmarks wiki
-// page](https://github.com/icyphy/lingua-franca/wiki/Benchmarks).
 target C {
-    flags: "-O2",
     fast: true
 }
 
@@ -38,7 +35,6 @@ reactor Destination {
             fprintf(stderr, "ERROR: Expected 12 but got %d.\n", self->s);
             exit(1);
         }
-        lf_print("Approx. time per reaction: %lldns", lf_time_physical_elapsed()/(self->s+1));
     =}
 }
 

--- a/test/C/src/federated/DistributedCountDecentralizedLate.lf
+++ b/test/C/src/federated/DistributedCountDecentralizedLate.lf
@@ -19,7 +19,7 @@ reactor Print {
     state success_stp_violation: int(0)
     // Force a timer to be invoke periodically to ensure logical time will
     // advance in the absence of incoming messages.
-    timer t(0, 10 usec)
+    timer t(0, 10 msec)
     state c: int(0)
 
     reaction(in) {=

--- a/test/C/src/federated/DistributedCountDecentralizedLateHierarchy.lf
+++ b/test/C/src/federated/DistributedCountDecentralizedLateHierarchy.lf
@@ -20,7 +20,7 @@ reactor ImportantActuator {
     state success: int(0)
     state success_stp_violation: int(0)
     // Force a timer to be invoke periodically
-    timer t(0, 10 usec)
+    timer t(0, 10 msec)
     // to ensure logical time will advance in the absence of incoming messages.
     state c: int(0)
 

--- a/test/Cpp/src/TimeLimit.lf
+++ b/test/Cpp/src/TimeLimit.lf
@@ -30,15 +30,21 @@ reactor Destination {
         }
         s++;
     =}
+    
+    reaction(shutdown) {= 
+        std::cout << "**** shutdown reaction invoked.\n";
+        if (s != 12) {
+            std::cerr << "ERROR: Expected 12 but got " << s << '\n';
+            exit(1);
+        }
+    =}
 }
 
-main reactor TimeLimit(period: time(100 usec)) {
+main reactor TimeLimit(period: time(1 sec)) {
     timer stop(10 sec)
     c = new Clock(period = period)
     d = new Destination()
     c.y -> d.x
 
     reaction(stop) {= environment()->sync_shutdown(); =}
-
-    reaction(shutdown) {= std::cout << "**** shutdown reaction invoked.\n"; =}
 }

--- a/test/Cpp/src/TimeLimit.lf
+++ b/test/Cpp/src/TimeLimit.lf
@@ -1,6 +1,5 @@
 // Test that the stop function can be used to internally to impose a a time
-// limit. This is also used to test performance (number of reactions per
-// second). Correct output for this 1, 2, 3, 4. Failure for this test is failing
+// limit. Correct output for this 1, 2, 3, 4. Failure for this test is failing
 // to halt or getting the wrong data.
 target Cpp {
     fast: true

--- a/test/Cpp/src/TimeLimit.lf
+++ b/test/Cpp/src/TimeLimit.lf
@@ -30,8 +30,8 @@ reactor Destination {
         }
         s++;
     =}
-    
-    reaction(shutdown) {= 
+
+    reaction(shutdown) {=
         std::cout << "**** shutdown reaction invoked.\n";
         if (s != 12) {
             std::cerr << "ERROR: Expected 12 but got " << s << '\n';

--- a/test/Cpp/src/concurrent/TimeLimitThreaded.lf
+++ b/test/Cpp/src/concurrent/TimeLimitThreaded.lf
@@ -30,15 +30,21 @@ reactor Destination {
         }
         s++;
     =}
+    
+    reaction(shutdown) {= 
+        std::cout << "**** shutdown reaction invoked.\n";
+        if (s != 12) {
+            std::cerr << "ERROR: Expected 12 but got " << s << '\n';
+            exit(1);
+        }
+    =}
 }
 
-main reactor(period: time(100 usec)) {
+main reactor(period: time(1 sec)) {
     timer stop(10 sec)
     c = new Clock(period = period)
     d = new Destination()
     c.y -> d.x
 
     reaction(stop) {= environment()->sync_shutdown(); =}
-
-    reaction(shutdown) {= std::cout << "**** shutdown reaction invoked.\n"; =}
 }

--- a/test/Cpp/src/concurrent/TimeLimitThreaded.lf
+++ b/test/Cpp/src/concurrent/TimeLimitThreaded.lf
@@ -30,8 +30,8 @@ reactor Destination {
         }
         s++;
     =}
-    
-    reaction(shutdown) {= 
+
+    reaction(shutdown) {=
         std::cout << "**** shutdown reaction invoked.\n";
         if (s != 12) {
             std::cerr << "ERROR: Expected 12 but got " << s << '\n';

--- a/test/Python/src/Deadline.lf
+++ b/test/Python/src/Deadline.lf
@@ -5,6 +5,8 @@ target Python {
     timeout: 6 sec
 }
 
+preamble {= import time =}
+
 reactor Source(period(3 sec)) {
     output y
     timer t(0, period)
@@ -14,10 +16,7 @@ reactor Source(period(3 sec)) {
         if self.count % 2 != 0:
             # The count variable is odd.
             # Take time to cause a deadline violation.
-            sleep_time = MSEC(1500)
-            start_time = lf.time.physical()
-            while (lf.time.physical() < start_time + sleep_time):
-                pass
+            time.sleep(1.5)
 
         print("Source sends: ", self.count)
         y.set(self.count)

--- a/test/Python/src/DeadlineHandledAbove.lf
+++ b/test/Python/src/DeadlineHandledAbove.lf
@@ -2,6 +2,8 @@
 # container reacts to that output.
 target Python
 
+preamble {= import time =}
+
 reactor Deadline(threshold(100 msec)) {
     input x
     output deadline_violation
@@ -20,10 +22,7 @@ main reactor DeadlineHandledAbove {
     d = new Deadline(threshold = 10 msec)
 
     reaction(startup) -> d.x {=
-        sleep_time = MSEC(200)
-        start_time = lf.time.physical()
-        while lf.time.physical() < (start_time + sleep_time):
-            pass
+        time.sleep(0.2)
         d.x.set(42)
     =}
 

--- a/test/Python/src/TimeLimit.lf
+++ b/test/Python/src/TimeLimit.lf
@@ -35,14 +35,14 @@ reactor Destination {
 
     reaction(shutdown) {=
         print("**** shutdown reaction invoked.")
-        if self.s != 10000002:
+        if self.s != 12:
             sys.stderr.write("ERROR: Expected 10000002 but got {:d}.\n".format(self.s))
             exit(1)
         print(f"Approx. time per reaction: {lf.time.physical_elapsed()/(self.s+1):.1f}ns")
     =}
 }
 
-main reactor TimeLimit(period(1 usec)) {
+main reactor TimeLimit(period(1 sec)) {
     timer stop(10 sec)
     c = new Clock(period = period)
     d = new Destination()

--- a/test/Python/src/TimeLimit.lf
+++ b/test/Python/src/TimeLimit.lf
@@ -1,10 +1,6 @@
 # Test that the stop function can be used to internally impose a a time limit.
-# This is also used to test performance (number of reactions per second).
 # Correct output for this 1, 2, 3, 4. Failure for this test is failing to halt
-# or getting the wrong data. On a 2.6 GHz Intel Core i7 running MacOS Mojave,
-# using a single core, this executes 10,000,000 cycles (two reactions in each
-# cycle) in 0.74 seconds, for over 27 million reactions per second. This
-# translates to 37 nanoseconds per reaction invocation.
+# or getting the wrong data.
 target Python {
     fast: true
 }
@@ -36,9 +32,8 @@ reactor Destination {
     reaction(shutdown) {=
         print("**** shutdown reaction invoked.")
         if self.s != 12:
-            sys.stderr.write("ERROR: Expected 10000002 but got {:d}.\n".format(self.s))
+            sys.stderr.write("ERROR: Expected 12 but got {:d}.\n".format(self.s))
             exit(1)
-        print(f"Approx. time per reaction: {lf.time.physical_elapsed()/(self.s+1):.1f}ns")
     =}
 }
 


### PR DESCRIPTION
Essentially, this change ensures that all LF tests are run with the `logging: Debug` target property set. Since for some tests this produces huge amounts of output, this PR also fixes those tests. Furthermore, it fixes some corner cases in the error reporting mechanism, so that we should now see more informative error messages when something unexepected is happening (One example is an out of memory error in the threads that we use for processing stdout and stderr).