### PR TITLE
Fixed NPE in Epoch

### DIFF
--- a/org.lflang/src/org/lflang/generator/CodeMap.java
+++ b/org.lflang/src/org/lflang/generator/CodeMap.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.nodemodel.INode;
@@ -145,7 +146,8 @@ public class CodeMap {
             Position lfStart = Position.fromOneBased(
                 oneBasedLfLineAndColumn.getLine(), oneBasedLfLineAndColumn.getColumn()
             );
-            final Path lfPath = Path.of(bestEffortGetEResource(astNode).getURI().toFileString());
+            final URI uri = bestEffortGetEResource(astNode).getURI();
+            final Path lfPath = Path.of(uri.isFile() ? uri.toFileString() : uri.path());
             if (verbatim) lfStart = lfStart.plus(node.getText().substring(0, indexOf(node.getText(), representation)));
             return new Correspondence(
                 lfPath,


### PR DESCRIPTION
Recently, I fixed a bug in Windows error reporting in which the drive prefix (e.g., C:) was being excluded from the path (offending PR: #1391). I suspect that the reason why this caused NPEs in Epoch is that Epoch uses special URIs that are not file system paths, even in local development. Relevant documentation:
> toFileString()             If this URI may refer directly to a locally accessible file, as  determined by isFile, decodes and formats    the URI as a pathname to that file; returns null otherwise.

Closes #1424.