### PR TITLE
Useful error message upon encountering missing runtime sources

### DIFF
--- a/org.lflang/src/org/lflang/util/FileUtil.java
+++ b/org.lflang/src/org/lflang/util/FileUtil.java
@@ -12,7 +12,6 @@ import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -279,12 +278,7 @@ public class FileUtil {
 
         // Copy the file.
         if (sourceStream == null) {
-            throw new IOException(
-                "A required target resource could not be found: " + source + "\n" +
-                    "Perhaps a git submodule is missing or not up to date.\n" +
-                    "See https://github.com/icyphy/lingua-franca/wiki/downloading-and-building#clone-the-lingua-franca-repository.\n"
-                    +
-                    "Also try to refresh and clean the project explorer if working from eclipse.");
+            throw new TargetResourceNotFoundException(source);
         } else {
             try (sourceStream) {
                 copyInputStream(sourceStream, destination, skipIfUnchanged);
@@ -322,17 +316,15 @@ public class FileUtil {
     public static void copyDirectoryFromClassPath(final String source, final Path destination, final boolean skipIfUnchanged) throws IOException {
         final URL resource = FileConfig.class.getResource(source);
         if (resource == null) {
-            throw new IOException(
-                "A required target resource could not be found: " + source + "\n" +
-                    "Perhaps a git submodule is missing or not up to date.\n" +
-                    "See https://github.com/icyphy/lingua-franca/wiki/downloading-and-building#clone-the-lingua-franca-repository.\n"
-                    +
-                    "Also try to refresh and clean the project explorer if working from eclipse.");
+            throw new TargetResourceNotFoundException(source);
         }
 
         final URLConnection connection = resource.openConnection();
         if (connection instanceof JarURLConnection) {
-            copyDirectoryFromJar((JarURLConnection) connection, destination, skipIfUnchanged);
+            boolean copiedFiles = copyDirectoryFromJar((JarURLConnection) connection, destination, skipIfUnchanged);
+            if (!copiedFiles) {
+                throw new TargetResourceNotFoundException(source);
+            }
         } else {
             try {
                 Path dir = Paths.get(FileLocator.toFileURL(resource).toURI());
@@ -355,12 +347,14 @@ public class FileUtil {
      * @param connection a URLConnection to the source directory within the jar
      * @param destination The file system path that the source directory is copied to.
      * @param skipIfUnchanged If true, don't overwrite the file if its content would not be changed
+     * @return true if any files were copied
      * @throws IOException If the given source cannot be copied.
      */
-    private static void copyDirectoryFromJar(JarURLConnection connection, final Path destination, final boolean skipIfUnchanged) throws IOException {
+    private static boolean copyDirectoryFromJar(JarURLConnection connection, final Path destination, final boolean skipIfUnchanged) throws IOException {
         final JarFile jar = connection.getJarFile();
         final String connectionEntryName = connection.getEntryName();
 
+        boolean copiedFiles = false;
         // Iterate all entries in the jar file.
         for (Enumeration<JarEntry> e = jar.entries(); e.hasMoreElements(); ) {
             final JarEntry entry = e.nextElement();
@@ -377,10 +371,12 @@ public class FileUtil {
                     InputStream is = jar.getInputStream(entry);
                     try (is) {
                         copyInputStream(is, currentFile, skipIfUnchanged);
+                        copiedFiles = true;
                     }
                 }
             }
         }
+        return copiedFiles;
     }
 
     /**

--- a/org.lflang/src/org/lflang/util/TargetResourceNotFoundException.java
+++ b/org.lflang/src/org/lflang/util/TargetResourceNotFoundException.java
@@ -1,0 +1,14 @@
+package org.lflang.util;
+
+import java.io.IOException;
+
+public class TargetResourceNotFoundException extends IOException {
+    public TargetResourceNotFoundException(String resourcePath) {
+        super(String.format("""
+            A required resource could not be found on the classpath or is an empty directory: %s
+            Perhaps a git submodule is missing or not up to date.
+            Try running 'git submodule update --init --recursive' and rebuild.
+            Also see https://www.lf-lang.org/download#developer. 
+            """, resourcePath));
+    }
+}

--- a/org.lflang/src/org/lflang/util/TargetResourceNotFoundException.java
+++ b/org.lflang/src/org/lflang/util/TargetResourceNotFoundException.java
@@ -8,7 +8,7 @@ public class TargetResourceNotFoundException extends IOException {
             A required resource could not be found on the classpath or is an empty directory: %s
             Perhaps a git submodule is missing or not up to date.
             Try running 'git submodule update --init --recursive' and rebuild.
-            Also see https://www.lf-lang.org/download#developer. 
+            Also see https://www.lf-lang.org/docs/handbook/developer-setup. 
             """, resourcePath));
     }
 }


### PR DESCRIPTION
We used to have an error message in lfc, that notified the user if the runtime files are missing (i.e. the submodules are not checked out). It seems that with the introduction of `FileUtil` this feature got lost. It currently only complains if a resource cannot be found at all, but not if the resource is an empty directory. Aside from a bit of cleanup, this fix ensures that a useful error message is also produced if a submodule is missing.

This depends on https://github.com/lf-lang/lf-lang.github.io/pull/121. Without merging it, the link in the error message will not be available.