### PR TITLE
More robust ROS2 setup in CI

### DIFF
--- a/.github/actions/setup-ros2/action.yml
+++ b/.github/actions/setup-ros2/action.yml
@@ -4,9 +4,9 @@ runs:
   using: "composite"
   steps:
    - if: runner.os == 'Linux'
-      # azure ubuntu repo can be flaky so add an alternate source
-      # see https://github.com/ros-tooling/setup-ros/issues/80 and https://github.com/ros2/rmw_cyclonedds/pull/134
-      run: sed -e 's/azure.archive.ubuntu.com/us.archive.ubuntu.com/g' -e t -e d /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/nonazure.list
+     # azure ubuntu repo can be flaky so add an alternate source
+     # see https://github.com/ros-tooling/setup-ros/issues/80 and https://github.com/ros2/rmw_cyclonedds/pull/134
+     run: sed -e 's/azure.archive.ubuntu.com/us.archive.ubuntu.com/g' -e t -e d /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/nonazure.list
    - name: Setup ROS2
      uses: ros-tooling/setup-ros@v0.5
      with:

--- a/.github/actions/setup-ros2/action.yml
+++ b/.github/actions/setup-ros2/action.yml
@@ -1,0 +1,13 @@
+name: Install ROS2 rolling (Linux only)
+description: Install ROS2 rolling (Linux only)
+runs:
+  using: "composite"
+  steps:
+    - if: runner.os == 'Linux'
+      # azure ubuntu repo can be flaky so add an alternate source
+      # see https://github.com/ros-tooling/setup-ros/issues/80 and https://github.com/ros2/rmw_cyclonedds/pull/134
+      run: sed -e 's/azure.archive.ubuntu.com/us.archive.ubuntu.com/g' -e t -e d /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/nonazure.list
+   - name: Setup ROS2
+     uses: ros-tooling/setup-ros@v0.5
+     with:
+       required-ros-distributions: rolling

--- a/.github/actions/setup-ros2/action.yml
+++ b/.github/actions/setup-ros2/action.yml
@@ -4,6 +4,7 @@ runs:
   using: "composite"
   steps:
    - if: runner.os == 'Linux'
+     shell: bash
      # azure ubuntu repo can be flaky so add an alternate source
      # see https://github.com/ros-tooling/setup-ros/issues/80 and https://github.com/ros2/rmw_cyclonedds/pull/134
      run: sed -e 's/azure.archive.ubuntu.com/us.archive.ubuntu.com/g' -e t -e d /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/nonazure.list

--- a/.github/actions/setup-ros2/action.yml
+++ b/.github/actions/setup-ros2/action.yml
@@ -3,7 +3,7 @@ description: Install ROS2 rolling (Linux only)
 runs:
   using: "composite"
   steps:
-    - if: runner.os == 'Linux'
+   - if: runner.os == 'Linux'
       # azure ubuntu repo can be flaky so add an alternate source
       # see https://github.com/ros-tooling/setup-ros/issues/80 and https://github.com/ros2/rmw_cyclonedds/pull/134
       run: sed -e 's/azure.archive.ubuntu.com/us.archive.ubuntu.com/g' -e t -e d /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/nonazure.list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
   # Run the C++ integration tests on ROS2.
   cpp-ros2-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/cpp-ros2-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/cpp-ros2-tests.yml@ros2-ci
     needs: cancel
 
   # Run the Python integration tests.
@@ -121,5 +121,5 @@ jobs:
 
   # Run the serialization tests
   serialization-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/serialization-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/serialization-tests.yml@ros2-ci
     needs: cancel

--- a/.github/workflows/cpp-ros2-tests.yml
+++ b/.github/workflows/cpp-ros2-tests.yml
@@ -30,9 +30,7 @@ jobs:
           ref: ${{ inputs.runtime-ref }}
         if: ${{ inputs.runtime-ref }}
       - name: Setup ROS2
-        uses: ros-tooling/setup-ros@v0.4
-        with:
-          required-ros-distributions: rolling
+        uses: ./.github/actions/setup-ros2
       - name: Run C++ tests;
         run: |
           source /opt/ros/*/setup.bash

--- a/.github/workflows/serialization-tests.yml
+++ b/.github/workflows/serialization-tests.yml
@@ -21,9 +21,7 @@ jobs:
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Setup ROS2
-        uses: ros-tooling/setup-ros@v0.4
-        with:
-          required-ros-distributions: rolling
+        uses: ./.github/actions/setup-ros2
       - name: Install Protobuf Ubuntu
         run: |
           sudo apt-get update


### PR DESCRIPTION
Setting up ROS2 in CI can be flaky and recently ROS2 tests have been failing consistently. The problem is also mentioned in the README of the ROS action: https://github.com/ros-tooling/setup-ros/

This PR attempts at fixing this by applying the solution mentioned here: https://github.com/ros2/rmw_cyclonedds/pull/134

The PR further factors out the ROS2 setup in our own customized action, so that we don't need to duplicate code.