### PR TITLE
Fix docker tests in fed-gen

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/TestBase.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestBase.java
@@ -587,11 +587,12 @@ public abstract class TestBase {
     }
 
     /**
-     * Returns true if docker exists, false otherwise.
+     * Throws TestError if docker does not exist. Does nothing otherwise.
      */
-    private boolean checkDockerExists() {
-        LFCommand checkCommand = LFCommand.get("docker", List.of("info"));
-        return checkCommand.run() == 0;
+    private void checkDockerExists() throws TestError {
+        if (LFCommand.get("docker", List.of("info")) == null) {
+            throw new TestError(Message.MISSING_DOCKER, Result.NO_EXEC_FAIL);
+        }
     }
 
     /**
@@ -603,11 +604,8 @@ public abstract class TestBase {
      *
      * @param test The test to get the execution command for.
      */
-    private List<ProcessBuilder> getNonfederatedDockerExecCommand(LFTest test) {
-        if (!checkDockerExists()) {
-            System.out.println(Message.MISSING_DOCKER);
-            return List.of(new ProcessBuilder("exit", "1"));
-        }
+    private List<ProcessBuilder> getNonfederatedDockerExecCommand(LFTest test) throws TestError {
+        checkDockerExists();
         var srcGenPath = test.getFileConfig().getSrcGenPath();
         var dockerComposeFile = FileUtil.globFilesEndsWith(srcGenPath, "docker-compose.yml").get(0);
         return List.of(new ProcessBuilder("docker", "compose", "-f", dockerComposeFile.toString(), "rm", "-f"),
@@ -619,11 +617,8 @@ public abstract class TestBase {
      * Return a list of ProcessBuilders used to test the docker option under federated execution.
      * @param test The test to get the execution command for.
      */
-    private List<ProcessBuilder> getFederatedDockerExecCommand(LFTest test) {
-        if (!checkDockerExists()) {
-            System.out.println(Message.MISSING_DOCKER);
-            return List.of(new ProcessBuilder("exit", "1"));
-        }
+    private List<ProcessBuilder> getFederatedDockerExecCommand(LFTest test) throws TestError {
+        checkDockerExists();
         var srcGenPath = test.getFileConfig().getSrcGenPath();
         List<Path> dockerFiles = FileUtil.globFilesEndsWith(srcGenPath, ".Dockerfile");
         try {

--- a/org.lflang.tests/src/org/lflang/tests/TestBase.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestBase.java
@@ -157,9 +157,6 @@ public abstract class TestBase {
         public static final String DESC_SCHED_SWAPPING = "Running with non-default runtime scheduler ";
         public static final String DESC_ROS2 = "Running tests using ROS2.";
         public static final String DESC_MODAL = "Run modal reactor tests.";
-
-        /* Missing dependency messages */
-        public static final String MISSING_DOCKER = "Executable 'docker' not found or 'docker' daemon thread not running";
     }
 
     /** Constructor for test classes that test a single target. */
@@ -590,8 +587,11 @@ public abstract class TestBase {
      * Throws TestError if docker does not exist. Does nothing otherwise.
      */
     private void checkDockerExists() throws TestError {
-        if (LFCommand.get("docker", List.of("info")) == null) {
-            throw new TestError(Message.MISSING_DOCKER, Result.NO_EXEC_FAIL);
+        if (LFCommand.get("docker", List.of()) == null) {
+            throw new TestError("Executable 'docker' not found" , Result.NO_EXEC_FAIL);
+        }
+        if (LFCommand.get("docker-compose", List.of()) == null) {
+            throw new TestError("Executable 'docker-compose' not found" , Result.NO_EXEC_FAIL);
         }
     }
 

--- a/org.lflang.tests/src/org/lflang/tests/TestBase.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestBase.java
@@ -611,9 +611,6 @@ public abstract class TestBase {
         if (LFCommand.get("docker", List.of()) == null) {
             throw new TestError("Executable 'docker' not found" , Result.NO_EXEC_FAIL);
         }
-        if (LFCommand.get("docker-compose", List.of()) == null) {
-            throw new TestError("Executable 'docker-compose' not found" , Result.NO_EXEC_FAIL);
-        }
     }
 
     /**

--- a/org.lflang.tests/src/org/lflang/tests/TestBase.java
+++ b/org.lflang.tests/src/org/lflang/tests/TestBase.java
@@ -622,28 +622,10 @@ public abstract class TestBase {
     }
 
     /**
-     * Return a list of ProcessBuilders used to test the docker option under non-federated execution.
-     * See the following for references on the instructions called:
-     * docker build: https://docs.docker.com/engine/reference/commandline/build/
-     * docker run: https://docs.docker.com/engine/reference/run/
-     * docker image: https://docs.docker.com/engine/reference/commandline/image/
-     *
+     * Return a list of ProcessBuilders used to test the docker execution.
      * @param test The test to get the execution command for.
      */
-    private List<ProcessBuilder> getNonfederatedDockerExecCommand(LFTest test) throws TestError {
-        checkDockerExists();
-        var srcGenPath = test.getFileConfig().getSrcGenPath();
-        var dockerComposeFile = FileUtil.globFilesEndsWith(srcGenPath, "docker-compose.yml").get(0);
-        return List.of(new ProcessBuilder("docker", "compose", "-f", dockerComposeFile.toString(), "rm", "-f"),
-                       new ProcessBuilder("docker", "compose", "-f", dockerComposeFile.toString(), "up", "--build"),
-                       new ProcessBuilder("docker", "compose", "-f", dockerComposeFile.toString(), "down", "--rmi", "local"));
-    }
-
-    /**
-     * Return a list of ProcessBuilders used to test the docker option under federated execution.
-     * @param test The test to get the execution command for.
-     */
-    private List<ProcessBuilder> getFederatedDockerExecCommand(LFTest test) throws TestError {
+    private List<ProcessBuilder> getDockerExecCommand(LFTest test) throws TestError {
         checkDockerExists();
         var srcGenPath = test.getFileConfig().getSrcGenPath();
         var dockerComposeFile = FileUtil.globFilesEndsWith(srcGenPath, "docker-compose.yml").get(0);
@@ -661,10 +643,9 @@ public abstract class TestBase {
         var relativePathName = srcBasePath.relativize(test.getFileConfig().srcPath).toString();
 
         // special case to test docker file generation
-        if (relativePathName.equalsIgnoreCase(TestCategory.DOCKER.getPath())) {
-            return getNonfederatedDockerExecCommand(test);
-        } else if (relativePathName.equalsIgnoreCase(TestCategory.DOCKER_FEDERATED.getPath())) {
-            return getFederatedDockerExecCommand(test);
+        if (relativePathName.equalsIgnoreCase(TestCategory.DOCKER.getPath()) ||
+            relativePathName.equalsIgnoreCase(TestCategory.DOCKER_FEDERATED.getPath())) {
+            return getDockerExecCommand(test);
         } else {
             LFCommand command = test.getFileConfig().getCommand();
             if (command == null) {

--- a/org.lflang/src/org/lflang/generator/DockerData.java
+++ b/org.lflang/src/org/lflang/generator/DockerData.java
@@ -19,10 +19,6 @@ public class DockerData {
     private String fileContent;
 
     /**
-     * The name of the docker compose service for the LF module.
-     */
-    private String composeServiceName;
-    /**
      * The build context of the docker container.
      */
     private String dockerContext;
@@ -55,7 +51,6 @@ public class DockerData {
 
     public Path getFilePath() { return filePath; }
     public String getFileContent() { return fileContent; }
-    public String getComposeServiceName() { return composeServiceName; }
     public String getDockerContext() { return dockerContext; }
 
     /**
@@ -67,7 +62,7 @@ public class DockerData {
             dockerFilePath.toFile().delete();
         }
         FileUtil.writeToFile(this.getFileContent(), dockerFilePath);
-        System.out.println("Dockerfile for "+this.getComposeServiceName()+" written to "+this.getFilePath());
+        System.out.println("Dockerfile written to " + this.getFilePath());
     }
 
     /**


### PR DESCRIPTION
This fixes several problems in the docker test execution. It simplifies and generalizes the script that is generated in TestBase for running federated docker test. The script has now a little "smartness" build into it. It simply starts all containers and uses grep to find if any of them failed (as opposed to start each container separately as was done before).

I also noticed that the non-federated docker tests were broken, as any errors within the container were not picked up by our test framework. Both test categories now use the same script. This also allowed a significant cleanup of the test code.

We might not be fully in the green yet. During my testing I observed multiple times that federates could not connect to the RTI. The log looked always looked smth like this:
```
DistributedCountContainerized-c    | Federate 0: Could not connect to RTI at rti. Will try again every 2 seconds.
DistributedCountContainerized-c    | Federate 0: Failed to connect to RTI on port 15065. Trying 15066.
DistributedCountContainerized-c    | Federate 0: Could not connect to RTI at rti. Will try again every 2 seconds.
DistributedCountContainerized-c    | Federate 0: Failed to connect to RTI on port 15066. Trying 15067.
DistributedCountContainerized-rti  | WARNING: RTI failed to accept the socket. Resource temporarily unavailable. Trying again.
DistributedCountContainerized-c    | Federate 0: Could not connect to RTI at rti. Will try again every 2 seconds.
DistributedCountContainerized-c    | Federate 0: Failed to connect to RTI on port 15067. Trying 15068.
DistributedCountContainerized-c    | Federate 0: Could not connect to RTI at rti. Will try again every 2 seconds.
DistributedCountContainerized-c    | Federate 0: Failed to connect to RTI on port 15068. Trying 15069.
DistributedCountContainerized-c    | Federate 0: Could not connect to RTI at rti. Will try again every 2 seconds.
DistributedCountContainerized-c    | Federate 0: Failed to connect to RTI on port 15069. Trying 15070.
``` 
I am not sure if this is a problem in my setup or a problem with our tests. I always had to restart the docker daemon to make it work again.