### PR TITLE
Compute hash of Gradle configuration in Bash

### DIFF
--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -15,12 +15,16 @@ runs:
         cat gradle.properties
         echo $JAVA_HOME
       shell: bash
+    - name: Create hash of Gradle configuration
+      run: |
+        echo "gradle-hash"="$(find . -type f \( -name "gradle.properties" -o -name "gradle-wrapper.properties" \) -exec cat {} + | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
+      shell: bash
     - name: Cache
       uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
-        key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle-wrapper.properties') }}
+        key: gradle-${{ runner.os }}-${{ env.gradle-hash }}
         # restore-keys: |
         #   ${{ runner.os }}-gradle-

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Perform TypeScript tests
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.*
-      - name: Remove generated sources of tests to make glob star tractable
-        run: |
-          rm -rf test/TypeScript/src-gen
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:


### PR DESCRIPTION
This PR fixes a botched attempt at tying our Gradle cache to our Gradle configuration using a hash. It straightforwardly computes a hash over the concatenation of all `gradle.properties` and `gradle-wrapper.properties` found in the workspace.