### PR TITLE
Fix bug in Windows diagnostic reporting.

### DIFF
--- a/org.lflang/src/org/lflang/generator/CodeMap.java
+++ b/org.lflang/src/org/lflang/generator/CodeMap.java
@@ -145,7 +145,7 @@ public class CodeMap {
             Position lfStart = Position.fromOneBased(
                 oneBasedLfLineAndColumn.getLine(), oneBasedLfLineAndColumn.getColumn()
             );
-            final Path lfPath = Path.of(bestEffortGetEResource(astNode).getURI().path());
+            final Path lfPath = Path.of(bestEffortGetEResource(astNode).getURI().toFileString());
             if (verbatim) lfStart = lfStart.plus(node.getText().substring(0, indexOf(node.getText(), representation)));
             return new Correspondence(
                 lfPath,


### PR DESCRIPTION
The drive (e.g., C:) was being dropped in the mapping from target code to the LF source.