### PR TITLE
Fix in validation so that warnings are not reported as errors

### DIFF
--- a/org.lflang/src/org/lflang/generator/GeneratorBase.java
+++ b/org.lflang/src/org/lflang/generator/GeneratorBase.java
@@ -267,7 +267,6 @@ public abstract class GeneratorBase extends AbstractLFValidator {
         // to validate, which happens in setResources().
         setReactorsAndInstantiationGraph(context.getMode());
 
-        GeneratorUtils.validate(context, context.getFileConfig(), instantiationGraph, errorReporter);
         List<Resource> allResources = GeneratorUtils.getResources(reactors);
         resources.addAll(allResources.stream()  // FIXME: This filter reproduces the behavior of the method it replaces. But why must it be so complicated? Why are we worried about weird corner cases like this?
             .filter(it -> !Objects.equal(it, context.getFileConfig().resource) || mainDef != null && it == mainDef.getReactorClass().eResource())

--- a/org.lflang/src/org/lflang/generator/GeneratorUtils.java
+++ b/org.lflang/src/org/lflang/generator/GeneratorUtils.java
@@ -156,9 +156,9 @@ public class GeneratorUtils {
         }
         for (Resource resource : resources) {
             for (Action action : findAll(resource, Action.class)) {
-                if (action.getOrigin() == ActionOrigin.PHYSICAL && 
+                if (action.getOrigin() == ActionOrigin.PHYSICAL &&
                     // Check if the user has explicitly set keepalive to false
-                    !targetConfig.setByUser.contains(TargetProperty.KEEPALIVE) && 
+                    !targetConfig.setByUser.contains(TargetProperty.KEEPALIVE) &&
                     !targetConfig.keepalive
                 ) {
                     // If not, set it to true
@@ -212,70 +212,6 @@ public class GeneratorUtils {
                 return current;
             }
         };
-    }
-
-    /**
-     * Validate the files containing reactors in the given
-     * {@code instantiationGraph}. If a file is imported by
-     * another file in the instantiation graph, propagate the
-     * resulting errors to the importing file.
-     * @param context The context providing the cancel
-     *                indicator used by the validator.
-     * @param fileConfig The file system configuration.
-     * @param instantiationGraph A DAG containing all
-     *                           reactors of interest.
-     * @param errorReporter An error acceptor.
-     */
-    public static void validate(
-        IGeneratorContext context,
-        FileConfig fileConfig,
-        InstantiationGraph instantiationGraph,
-        ErrorReporter errorReporter
-    ) {
-        // NOTE: This method was previously misnamed validateImports.
-        // It validates all files, including the main file that does the importing.
-        // Also, it is now the only invocation of validation during code generation,
-        // and yet it used to only report errors in the files doing the importing.
-        IResourceValidator validator = ((XtextResource) fileConfig.resource).getResourceServiceProvider()
-                                                                            .getResourceValidator();
-        HashSet<Resource> bad = new HashSet<>();
-        HashSet<Resource> visited = new HashSet<>();
-        // The graph must be traversed in topological order so that errors will propagate through arbitrarily many
-        // levels.
-        for (Reactor reactor : instantiationGraph.nodesInTopologicalOrder()) {
-            Resource resource = reactor.eResource();
-            if (visited.contains(resource)) continue;
-            visited.add(resource);
-            List<Issue> issues = validator.validate(resource, CheckMode.ALL, context.getCancelIndicator());
-            if (
-                bad.contains(resource) || issues.size() > 0
-            ) {
-                // Report the error on this resource.
-                Path path = null;
-                try {
-                    path = FileUtil.toPath(resource);
-                } catch (IOException e) {
-                    path = Paths.get("Unknown file"); // Not sure if this is what we want.
-                }
-                for (Issue issue : issues) {
-                    errorReporter.reportError(path, issue.getLineNumber(), issue.getMessage());
-                }
-                
-                // Report errors on resources that import this one.
-                for (Reactor downstreamReactor : instantiationGraph.getDownstreamAdjacentNodes(reactor)) {
-                    for (Import importStatement : ((Model) downstreamReactor.eContainer()).getImports()) {
-                        // FIXME: This will report the error on ALL import statements in
-                        // file doing the importing, not just the one importing this resource.
-                        // I have no idea how to determine which import statement is the right one.
-                        errorReporter.reportError(importStatement, String.format(
-                            "Unresolved compilation issues in '%s': "
-                                + issues.toString(), importStatement.getImportURI()
-                        ));
-                        bad.add(downstreamReactor.eResource());
-                    }
-                }
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
This does not change the output of `lfc` even when an error appears in an imported reactor.

The code just was not doing much except for redundant work, since it was being invoked after a round of validation checks had already passed. Actually it was even worse than that, because it was running the validator without the right `ValidationIssueAcceptor` injected, resulting in behavior that was not consistent with that implemented in `StandaloneIssueAcceptor`. This is why warnings were (wrongly) being converted to errors.

I decided to delete the method in `GeneratorUtils` rather than a) make this code work properly and b) spend some unknown number of hours fighting with Guice. I think this is an acceptable solution because it is doubtful whether the behavior that the method was supposed to implement is what we want. Specifically, if an error is reported on an imported reactor, it is not obvious to me that the error should also be reported on import statements that import the reactor.