### PR TITLE
Empty bracket pairs properly tokenized

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaParsingTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaParsingTest.java
@@ -94,6 +94,18 @@ class LinguaFrancaParsingTest {
         parseWithoutError(testCase);
     }
 
+    @Test
+    public void testTokenizeEmptyWidth() throws Exception {
+        String testCase = """
+                target C;
+                main reactor {
+                    state foo: int[];
+                    state foo: int[   ]; //spaces are allowed
+                }
+            """;
+        parseWithoutError(testCase);
+    }
+
     private Model parseWithoutError(String s) throws Exception {
         Model model = parser.parse(s);
         Assertions.assertNotNull(model);

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -332,11 +332,11 @@ Type:
 ;
 
 ArraySpec:
-    ofVariableLength?='[]' | '[' length=INT ']';
-    
+    '[' ( ofVariableLength?=']' | length=INT ']' );
+
 WidthSpec:
-    ofVariableLength?='[]' | '[' (terms+=WidthTerm) ('+' terms+=WidthTerm)* ']';
-    
+    '[' ( ofVariableLength?=']' | (terms+=WidthTerm) ('+' terms+=WidthTerm)* ']' );
+
 WidthTerm:
     width=INT
     | parameter=[Parameter]
@@ -502,7 +502,7 @@ Token:
     // Braces
     '(' | ')' | '{' | '}' |
     // Brackets
-    '[' | ']' | '<' | '>' | '[]' |
+    '[' | ']' | '<' | '>' |
     // Punctuation
     ':' | ';' | ',' | '.' | '::' |
     // Slashes


### PR DESCRIPTION
This allows spaces in empty bracket pairs in types, like `int[  ]`. Although it doesn't look good, I think it's surprising to make the language space-sensitive in this case only. It also allows commenting things out, eg `int[/*4*/]`.

The change removes one token from the grammar: `[]` is now tokenized as `[` then `]`, like in C and all other target languages that use these tokens.

This change is extracted from #544