### PR TITLE
Link reactor-c lib with zephyr kernel lib

### DIFF
--- a/org.lflang/src/org/lflang/generator/c/CCmakeGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CCmakeGenerator.java
@@ -371,6 +371,9 @@ public class CCmakeGenerator {
         var code = new CodeBuilder();
         code.pr("add_subdirectory(core)");
         code.pr("target_link_libraries(core PUBLIC zephyr_interface)");
+        // FIXME: Linking the reactor-c corelib with the zephyr kernel lib
+        //  resolves linker issues but I am not yet sure if it is safe
+        code.pr("target_link_libraries(core PRIVATE kernel)");
         code.newLine();
 
         if (hasMain) {


### PR DESCRIPTION
Addresses compilation errors when building threaded LF programs targeting Zephyr