### PR TITLE
Do not run setup-python step in CI.

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -29,8 +29,6 @@ jobs:
           fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
-      - name: Setup Python
-        uses: actions/setup-python@v2
       - name: Install dependencies OS X
         run: |
           brew install coreutils
@@ -59,13 +57,6 @@ jobs:
       - name: Run Python tests
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.PythonTest.*
-        if: ${{ runner.os != 'macOS' }}
-      - name: Run Python tests macOS
-        run: |
-          python3 -m venv env
-          source env/bin/activate
-          ./gradlew test --tests org.lflang.tests.runtime.PythonTest.*
-        if: ${{ runner.os == 'macOS' }}
       - name: Report to CodeCov
         uses: codecov/codecov-action@v2.1.0
         with:


### PR DESCRIPTION
I have come to suspect that the macOS Python struggles are due to CMake getting confused about which version of Python to use. The `actions/setup-python` step seems unnecessary, and it creates an extra Python version on the system, so it might be the culprit.