### PR TITLE
[ts] Bugfix that re-enables the use of custom configuration files

### DIFF
--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -215,7 +215,8 @@ class TSGenerator(
             val configFileDest = fileConfig.srcGenPath.resolve(configFile)
             val configFileInSrc = fileConfig.srcPath.resolve(configFile)
             if (configFileInSrc.toFile().exists()) {
-                println("Copying '" + configFile + "' from " + fileConfig.srcPath)
+                println("Copying $configFileInSrc to $configFileDest")
+                Files.createDirectories(configFileDest.parent)
                 Files.copy(configFileInSrc, configFileDest, StandardCopyOption.REPLACE_EXISTING)
             } else {
                 println(


### PR DESCRIPTION
A custom `package.json` can be provided alongside an LF file. The compiler finds it and copies it to the generated source directory. This capability was broken and this PR fixes it.