### PR TITLE
Draft: Fix index deadline

### DIFF
--- a/org.lflang/src/org/lflang/generator/ReactionInstance.java
+++ b/org.lflang/src/org/lflang/generator/ReactionInstance.java
@@ -186,6 +186,7 @@ public class ReactionInstance extends NamedInstance<Reaction> {
         if (this.definition.getDeadline() != null) {
             this.declaredDeadline = new DeadlineInstance(
                 this.definition.getDeadline(), this);
+            this.deadline = this.declaredDeadline.maxDelay;
         }
     }
 


### PR DESCRIPTION
This PR fixes two things:

1. The ReactionInstance.deadline field was not initialized which made the index field of the `reaction_t` always use FOREVER as the deadline. I.e. the EDF scheduling of reactions didn't work on single-threaded
2. Add getInheretedDeadline() function to ReacitonInstance where it searches for the minimum deadline of its downstream reactions. This is then used to calculate the priority of a reaction.

This solves the problem of AfterDelay reactors blocking deadline reactions because they have low priority.

I am using this fix on an outdated branch it seems to work.

TODO:
- [ ] Fix getInheritedDeadline() it should search recursively through the downstream.