### PR TITLE
Fixing the loss of the hostname that is specified in a federated lf f…

### DIFF
--- a/org.lflang/src/org/lflang/federated/generator/FedGenerator.java
+++ b/org.lflang/src/org/lflang/federated/generator/FedGenerator.java
@@ -331,6 +331,13 @@ public class FedGenerator {
         mainDef.setName(fedReactor.getName());
         mainDef.setReactorClass(fedReactor);
 
+        // Make sure that if no federation RTI properties were given in the
+        // cmdline, then those specified in the lf file are not lost
+        if (federationRTIProperties.get("host").equals("localhost") &&
+                    !fedReactor.getHost().getAddr().equals("localhost")) {
+            federationRTIProperties.put("host", fedReactor.getHost().getAddr());
+        }
+
         // Since federates are always within the main (federated) reactor,
         // create a list containing just that one containing instantiation.
         // This will be used to look up parameter values.


### PR DESCRIPTION
This workaround, based on `fed-gen` branch, fixes the loss of the RTI hostname in a containerized federated execution.
`lfc` validator generates a warning though when the domain name is an invalid fully qualified one.
This should not be the case for containerized federated execution, because Docker embeds a DNS server.

Should the validator be fixed accordingly?