### PR TITLE
Don't build the RTI docker image in CI tests

### DIFF
--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -60,9 +60,6 @@ jobs:
           cd arduino-1.8.19/
           sudo ./install.sh
         if: ${{ runner.os == 'Linux' }}
-      - name: Build RTI docker image
-        uses: ./.github/actions/build-rti-docker
-        if: ${{ runner.os == 'Linux' }}
       - name: Perform tests for C target with default scheduler
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.CTest.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
   # Run the C integration tests.
   c-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@ci-no-rti-image
     needs: cancel
   
   # Run the C Zephyr integration tests.
@@ -94,7 +94,7 @@ jobs:
 
   # Run the Python integration tests.
   py-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/py-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/py-tests.yml@ci-no-rti-image
     needs: cancel
 
   # Run the Rust integration tests.

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -55,9 +55,6 @@ jobs:
           path: org.lflang/src/lib/py/reactor-c-py
           ref: ${{ inputs.reactor-c-py-ref }}
         if: ${{ inputs.reactor-c-py-ref }}
-      - name: Build RTI docker image
-        uses: ./.github/actions/build-rti-docker
-        if: ${{ runner.os == 'Linux' }}
       - name: Run Python tests
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.PythonTest.*


### PR DESCRIPTION
Our tests pull the image from docker hub and hence there is no need to build the image locally.