### PR TITLE
Set external runtime path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
 
   # Run the TypeScript integration tests.
   ts-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@set-external-runtime-path
     needs: cancel
 
   # Run the serialization tests

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -34,7 +34,7 @@ jobs:
           ref: master
       - name: Perform TypeScript tests
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="./reactor-ts"
+          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="git://github.com/lf-lang/reactor-ts.git#master
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -26,9 +26,15 @@ jobs:
         run: |
           brew install coreutils
         if: ${{ runner.os == 'macOS' }}
+      - name: Clone reactor-ts
+        uses: actions/checkout@v3
+        with:
+          repository: lf-lang/reactor-ts
+          path: ./reactor-ts
+          ref: master
       - name: Perform TypeScript tests
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.*
+          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="./reactor-ts"
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -34,7 +34,7 @@ jobs:
           ref: master
       - name: Perform TypeScript tests
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="git://github.com/lf-lang/reactor-ts.git#master
+          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="git://github.com/lf-lang/reactor-ts.git#master"
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:

--- a/org.lflang/src/org/lflang/TargetProperty.java
+++ b/org.lflang/src/org/lflang/TargetProperty.java
@@ -255,7 +255,7 @@ public enum TargetProperty {
      * compiled binary.
      */
     EXTERNAL_RUNTIME_PATH("external-runtime-path", PrimitiveType.STRING,
-            List.of(Target.CPP),
+            List.of(Target.CPP, Target.TS),
             (config) -> ASTUtils.toElement(config.externalRuntimePath),
             (config, value, err) -> {
                 config.externalRuntimePath = ASTUtils.elementToSingleString(value);
@@ -411,7 +411,7 @@ public enum TargetProperty {
 
     /**
      * Directive to specify the platform for cross code generation. This is either a string of the platform
-     * or a dictionary of options that includes the string name. 
+     * or a dictionary of options that includes the string name.
      */
     PLATFORM("platform", UnionType.PLATFORM_STRING_OR_DICTIONARY, Target.ALL,
             (config) -> {

--- a/org.lflang/src/org/lflang/cli/Lfc.java
+++ b/org.lflang/src/org/lflang/cli/Lfc.java
@@ -113,7 +113,7 @@ public class Lfc extends CliBase {
     @Option(
         names = {"-q", "--quiet"},
         arity = "0",
-        description = 
+        description =
             "Suppress output of the target compiler and other commands")
     private boolean quiet;
 
@@ -195,7 +195,7 @@ public class Lfc extends CliBase {
 
             final Resource resource = getResource(path);
             if (resource == null) {
-                reporter.printFatalErrorAndExit(path 
+                reporter.printFatalErrorAndExit(path
                     + " is not an LF file. Use the .lf file extension to"
                     + " denote LF files.");
             } else if (federated) {
@@ -261,27 +261,26 @@ public class Lfc extends CliBase {
             BuildParm.SCHEDULER,
             BuildParm.THREADING,
             BuildParm.WORKERS)
-        .map(param -> param.getKey())
+        .map(BuildParm::getKey)
         .collect(Collectors.toUnmodifiableSet());
 
         Properties props = new Properties();
 
         for (OptionSpec option : spec.options()) {
             String optionName = option.longestName();
+            if (optionName.startsWith("--")) optionName = optionName.substring(2);
             // Check whether this option needs to be passed on to the code
             // generator as a property.
-            if (passOnParams.contains(optionName)) {
+            Object valueObject = option.getValue();
+            if (passOnParams.contains(optionName) && valueObject != null) {
                 String value = "";
-                // Boolean or Integer option.
-                if (option.getValue() instanceof Boolean ||
-                        option.getValue() instanceof Integer) {
-                    value = String.valueOf(option.getValue());
-                // String option.
-                } else if (option.getValue() instanceof String) {
-                    value = option.getValue();
-                // Path option.
-                } else if (option.getValue() instanceof Path) {
-                    value = option.getValue().toString();
+                if (valueObject instanceof Boolean ||
+                        valueObject instanceof Integer) {
+                    value = String.valueOf(valueObject);
+                } else if (valueObject instanceof String s) {
+                    value = s;
+                } else if (valueObject instanceof Path) {
+                    value = valueObject.toString();
                 }
                 props.setProperty(optionName, value);
             }

--- a/org.lflang/src/org/lflang/generator/LFGeneratorContext.java
+++ b/org.lflang/src/org/lflang/generator/LFGeneratorContext.java
@@ -1,15 +1,12 @@
 package org.lflang.generator;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.generator.IFileSystemAccess2;
 import org.eclipse.xtext.generator.IGeneratorContext;
-import org.eclipse.xtext.util.RuntimeIOException;
 
 import org.lflang.ErrorReporter;
 import org.lflang.FileConfig;
@@ -79,7 +76,7 @@ public interface LFGeneratorContext extends IGeneratorContext {
     }
 
     /**
-     * Return the mode of operation, which indicates how the compiler has been invoked 
+     * Return the mode of operation, which indicates how the compiler has been invoked
      * (e.g., from within Epoch, from the command line, or via a Language Server).
      */
     Mode getMode();


### PR DESCRIPTION
When we make changes to reactor-ts and accompanying changes in
lingua-franca we cannot point to the version of reactor-ts that is
published on NPM. We need to clone a specific ref and point to it.

Locally, pointing to the correct runtime version fixes the problem that
I observed in https://github.com/lf-lang/lingua-franca/pull/1607. If this change to the yaml file is correct then
this should make that PR mergeable.

This PR also fixes a bug in the way we pass CLI args because this bug was inhibiting my ability to debug #1607. I decided to fix the bug rather than working around it