### PR TITLE
Fix passing of command line options from lfc to the generator

### DIFF
--- a/org.lflang/src/org/lflang/cli/CliBase.java
+++ b/org.lflang/src/org/lflang/cli/CliBase.java
@@ -1,22 +1,15 @@
 package org.lflang.cli;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Properties;
 import java.util.stream.Collectors;
 
 import picocli.CommandLine;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
-import picocli.CommandLine.ParseResult;
-import picocli.CommandLine.Spec;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -29,8 +22,6 @@ import org.eclipse.xtext.validation.Issue;
 import org.lflang.ErrorReporter;
 import org.lflang.LFRuntimeModule;
 import org.lflang.LFStandaloneSetup;
-import org.lflang.LocalStrings;
-import org.lflang.generator.LFGeneratorContext.BuildParm;
 import org.lflang.util.FileUtil;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -45,11 +36,6 @@ import com.google.inject.Provider;
  * @author Atharva Patil
  */
 public abstract class CliBase implements Runnable {
-    /**
-     * Models a command specification, including the options, positional
-     * parameters and subcommands supported by the command.
-     */
-    @Spec CommandSpec spec;
 
     /**
      * Options and parameters present in both Lfc and Lff.
@@ -65,8 +51,8 @@ public abstract class CliBase implements Runnable {
         defaultValue = "",
         fallbackValue = "",
         description = "Specify the root output directory.")
-
     private Path outputPath;
+
     /**
      * Used to collect all errors that happen during validation/generation.
      */
@@ -102,13 +88,6 @@ public abstract class CliBase implements Runnable {
      */
     @Inject
     private IResourceValidator validator;
-
-    /** Name of the program, eg "lfc". */
-    private final String toolName;
-
-    protected CliBase(String toolName) {
-        this.toolName = toolName;
-    }
 
     protected static void cliMain(
             String toolName, Class<? extends CliBase> toolClass,

--- a/org.lflang/src/org/lflang/cli/Lfc.java
+++ b/org.lflang/src/org/lflang/cli/Lfc.java
@@ -1,20 +1,12 @@
 package org.lflang.cli;
 
 
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Model.OptionSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.generator.GeneratorDelegate;
 import org.eclipse.xtext.generator.JavaIoFileSystemAccess;
@@ -54,15 +46,8 @@ public class Lfc extends CliBase {
     @Inject
     private JavaIoFileSystemAccess fileAccess;
 
-    public Lfc() {
-        super("lfc");
-    }
-
-    /**
+    /*
      * Supported CLI options.
-     *
-     * @author Marten Lohstroh
-     * @author Atharva Patil
      */
 
     @Option(
@@ -101,7 +86,7 @@ public class Lfc extends CliBase {
     @Option(
         names = {"-l", "--lint"},
         arity = "0",
-        description = "Enable or disable linting of generated code.")
+        description = "Enable linting of generated code.")
     private boolean lint;
 
     @Option(
@@ -143,7 +128,7 @@ public class Lfc extends CliBase {
     @Option(
         names = {"-w", "--workers"},
         description = "Specify the default number of worker threads.")
-    private int workers;
+    private Integer workers;
 
     /**
      * Main function of the stand-alone compiler.
@@ -245,47 +230,48 @@ public class Lfc extends CliBase {
      * @return Properties for the code generator.
      */
     protected Properties filterPassOnProps() {
-        // Parameters corresponding to the options that need to be passed on to
-        // the generator as properties.
-        final Set<String> passOnParams = Stream.of(
-            BuildParm.BUILD_TYPE,
-            BuildParm.CLEAN,
-            BuildParm.TARGET_COMPILER,
-            BuildParm.EXTERNAL_RUNTIME_PATH,
-            BuildParm.LOGGING,
-            BuildParm.LINT,
-            BuildParm.NO_COMPILE,
-            BuildParm.QUIET,
-            BuildParm.RTI,
-            BuildParm.RUNTIME_VERSION,
-            BuildParm.SCHEDULER,
-            BuildParm.THREADING,
-            BuildParm.WORKERS)
-        .map(param -> param.getKey())
-        .collect(Collectors.toUnmodifiableSet());
-
         Properties props = new Properties();
 
-        for (OptionSpec option : spec.options()) {
-            String optionName = option.longestName();
-            // Check whether this option needs to be passed on to the code
-            // generator as a property.
-            if (passOnParams.contains(optionName)) {
-                String value = "";
-                // Boolean or Integer option.
-                if (option.getValue() instanceof Boolean ||
-                        option.getValue() instanceof Integer) {
-                    value = String.valueOf(option.getValue());
-                // String option.
-                } else if (option.getValue() instanceof String) {
-                    value = option.getValue();
-                // Path option.
-                } else if (option.getValue() instanceof Path) {
-                    value = option.getValue().toString();
-                }
-                props.setProperty(optionName, value);
-            }
+        if(buildType != null) {
+            props.setProperty(BuildParm.BUILD_TYPE.getKey(), buildType);
         }
+        if(clean) {
+            props.setProperty(BuildParm.CLEAN.getKey(), "true");
+        }
+        if(externalRuntimePath != null) {
+            props.setProperty(BuildParm.EXTERNAL_RUNTIME_PATH.getKey(), externalRuntimePath.toString());
+        }
+        if(lint) {
+            props.setProperty(BuildParm.LINT.getKey(), "true");
+        }
+        if(logging != null) {
+            props.setProperty(BuildParm.LOGGING.getKey(), logging);
+        }
+        if(noCompile) {
+            props.setProperty(BuildParm.NO_COMPILE.getKey(), "true");
+        }
+        if(targetCompiler != null) {
+            props.setProperty(BuildParm.TARGET_COMPILER.getKey(), targetCompiler);
+        }
+        if(quiet) {
+            props.setProperty(BuildParm.QUIET.getKey(), "true");
+        }
+        if(rti != null) {
+            props.setProperty(BuildParm.RTI.getKey(), rti);
+        }
+        if(runtimeVersion != null) {
+            props.setProperty(BuildParm.RUNTIME_VERSION.getKey(), runtimeVersion);
+        }
+        if(scheduler != null) {
+            props.setProperty(BuildParm.SCHEDULER.getKey(), scheduler);
+        }
+        if(threading != null) {
+            props.setProperty(BuildParm.THREADING.getKey(), threading);
+        }
+        if(workers != null) {
+            props.setProperty(BuildParm.WORKERS.getKey(), workers.toString());
+        }
+
         return props;
     }
 }

--- a/org.lflang/src/org/lflang/cli/Lfc.java
+++ b/org.lflang/src/org/lflang/cli/Lfc.java
@@ -232,46 +232,46 @@ public class Lfc extends CliBase {
     protected Properties filterPassOnProps() {
         Properties props = new Properties();
 
-        if(buildType != null) {
+        if (buildType != null) {
             props.setProperty(BuildParm.BUILD_TYPE.getKey(), buildType);
         }
-        if(clean) {
+        if (clean) {
             props.setProperty(BuildParm.CLEAN.getKey(), "true");
         }
-        if(externalRuntimePath != null) {
+        if (externalRuntimePath != null) {
             props.setProperty(BuildParm.EXTERNAL_RUNTIME_PATH.getKey(), externalRuntimePath.toString());
         }
-        if(lint) {
+        if (lint) {
             props.setProperty(BuildParm.LINT.getKey(), "true");
         }
-        if(logging != null) {
+        if (logging != null) {
             props.setProperty(BuildParm.LOGGING.getKey(), logging);
         }
-        if(noCompile) {
+        if (noCompile) {
             props.setProperty(BuildParm.NO_COMPILE.getKey(), "true");
         }
-        if(targetCompiler != null) {
+        if (targetCompiler != null) {
             props.setProperty(BuildParm.TARGET_COMPILER.getKey(), targetCompiler);
         }
-        if(quiet) {
+        if (quiet) {
             props.setProperty(BuildParm.QUIET.getKey(), "true");
         }
-        if(rti != null) {
+        if (rti != null) {
             props.setProperty(BuildParm.RTI.getKey(), rti);
         }
-        if(runtimeVersion != null) {
+        if (runtimeVersion != null) {
             props.setProperty(BuildParm.RUNTIME_VERSION.getKey(), runtimeVersion);
         }
-        if(scheduler != null) {
+        if (scheduler != null) {
             props.setProperty(BuildParm.SCHEDULER.getKey(), scheduler);
         }
-        if(threading != null) {
+        if (threading != null) {
             props.setProperty(BuildParm.THREADING.getKey(), threading);
         }
-        if(workers != null) {
+        if (workers != null) {
             props.setProperty(BuildParm.WORKERS.getKey(), workers.toString());
         }
-
+        
         return props;
     }
 }

--- a/org.lflang/src/org/lflang/cli/Lff.java
+++ b/org.lflang/src/org/lflang/cli/Lff.java
@@ -3,25 +3,17 @@ package org.lflang.cli;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileVisitResult;
-import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Properties;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
 import org.eclipse.emf.ecore.resource.Resource;
 
 import org.lflang.ast.FormattingUtils;
-import org.lflang.LocalStrings;
 import org.lflang.util.FileUtil;
 
 /**
@@ -66,10 +58,6 @@ public class Lff extends CliBase {
         names = {"-v", "--verbose"},
         description = "Print more details on files affected.")
     private boolean verbose = false;
-
-    public Lff() {
-        super("lff");
-    }
 
     /**
      * Main function of the formatter.


### PR DESCRIPTION
Currently, all command line options that need to be passed on from lfc to the code generator do not work. The reason for this, is that the long option names (e.g. `--clean`) are compared with the property names (e.g. `clean`).  This change provides a fix. Concretely, it replaces the automagic passing in a for loop from before with explicit code for each individual option. While it is a bit more verbose, this has some advantages:
- The code is readable and understandable
- IntelliJ produces a useful warning when an option is not used and therefore not passed on

This change further removes some unused code and includes other small cleanups. All in all, this removes all warnings shown bu IntelliJ.