### PR TITLE
Enable Gradle Cache

### DIFF
--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -15,5 +15,7 @@ runs:
         cat gradle.properties
         echo $JAVA_HOME
       shell: bash
+    - name: Gradle Cache
+      uses: burrunan/gradle-cache-action@v1
     - name: Validate Gradle wrapper
       uses: gradle/wrapper-validation-action@v1.0.5

--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -17,5 +17,3 @@ runs:
       shell: bash
     - name: Gradle Cache
       uses: burrunan/gradle-cache-action@v1
-    - name: Validate Gradle wrapper
-      uses: gradle/wrapper-validation-action@v1.0.5

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: zephyrprojectrtos/zephyr-build:latest
-      options: --entrypoint /bin/sh 
+      options: -u root --entrypoint /bin/sh 
     steps:
       - name: Install Java 17, Maven and set JAVA_HOME
         run: |
@@ -44,6 +44,8 @@ jobs:
           submodules: true
           ref: ${{ inputs.compiler-ref }}
           fetch-depth: 0
+      - name: Try to get around git safe issues
+        run: git config --global --add safe.directory /__w/lingua-franca/lingua-franca 
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Check out specific ref of reactor-c

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -30,6 +30,8 @@ jobs:
           sudo apt-get install -y openjdk-17-jdk
           sudo apt-get install -y maven
           echo "JAVA_HOME_17_X64=/usr/lib/jvm/java-17-openjdk-amd64" >> $GITHUB_ENV
+      - name: Get around Git safe issues
+        run: git config --global --add safe.directory '*'
       - name: Initialize zephyr
         run: |
           west init /workdir/zephyrproject --mr v3.2.0
@@ -44,8 +46,6 @@ jobs:
           submodules: true
           ref: ${{ inputs.compiler-ref }}
           fetch-depth: 0
-      - name: Get around Git safe issues
-        run: git config --global --add safe.directory /__w/lingua-franca/lingua-franca
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Check out specific ref of reactor-c

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: zephyrprojectrtos/zephyr-build:latest
-      options: --entrypoint /bin/sh 
+      options: -u root --entrypoint /bin/sh 
     steps:
       - name: Install Java 17, Maven and set JAVA_HOME
         run: |
@@ -44,6 +44,8 @@ jobs:
           submodules: true
           ref: ${{ inputs.compiler-ref }}
           fetch-depth: 0
+      - name: Get around Git safe issues
+        run: git config --global --add safe.directory /__w/lingua-franca/lingua-franca
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Check out specific ref of reactor-c

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -30,8 +30,6 @@ jobs:
           sudo apt-get install -y openjdk-17-jdk
           sudo apt-get install -y maven
           echo "JAVA_HOME_17_X64=/usr/lib/jvm/java-17-openjdk-amd64" >> $GITHUB_ENV
-      - name: Get around Git safe issues
-        run: git config --global --add safe.directory '*'
       - name: Initialize zephyr
         run: |
           west init /workdir/zephyrproject --mr v3.2.0
@@ -46,8 +44,12 @@ jobs:
           submodules: true
           ref: ${{ inputs.compiler-ref }}
           fetch-depth: 0
+      - name: Get around Git safe issues
+        run: git config --global --add safe.directory '*'
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
+        needs: Get around Git safe issues
+        
       - name: Check out specific ref of reactor-c
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: zephyrprojectrtos/zephyr-build:latest
-      options: -u root --entrypoint /bin/sh 
+      options: --entrypoint /bin/sh 
     steps:
       - name: Install Java 17, Maven and set JAVA_HOME
         run: |
@@ -44,12 +44,8 @@ jobs:
           submodules: true
           ref: ${{ inputs.compiler-ref }}
           fetch-depth: 0
-      - name: Get around Git safe issues
-        run: git config --global --add safe.directory '*'
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
-        needs: Get around Git safe issues
-        
       - name: Check out specific ref of reactor-c
         uses: actions/checkout@v3
         with:
@@ -57,6 +53,5 @@ jobs:
           path: org.lflang/src/lib/c/reactor-c
           ref: ${{ inputs.runtime-ref }}
         if: ${{ inputs.runtime-ref }}
-
       - name: Perform Zephyr tests for C target with default scheduler
         run: ./gradlew test --tests org.lflang.tests.runtime.CZephyrTest.runZephyrTests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
   
   # Run the C Zephyr integration tests.
   c-zephyr-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@gradle-cache
+    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@master
     needs: cancel
 
   # Run the CCpp integration tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
   
   # Run the C Zephyr integration tests.
   c-zephyr-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@gradle-cache
     needs: cancel
 
   # Run the CCpp integration tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
   
   # Run the C Zephyr integration tests.
   c-zephyr-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml
     needs: cancel
 
   # Run the CCpp integration tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
   
   # Run the C Zephyr integration tests.
   c-zephyr-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml
+    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@gradle-cache
     needs: cancel
 
   # Run the CCpp integration tests.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionSha256Sum=1a03a997b0542d721e9d74d1fe86e20a80933507ef1e1afc3b1c26c5585d6a1c
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
-distributionSha256Sum=1a03a997b0542d721e9d74d1fe86e20a80933507ef1e1afc3b1c26c5585d6a1c
+distributionSha256Sum=6147605a23b4eff6c334927a86ff3508cb5d6722cd624c97ded4c2e8640f1f87
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR adds caching of the Gradle build files (usually in `~/.gradle` and it removes the automatic integrity check for `gradlew` because it kept causing jobs due fail due to network errors. We now carry a hash of the current `gradlew` in `gradle/wrapper/gradle-wrapper.properties`, so whenever we update the version, we also need to update the hash.