### PR TITLE
Draft proposal for making the grammar unambiguous

### DIFF
--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -202,7 +202,7 @@ Reaction:
     ('(' (triggers+=TriggerRef (',' triggers+=TriggerRef)*)? ')')
     (sources+=VarRef (',' sources+=VarRef)*)?
     ('->' effects+=VarRefOrModeTransition (',' effects+=VarRefOrModeTransition)*)?
-    ((code=Code ('named' ID)?) | 'named' ID)(stp=STP)?(deadline=Deadline)?
+    ((('named' ID)? code=Code) | 'named' ID)(stp=STP)?(deadline=Deadline)?
     ;
 
 TriggerRef:

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -496,7 +496,7 @@ Token:
     'mutable' | 'input' | 'output' | 'timer' | 'action' | 'reaction' |
     'startup' | 'shutdown' | 'after' | 'deadline' | 'mutation' | 'preamble' |
     'new' | 'federated' | 'at' | 'as' | 'from' | 'widthof' | 'const' | 'method' |
-    'interleaved' | 'mode' | 'initial' | 'reset' | 'history' |
+    'interleaved' | 'mode' | 'initial' | 'reset' | 'history' | 'named' |
     // Other terminals
     NEGINT | TRUE | FALSE |
     // Action origins

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -202,10 +202,8 @@ Reaction:
     ('(' (triggers+=TriggerRef (',' triggers+=TriggerRef)*)? ')')
     (sources+=VarRef (',' sources+=VarRef)*)?
     ('->' effects+=VarRefOrModeTransition (',' effects+=VarRefOrModeTransition)*)?
-    (((code=Code)(stp=STP)?(deadline=Deadline)?) |
-     ('{' '}' (stp=STP)?(deadline=Deadline)?) |
-     ';'
-    );
+    ((code=Code ('named' ID)?) | 'named' ID)(stp=STP)?(deadline=Deadline)?
+    ;
 
 TriggerRef:
     BuiltinTriggerRef | VarRef;

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -199,12 +199,13 @@ Reaction:
     (attributes+=Attribute)*
     (('reaction') | mutation ?= 'mutation')
     (name=ID)?
-    ('(' (triggers+=TriggerRef (',' triggers+=TriggerRef)*)? ')')?
+    ('(' (triggers+=TriggerRef (',' triggers+=TriggerRef)*)? ')')
     (sources+=VarRef (',' sources+=VarRef)*)?
     ('->' effects+=VarRefOrModeTransition (',' effects+=VarRefOrModeTransition)*)?
-    (code=Code)?
-    (stp=STP)?
-    (deadline=Deadline)?;
+    (((code=Code)(stp=STP)?(deadline=Deadline)?) |
+     ('{' '}' (stp=STP)?(deadline=Deadline)?) |
+     ';'
+    );
 
 TriggerRef:
     BuiltinTriggerRef | VarRef;


### PR DESCRIPTION
This PR makes the grammar unambiguous, but I'm not at all certain about these changes.
1. With the optional reaction name, we need to make the triggers mandatory, or else we won't be able to distinguish between the given name and the sources.
2. In the absence of a body, we need some placeholder. We could use `;`, but that would be awkward in the presence of a deadline. Using `.` in this case might make sense, but we can't because this collides with hierarchical effects. In this PR I use `{` `}` (and require `;` if there is no body and there are no deadlines).