### PR TITLE
Preserve time units when formatting LF code

### DIFF
--- a/org.lflang/src/org/lflang/ast/ToLf.java
+++ b/org.lflang/src/org/lflang/ast/ToLf.java
@@ -274,7 +274,12 @@ public class ToLf extends LfSwitch<MalleableString> {
   @Override
   public MalleableString caseTime(Time t) {
     // (interval=INT unit=TimeUnit)
-    return MalleableString.anyOf(ASTUtils.toTimeValue(t).toString());
+    final var interval = Integer.toString(t.getInterval());
+    if (t.getUnit() == null) {
+      return MalleableString.anyOf(interval);
+    }
+
+    return MalleableString.anyOf(interval + " " + t.getUnit());
   }
 
   @Override


### PR DESCRIPTION
Currently, the formatter changes time units to the "canonical" name as defined in `TimeUnit`. For instance, it would change `2 s` to `2 sec`. I think we should leave the decision of which time units to choose to the user. Personally (maybe because I am European), I prefer SI units. Which unit works the best might also depend on the target language. For instance, the C++ chrono library allows writing `2s`, but not `2sec`. So it would be idiomatic to use the SI units in LF-C++ programs.