### PR TITLE
Make Cmake output less verbose by suppressing install messages

### DIFF
--- a/org.lflang/src/org/lflang/generator/c/CCmakeGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CCmakeGenerator.java
@@ -164,6 +164,10 @@ public class CCmakeGenerator {
         cMakeCode.pr("endif()\n");
         cMakeCode.newLine();
 
+        cMakeCode.pr("# do not print install messages\n");
+        cMakeCode.pr("set(CMAKE_INSTALL_MESSAGE NEVER)\n");
+        cMakeCode.newLine();
+
         if (CppMode) {
             // Suppress warnings about const char*.
             cMakeCode.pr("set(CMAKE_CXX_FLAGS \"${CMAKE_CXX_FLAGS} -Wno-write-strings\")");

--- a/org.lflang/src/org/lflang/generator/cpp/CppStandaloneCmakeGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppStandaloneCmakeGenerator.kt
@@ -72,6 +72,9 @@ class CppStandaloneCmakeGenerator(private val targetConfig: TargetConfig, privat
             |# don't automatically build and install all targets
             |set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
             |
+            |# do not print install messages
+            |set(CMAKE_INSTALL_MESSAGE NEVER)
+            |
             |include($S{CMAKE_ROOT}/Modules/ExternalProject.cmake)
             |include(GNUInstallDirs)
             |


### PR DESCRIPTION
With this change, the output produced by cmake when installing the project is reduced to this:
```
Install the project...
-- Install configuration: "Release"
```
Before this change, it would also print a verbose list of all installed files (which in the C++ target can be quite long). This list does not provide much useful information though and we might as well suppress it.