### PR TITLE
Remove use of deprecated reactor-c API in tests

### DIFF
--- a/test/Python/src/PingPong.lf
+++ b/test/Python/src/PingPong.lf
@@ -39,7 +39,7 @@ reactor Ping(count(10)) {
         if self.pingsLeft > 0:
             serve.schedule(0)
         else:
-            request_stop()
+            lf_request_stop()
     =}
 }
 

--- a/test/Python/src/TimeLimit.lf
+++ b/test/Python/src/TimeLimit.lf
@@ -43,5 +43,5 @@ main reactor TimeLimit(period(1 sec)) {
     d = new Destination()
     c.y -> d.x
 
-    reaction(stop) {= request_stop() =}
+    reaction(stop) {= lf_request_stop() =}
 }

--- a/test/Python/src/docker/FilesPropertyContainerized.lf
+++ b/test/Python/src/docker/FilesPropertyContainerized.lf
@@ -7,7 +7,7 @@ preamble {=
     try:
         import hello
     except:
-        request_stop()
+        lf_request_stop()
 =}
 
 main reactor {
@@ -15,7 +15,7 @@ main reactor {
         try:
             import hello
         except:
-            request_stop()
+            lf_request_stop()
     =}
     state passed(false)
     timer t(1 msec)

--- a/test/Python/src/docker/federated/DistributedStopDecentralizedContainerized.lf
+++ b/test/Python/src/docker/federated/DistributedStopDecentralizedContainerized.lf
@@ -1,5 +1,5 @@
 /**
- * Test for request_stop() in federated execution with decentralized
+ * Test for lf_request_stop() in federated execution with decentralized
  * coordination.
  *
  * @author Soroush Bateni

--- a/test/Python/src/federated/CycleDetection.lf
+++ b/test/Python/src/federated/CycleDetection.lf
@@ -36,7 +36,7 @@ reactor UserInput {
             self.sys.stderr.write("Did not receive the expected balance. Expected: 200. Got: {}.\n".format(balance.value))
             self.sys.exit(1)
         print("Balance: {}".format(balance.value))
-        request_stop()
+        lf_request_stop()
     =}
 
     reaction(shutdown) {= print("Test passed!") =}

--- a/test/Python/src/federated/DistributedSendClass.lf
+++ b/test/Python/src/federated/DistributedSendClass.lf
@@ -9,7 +9,7 @@ preamble {=
 reactor A {
     input o
 
-    reaction(o) {= request_stop() =}
+    reaction(o) {= lf_request_stop() =}
 }
 
 reactor B {

--- a/test/Python/src/federated/DistributedStop.lf
+++ b/test/Python/src/federated/DistributedStop.lf
@@ -1,5 +1,5 @@
 /**
- * Test for request_stop() in federated execution with centralized coordination.
+ * Test for lf_request_stop() in federated execution with centralized coordination.
  *
  * @author Soroush Bateni
  */
@@ -21,16 +21,16 @@ reactor Sender {
         if lf_tag().microstep == 0:
             # Instead of having a separate reaction
             # for 'act' like Stop.lf, we trigger the
-            # same reaction to test request_stop() being
+            # same reaction to test lf_request_stop() being
             # called multiple times
             act.schedule(0)
         if lf.time.logical_elapsed() == USEC(1):
-            # Call request_stop() both at (1 usec, 0) and
+            # Call lf_request_stop() both at (1 usec, 0) and
             # (1 usec, 1)
             print("Requesting stop at ({}, {}).".format(
                      lf.time.logical_elapsed(),
                      lf_tag().microstep))
-            request_stop()
+            lf_request_stop()
 
         _1usec1 = Tag(time=USEC(1) + get_start_time(), microstep=1)
         if lf.tag_compare(lf_tag(), _1usec1) == 0:
@@ -74,7 +74,7 @@ reactor Receiver(
             print("Requesting stop at ({}, {}).".format(
                      lf.time.logical_elapsed(),
                      lf_tag().microstep))
-            request_stop()
+            lf_request_stop()
             # The receiver should receive a message at tag
             # (1 usec, 1) and trigger this reaction
             self.reaction_invoked_correctly = True

--- a/test/Python/src/federated/DistributedStopDecentralized.lf
+++ b/test/Python/src/federated/DistributedStopDecentralized.lf
@@ -1,5 +1,5 @@
 /**
- * Test for request_stop() in federated execution with decentralized
+ * Test for lf_request_stop() in federated execution with decentralized
  * coordination.
  *
  * @author Soroush Bateni

--- a/test/Python/src/federated/DistributedStopZero.lf
+++ b/test/Python/src/federated/DistributedStopZero.lf
@@ -1,5 +1,5 @@
 /**
- * Test for request_stop() in federated execution with centralized coordination
+ * Test for lf_request_stop() in federated execution with centralized coordination
  * at tag (0,0).
  *
  * @author Soroush Bateni
@@ -28,7 +28,7 @@ reactor Sender {
             print("Requesting stop at ({}, {}).".format(
                      lf.time.logical_elapsed(),
                      lf_tag().microstep))
-            request_stop()
+            lf_request_stop()
     =}
 
     reaction(shutdown) {=
@@ -60,7 +60,7 @@ reactor Receiver {
             print("Requesting stop at ({}, {}).".format(
                      lf.time.logical_elapsed(),
                      lf_tag().microstep))
-            request_stop()
+            lf_request_stop()
     =}
 
     reaction(shutdown) {=

--- a/test/Python/src/federated/HelloDistributed.lf
+++ b/test/Python/src/federated/HelloDistributed.lf
@@ -13,7 +13,7 @@ reactor Source {
     reaction(startup) -> out {=
         print("Sending 'Hello World!' message from source federate.");
         out.set("Hello World!")
-        request_stop()
+        lf_request_stop()
     =}
 }
 

--- a/test/Python/src/federated/PingPongDistributed.lf
+++ b/test/Python/src/federated/PingPongDistributed.lf
@@ -37,7 +37,7 @@ reactor Ping(count(10)) {
         if self.pingsLeft > 0:
             serve.schedule(0)
         else:
-            request_stop()
+            lf_request_stop()
     =}
 }
 
@@ -53,7 +53,7 @@ reactor Pong(expected(10)) {
         print("At logical time {}, Pong received {}.\n".format(lf.time.logical_elapsed(), receive.value))
         send.set(receive.value)
         if self.count == self.expected:
-            request_stop()
+            lf_request_stop()
     =}
 
     reaction(shutdown) {=

--- a/test/Python/src/federated/StopAtShutdown.lf
+++ b/test/Python/src/federated/StopAtShutdown.lf
@@ -1,5 +1,5 @@
 /**
- * Check that request_stop() doesn't cause any issues at the shutdown tag.
+ * Check that lf_request_stop() doesn't cause any issues at the shutdown tag.
  *
  * Original bug discovered by Steven Wong <housengw@berkeley.edu>
  *
@@ -16,7 +16,7 @@ reactor A {
 
     reaction(in_) {= print("Got it") =}
 
-    reaction(shutdown) {= request_stop() =}
+    reaction(shutdown) {= lf_request_stop() =}
 }
 
 reactor B {
@@ -25,7 +25,7 @@ reactor B {
 
     reaction(t) -> out {= out.set(1) =}
 
-    reaction(shutdown) {= request_stop() =}
+    reaction(shutdown) {= lf_request_stop() =}
 }
 
 federated reactor {

--- a/test/Python/src/federated/failing/ClockSync.lf
+++ b/test/Python/src/federated/failing/ClockSync.lf
@@ -50,19 +50,19 @@ reactor Printer {
 
     reaction(startup) {=
         interval_t offset = _lf_time_physical_clock_offset + _lf_time_test_physical_clock_offset;
-        info_print("Clock sync error at startup is %lld ns.", offset);
+        lf_print("Clock sync error at startup is %lld ns.", offset);
     =}
 
     reaction(in) {=
-        info_print("Received %d.", in->value);
+        lf_print("Received %d.", in->value);
     =}
 
     reaction(shutdown) {=
         interval_t offset = _lf_time_physical_clock_offset + _lf_time_test_physical_clock_offset;
-        info_print("Clock sync error at shutdown is %lld ns.", offset);
+        lf_print("Clock sync error at shutdown is %lld ns.", offset);
         // Error out if the offset is bigger than 100 msec.
         if (offset > MSEC(100)) {
-            error_print("Offset exceeds test threshold of 100 msec.");
+            lf_print_error("Offset exceeds test threshold of 100 msec.");
             exit(1);
         }
     =}

--- a/test/Python/src/federated/failing/DistributedLoopedActionDecentralized.lf
+++ b/test/Python/src/federated/failing/DistributedLoopedActionDecentralized.lf
@@ -52,7 +52,7 @@ reactor STPReceiver(take_a_break_after(10), break_interval(400 msec), stp_offset
         # time step.
         if current_tag.time != self.last_time_updated_stp :
             print(f"Raising the STP offset by {MSEC(10)}.")
-            set_stp_offset(MSEC(10))
+            lf_set_stp_offset(MSEC(10))
             self.last_time_updated_stp = current_tag.time
     =}
 

--- a/test/Python/src/federated/failing/LoopDistributedCentralized.lf
+++ b/test/Python/src/federated/failing/LoopDistributedCentralized.lf
@@ -18,7 +18,7 @@ preamble {=
     // Thread to trigger an action once every second.
     void* ping(void* actionref) {
         while(!stop) {
-            info_print("Scheduling action.");
+            lf_print("Scheduling action.");
             schedule(actionref, 0);
             sleep(1);
         }
@@ -34,7 +34,7 @@ reactor Looper(incr:int(1), delay:time(0 msec)) {
     reaction(startup) -> a {=
         // Start the thread that listens for Enter or Return.
         lf_thread_t thread_id;
-        info_print("Starting thread.");
+        lf_print("Starting thread.");
         lf_thread_create(&thread_id, &ping, a);
     =}
     reaction(a) -> out {=
@@ -45,10 +45,10 @@ reactor Looper(incr:int(1), delay:time(0 msec)) {
         instant_t time_lag = lf.time.physical() - lf.time.logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         lf_comma_separated_time(time_buffer, time_lag);
-        info_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
     =}
     reaction(shutdown) {=
-        info_print("******* Shutdown invoked.");
+        lf_print("******* Shutdown invoked.");
         // Stop the thread that is scheduling actions.
         stop = true;
         if (self->count != 5 * self->incr) {

--- a/test/Python/src/federated/failing/LoopDistributedCentralizedPrecedence.lf
+++ b/test/Python/src/federated/failing/LoopDistributedCentralizedPrecedence.lf
@@ -29,7 +29,7 @@ reactor Looper(incr:int(1), delay:time(0 msec)) {
         instant_t time_lag = lf.time.physical() - lf.time.logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         lf_comma_separated_time(time_buffer, time_lag);
-        info_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
         self->received_count = self->count;
     =}
     reaction(t) {=
@@ -38,7 +38,7 @@ reactor Looper(incr:int(1), delay:time(0 msec)) {
         }
     =}
     reaction(shutdown) {=
-        info_print("******* Shutdown invoked.");
+        lf_print("******* Shutdown invoked.");
         if (self->count != 6 * self->incr) {
             lf_print_error_and_exit("Failed to receive all six expected inputs.");
         }

--- a/test/Python/src/federated/failing/LoopDistributedDecentralized.lf
+++ b/test/Python/src/federated/failing/LoopDistributedDecentralized.lf
@@ -17,7 +17,7 @@ preamble {=
     // Thread to trigger an action once every second.
     void* ping(void* actionref) {
         while(!stop) {
-            info_print("Scheduling action.");
+            lf_print("Scheduling action.");
             schedule(actionref, 0);
             sleep(1);
         }
@@ -33,11 +33,11 @@ reactor Looper(incr:int(1), delay:time(0 msec), stp_offset:time(0)) {
     reaction(startup) -> a {=
         // Start the thread that listens for Enter or Return.
         lf_thread_t thread_id;
-        info_print("Starting thread.");
+        lf_print("Starting thread.");
         lf_thread_create(&thread_id, &ping, a);
     =}
     reaction(a) -> out {=
-        info_print("Setting out.");
+        lf_print("Setting out.");
         SET(out, self->count);
         self->count += self->incr;
     =}
@@ -45,20 +45,20 @@ reactor Looper(incr:int(1), delay:time(0 msec), stp_offset:time(0)) {
         instant_t time_lag = lf.time.physical() - lf.time.logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         lf_comma_separated_time(time_buffer, time_lag);
-        info_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
     =} STP (stp_offset) {=
         instant_t time_lag = lf.time.physical() - lf.time.logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         lf_comma_separated_time(time_buffer, time_lag);
-        info_print("STP offset was violated. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("STP offset was violated. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
     =} deadline (10 msec) {=
         instant_t time_lag = lf.time.physical() - lf.time.logical();
         char time_buffer[28]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         lf_comma_separated_time(time_buffer, time_lag);
-        info_print("Deadline miss. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
+        lf_print("Deadline miss. Received %d. Logical time is behind physical time by %s nsec.", in->value, time_buffer);
     =}
     reaction(shutdown) {=
-        info_print("******* Shutdown invoked.");
+        lf_print("******* Shutdown invoked.");
         // Stop the thread that is scheduling actions.
         stop = true;
         if (self->count != 5 * self->incr) {

--- a/test/Python/src/federated/failing/LoopDistributedDouble.lf
+++ b/test/Python/src/federated/failing/LoopDistributedDouble.lf
@@ -17,7 +17,7 @@ preamble {=
     # Thread to trigger an action once every second.
     void* ping(void* actionref) {
         while(!stop) {
-            info_print("Scheduling action.");
+            lf_print("Scheduling action.");
             schedule(actionref, 0);
             sleep(1);
         }
@@ -36,7 +36,7 @@ reactor Looper(incr(1), delay(0 msec)) {
     reaction(startup) -> a {=
         # Start the thread that listens for Enter or Return.
         lf_thread_t thread_id;
-        info_print("Starting thread.");
+        lf_print("Starting thread.");
         lf_thread_create(&thread_id, &ping, a);
     =}
     reaction(a) -> out, out2 {=
@@ -48,24 +48,24 @@ reactor Looper(incr(1), delay(0 msec)) {
         self->count += self->incr;
     =}
     reaction(in) {=
-        info_print("Received %d at logical time (%lld, %d).",
+        lf_print("Received %d at logical time (%lld, %d).",
             in->value,
             current_tag.time - start_time, current_tag.microstep
         );
     =}
     reaction(in2) {=
-        info_print("Received %d on in2 at logical time (%lld, %d).",
+        lf_print("Received %d on in2 at logical time (%lld, %d).",
             in2->value,
             current_tag.time - start_time, current_tag.microstep
         );
     =}
     reaction(t) {=
-        info_print("Timer triggered at logical time (%lld, %d).",
+        lf_print("Timer triggered at logical time (%lld, %d).",
             current_tag.time - start_time, current_tag.microstep
         );
     =}
     reaction(shutdown) {=
-        info_print("******* Shutdown invoked.");
+        lf_print("******* Shutdown invoked.");
         // Stop the thread that is scheduling actions.
         stop = true;
         if (self->count != 5 * self->incr) {


### PR DESCRIPTION
Required by https://github.com/lf-lang/reactor-c/pull/148/