### PR TITLE
Do not hardcode compile definitions in generated CMakeLists.txt

### DIFF
--- a/org.lflang/src/org/lflang/generator/c/CCmakeGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CCmakeGenerator.java
@@ -194,11 +194,6 @@ public class CCmakeGenerator {
         if (targetConfig.platformOptions.platform != Platform.AUTO) {
             cMakeCode.pr("set(CMAKE_SYSTEM_NAME "+targetConfig.platformOptions.platform.getcMakeName()+")");
         }
-
-        cMakeCode.pr("# Target definitions\n");
-        targetConfig.compileDefinitions.forEach((key, value) -> cMakeCode.pr(
-            "add_compile_definitions("+key+"="+value+")\n"
-        ));
         cMakeCode.newLine();
 
         if (targetConfig.platformOptions.platform == Platform.ZEPHYR) {


### PR DESCRIPTION
This is redundant to passing them on the command line. This change is in line with my long-term goal of disentangling the code generator from the build system.