### PR TITLE
Improved reporting of error that do not relate to a specific file

### DIFF
--- a/org.lflang/src/org/lflang/cli/ReportingUtil.kt
+++ b/org.lflang/src/org/lflang/cli/ReportingUtil.kt
@@ -261,9 +261,9 @@ class ReportingBackend constructor(
         val snippet: String? = filePath?.let { formatIssue(issue, filePath) }
 
         if (snippet == null) {
-            val displayPath: String = filePath?.let { io.wd.relativize(it) }?.toString() ?: "(unknown file)"
-            fullMessage += " --> " + displayPath + ":" + issue.line + ":" + issue.column
-            fullMessage += " - " + issue.message
+            filePath?.let { io.wd.relativize(it) }?.let {
+                fullMessage += " --> " + it + ":" + issue.line + ":" + issue.column + " - "
+            }
         } else {
             fullMessage += snippet
         }


### PR DESCRIPTION
In cases where LFC would currently print the following:
```
lfc: error:  failed with error code 2
 --> (unknown file):null:1 -  failed with error code 2

lfc: fatal error: Aborting due to previous error
```

LFC now prints the following:
```
lfc: error:  failed with error code 2


lfc: fatal error: Aborting due to previous error
```