### PR TITLE
Cleanup AttributeUtils

### DIFF
--- a/org.lflang.diagram/src/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/org.lflang.diagram/src/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -38,9 +38,6 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
-import org.eclipse.elk.alg.layered.options.EdgeStraighteningStrategy;
-import org.eclipse.elk.alg.layered.options.FixedAlignment;
-import org.eclipse.elk.alg.layered.options.GreedySwitchType;
 import org.eclipse.elk.alg.layered.options.LayerConstraint;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.alg.layered.options.NodePlacementStrategy;
@@ -1390,7 +1387,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
     
     private Iterable<KNode> createUserComments(EObject element, KNode targetNode) {
         if (getBooleanValue(SHOW_USER_LABELS)) {
-            String commentText = AttributeUtils.label(element);
+            String commentText = AttributeUtils.getAttributeValue(element, "label");
             
             if (!StringExtensions.isNullOrEmpty(commentText)) {
                 KNode comment = _kNodeExtensions.createNode();

--- a/org.lflang.diagram/src/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/org.lflang.diagram/src/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -1387,7 +1387,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
     
     private Iterable<KNode> createUserComments(EObject element, KNode targetNode) {
         if (getBooleanValue(SHOW_USER_LABELS)) {
-            String commentText = AttributeUtils.getAttributeValue(element, "label");
+            String commentText = AttributeUtils.getLabel(element);
             
             if (!StringExtensions.isNullOrEmpty(commentText)) {
                 KNode comment = _kNodeExtensions.createNode();

--- a/org.lflang.diagram/src/org/lflang/diagram/synthesis/util/ReactorIcons.java
+++ b/org.lflang.diagram/src/org/lflang/diagram/synthesis/util/ReactorIcons.java
@@ -24,13 +24,10 @@
 ***************/
 package org.lflang.diagram.synthesis.util;
 
-import java.io.InputStream;
-import java.util.HashMap;
-
 //import org.eclipse.swt.graphics.ImageData;
 //import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.lflang.ASTUtils;
+
 import org.lflang.AttributeUtils;
 import org.lflang.diagram.synthesis.AbstractSynthesisExtensions;
 import org.lflang.lf.ReactorDecl;
@@ -38,10 +35,7 @@ import org.lflang.util.FileUtil;
 
 import com.google.inject.Inject;
 
-import de.cau.cs.kieler.klighd.krendering.Colors;
 import de.cau.cs.kieler.klighd.krendering.KContainerRendering;
-import de.cau.cs.kieler.klighd.krendering.KGridPlacementData;
-import de.cau.cs.kieler.klighd.krendering.KRectangle;
 import de.cau.cs.kieler.klighd.krendering.ViewSynthesisShared;
 import de.cau.cs.kieler.klighd.krendering.extensions.KContainerRenderingExtensions;
 import de.cau.cs.kieler.klighd.krendering.extensions.KRenderingExtensions;
@@ -74,10 +68,7 @@ public class ReactorIcons extends AbstractSynthesisExtensions {
         error = null;
         
         // Get annotation
-        String iconPath = AttributeUtils.findAttributeByName(reactor, "icon");
-        if (iconPath == null) { // Fallback to old syntax (in comment)
-            iconPath = ASTUtils.findAnnotationInComments(reactor, "@icon");
-        }
+        var iconPath = AttributeUtils.getIconPath(reactor);
         if (iconPath != null && !iconPath.isEmpty()) {
             var iconLocation = FileUtil.locateFile(iconPath, reactor.eResource());
             if (iconLocation == null) {

--- a/org.lflang/src/org/lflang/ASTUtils.java
+++ b/org.lflang/src/org/lflang/ASTUtils.java
@@ -50,7 +50,6 @@ import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.INode;
 import org.eclipse.xtext.nodemodel.impl.HiddenLeafNode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
-import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.util.Pair;
 import org.eclipse.xtext.util.Tuples;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
@@ -1795,28 +1794,6 @@ public class ASTUtils {
             }
             return false;
         };
-    }
-    
-    /**
-     * Retrieve a specific annotation in a comment associated with the given model element in the AST.
-     * 
-     * This will look for a comment. If one is found, it searches for the given annotation `key`.
-     * and extracts any string that follows the annotation marker.  
-     * 
-     * @param object the AST model element to search a comment for
-     * @param key the specific annotation key to be extracted
-     * @return `null` if no JavaDoc style comment was found or if it does not contain the given key.
-     *     The string immediately following the annotation marker otherwise.
-     */
-    public static String findAnnotationInComments(EObject object, String key) {
-        if (!(object.eResource() instanceof XtextResource)) return null;
-        ICompositeNode node = NodeModelUtils.findActualNodeFor(object);
-        return getPrecedingComments(node, n -> true).flatMap(String::lines)
-            .filter(line -> line.contains(key))
-            .map(String::trim)
-            .map(it -> it.substring(it.indexOf(key) + key.length()))
-            .map(it -> it.endsWith("*/") ? it.substring(0, it.length() - "*/".length()) : it)
-            .findFirst().orElse(null);
     }
 
     /**

--- a/org.lflang/src/org/lflang/ASTUtils.java
+++ b/org.lflang/src/org/lflang/ASTUtils.java
@@ -1026,6 +1026,30 @@ public class ASTUtils {
         return true;
     }
 
+    /**
+     * Report whether the given string literal is a boolean value or not.
+     * @param literal AST node to inspect.
+     * @return True if the given value is a boolean, false otherwise.
+     */
+    public static boolean isBoolean(String literal) {
+        return literal.equalsIgnoreCase("true") || literal.equalsIgnoreCase("false");
+    }
+
+    /**
+     * Report whether the given string literal is a float value or not.
+     * @param literal AST node to inspect.
+     * @return True if the given value is a float, false otherwise.
+     */
+    public static boolean isFloat(String literal) {
+        try {
+            //noinspection ResultOfMethodCallIgnored
+            Float.parseFloat(literal);
+        } catch (NumberFormatException e) {
+            return false;
+        }
+        return true;
+    }
+
 	/**
      * Report whether the given code is an integer number or not.
      * @param code AST node to inspect.

--- a/org.lflang/src/org/lflang/AstExtensions.kt
+++ b/org.lflang/src/org/lflang/AstExtensions.kt
@@ -258,7 +258,7 @@ val Resource.model: Model get() = this.allContents.asSequence().filterIsInstance
  * If the reaction is annotated with a label, then the label is returned. Otherwise, a reaction name
  * is generated based on its priority.
  */
-val Reaction.label get(): String = AttributeUtils.label(this) ?: "reaction_$priority"
+val Reaction.label get(): String = AttributeUtils.getLabel(this) ?: "reaction_$priority"
 
 /** Get the priority of a receiving reaction */
 val Reaction.priority

--- a/org.lflang/src/org/lflang/AttributeUtils.java
+++ b/org.lflang/src/org/lflang/AttributeUtils.java
@@ -32,6 +32,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.lflang.lf.Action;
 import org.lflang.lf.Attribute;
 import org.lflang.lf.Input;
+import org.lflang.lf.Instantiation;
 import org.lflang.lf.Output;
 import org.lflang.lf.Parameter;
 import org.lflang.lf.Reaction;
@@ -71,6 +72,8 @@ public class AttributeUtils {
             return ((Input) node).getAttributes();
         } else if (node instanceof Output) {
             return ((Output) node).getAttributes();
+        } else if (node instanceof Instantiation) {
+            return ((Instantiation) node).getAttributes();
         }
         throw new IllegalArgumentException("Not annotatable: " + node);
     }

--- a/org.lflang/src/org/lflang/AttributeUtils.java
+++ b/org.lflang/src/org/lflang/AttributeUtils.java
@@ -42,6 +42,7 @@ import org.lflang.lf.Reaction;
 import org.lflang.lf.Reactor;
 import org.lflang.lf.StateVar;
 import org.lflang.lf.Timer;
+import org.lflang.util.StringUtil;
 
 /**
  * A helper class for processing attributes in the AST.
@@ -105,7 +106,7 @@ public class AttributeUtils {
         if (attr == null || attr.getAttrParms().isEmpty()) {
             return null;
         }
-        return attr.getAttrParms().get(0).getValue();
+        return StringUtil.removeQuotes(attr.getAttrParms().get(0).getValue());
     }
 
     /**

--- a/org.lflang/src/org/lflang/AttributeUtils.java
+++ b/org.lflang/src/org/lflang/AttributeUtils.java
@@ -79,20 +79,19 @@ public class AttributeUtils {
     }
 
     /**
-     * Return the value of the attribute with the given name
+     * Return the attribute with the given name
      * if present, otherwise return null.
      *
      * @throws IllegalArgumentException If the node cannot have attributes
      */
-    public static String findAttributeByName(EObject node, String name) {
+    public static Attribute findAttributeByName(EObject node, String name) {
         List<Attribute> attrs = getAttributes(node);
         return attrs.stream()
                     .filter(it -> it.getAttrName().equalsIgnoreCase(name)) // case-insensitive search (more user-friendly)
-                    .map(it -> it.getAttrParms().get(0).getValue().getStr())
                     .findFirst()
                     .orElse(null);
     }
-    
+
     /**
      * Return the value of the {@code @label} attribute if
      * present, otherwise return null.
@@ -100,7 +99,11 @@ public class AttributeUtils {
      * @throws IllegalArgumentException If the node cannot have attributes
      */
     public static String findLabelAttribute(EObject node) {
-        return findAttributeByName(node, "label");
+        final var attr = findAttributeByName(node, "label");
+        if (attr != null) {
+            return attr.getAttrParms().get(0).getValue();
+        }
+        return null;
     }
 
     /**
@@ -109,12 +112,7 @@ public class AttributeUtils {
      * @param node An AST node.
      */
     public static boolean isSparse(EObject node) {
-        if (node instanceof Input) {
-            for (var attribute : getAttributes(node)) {
-                if (attribute.getAttrName().equalsIgnoreCase("sparse")) return true;
-            }
-        }
-        return false;
+        return findAttributeByName(node, "sparse") != null;
     }
 
     /**

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -246,14 +246,7 @@ Attribute:
 ;
 
 AttrParm:
-    (name=ID '=')? value=AttrParmValue;
-
-AttrParmValue:
-    str=STRING
-    | int=SignedInt
-    | bool=Boolean
-    | float=SignedFloat
-;
+    (name=ID '=')? value=Literal;
 
 /////////// For target parameters
 

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -219,6 +219,7 @@ Preamble:
     (visibility=Visibility)? 'preamble' code=Code;
 
 Instantiation:
+    (attributes+=Attribute)*
     name=ID '=' 'new' (widthSpec=WidthSpec)?
     reactorClass=[ReactorDecl] ('<' typeParms+=TypeParm (',' typeParms+=TypeParm)* '>')? '(' 
     (parameters+=Assignment (',' parameters+=Assignment)*)? 

--- a/org.lflang/src/org/lflang/ast/IsEqual.java
+++ b/org.lflang/src/org/lflang/ast/IsEqual.java
@@ -15,7 +15,6 @@ import org.lflang.lf.Array;
 import org.lflang.lf.ArraySpec;
 import org.lflang.lf.Assignment;
 import org.lflang.lf.AttrParm;
-import org.lflang.lf.AttrParmValue;
 import org.lflang.lf.Attribute;
 import org.lflang.lf.BuiltinTriggerRef;
 import org.lflang.lf.Code;
@@ -260,17 +259,7 @@ public class IsEqual extends LfSwitch<Boolean> {
     public Boolean caseAttrParm(AttrParm object) {
         return new ComparisonMachine<>(object, AttrParm.class)
             .equalAsObjects(AttrParm::getName)
-            .equivalent(AttrParm::getValue)
-            .conclusion;
-    }
-
-    @Override
-    public Boolean caseAttrParmValue(AttrParmValue object) {
-        return new ComparisonMachine<>(object, AttrParmValue.class)
-            .equalAsObjects(AttrParmValue::getBool)
-            .equalAsObjects(AttrParmValue::getFloat)
-            .equalAsObjects(AttrParmValue::getInt)
-            .equalAsObjects(AttrParmValue::getStr)
+            .equalAsObjects(AttrParm::getValue)
             .conclusion;
     }
 

--- a/org.lflang/src/org/lflang/ast/ToLf.java
+++ b/org.lflang/src/org/lflang/ast/ToLf.java
@@ -30,7 +30,6 @@ import org.lflang.lf.Array;
 import org.lflang.lf.ArraySpec;
 import org.lflang.lf.Assignment;
 import org.lflang.lf.AttrParm;
-import org.lflang.lf.AttrParmValue;
 import org.lflang.lf.Attribute;
 import org.lflang.lf.BuiltinTriggerRef;
 import org.lflang.lf.Code;
@@ -288,24 +287,7 @@ public class ToLf extends LfSwitch<MalleableString> {
         // (name=ID '=')? value=AttrParmValue;
         var builder = new Builder();
         if (object.getName() != null) builder.append(object.getName()).append(" = ");
-        return builder.append(doSwitch(object.getValue())).get();
-    }
-
-    @Override
-    public MalleableString caseAttrParmValue(AttrParmValue object) {
-        // str=STRING
-        //  | int=SignedInt
-        //  | bool=Boolean
-        //  | float=SignedFloat
-        if (object.getStr() != null) {
-            return MalleableString.anyOf(StringUtil.addDoubleQuotes(object.getStr()));
-        }
-        if (object.getInt() != null) return MalleableString.anyOf(object.getInt());
-        if (object.getBool() != null) return MalleableString.anyOf(object.getBool());
-        if (object.getFloat() != null) return MalleableString.anyOf(object.getFloat());
-        throw new IllegalArgumentException(
-            "The attributes of an AttrParmValue should not all be null."
-        );
+        return builder.append(object.getValue()).get();
     }
 
     @Override

--- a/org.lflang/src/org/lflang/generator/rust/RustModel.kt
+++ b/org.lflang/src/org/lflang/generator/rust/RustModel.kt
@@ -547,7 +547,7 @@ object RustModelBuilder {
                     body = n.code.toText(),
                     isStartup = n.triggers.any { it is BuiltinTriggerRef && it.type == BuiltinTrigger.STARTUP },
                     isShutdown = n.triggers.any { it is BuiltinTriggerRef && it.type == BuiltinTrigger.SHUTDOWN },
-                    debugLabel = AttributeUtils.label(n),
+                    debugLabel = AttributeUtils.getLabel(n),
                     loc = n.locationInfo().let {
                         // remove code block
                         it.copy(lfText = it.lfText.replace(TARGET_BLOCK_R, "{= ... =}"))

--- a/org.lflang/src/org/lflang/util/StringUtil.java
+++ b/org.lflang/src/org/lflang/util/StringUtil.java
@@ -73,11 +73,21 @@ public final class StringUtil {
         if (str.length() < 2) {
             return str;
         }
-        if (str.startsWith("\"") && str.endsWith("\"")
-            || str.startsWith("'") && str.endsWith("'")) {
+        if (hasQuotes(str)) {
             return str.substring(1, str.length() - 1);
         }
         return str;
+    }
+
+    /**
+     * Return true if the given string is surrounded by single or double
+     * quotes,
+     */
+    public static boolean hasQuotes(String str) {
+        if (str == null) {
+            return false;
+        }
+        return str.startsWith("\"") && str.endsWith("\"") || str.startsWith("'") && str.endsWith("'");
     }
 
     /**

--- a/org.lflang/src/org/lflang/validation/AttributeSpec.java
+++ b/org.lflang/src/org/lflang/validation/AttributeSpec.java
@@ -36,6 +36,7 @@ import org.lflang.ASTUtils;
 import org.lflang.lf.AttrParm;
 import org.lflang.lf.Attribute;
 import org.lflang.lf.LfPackage.Literals;
+import org.lflang.util.StringUtil;
 
 /**
  * Specification of the structure of an attribute annotation.
@@ -155,28 +156,35 @@ class AttributeSpec {
         // Check if a parameter has the right type.
         // Currently only String, Int, Boolean, and Float are supported.
         public void check(LFValidator validator, AttrParm parm) {
-            switch(type) {
-                case STRING:
-                    // nothing to check, all literals are reported as strings
-                    break;
-                case INT:
-                    if (!ASTUtils.isInteger(parm.getValue())) {
-                        validator.error("Incorrect type: \"" + parm.getName() + "\"" + " should have type Int.",
-                                        Literals.ATTRIBUTE__ATTR_NAME);
-                    }
-                    break;
-                case BOOLEAN:
-                    if (!ASTUtils.isBoolean(parm.getValue())) {
-                        validator.error("Incorrect type: \"" + parm.getName() + "\"" + " should have type Boolean.",
-                                        Literals.ATTRIBUTE__ATTR_NAME);
-                    }
-                    break;
-                case FLOAT:
-                    if (!ASTUtils.isFloat(parm.getValue())) {
-                        validator.error("Incorrect type: \"" + parm.getName() + "\"" + " should have type Float.",
-                                        Literals.ATTRIBUTE__ATTR_NAME);
-                    }
-                    break;
+            switch (type) {
+            case STRING:
+                if (!StringUtil.hasQuotes(parm.getValue())) {
+                    validator.error("Incorrect type: \"" + parm.getName() + "\""
+                            + " should have type String.",
+                        Literals.ATTRIBUTE__ATTR_NAME);
+                }
+                break;
+            case INT:
+                if (!ASTUtils.isInteger(parm.getValue())) {
+                    validator.error(
+                        "Incorrect type: \"" + parm.getName() + "\"" + " should have type Int.",
+                        Literals.ATTRIBUTE__ATTR_NAME);
+                }
+                break;
+            case BOOLEAN:
+                if (!ASTUtils.isBoolean(parm.getValue())) {
+                    validator.error(
+                        "Incorrect type: \"" + parm.getName() + "\"" + " should have type Boolean.",
+                        Literals.ATTRIBUTE__ATTR_NAME);
+                }
+                break;
+            case FLOAT:
+                if (!ASTUtils.isFloat(parm.getValue())) {
+                    validator.error(
+                        "Incorrect type: \"" + parm.getName() + "\"" + " should have type Float.",
+                        Literals.ATTRIBUTE__ATTR_NAME);
+                }
+                break;
             }
         }
     }

--- a/org.lflang/src/org/lflang/validation/AttributeSpec.java
+++ b/org.lflang/src/org/lflang/validation/AttributeSpec.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.lflang.ASTUtils;
 import org.lflang.lf.AttrParm;
 import org.lflang.lf.Attribute;
 import org.lflang.lf.LfPackage.Literals;
@@ -156,25 +157,22 @@ class AttributeSpec {
         public void check(LFValidator validator, AttrParm parm) {
             switch(type) {
                 case STRING:
-                    if (parm.getValue().getStr() == null) {
-                        validator.error("Incorrect type: \"" + parm.getName() + "\"" + " should have type String.",
-                                        Literals.ATTRIBUTE__ATTR_NAME);
-                    }
+                    // nothing to check, all literals are reported as strings
                     break;
                 case INT:
-                    if (parm.getValue().getInt() == null) {
+                    if (!ASTUtils.isInteger(parm.getValue())) {
                         validator.error("Incorrect type: \"" + parm.getName() + "\"" + " should have type Int.",
                                         Literals.ATTRIBUTE__ATTR_NAME);
                     }
                     break;
                 case BOOLEAN:
-                    if (parm.getValue().getBool() == null) {
+                    if (!ASTUtils.isBoolean(parm.getValue())) {
                         validator.error("Incorrect type: \"" + parm.getName() + "\"" + " should have type Boolean.",
                                         Literals.ATTRIBUTE__ATTR_NAME);
                     }
                     break;
                 case FLOAT:
-                    if (parm.getValue().getFloat() == null) {
+                    if (!ASTUtils.isFloat(parm.getValue())) {
                         validator.error("Incorrect type: \"" + parm.getName() + "\"" + " should have type Float.",
                                         Literals.ATTRIBUTE__ATTR_NAME);
                     }

--- a/org.lflang/src/org/lflang/validation/LFValidator.java
+++ b/org.lflang/src/org/lflang/validation/LFValidator.java
@@ -1274,7 +1274,7 @@ public class LFValidator extends BaseLFValidator {
                     .findFirst()
                     .orElse(null);
         if (iconAttr != null) {
-            var path = iconAttr.getAttrParms().get(0).getValue().getStr();
+            var path = iconAttr.getAttrParms().get(0).getValue();
             
             // Check file extension
             var validExtensions = Set.of("bmp", "png", "gif", "ico", "jpeg");


### PR DESCRIPTION
While trying to use the Attribute syntax I found that the `AttributeUtils` could use some cleanups. In particular, this change removes the grammar rule `AttrParmValue` and instead simply uses `Literal`. Since some of the type checking done required new functions for checking literals, I also decided to move all functions regarding expressions to a new class `ExpressionUtils`. And while doing so I also realized that AstUtils, ExpressionUtils, and AttributeUtils woulb probably better located in the `org.lflang.ast` subpackage. I realize that this last change might be causing conflicts with other large outstanding PRs. Feel free to revert the last commit if it seems too intrusive.