### PR TITLE
Update the test framework in fed-gen to the changes made in master

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,11 @@ subprojects {
             jvmTarget = kotlinJvmTarget
         }
     }
+    compileTestKotlin {
+        kotlinOptions {
+            jvmTarget = kotlinJvmTarget
+        }
+    }
 
     dependencies {
         implementation platform("org.eclipse.xtext:xtext-dev-bom:${xtextVersion}")
@@ -73,6 +78,10 @@ subprojects {
     test {
         filter {
             setFailOnNoMatchingTests(false)
+        }
+        testLogging {
+            // print exception message when a test fails.
+            exceptionFormat "full"
         }
     }
 }

--- a/org.lflang.tests/src/org/lflang/tests/Configurators.java
+++ b/org.lflang.tests/src/org/lflang/tests/Configurators.java
@@ -30,7 +30,7 @@ import org.lflang.tests.TestRegistry.TestCategory;
  * Configuration procedures for {@link TestBase} methods.
  *
  * @author Clément Fournier
- * @author Marten Lohstroh <marten@berkeley.edu>
+ * @author Marten Lohstroh
  */
 public class Configurators {
 
@@ -57,8 +57,8 @@ public class Configurators {
      * @return True if successful, false otherwise.
      */
     public static boolean disableThreading(LFTest test) {
-        test.context.getArgs().setProperty("threading", "false");
-        test.context.getArgs().setProperty("workers", "1");
+        test.getContext().getArgs().setProperty("threading", "false");
+        test.getContext().getArgs().setProperty("workers", "1");
         return true;
     }
 

--- a/org.lflang.tests/src/org/lflang/tests/LFTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/LFTest.java
@@ -18,25 +18,22 @@ import org.lflang.generator.LFGeneratorContext;
 /**
  * Information about an indexed Lingua Franca test program.
  * 
- * @author Marten Lohstroh <marten@berkeley.edu>
+ * @author Marten Lohstroh
  *
  */
 public class LFTest implements Comparable<LFTest> {
 
     /** The path to the test. */
-    public final Path srcFile;
+    private final Path srcPath;
 
     /** The name of the test. */
-    public final String name;
+    private final String name;
 
     /** The result of the test. */
-    public Result result = Result.UNKNOWN;
-    
-    /** The exit code of the test. **/
-    public String exitValue = "?";
+    private Result result = Result.UNKNOWN;
 
     /** Context provided to the code generators */
-    public LFGeneratorContext context;
+    private LFGeneratorContext context;
 
     /** Path of the test program relative to the package root. */
     private final Path relativePath;
@@ -45,13 +42,13 @@ public class LFTest implements Comparable<LFTest> {
     private final ByteArrayOutputStream compilationLog = new ByteArrayOutputStream();
 
     /** Specialized object for capturing output streams while executing the test. */
-    public final ExecutionLogger execLog = new ExecutionLogger();
+    private final ExecutionLogger execLog = new ExecutionLogger();
 
     /** String builder for collecting issues encountered during test execution. */
-    public final StringBuilder issues = new StringBuilder();
+    private final StringBuilder issues = new StringBuilder();
 
     /** The target of the test program. */
-    public final Target target;
+    private final Target target;
 
     /**
      * Create a new test.
@@ -61,15 +58,26 @@ public class LFTest implements Comparable<LFTest> {
      */
     public LFTest(Target target, Path srcFile) {
         this.target = target;
-        this.srcFile = srcFile;
+        this.srcPath = srcFile;
         this.name = FileConfig.findPackageRoot(srcFile, s -> {}).relativize(srcFile).toString();
         this.relativePath = Paths.get(name);
+    }
+
+    /** Copy constructor */
+    public LFTest(LFTest test) {
+        this(test.target, test.srcPath);
     }
 
     /** Stream object for capturing standard and error output. */
     public OutputStream getOutputStream() {
         return compilationLog;
     }
+
+    public FileConfig getFileConfig() { return context.getFileConfig(); }
+
+    public LFGeneratorContext getContext() { return context; }
+
+    public Path getSrcPath() { return srcPath; }
 
     /**
      * Comparison implementation to allow for tests to be sorted (e.g., when added to a
@@ -116,6 +124,10 @@ public class LFTest implements Comparable<LFTest> {
         return result != Result.TEST_PASS;
     }
 
+    public boolean hasPassed() {
+        return result == Result.TEST_PASS;
+    }
+
     /**
      * Compile a string that contains all collected errors and return it.
      * @return A string that contains all collected errors.
@@ -125,17 +137,33 @@ public class LFTest implements Comparable<LFTest> {
             System.out.println("+---------------------------------------------------------------------------+");
             System.out.println("Failed: " + this);
             System.out.println("-----------------------------------------------------------------------------");
-            System.out.println("Reason: " + this.result.message + " Exit code: " + this.exitValue);
-            if (this.exitValue.equals("139")) {
-                // The java ProcessBuiler and Process interface does not allow us to reliably retrieve stderr and stdout
-                // from a process that segfaults. We can only print a message indicating that the putput is incomplete.
-                System.out.println("This exit code typically indicates a segfault. In this case, the execution output is likely missing or incomplete.");
-            }
+            System.out.println("Reason: " + this.result.message);
             printIfNotEmpty("Reported issues", this.issues.toString());
             printIfNotEmpty("Compilation output", this.compilationLog.toString());
             printIfNotEmpty("Execution output", this.execLog.toString());
             System.out.println("+---------------------------------------------------------------------------+");
         }
+    }
+
+    public void handleTestError(TestError e) {
+        result = e.getResult();
+        if (e.getMessage() != null) {
+            issues.append(e.getMessage());
+        }
+        if (e.getException() != null) {
+            issues.append(System.lineSeparator());
+            issues.append(TestBase.stackTraceToString(e));
+        }
+    }
+
+    public void markPassed() {
+        result = Result.TEST_PASS;
+        // clear the execution log to free memory
+        execLog.clear();
+    }
+
+    void configure(LFGeneratorContext context) {
+        this.context = context;
     }
 
     /**
@@ -186,7 +214,7 @@ public class LFTest implements Comparable<LFTest> {
      * recording output streams up until the moment that a test is interrupted
      * upon timing out.
      *
-     * @author Marten Lohstroh <marten@berkeley.edu>
+     * @author Marten Lohstroh
      *
      */
     public static final class ExecutionLogger {
@@ -222,7 +250,7 @@ public class LFTest implements Comparable<LFTest> {
          * @param inputStream The stream to read from.
          */
         private Thread recordStream(StringBuffer builder, InputStream inputStream) {
-            Thread t = new Thread(() -> {
+            return new Thread(() -> {
                 try (Reader reader = new InputStreamReader(inputStream)) {
                     int len;
                     char[] buf = new char[1024];
@@ -232,9 +260,8 @@ public class LFTest implements Comparable<LFTest> {
                 } catch (IOException e) {
                     throw new RuntimeIOException(e);
                 }
+
             });
-            t.start();
-            return t;
         }
 
         @Override
@@ -245,5 +272,22 @@ public class LFTest implements Comparable<LFTest> {
         public void clear() {
             buffer = null;
         }
+    }
+
+
+    /**
+     * Return a thread responsible for recording the standard output stream of the given process.
+     * A separate thread is used so that the activity can be preempted.
+     */
+    public Thread recordStdOut(Process process) {
+        return execLog.recordStdOut(process);
+    }
+
+    /**
+     * Return a thread responsible for recording the error stream of the given process.
+     * A separate thread is used so that the activity can be preempted.
+     */
+    public Thread recordStdErr(Process process) {
+        return execLog.recordStdErr(process);
     }
 }

--- a/org.lflang.tests/src/org/lflang/tests/LfParsingUtil.java
+++ b/org.lflang.tests/src/org/lflang/tests/LfParsingUtil.java
@@ -1,0 +1,100 @@
+package org.lflang.tests;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.resource.XtextResourceSet;
+import org.junit.jupiter.api.Assertions;
+
+import org.lflang.LFStandaloneSetup;
+import org.lflang.lf.Model;
+
+import com.google.inject.Injector;
+
+/**
+ * @author Clément Fournier
+ */
+public class LfParsingUtil {
+
+    /**
+     * Parse the given file, asserts that there are no parsing errors.
+     */
+    public static Model parseValidModel(
+        String fileName,
+        String reformattedTestCase
+    ) {
+        Model resultingModel = parse(reformattedTestCase);
+        checkValid(fileName, resultingModel);
+        return resultingModel;
+    }
+
+    private static void checkValid(String fileName, Model resultingModel) {
+        Assertions.assertNotNull(resultingModel);
+        if (!resultingModel.eResource().getErrors().isEmpty()) {
+            resultingModel.eResource().getErrors().forEach(System.err::println);
+            Assertions.assertTrue(resultingModel.eResource().getErrors().isEmpty(),
+                "Parsing errors in " + fileName);
+        }
+    }
+
+    public static Model parseSourceAsIfInDirectory(
+        Path directory,
+        String sourceText
+    ) {
+        int num = 0;
+        while (Files.exists(directory.resolve("file" + num + ".lf"))) {
+            num++;
+        }
+        Path file = directory.resolve("file" + num + ".lf");
+        try {
+            Files.writeString(file, sourceText);
+            Model resultingModel = parse(file);
+            checkValid("file in " + directory, resultingModel);
+            return resultingModel;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            try {
+                Files.deleteIfExists(file);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+    public static Model parse(String fileContents) {
+        Path file = null;
+        try {
+            file = Files.createTempFile("lftests", ".lf");
+            Files.writeString(file, fileContents);
+            return parse(file);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (file != null) {
+                try {
+                    Files.deleteIfExists(file);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    public static Model parse(Path file) {
+        // Source: https://wiki.eclipse.org/Xtext/FAQ#How_do_I_load_my_model_in_a_standalone_Java_application_.3F
+        Injector injector = new LFStandaloneSetup().createInjectorAndDoEMFRegistration();
+        XtextResourceSet resourceSet = injector.getInstance(XtextResourceSet.class);
+        resourceSet.addLoadOption(XtextResource.OPTION_RESOLVE_ALL, Boolean.TRUE);
+        Resource resource = resourceSet.getResource(
+            URI.createFileURI(file.toFile().getAbsolutePath()),
+            true
+        );
+        return (Model) resource.getContents().get(0);
+    }
+}

--- a/org.lflang.tests/src/org/lflang/tests/RuntimeTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/RuntimeTest.java
@@ -12,7 +12,7 @@ import org.lflang.tests.TestRegistry.TestCategory;
 /**
  * A collection of JUnit tests to perform on a given set of targets.
  * 
- * @author Marten Lohstroh <marten@berkeley.edu>
+ * @author Marten Lohstroh
  *
  */
 public abstract class RuntimeTest extends TestBase {

--- a/org.lflang.tests/src/org/lflang/tests/RuntimeTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/RuntimeTest.java
@@ -97,7 +97,7 @@ public abstract class RuntimeTest extends TestBase {
         runTestsFor(List.of(Target.C),
                     Message.DESC_AS_FEDERATED,
                     categories::contains,
-                    it -> ASTUtils.makeFederated(it.context.getFileConfig().resource),
+                    it -> ASTUtils.makeFederated(it.getFileConfig().resource),
                     true);
     }
 

--- a/org.lflang.tests/src/org/lflang/tests/TestBase.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestBase.java
@@ -1,7 +1,7 @@
 package org.lflang.tests;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -25,6 +25,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource.Diagnostic;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.xtext.diagnostics.Severity;
 import org.eclipse.xtext.generator.JavaIoFileSystemAccess;
@@ -60,7 +61,7 @@ import com.google.inject.Provider;
 /**
  * Base class for test classes that define JUnit tests.
  *
- * @author Marten Lohstroh <marten@berkeley.edu>
+ * @author Marten Lohstroh
  */
 @ExtendWith(InjectionExtension.class)
 @InjectWith(LFInjectorProvider.class)
@@ -100,14 +101,14 @@ public abstract class TestBase {
 
     /**
      * An enumeration of test levels.
-     * @author Marten Lohstroh <marten@berkeley.edu>
+     * @author Marten Lohstroh
      *
      */
     public enum TestLevel {VALIDATION, CODE_GEN, BUILD, EXECUTION}
 
     /**
      * Static function for converting a path to its associated test level.
-     * @author Anirudh Rengarajan <arengarajan@berkeley.edu>
+     * @author Anirudh Rengarajan
      */
     public static TestLevel pathToLevel(Path path) {
         while(path.getParent() != null) {
@@ -125,7 +126,7 @@ public abstract class TestBase {
     /**
      * A collection messages often used throughout the test package.
      *
-     * @author Marten Lohstroh <marten@berkeley.edu>
+     * @author Marten Lohstroh
      *
      */
     public static class Message {
@@ -360,7 +361,7 @@ public abstract class TestBase {
             test.reportErrors();
         }
         for (LFTest lfTest : tests) {
-            assertSame(Result.TEST_PASS, lfTest.result);
+            assertTrue(lfTest.hasPassed());
         }
     }
 
@@ -375,7 +376,7 @@ public abstract class TestBase {
      * @param level The level of testing in which the generator context will be
      * used.
      */
-    private void configure(LFTest test, Configurator configurator, TestLevel level) {
+    private void configure(LFTest test, Configurator configurator, TestLevel level) throws IOException, TestError {
         var props = new Properties();
         props.setProperty("hierarchical-bin", "true");
         var sysProps = System.getProperties();
@@ -391,22 +392,22 @@ public abstract class TestBase {
         }
 
         var r = resourceSetProvider.get().getResource(
-            URI.createFileURI(test.srcFile.toFile().getAbsolutePath()),
+            URI.createFileURI(test.getSrcPath().toFile().getAbsolutePath()),
             true);
 
         if (r.getErrors().size() > 0) {
-            test.result = Result.PARSE_FAIL;
-            throw new AssertionError("Test did not parse correctly.");
+            String message = r.getErrors().stream().map(Diagnostic::toString).collect(Collectors.joining(System.lineSeparator()));
+            throw new TestError(message, Result.PARSE_FAIL);
         }
 
-        fileAccess.setOutputPath(FileConfig.findPackageRoot(test.srcFile, s -> {}).resolve(FileConfig.DEFAULT_SRC_GEN_DIR).toString());
+        fileAccess.setOutputPath(FileConfig.findPackageRoot(test.getSrcPath(), s -> {}).resolve(FileConfig.DEFAULT_SRC_GEN_DIR).toString());
 
         var context = new MainContext(
             LFGeneratorContext.Mode.STANDALONE, CancelIndicator.NullImpl, (m, p) -> {}, props, r, fileAccess,
             fileConfig -> new DefaultErrorReporter()
         );
 
-        test.context = context;
+        test.configure(context);
 
         // Set the no-compile flag the test is not supposed to reach the build stage.
         if (level.compareTo(TestLevel.BUILD) < 0) {
@@ -417,32 +418,29 @@ public abstract class TestBase {
 
         // Update the test by applying the configuration. E.g., to carry out an AST transformation.
         if (configurator != null && !configurator.configure(test)) {
-            test.result = Result.CONFIG_FAIL;
-            throw new AssertionError("Test configuration unsuccessful.");
+            throw new TestError("Test configuration unsuccessful.", Result.CONFIG_FAIL);
         }
     }
 
     /**
-     * Validate the given test. Throw an AssertionError if validation failed.
+     * Validate the given test. Throw an TestError if validation failed.
      */
-    private void validate(LFTest test) {
+    private void validate(LFTest test) throws TestError {
         // Validate the resource and store issues in the test object.
         try {
-            var context = test.context;
+            var context = test.getContext();
             var issues = validator.validate(context.getFileConfig().resource,
                                             CheckMode.ALL, context.getCancelIndicator());
             if (issues != null && !issues.isEmpty()) {
-                String issuesToString = issues.stream().map(Objects::toString).collect(Collectors.joining(System.lineSeparator()));
-                test.issues.append(issuesToString);
                 if (issues.stream().anyMatch(it -> it.getSeverity() == Severity.ERROR)) {
-                    test.result = Result.VALIDATE_FAIL;
+                    String message = issues.stream().map(Objects::toString).collect(Collectors.joining(System.lineSeparator()));
+                    throw new TestError(message, Result.VALIDATE_FAIL);
                 }
             }
-        } catch (Exception e) {
-            test.result = Result.VALIDATE_FAIL;
-        }
-        if (test.result == Result.VALIDATE_FAIL) {
-            throw new AssertionError("Validation unsuccessful.");
+        } catch (TestError e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new TestError("Exception during validation.", Result.VALIDATE_FAIL, e);
         }
     }
 
@@ -457,15 +455,17 @@ public abstract class TestBase {
 
     /**
      * Invoke the code generator for the given test.
+     *
      * @param test The test to generate code for.
      */
-    private void generateCode(LFTest test) {
-        if (test.context.getFileConfig().resource != null) {
-            generator.doGenerate(test.context.getFileConfig().resource, fileAccess, test.context);
-            if (generator.errorsOccurred()) {
-                test.result = Result.CODE_GEN_FAIL;
-                throw new AssertionError("Code generation unsuccessful.");
-            }
+    private void generateCode(LFTest test) throws TestError {
+        try {
+            generator.doGenerate(test.getFileConfig().resource, fileAccess, test.getContext());
+        } catch (Throwable e) {
+            throw new TestError("Code generation unsuccessful.", Result.CODE_GEN_FAIL, e);
+        }
+        if (generator.errorsOccurred()) {
+            throw new TestError("Code generation unsuccessful.", Result.CODE_GEN_FAIL);
         }
     }
 
@@ -475,16 +475,17 @@ public abstract class TestBase {
      * did not execute, took too long to execute, or executed but exited with
      * an error code.
      */
-    private void execute(LFTest test) {
+    private void execute(LFTest test) throws TestError {
         final List<ProcessBuilder> pbList = getExecCommand(test);
+
         if (pbList.isEmpty()) {
             return;
         }
         try {
             for (ProcessBuilder pb : pbList) {
                 var p = pb.start();
-                var stdout = test.execLog.recordStdOut(p);
-                var stderr = test.execLog.recordStdErr(p);
+                var stdout = test.recordStdOut(p);
+                var stderr = test.recordStdErr(p);
 
                 var stdoutException = new AtomicReference<Throwable>(null);
                 var stderrException = new AtomicReference<Throwable>(null);
@@ -492,49 +493,53 @@ public abstract class TestBase {
                 stdout.setUncaughtExceptionHandler((thread, throwable) -> stdoutException.set(throwable));
                 stderr.setUncaughtExceptionHandler((thread, throwable) -> stderrException.set(throwable));
 
+                stderr.start();
+                stdout.start();
+
                 if (!p.waitFor(MAX_EXECUTION_TIME_SECONDS, TimeUnit.SECONDS)) {
                     stdout.interrupt();
                     stderr.interrupt();
                     p.destroyForcibly();
-                    test.result = Result.TEST_TIMEOUT;
-                    return;
+                    throw new TestError(Result.TEST_TIMEOUT);
                 } else {
                     if (stdoutException.get() != null || stderrException.get() != null) {
-                        test.result = Result.TEST_EXCEPTION;
-                        test.execLog.buffer.setLength(0);
+                        StringBuffer sb = new StringBuffer();
                         if (stdoutException.get() != null) {
-                            test.execLog.buffer.append("Error during stdout handling:\n");
-                            appendStackTrace(stdoutException.get(), test.execLog.buffer);
+                            sb.append("Error during stdout handling:" + System.lineSeparator());
+                            sb.append(stackTraceToString(stdoutException.get()));
                         }
                         if (stderrException.get() != null) {
-                            test.execLog.buffer.append("Error during stderr handling:\n");
-                            appendStackTrace(stderrException.get(), test.execLog.buffer);
+                            sb.append("Error during stderr handling:" + System.lineSeparator());
+                            sb.append(stackTraceToString(stderrException.get()));
                         }
-                        return;
+                        throw new TestError(sb.toString(), Result.TEST_EXCEPTION);
                     }
                     if (p.exitValue() != 0) {
-                        test.result = Result.TEST_FAIL;
-                        test.exitValue = Integer.toString(p.exitValue());
-                        return;
+                        String message = "Exit code: " + p.exitValue();
+                        if (p.exitValue() == 139) {
+                            // The java ProcessBuiler and Process interface does not allow us to reliably retrieve stderr and stdout
+                            // from a process that segfaults. We can only print a message indicating that the putput is incomplete.
+                            message += System.lineSeparator() +
+                            "This exit code typically indicates a segfault. In this case, the execution output is likely missing or incomplete.";
+                        }
+                        throw new TestError(message, Result.TEST_FAIL);
                     }
                 }
             }
-        } catch (Exception e) {
-            test.result = Result.TEST_EXCEPTION;
-            // Add the stack trace to the test output
-            appendStackTrace(e, test.execLog.buffer);
-            return;
+        } catch (TestError e) {
+            throw  e;
+        } catch (Throwable e) {
+            throw new TestError("Exception during test execution.", Result.TEST_EXCEPTION, e);
         }
-        test.result = Result.TEST_PASS;
-        // clear the log if the test succeeded to free memory
-        test.execLog.clear();
     }
 
-    private static void appendStackTrace(Throwable t, StringBuffer buffer) {
+    static public String stackTraceToString(Throwable t) {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
         t.printStackTrace(pw);
-        buffer.append(sw);
+        pw.flush();
+        pw.close();
+        return sw.toString();
     }
 
     /**
@@ -590,7 +595,7 @@ public abstract class TestBase {
             System.out.println(Message.MISSING_DOCKER);
             return List.of(new ProcessBuilder("exit", "1"));
         }
-        var srcGenPath = test.context.getFileConfig().getSrcGenPath();
+        var srcGenPath = test.getFileConfig().getSrcGenPath();
         var dockerComposeFile = FileUtil.globFilesEndsWith(srcGenPath, "docker-compose.yml").get(0);
         var dockerComposeCommand = DockerGeneratorBase.getDockerComposeCommand();
         return List.of(new ProcessBuilder(dockerComposeCommand, "-f", dockerComposeFile.toString(), "rm", "-f"),
@@ -607,7 +612,7 @@ public abstract class TestBase {
             System.out.println(Message.MISSING_DOCKER);
             return List.of(new ProcessBuilder("exit", "1"));
         }
-        var srcGenPath = test.context.getFileConfig().getSrcGenPath();
+        var srcGenPath = test.getFileConfig().getSrcGenPath();
         List<Path> dockerFiles = FileUtil.globFilesEndsWith(srcGenPath, ".Dockerfile");
         try {
             File testScript = File.createTempFile("dockertest", null);
@@ -631,9 +636,9 @@ public abstract class TestBase {
      * that should be used to execute the test program.
      * @param test The test to get the execution command for.
      */
-    private List<ProcessBuilder> getExecCommand(LFTest test) {
-        var srcBasePath = test.context.getFileConfig().srcPkgPath.resolve("src");
-        var relativePathName = srcBasePath.relativize(test.context.getFileConfig().srcPath).toString();
+    private List<ProcessBuilder> getExecCommand(LFTest test) throws TestError {
+        var srcBasePath = test.getFileConfig().srcPkgPath.resolve("src");
+        var relativePathName = srcBasePath.relativize(test.getFileConfig().srcPath).toString();
 
         // special case to test docker file generation
         if (relativePathName.equalsIgnoreCase(TestCategory.DOCKER.getPath())) {
@@ -641,10 +646,9 @@ public abstract class TestBase {
         } else if (relativePathName.equalsIgnoreCase(TestCategory.DOCKER_FEDERATED.getPath())) {
             return getFederatedDockerExecCommand(test);
         } else {
-            LFCommand command = test.context.getFileConfig().getCommand();
+            LFCommand command = test.getFileConfig().getCommand();
             if (command == null) {
-                test.result = Result.NO_EXEC_FAIL;
-                test.issues.append("File: ").append(test.context.getFileConfig().getExecutable()).append(System.lineSeparator());
+                throw new TestError("File: " + test.getFileConfig().getExecutable(), Result.NO_EXEC_FAIL);
             }
             return command == null ? List.of() : List.of(
                 new ProcessBuilder(command.command()).directory(command.directory())
@@ -678,16 +682,13 @@ public abstract class TestBase {
                 }
                 if (level == TestLevel.EXECUTION) {
                     execute(test);
-                } else if (test.result == Result.UNKNOWN) {
-                    test.result = Result.TEST_PASS;
                 }
-
-            } catch (AssertionError e) {
-                // Do not report assertion errors. They are pretty printed
-                // during reporting.
-            } catch (Exception e) {
-                test.issues.append(e.getMessage());
-                e.printStackTrace();
+                test.markPassed();
+            } catch (TestError e) {
+                test.handleTestError(e);
+            } catch (Throwable e) {
+                test.handleTestError(new TestError(
+                    "Unknown exception during test execution", Result.TEST_EXCEPTION, e));
             } finally {
                 restoreOutputs();
             }

--- a/org.lflang.tests/src/org/lflang/tests/TestBase.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestBase.java
@@ -379,6 +379,8 @@ public abstract class TestBase {
     private void configure(LFTest test, Configurator configurator, TestLevel level) throws IOException, TestError {
         var props = new Properties();
         props.setProperty("hierarchical-bin", "true");
+        addExtraLfcArgs(props);
+
         var sysProps = System.getProperties();
         // Set the external-runtime-path property if it was specified.
         if (sysProps.containsKey("runtime")) {
@@ -413,8 +415,6 @@ public abstract class TestBase {
         if (level.compareTo(TestLevel.BUILD) < 0) {
             context.getArgs().setProperty("no-compile", "");
         }
-
-        addExtraLfcArgs(context.getArgs());
 
         // Update the test by applying the configuration. E.g., to carry out an AST transformation.
         if (configurator != null && !configurator.configure(test)) {

--- a/org.lflang.tests/src/org/lflang/tests/TestError.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestError.java
@@ -1,0 +1,28 @@
+package org.lflang.tests;
+
+import org.lflang.tests.LFTest.Result;
+
+/// Indicates an error during test execution
+public class TestError extends Exception {
+
+    private Throwable exception;
+    private Result result;
+
+    public TestError(String errorMessage, Result result, Throwable exception) {
+        super(errorMessage);
+        this.exception = exception;
+        this.result = result;
+    }
+
+    public TestError(String errorMessage, Result result) {
+        this(errorMessage, result, null);
+    }
+
+    public TestError(Result result) {
+        this(null, result, null);
+    }
+
+    public Result getResult() {return result;}
+
+    public Throwable getException() {return exception;}
+}

--- a/org.lflang.tests/src/org/lflang/tests/TestRegistry.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestRegistry.java
@@ -37,7 +37,7 @@ import org.lflang.tests.TestBase.TestLevel;
 /**
  * A registry to retrieve tests from, organized by target and category.
  * 
- * @author Marten Lohstroh <marten@berkeley.edu>
+ * @author Marten Lohstroh
  */
 public class TestRegistry {
     
@@ -125,7 +125,7 @@ public class TestRegistry {
      * - C/Threaded.lf (maps to COMMON)
      * - C/threaded/federated/foo.lf (maps to FEDERATED)
      * 
-     * @author Marten Lohstroh <marten@berkeley.edu>
+     * @author Marten Lohstroh
      */
     public enum TestCategory {
         /** Tests about concurrent execution. */
@@ -254,7 +254,7 @@ public class TestRegistry {
         if (copy) {
             Set<LFTest> copies = new TreeSet<>();
             for (LFTest test : registered.getTests(target, category)) {
-                copies.add(new LFTest(test.target, test.srcFile));
+                copies.add(new LFTest(test));
             }
             return copies;
         } else {
@@ -278,7 +278,7 @@ public class TestRegistry {
         s.append(TestBase.THIN_LINE);
         
         for (LFTest test : ignored) {
-            s.append("No main reactor in: ").append(test.name).append("\n");
+            s.append("No main reactor in: ").append(test).append("\n");
         }
         
         Set<LFTest> own = getRegisteredTests(target, category, false);
@@ -314,7 +314,7 @@ public class TestRegistry {
      * is TestCategory.COMMON, meaning that test files in the top-level test
      * directory for a given target will be mapped to that category.
      * 
-     * @author Marten Lohstroh <marten@berkeley.edu>
+     * @author Marten Lohstroh
      */
     public static class TestDirVisitor extends SimpleFileVisitor<Path> {
 
@@ -386,32 +386,22 @@ public class TestRegistry {
         @Override
         public FileVisitResult visitFile(Path path, BasicFileAttributes attr) {
             if (attr.isRegularFile() && path.toString().endsWith(".lf")) {
-                // Parse the file. If this is unsuccessful, add the test and
-                // report that it didn't compile.
-                Resource r = rs.getResource(
-                        URI.createFileURI(path.toFile().getAbsolutePath()),
-                        true);
+                // Try to parse the file.
+                Resource r = rs.getResource(URI.createFileURI(path.toFile().getAbsolutePath()),true);
                 // FIXME: issue warning if target doesn't match!
                 LFTest test = new LFTest(target, path);
-                EList<Diagnostic> errors = r.getErrors();
-                if (!errors.isEmpty()) {
-                    for (Diagnostic d : errors) {
-                        test.issues.append(d.toString());
-                    }
-                    test.result = Result.PARSE_FAIL;
-                } else {
-                    Iterator<Reactor> reactors =
-                        IteratorExtensions.filter(r.getAllContents(), Reactor.class);
 
-                    if (!IteratorExtensions.exists(reactors,
-                            it -> it.isMain() || it.isFederated())) {
-                        // If the test compiles but doesn't have a main reactor,
-                        // _do not add the file_. We assume it is a library
-                        // file.
-                        ignored.getTests(this.target, this.stack.peek()).add(test);
-                        return CONTINUE;
-                    }
+                Iterator<Reactor> reactors = IteratorExtensions.filter(r.getAllContents(), Reactor.class);
+
+                if (r.getErrors().isEmpty() && !IteratorExtensions.exists(reactors,
+                    it -> it.isMain() || it.isFederated())) {
+                    // If the test compiles but doesn't have a main reactor,
+                    // _do not add the file_. We assume it is a library
+                    // file.
+                    ignored.getTests(this.target, this.stack.peek()).add(test);
+                    return CONTINUE;
                 }
+
                 registered.getTests(this.target, this.stack.peek()).add(test);
             }
             return CONTINUE;

--- a/org.lflang.tests/src/org/lflang/tests/compiler/LetInferenceTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LetInferenceTests.java
@@ -25,43 +25,15 @@ package org.lflang.tests.compiler;/* Parsing unit tests. */
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ***************/
 
-import java.nio.file.Path;
 import javax.inject.Inject;
 
-import org.eclipse.emf.common.util.TreeIterator;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.xtext.generator.IFileSystemAccess;
-import org.eclipse.xtext.generator.IFileSystemAccess2;
-import org.eclipse.xtext.generator.IGeneratorContext;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.extensions.InjectionExtension;
 import org.eclipse.xtext.testing.util.ParseHelper;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import org.lflang.ASTUtils;
-import org.lflang.DefaultErrorReporter;
-import org.lflang.FileConfig;
-import org.lflang.TimeUnit;
-import org.lflang.TimeValue;
-import org.lflang.generator.LFGeneratorContext;
-import org.lflang.generator.ReactionInstance;
-import org.lflang.generator.ReactorInstance;
-import org.lflang.generator.c.CFileConfig;
-import org.lflang.ast.AfterDelayTransformation;
-import org.lflang.generator.ReactionInstance;
-import org.lflang.generator.ReactorInstance;
-import org.lflang.generator.c.CDelayBodyGenerator;
-import org.lflang.generator.c.CGenerator;
-import org.lflang.generator.c.CTypes;
-import org.lflang.lf.Instantiation;
-import org.lflang.lf.LfFactory;
 import org.lflang.lf.Model;
-import org.lflang.lf.Reactor;
 import org.lflang.tests.LFInjectorProvider;
-import static org.lflang.ASTUtils.*;
 
 @ExtendWith(InjectionExtension.class)
 @InjectWith(LFInjectorProvider.class)

--- a/org.lflang.tests/src/org/lflang/tests/compiler/LetInferenceTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LetInferenceTests.java
@@ -50,7 +50,12 @@ import org.lflang.generator.LFGeneratorContext;
 import org.lflang.generator.ReactionInstance;
 import org.lflang.generator.ReactorInstance;
 import org.lflang.generator.c.CFileConfig;
+import org.lflang.ast.AfterDelayTransformation;
+import org.lflang.generator.ReactionInstance;
+import org.lflang.generator.ReactorInstance;
+import org.lflang.generator.c.CDelayBodyGenerator;
 import org.lflang.generator.c.CGenerator;
+import org.lflang.generator.c.CTypes;
 import org.lflang.lf.Instantiation;
 import org.lflang.lf.LfFactory;
 import org.lflang.lf.Model;
@@ -64,10 +69,10 @@ import static org.lflang.ASTUtils.*;
 /**
  * Test for getting minimum delay in reactions.
  * Checking the actions and port's delay,then get the minimum reaction delay.
- * @author{Wonseo Choi <wonsuh1202@hanyang.ac.kr>}
- * @author{Yunsang Cho <snsc7878@hanyang.ac.kr>}
- * @author{Marten Lohstroh <marten@berkeley.edu>}
- * @author{Hokeun Kim <hokeunkim@berkeley.edu>}
+ * @author Wonseo Choi
+ * @author Yunsang Cho
+ * @author Marten Lohstroh
+ * @author Hokeun Kim
  */
 class LetInferenceTest  {
 

--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaASTUtilsTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaASTUtilsTest.java
@@ -53,7 +53,7 @@ import org.lflang.tests.LFInjectorProvider;
 /**
  * Collection of unit tests on the ASTutils.
  * 
- * @author{Christian Menard <christian.menard@tu-dresden.de>}
+ * @author Christian Menard
  */
 
 @ExtendWith(InjectionExtension.class)

--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaDependencyAnalysisTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaDependencyAnalysisTest.java
@@ -52,7 +52,7 @@ import static org.lflang.ASTUtils.*;
 
 /**
  * A collection of tests to ensure dependency analysis is done correctly.
- * @author{Marten Lohstroh <marten@berkeley.edu>}
+ * @author Marten Lohstroh
  */
 class LinguaFrancaDependencyAnalysisTest {
 	@Inject

--- a/org.lflang.tests/src/org/lflang/tests/compiler/RoundTripTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/RoundTripTests.java
@@ -1,33 +1,27 @@
 package org.lflang.tests.compiler;
 
-import java.io.IOException;
-import java.io.PrintWriter;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.xtext.resource.XtextResource;
-import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.extensions.InjectionExtension;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.opentest4j.AssertionFailedError;
 
-import org.lflang.LFStandaloneSetup;
 import org.lflang.Target;
 import org.lflang.ast.FormattingUtils;
 import org.lflang.ast.IsEqual;
 import org.lflang.lf.Model;
 import org.lflang.tests.LFInjectorProvider;
 import org.lflang.tests.LFTest;
+import org.lflang.tests.LfParsingUtil;
 import org.lflang.tests.TestRegistry;
 import org.lflang.tests.TestRegistry.TestCategory;
-
-import com.google.inject.Injector;
 
 @ExtendWith(InjectionExtension.class)
 @InjectWith(LFInjectorProvider.class)
@@ -38,83 +32,36 @@ public class RoundTripTests {
         for (Target target : Target.values()) {
             for (TestCategory category : TestCategory.values()) {
                 for (LFTest test : TestRegistry.getRegisteredTests(target, category, false)) {
-                    run(test.srcFile);
+                    run(test.getSrcPath());
                 }
             }
         }
     }
 
     private void run(Path file) throws Exception {
-        Model originalModel = parse(file);
-        Assertions.assertTrue(originalModel.eResource().getErrors().isEmpty());
+        Model originalModel = LfParsingUtil.parse(file);
+        assertThat(originalModel.eResource().getErrors(), equalTo(emptyList()));
         // TODO: Check that the output is a fixed point
         final int smallLineLength = 20;
         final String squishedTestCase = FormattingUtils.render(originalModel, smallLineLength);
-        final Model resultingModel = getResultingModel(file, squishedTestCase);
-        Assertions.assertNotNull(resultingModel);
-        if (!resultingModel.eResource().getErrors().isEmpty()) {
-            resultingModel.eResource().getErrors().forEach(System.err::println);
-            Assertions.assertTrue(resultingModel.eResource().getErrors().isEmpty());
-        }
-        if (!new IsEqual(originalModel).doSwitch(resultingModel)) {
-            System.out.printf(
-                "The following is what %s looks like after applying formatting with the preferred line "
-                    + "length set to %d columns:%n%s%n%n",
+        final Model resultingModel = LfParsingUtil.parseSourceAsIfInDirectory(file.getParent(), squishedTestCase);
+
+        assertThat(resultingModel.eResource().getErrors(), equalTo(emptyList()));
+        Assertions.assertTrue(
+            new IsEqual(originalModel).doSwitch(resultingModel),
+            String.format(
+                "The reformatted version of %s was not equivalent to the original file.%n"
+                    + "Formatted file:%n%s%n%n",
                 file,
-                smallLineLength,
                 squishedTestCase
-            );
-            throw new AssertionError(String.format(
-                "The reformatted version of %s was not equivalent to the original file.",
-                file.getFileName()
-            ));
-        }
-        final String normalTestCase = FormattingUtils.render(originalModel);
-        try {
-            Assertions.assertEquals(
-                Files.readString(file).replaceAll("\\r\\n?", "\n"),
-                normalTestCase
-            );
-        } catch (AssertionFailedError e) {
-            System.err.printf(
-                "An assertion failed while checking that the content of %s is the same before and "
-                    + "after formatting. Check that %s is formatted according to lff and the "
-                    + "formatter provided with the VS Code extension.%n",
-                file,
-                file.getFileName()
-            );
-            System.out.printf(
-                "The following is what %s looks like after applying formatting normally:%n%s%n%n",
-                file.getFileName(),
-                normalTestCase
-            );
-            throw e;
-        }
-    }
-
-    private Model getResultingModel(
-        Path file,
-        String reformattedTestCase
-    ) throws IOException {
-        final Path swap = file.getParent().resolve(file.getFileName().toString() + ".swp");
-        Files.move(file, swap, StandardCopyOption.REPLACE_EXISTING);
-        try (PrintWriter out = new PrintWriter(file.toFile())) {
-            out.println(reformattedTestCase);
-        }
-        Model resultingModel = parse(file);
-        Files.move(swap, file, StandardCopyOption.REPLACE_EXISTING);
-        return resultingModel;
-    }
-
-    private Model parse(Path file) {
-        // Source: https://wiki.eclipse.org/Xtext/FAQ#How_do_I_load_my_model_in_a_standalone_Java_application_.3F
-        Injector injector = new LFStandaloneSetup().createInjectorAndDoEMFRegistration();
-        XtextResourceSet resourceSet = injector.getInstance(XtextResourceSet.class);
-        resourceSet.addLoadOption(XtextResource.OPTION_RESOLVE_ALL, Boolean.TRUE);
-        Resource resource = resourceSet.getResource(
-            URI.createFileURI(file.toFile().getAbsolutePath()),
-            true
+            )
         );
-        return (Model) resource.getContents().get(0);
+        final String normalTestCase = FormattingUtils.render(originalModel);
+        Assertions.assertEquals(
+            Files.readString(file).replaceAll("\\r\\n?", "\n"),
+            normalTestCase,
+            "File is not formatted properly, or formatter is bugged. Check " + file
+        );
     }
+
 }

--- a/org.lflang.tests/src/org/lflang/tests/lsp/ErrorInserter.java
+++ b/org.lflang.tests/src/org/lflang/tests/lsp/ErrorInserter.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableList;
 
 /**
  * Insert problems into integration tests.
- * @author Peter Donovan <peterdonovan@berkeley.edu>
+ * @author Peter Donovan
  */
 @SuppressWarnings("ClassCanBeRecord")
 class ErrorInserter {

--- a/org.lflang.tests/src/org/lflang/tests/lsp/LspTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/lsp/LspTests.java
@@ -137,13 +137,8 @@ class LspTests {
         for (LFTest test : selectTests(target, random)) {
             client.clearDiagnostics();
             if (alterer != null) {
-                try (AlteredTest altered = alterer.alterTest(test.srcFile)) {
-                    runTest(altered.getSrcFile());
-                    Assertions.assertTrue(requirementGetter.apply(altered).test(client.getReceivedDiagnostics()));
-                }
-            } else {
                 try (AlteredTest altered = alterer.alterTest(test.getSrcPath())) {
-                    runTest(altered.getPath());
+                    runTest(altered.getSrcFile());
                     Assertions.assertTrue(requirementGetter.apply(altered).test(client.getReceivedDiagnostics()));
                 }
             } else {

--- a/org.lflang.tests/src/org/lflang/tests/lsp/LspTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/lsp/LspTests.java
@@ -29,7 +29,7 @@ import org.lflang.tests.lsp.ErrorInserter.AlteredTest;
 /**
  * Test the code generator features that are required by the language server.
  *
- * @author Peter Donovan <peterdonovan@berkeley.edu>
+ * @author Peter Donovan
  */
 class LspTests {
 
@@ -142,6 +142,12 @@ class LspTests {
                     Assertions.assertTrue(requirementGetter.apply(altered).test(client.getReceivedDiagnostics()));
                 }
             } else {
+                try (AlteredTest altered = alterer.alterTest(test.getSrcPath())) {
+                    runTest(altered.getPath());
+                    Assertions.assertTrue(requirementGetter.apply(altered).test(client.getReceivedDiagnostics()));
+                }
+            } else {
+                runTest(test.getSrcPath());
                 Assertions.assertTrue(requirementGetter.apply(null).test(client.getReceivedDiagnostics()));
             }
         }

--- a/org.lflang.tests/src/org/lflang/tests/lsp/MockLanguageClient.java
+++ b/org.lflang.tests/src/org/lflang/tests/lsp/MockLanguageClient.java
@@ -16,7 +16,7 @@ import org.eclipse.lsp4j.services.LanguageClient;
 /**
  * A {@code MockLanguageClient} is a language client that should be used in language server tests.
  *
- * @author Peter Donovan <peterdonovan@berkeley.edu>
+ * @author Peter Donovan
  */
 public class MockLanguageClient implements LanguageClient {
 

--- a/org.lflang.tests/src/org/lflang/tests/lsp/MockReportProgress.java
+++ b/org.lflang.tests/src/org/lflang/tests/lsp/MockReportProgress.java
@@ -5,7 +5,7 @@ import org.lflang.generator.IntegratedBuilder;
 /**
  * Collect progress reports and check that they have the expected properties.
  *
- * @author Peter Donovan <peterdonovan@berkeley.edu>
+ * @author Peter Donovan
  */
 public class MockReportProgress implements IntegratedBuilder.ReportProgress {
     private int previousPercentProgress;

--- a/org.lflang.tests/src/org/lflang/tests/runtime/CCppTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/runtime/CCppTest.java
@@ -12,7 +12,7 @@ import org.lflang.tests.TestRegistry.TestCategory;
  *
  * NOTE: This test does not inherit any tests because it directly extends TestBase.
  *
- * @author Marten Lohstroh <marten@berkeley.edu>
+ * @author Marten Lohstroh
  */
 public class CCppTest extends TestBase {
 
@@ -31,7 +31,7 @@ public class CCppTest extends TestBase {
     public void runAsCCpp() {
         Assumptions.assumeFalse(isWindows(), Message.NO_WINDOWS_SUPPORT);
         runTestsForTargets(Message.DESC_AS_CCPP, CCppTest::isExcludedFromCCpp,
-                           it -> ASTUtils.changeTargetName(it.context.getFileConfig().resource,
+                           it -> ASTUtils.changeTargetName(it.getFileConfig().resource,
                                                            Target.CCPP.getDisplayName()),
                            true);
     }

--- a/org.lflang.tests/src/org/lflang/tests/runtime/CSchedulerTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/runtime/CSchedulerTest.java
@@ -59,7 +59,7 @@ public class CSchedulerTest extends TestBase {
             Message.DESC_SCHED_SWAPPING + scheduler.toString() +".",
             categories::contains,
             test -> {
-                test.context.getArgs()
+                test.getContext().getArgs()
                     .setProperty(
                         "scheduler",
                         scheduler.toString()

--- a/org.lflang.tests/src/org/lflang/tests/runtime/CTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/runtime/CTest.java
@@ -43,7 +43,7 @@ import org.lflang.tests.TestRegistry.TestCategory;
  * like Eclipse and IntelliJ.
  * This is typically done by right-clicking on the name of the test method and
  * then clicking "Run".*
- * @author Marten Lohstroh <marten@berkeley.edu>
+ * @author Marten Lohstroh
  */
 public class CTest extends RuntimeTest {
 

--- a/org.lflang.tests/src/org/lflang/tests/runtime/CppRos2Test.java
+++ b/org.lflang.tests/src/org/lflang/tests/runtime/CppRos2Test.java
@@ -30,7 +30,6 @@ public class CppRos2Test extends TestBase {
         Element trueLiteral = LfFactory.eINSTANCE.createElement();
         trueLiteral.setLiteral("true");
         runTestsForTargets(Message.DESC_ROS2, it -> true,
-                           it -> ASTUtils.addTargetProperty(it.context.getFileConfig().resource, "ros2", trueLiteral),
                            it -> ASTUtils.addTargetProperty(it.getFileConfig().resource, "ros2", trueLiteral),
                            true);
     }

--- a/org.lflang.tests/src/org/lflang/tests/runtime/CppRos2Test.java
+++ b/org.lflang.tests/src/org/lflang/tests/runtime/CppRos2Test.java
@@ -15,7 +15,7 @@ import org.lflang.tests.TestRegistry.TestCategory;
  *
  * NOTE: This test does not inherit any tests because it directly extends TestBase.
  *
- * @author Christian Menard <christian.menard@tu-dresden.de>
+ * @author Christian Menard
  */
 public class CppRos2Test extends TestBase {
 
@@ -31,6 +31,7 @@ public class CppRos2Test extends TestBase {
         trueLiteral.setLiteral("true");
         runTestsForTargets(Message.DESC_ROS2, it -> true,
                            it -> ASTUtils.addTargetProperty(it.context.getFileConfig().resource, "ros2", trueLiteral),
+                           it -> ASTUtils.addTargetProperty(it.getFileConfig().resource, "ros2", trueLiteral),
                            true);
     }
 }

--- a/org.lflang.tests/src/org/lflang/tests/runtime/CppTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/runtime/CppTest.java
@@ -39,7 +39,7 @@ import org.lflang.tests.RuntimeTest;
  * This is typically done by right-clicking on the name of the test method and
  * then clicking "Run".
  *
- * @author Marten Lohstroh <marten@berkeley.edu>
+ * @author Marten Lohstroh
  */
 public class CppTest extends RuntimeTest {
 

--- a/org.lflang.tests/src/org/lflang/tests/runtime/PythonTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/runtime/PythonTest.java
@@ -41,7 +41,7 @@ import org.lflang.tests.RuntimeTest;
  * This is typically done by right-clicking on the name of the test method and
  * then clicking "Run".
  *
- * @author Marten Lohstroh {@literal <marten@berkeley.edu>}
+ * @author Marten Lohstroh
  */
 public class PythonTest extends RuntimeTest {
 

--- a/org.lflang.tests/src/org/lflang/tests/runtime/TypeScriptTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/runtime/TypeScriptTest.java
@@ -14,7 +14,7 @@ import org.lflang.tests.RuntimeTest;
  * This is typically done by right-clicking on the name of the test method and
  * then clicking "Run".
  *
- * @author Marten Lohstroh <marten@berkeley.edu>
+ * @author Marten Lohstroh
  */
 public class TypeScriptTest extends RuntimeTest {
     public TypeScriptTest() {


### PR DESCRIPTION
This is a manual merge of most of the changes made in `org.lflang.tests` from master into fed-gen. Since this is not an actual merge, it does not automatically tell git how to resolve all the conflicts. However, when doing the actual merge, the changes made here are of great help. For all the conflicts arising in `org.lflang.tests` it should be safe to simply select the version from this branch and discard the master version.