### PR TITLE
Remove klighd dependency and excludes org/lflang/diagram from gradle compilation

### DIFF
--- a/gradle/source-layout.gradle
+++ b/gradle/source-layout.gradle
@@ -6,8 +6,14 @@ if (name.endsWith(".tests")) {
 			resources.srcDirs = []
 		}
 		test {
-			java.srcDirs = ['src', 'src-gen']
-			kotlin.srcDirs = ['src', 'src-gen']
+			java {
+                          srcDirs = ['src', 'src-gen']
+                          exclude "org/lflang/diagram/**"
+                        }
+			kotlin {
+                          srcDirs = ['src', 'src-gen']
+                          exclude "org/lflang/diagram/**"
+                        }
 			resources.srcDirs = ['src', 'src-gen']
 			xtendOutputDir = 'xtend-gen'
 		}
@@ -19,7 +25,10 @@ if (name.endsWith(".tests")) {
                           srcDirs = ['src', 'src-gen']
                           exclude "org/lflang/diagram/**"
                         }
-			kotlin.srcDirs = ['src', 'src-gen']
+			kotlin {
+                          srcDirs = ['src', 'src-gen']
+                          exclude "org/lflang/diagram/**"
+                        }
 			xtendOutputDir = 'xtend-gen'
 			resources {
 				srcDirs = ['src', 'src-gen']

--- a/gradle/source-layout.gradle
+++ b/gradle/source-layout.gradle
@@ -15,7 +15,10 @@ if (name.endsWith(".tests")) {
 } else {
 	sourceSets {
 		main {
-			java.srcDirs = ['src', 'src-gen']
+			java {
+                          srcDirs = ['src', 'src-gen']
+                          exclude "org/lflang/diagram/**"
+                        }
 			kotlin.srcDirs = ['src', 'src-gen']
 			xtendOutputDir = 'xtend-gen'
 			resources {

--- a/org.lflang.tests/build.gradle
+++ b/org.lflang.tests/build.gradle
@@ -1,9 +1,9 @@
 repositories {
     mavenCentral()
     // TODO Replace this unofficial maven repository as soon as Klighd is released to maven central in the future.
-    maven {
-        url "https://rtsys.informatik.uni-kiel.de/~kieler/files/repo/"
-    }
+    //maven {
+    //    url "https://rtsys.informatik.uni-kiel.de/~kieler/files/repo/"
+    //}
 }
 dependencies {
     implementation project(':org.lflang')

--- a/org.lflang/build.gradle
+++ b/org.lflang/build.gradle
@@ -3,9 +3,9 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 repositories {
     mavenCentral()
     // TODO Replace this unofficial maven repository as soon as Klighd is released to maven central in the future.
-    maven {
-        url "https://rtsys.informatik.uni-kiel.de/~kieler/files/repo/"
-    }
+    //maven {
+    //    url "https://rtsys.informatik.uni-kiel.de/~kieler/files/repo/"
+    //}
 }
 dependencies {
     implementation "org.eclipse.xtext:org.eclipse.xtext:${xtextVersion}"
@@ -20,14 +20,14 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.12.4'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.12.4'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.4'
-    implementation ("de.cau.cs.kieler.klighd:de.cau.cs.kieler.klighd.lsp:${klighdVersion}") {
-        exclude group: 'org.eclipse.platform', module: 'org.eclipse.swt.*'
-        exclude group: 'org.eclipse.platform', module: 'org.eclipse.swt'
-    }
-    implementation ("de.cau.cs.kieler.klighd:de.cau.cs.kieler.klighd.standalone:${klighdVersion}") {
-        exclude group: 'org.eclipse.platform', module: 'org.eclipse.swt.*'
-        exclude group: 'org.eclipse.platform', module: 'org.eclipse.swt'
-    }
+    //implementation ("de.cau.cs.kieler.klighd:de.cau.cs.kieler.klighd.lsp:${klighdVersion}") {
+    //    exclude group: 'org.eclipse.platform', module: 'org.eclipse.swt.*'
+    //    exclude group: 'org.eclipse.platform', module: 'org.eclipse.swt'
+    //}
+    //implementation ("de.cau.cs.kieler.klighd:de.cau.cs.kieler.klighd.standalone:${klighdVersion}") {
+    //    exclude group: 'org.eclipse.platform', module: 'org.eclipse.swt.*'
+    //    exclude group: 'org.eclipse.platform', module: 'org.eclipse.swt'
+    //}
 }
 
 configurations {


### PR DESCRIPTION
This is a temporary workaround for the gradle compilation issues that currently appear as the klighd dependency cannot be resolved. I hope we can fix it soon in other ways, but if there is no quick fix we might need to merge this workaround. This will break the language server though...