### PR TITLE
Fix tracing options so that they appear in targetConfig

### DIFF
--- a/org.lflang/src/org/lflang/federated/generator/FedGenerator.java
+++ b/org.lflang/src/org/lflang/federated/generator/FedGenerator.java
@@ -244,6 +244,7 @@ public class FedGenerator {
         } else {
             launcher = FedLauncherFactory.getLauncher(
                 federates.get(0), // FIXME: This would not work for mixed-target programs.
+                targetConfig,
                 fileConfig,
                 errorReporter
             );

--- a/org.lflang/src/org/lflang/federated/launcher/FedLauncherFactory.java
+++ b/org.lflang/src/org/lflang/federated/launcher/FedLauncherFactory.java
@@ -15,10 +15,11 @@ public class FedLauncherFactory {
 
     public static FedLauncher getLauncher (
         FederateInstance federate,
+        TargetConfig targetConfig,
         FedFileConfig fileConfig,
         ErrorReporter errorReporter
     ) {
-        return getLauncher(Target.fromDecl(federate.target), federate.targetConfig, fileConfig, errorReporter);
+        return getLauncher(Target.fromDecl(federate.target), targetConfig, fileConfig, errorReporter);
     }
 
     /**


### PR DESCRIPTION
This is a fix to make tracing options appear in tragetConfig (Issue #1602).