### PR TITLE
Avoid reading the same input stream twice

### DIFF
--- a/org.lflang/src/org/lflang/util/FileUtil.java
+++ b/org.lflang/src/org/lflang/util/FileUtil.java
@@ -249,12 +249,17 @@ public class FileUtil {
      */
     private static void copyInputStream(InputStream source, Path destination, boolean skipIfUnchanged) throws IOException {
         Files.createDirectories(destination.getParent());
+
+        // Read the stream once and keep a copy of all bytes. This is required as a stream cannot be read twice.
+        final var bytes = source.readAllBytes();
+        // abort if the destination file does not change
         if(skipIfUnchanged && Files.isRegularFile(destination)) {
-            if (Arrays.equals(source.readAllBytes(), Files.readAllBytes(destination))) {
+            if (Arrays.equals(bytes, Files.readAllBytes(destination))) {
                 return;
             }
         }
-        Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
+
+        Files.write(destination, bytes);
     }
 
     /**


### PR DESCRIPTION
This fixes a nasty bug in FileUtil, where an input stream was read twice while copying. The first read was to check if the destination file needs to be modified, and the second read was to actually perform the copy. Since input streams can only be read once, the second read would then copy an empty byte array and hence write an empty file.

This likely fixes https://github.com/lf-lang/lingua-franca/issues/1460