### PR TITLE
Changed test/Readme linking blank Wiki page to lf-handbook

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -41,4 +41,4 @@ cd $LF
 
 ### See also
 
-- [Regression Tests (wiki)](https://github.com/lf-lang/lingua-franca/wiki/Regression-Tests)
+- [Regression Tests (Handbook)](https://www.lf-lang.org/docs/handbook/regression-tests?target=c)


### PR DESCRIPTION
The Readme file linked the old Wiki page. Changed the link to the handbook page.