### PR TITLE
Use of newer actions to reduce number of produced warnings in CI

### DIFF
--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -18,4 +18,4 @@ runs:
         echo $(mvn -v)
       shell: bash
     - name: Validate Gradle wrapper
-      uses: gradle/wrapper-validation-action@v1.0.4
+      uses: gradle/wrapper-validation-action@v1.0.5

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -63,7 +63,7 @@ jobs:
           ./gradlew test --tests org.lflang.tests.runtime.CCppTest.*
         if: ${{ inputs.use-cpp && !inputs.scheduler }}
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: org.lflang.tests/build/reports/xml/jacoco
           fail_ci_if_error: false

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: styfle/cancel-workflow-action@0.9.1
+      - uses: styfle/cancel-workflow-action@0.11.0
         with:
           all_but_latest: true
           access_token: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   # Cancel previous workflow runs.
   cancel:
-    uses: lf-lang/lingua-franca/.github/workflows/cancel.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/cancel.yml@ci-fixes
 
   # Test the Gradle and Maven build.
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,27 +18,27 @@ env:
 jobs:
   # Cancel previous workflow runs.
   cancel:
-    uses: lf-lang/lingua-franca/.github/workflows/cancel.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/cancel.yml@master
 
   # Test the Gradle and Maven build.
   build:
-    uses: lf-lang/lingua-franca/.github/workflows/build.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/build.yml@master
     needs: cancel
 
   # Check that automatic code formatting works.
   # TODO: Uncomment after fed-gen is merged.
   # format:
-  #   uses: lf-lang/lingua-franca/.github/workflows/format.yml@ci-fixes
+  #   uses: lf-lang/lingua-franca/.github/workflows/format.yml@master
   #   needs: cancel
 
   # Run the unit tests.
   unit-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/unit-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/unit-tests.yml@master
     needs: cancel
 
   # Run tests for the standalone compiler.
   cli-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/cli-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/cli-tests.yml@master
     needs: cancel
 
   # Run the C benchmark tests.
@@ -50,32 +50,32 @@ jobs:
 
   # Run tests for Eclipse.
   eclipse-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/eclipse-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/eclipse-tests.yml@master
     needs: cancel
 
   # Run language server tests.
   lsp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@master
     needs: cancel
 
   # Run the C integration tests.
   c-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@master
     needs: cancel
   
   # Run the C Arduino integration tests.
   c-arduino-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-arduino-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/c-arduino-tests.yml@master
     needs: cancel
   
   # Run the C Zephyr integration tests.
   c-zephyr-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@master
     needs: cancel
 
   # Run the CCpp integration tests.
   ccpp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@master
     with:
       use-cpp: true
     needs: cancel
@@ -89,22 +89,22 @@ jobs:
 
   # Run the C++ integration tests.
   cpp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/cpp-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/cpp-tests.yml@master
     needs: cancel
 
   # Run the C++ integration tests on ROS2.
   cpp-ros2-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/cpp-ros2-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/cpp-ros2-tests.yml@master
     needs: cancel
 
   # Run the Python integration tests.
   py-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/py-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/py-tests.yml@master
     needs: cancel
 
   # Run the Rust integration tests.
   rs-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/rs-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/rs-tests.yml@master
     needs: cancel
 
   # Run the Rust benchmark tests.
@@ -116,10 +116,10 @@ jobs:
 
   # Run the TypeScript integration tests.
   ts-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@master
     needs: cancel
 
   # Run the serialization tests
   serialization-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/serialization-tests.yml@ci-fixes
+    uses: lf-lang/lingua-franca/.github/workflows/serialization-tests.yml@master
     needs: cancel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
   # Run the unit tests.
   unit-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/unit-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/unit-tests.yml@ci-fixes
     needs: cancel
 
   # Run tests for the standalone compiler.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
 
   # Test the Gradle and Maven build.
   build:
-    uses: lf-lang/lingua-franca/.github/workflows/build.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/build.yml@ci-fixes
     needs: cancel
 
   # Check that automatic code formatting works.
   # TODO: Uncomment after fed-gen is merged.
   # format:
-  #   uses: lf-lang/lingua-franca/.github/workflows/format.yml@master
+  #   uses: lf-lang/lingua-franca/.github/workflows/format.yml@ci-fixes
   #   needs: cancel
 
   # Run the unit tests.
@@ -38,7 +38,7 @@ jobs:
 
   # Run tests for the standalone compiler.
   cli-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/cli-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/cli-tests.yml@ci-fixes
     needs: cancel
 
   # Run the C benchmark tests.
@@ -50,32 +50,32 @@ jobs:
 
   # Run tests for Eclipse.
   eclipse-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/eclipse-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/eclipse-tests.yml@ci-fixes
     needs: cancel
 
   # Run language server tests.
   lsp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@ci-fixes
     needs: cancel
 
   # Run the C integration tests.
   c-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@ci-fixes
     needs: cancel
   
   # Run the C Arduino integration tests.
   c-arduino-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-arduino-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/c-arduino-tests.yml@ci-fixes
     needs: cancel
   
   # Run the C Zephyr integration tests.
   c-zephyr-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@ci-fixes
     needs: cancel
 
   # Run the CCpp integration tests.
   ccpp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@ci-fixes
     with:
       use-cpp: true
     needs: cancel
@@ -89,22 +89,22 @@ jobs:
 
   # Run the C++ integration tests.
   cpp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/cpp-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/cpp-tests.yml@ci-fixes
     needs: cancel
 
   # Run the C++ integration tests on ROS2.
   cpp-ros2-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/cpp-ros2-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/cpp-ros2-tests.yml@ci-fixes
     needs: cancel
 
   # Run the Python integration tests.
   py-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/py-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/py-tests.yml@ci-fixes
     needs: cancel
 
   # Run the Rust integration tests.
   rs-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/rs-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/rs-tests.yml@ci-fixes
     needs: cancel
 
   # Run the Rust benchmark tests.
@@ -116,10 +116,10 @@ jobs:
 
   # Run the TypeScript integration tests.
   ts-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@ci-fixes
     needs: cancel
 
   # Run the serialization tests
   serialization-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/serialization-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/serialization-tests.yml@ci-fixes
     needs: cancel

--- a/.github/workflows/cpp-ros2-tests.yml
+++ b/.github/workflows/cpp-ros2-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out lingual-franca repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: lf-lang/lingua-franca
           submodules: true
@@ -23,7 +23,7 @@ jobs:
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Check out specific ref of reactor-cpp
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: lf-lang/reactor-cpp
           path: org.lflang/src/lib/cpp/reactor-cpp

--- a/.github/workflows/cpp-ros2-tests.yml
+++ b/.github/workflows/cpp-ros2-tests.yml
@@ -36,7 +36,7 @@ jobs:
           source /opt/ros/*/setup.bash
           ./gradlew test --tests org.lflang.tests.runtime.CppRos2Test.*
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: org.lflang.tests/build/reports/xml/jacoco
           fail_ci_if_error: false

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.CppTest.*
       - name: Report Java coverage to CodeCov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: org.lflang.tests/build/reports/xml/jacoco
           fail_ci_if_error: false
@@ -64,7 +64,7 @@ jobs:
           path: reactor-cpp.coverage
         if: matrix.platform == 'ubuntu-latest'
       - name: Report C++ coverage to CodeCov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: reactor-cpp.info
           fail_ci_if_error: false

--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -43,9 +43,9 @@ jobs:
         id: find
         run: |
           export tag=$(./latest-release.sh)
-          echo "::set-output name=ref::${tag}"
+          echo  "{ref}={${tag}}" >> $GITHUB_OUTPUT
           shopt -s extglob
           export ver="${tag##v}"
-          echo "::set-output name=ver::${ver}"
+          echo  "{ver}={${ver}}" >> $GITHUB_OUTPUT
           echo "Latest release tag: ${tag}"
           echo "Without a leading 'v': ${ver}"

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run language server Python tests without PyLint
         run: ./gradlew test --tests org.lflang.tests.lsp.LspTests.pythonValidationTestSyntaxOnly
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: org.lflang.tests/build/reports/xml/jacoco
           fail_ci_if_error: false
@@ -80,7 +80,7 @@ jobs:
       - name: Run language server tests
         run: ./gradlew clean test --tests org.lflang.tests.lsp.LspTests.*ValidationTest
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: org.lflang.tests/build/reports/xml/jacoco
           fail_ci_if_error: false

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install pnpm
         run: npm i -g pnpm
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.5
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-node${{ matrix.node-version }}-${{ hashFiles('org.lflang/src/lib/ts/package.json') }}

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.PythonTest.*
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: org.lflang.tests/build/reports/xml/jacoco
           fail_ci_if_error: false

--- a/.github/workflows/rs-tests.yml
+++ b/.github/workflows/rs-tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run Rust tests
         run: ./gradlew test --tests org.lflang.tests.runtime.RustTest.*
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: org.lflang.tests/build/reports/xml/jacoco
           fail_ci_if_error: false

--- a/.github/workflows/serialization-tests.yml
+++ b/.github/workflows/serialization-tests.yml
@@ -33,7 +33,7 @@ jobs:
           source /opt/ros/*/setup.bash
           ./gradlew test --tests org.lflang.tests.serialization.SerializationTest.*
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: org.lflang.tests/build/reports/xml/jacoco
           fail_ci_if_error: false

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.*
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: org.lflang.tests/build/reports/xml/jacoco
           fail_ci_if_error: false

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           ./gradlew test --tests org.lflang.tests.compiler.*
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: org.lflang.tests/build/reports/xml/jacoco
           fail_ci_if_error: false


### PR DESCRIPTION
There are currently a lot of warnings printed by GitHub actions due to the use of outdated Node.js versions and the use of now deprecated GitHub Actions features. The changes in this PR are meant to reduce the number of warnings.
 - [x] Nodejs warnings
 - [x] save-state (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
 - [x] set-output (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
