### PR TITLE
Package `org.lflang.cli` excluded from Eclipse build configuration

### DIFF
--- a/org.lflang/.classpath
+++ b/org.lflang/.classpath
@@ -6,7 +6,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry excluding="org/lflang/cli/" kind="src" path="src"/>
 	<classpathentry kind="src" path="src-gen"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
As suggested by @cmnrd, this excludes the org.lflang.cli package from Eclipse build configuration to prevent build errors, since contained classes depend on Kotlin.

Fixes #1436.