### PR TITLE
Fix zephyr tests

### DIFF
--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -37,6 +37,7 @@ jobs:
           west update
           echo "ZEPHYR_BASE=/workdir/zephyrproject/zephyr" >> $GITHUB_ENV
           echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-0.15.2/" >> $GITHUB_ENV
+          west zephyr-export
       - name: Check out lingua-franca repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -21,7 +21,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     container:
-      image: zephyrprojectrtos/zephyr-build:latest
+      image: zephyrprojectrtos/zephyr-build:v0.24.13
       options: -u root --entrypoint /bin/sh 
     steps:
       - name: Install Java 17, Maven and set JAVA_HOME
@@ -37,7 +37,6 @@ jobs:
           west update
           echo "ZEPHYR_BASE=/workdir/zephyrproject/zephyr" >> $GITHUB_ENV
           echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-0.15.2/" >> $GITHUB_ENV
-          west zephyr-export
       - name: Check out lingua-franca repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
   
   # Run the C Zephyr integration tests.
   c-zephyr-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@master
+    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@fix-zephyr-tests
     needs: cancel
 
   # Run the CCpp integration tests.


### PR DESCRIPTION
Use a known version of the Zephyr build docker image. Was using `latest` and some incompatible changes were released yesterday