### PR TITLE
Enable Epoch build for M1 Mac

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,11 @@
                             <ws>cocoa</ws>
                             <arch>x86_64</arch>
                         </environment>
+                        <environment>
+                            <os>macosx</os>
+                            <ws>cocoa</ws>
+                            <arch>aarch64</arch>
+                        </environment>
                     </environments>
                 </configuration>
             </plugin>


### PR DESCRIPTION
I propose adding ARM 64 Mac OS X as an Epoch build environment to support M1 Mac.