### PR TITLE
Add --json and --json-file CLI args to Lfc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ subprojects {
         implementation group: 'com.google.inject', name: 'guice', version: guiceVersion
         // https://picocli.info/
         implementation group: 'info.picocli', name: 'picocli', version: picocliVersion
-    }
-    dependencies {
+        // https://mvnrepository.com/artifact/com.google.code.gson/gson
+        implementation group: 'com.google.code.gson', name: 'gson', version: gsonVersion
         implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: kotlinVersion
         implementation group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: kotlinVersion
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ group=org.lflang
 version=0.4.1-SNAPSHOT
 
 [versions]
-picocliVersion=4.7.0
 googleJavaFormatVersion=1.15.0
 guiceVersion=5.1.0
+gsonVersion=2.10.1
 jacocoVersion=0.8.7
 jupiterVersion=5.8.2
 jUnitPlatformVersion=1.8.2
@@ -15,6 +15,7 @@ kotlinVersion=1.6.20
 lsp4jVersion=0.14.0
 mwe2LaunchVersion=2.12.2
 openTest4jVersion=1.2.0
+picocliVersion=4.7.0
 resourcesVersion=3.16.0
 shadowJarVersion=7.1.2
 spotlessVersion=6.11.0

--- a/org.lflang.tests/src/org/lflang/tests/cli/LfcCliTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/cli/LfcCliTest.java
@@ -210,6 +210,8 @@ public class LfcCliTest {
             });
     }
 
+    // Helper method for comparing argument values in tests testGeneratorArgs,
+    // testGeneratorArgsJsonString and testGeneratorArgsJsonFile.
     public void verifyGeneratorArgs(Path tempDir, String[] args) {
         LfcOneShotTestFixture fixture = new LfcOneShotTestFixture();
 

--- a/org.lflang.tests/src/org/lflang/tests/cli/LfcCliTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/cli/LfcCliTest.java
@@ -268,7 +268,7 @@ public class LfcCliTest {
             throws IOException {
         TempDirBuilder dir = dirBuilder(tempDir);
         dir.file("src/File.lf", LF_PYTHON_FILE);
-        dir.mkdirs("path//to/rti");
+        dir.mkdirs("path/to/rti");
 
         String[] args = {"--json", JSON_STRING};
         verifyGeneratorArgs(tempDir, args);

--- a/org.lflang.tests/src/org/lflang/tests/cli/LfcCliTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/cli/LfcCliTest.java
@@ -280,7 +280,7 @@ public class LfcCliTest {
         TempDirBuilder dir = dirBuilder(tempDir);
         dir.file("src/File.lf", LF_PYTHON_FILE);
         dir.file("src/test.json", JSON_STRING);
-        dir.mkdirs("path//to/rti");
+        dir.mkdirs("path/to/rti");
 
         String[] args = {"--json-file", "src/test.json"};
         verifyGeneratorArgs(tempDir, args);

--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -1795,7 +1795,7 @@ public class LinguaFrancaValidationTest {
         String testCase = """
                 target C;
                 reactor R {
-                    state s:int(0);
+                    state s:int = 0;
                 }
                 main reactor {
                     initial mode IM {
@@ -1836,7 +1836,7 @@ public class LinguaFrancaValidationTest {
                         reaction(startup) -> M {==}
                     }
                     mode M {
-                        reset state s:int(0);
+                        reset state s:int = 0;
                     }
                 }
             """;

--- a/org.lflang/src/org/lflang/cli/CliBase.java
+++ b/org.lflang/src/org/lflang/cli/CliBase.java
@@ -4,12 +4,22 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import picocli.CommandLine;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -23,6 +33,10 @@ import org.lflang.ErrorReporter;
 import org.lflang.LFRuntimeModule;
 import org.lflang.LFStandaloneSetup;
 import org.lflang.util.FileUtil;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonParseException;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
@@ -36,22 +50,42 @@ import com.google.inject.Provider;
  * @author Atharva Patil
  */
 public abstract class CliBase implements Runnable {
+    /**
+     * Models a command specification, including the options, positional
+     * parameters and subcommands supported by the command.
+     */
+    @Spec CommandSpec spec;
 
     /**
      * Options and parameters present in both Lfc and Lff.
      */
-    @Parameters(
-        arity = "1..",
-        paramLabel = "FILES",
-        description = "Paths of the files to run Lingua Franca programs on.")
-    protected List<Path> files;
+    static class MutuallyExclusive {
+         @Parameters(
+         arity = "1..",
+         paramLabel = "FILES",
+         description = "Paths of the files to run Lingua Franca programs on.")
+             protected List<Path> files;
 
-    @Option(
-        names = {"-o", "--output-path"},
-        defaultValue = "",
-        fallbackValue = "",
-        description = "Specify the root output directory.")
-    private Path outputPath;
+         @Option(
+         names="--json",
+         description="JSON object containing CLI arguments.")
+             private String jsonString;
+
+         @Option(
+         names="--json-file",
+         description="JSON file containing CLI arguments.")
+             private Path jsonFile;
+     }
+
+     @ArgGroup(exclusive = true, multiplicity = "1")
+     MutuallyExclusive topLevelArg;
+
+     @Option(
+     names = {"-o", "--output-path"},
+     defaultValue = "",
+     fallbackValue = "",
+     description = "Specify the root output directory.")
+         private Path outputPath;
 
     /**
      * Used to collect all errors that happen during validation/generation.
@@ -111,9 +145,39 @@ public abstract class CliBase implements Runnable {
     /**
      * The entrypoint of Picocli applications - the first method called when 
      * CliBase, which implements the Runnable interface, is instantiated.
-     * Lfc and Lff have their own specific implementations for this method.
      */ 
-    public abstract void run();
+    public void run() {
+        // If args are given in a json file, store its contents in jsonString.
+        if (topLevelArg.jsonFile != null) {
+            try {
+                topLevelArg.jsonString = new String(Files.readAllBytes(
+                        io.getWd().resolve(topLevelArg.jsonFile)));
+            } catch (IOException e) {
+                reporter.printFatalErrorAndExit(
+                        "No such file: " + topLevelArg.jsonFile);
+            }
+        }
+        // If args are given in a json string, (1) unpack them into an args
+        // array, and (2) call cmd.execute on them, which assigns them to their
+        // correct instance variables, then (3) recurses into run().
+        if (topLevelArg.jsonString != null) {
+            // Unpack args from json string.
+            String[] args = jsonStringToArgs(topLevelArg.jsonString);
+            // Execute application on unpacked args.
+            CommandLine cmd = spec.commandLine();
+            int exitCode = cmd.execute(args);
+            io.callSystemExit(exitCode);
+        // If args are already unpacked, invoke tool-specific logic.
+        } else {
+            runTool();
+        }
+    }
+
+    /*
+     * The entrypoint of tool-specific logic.
+     * Lfc and Lff have their own specific implementations for this method.
+     */
+    public abstract void runTool();
 
     public static Injector getInjector(String toolName, Io io) {
         final ReportingBackend reporter 
@@ -139,7 +203,7 @@ public abstract class CliBase implements Runnable {
      * @return Validated input paths.
      */
     protected List<Path> getInputPaths() {
-        List<Path> paths = files.stream()
+        List<Path> paths = topLevelArg.files.stream()
             .map(io.getWd()::resolve)
             .collect(Collectors.toList());
 
@@ -252,4 +316,54 @@ public abstract class CliBase implements Runnable {
         }
     }
 
+    private String[] jsonStringToArgs(String jsonString) {
+        ArrayList<String> argsList = new ArrayList<>();
+        JsonObject jsonObject = new JsonObject();
+
+        // Parse JSON string and get top-level JSON object.
+        try {
+            jsonObject = JsonParser.parseString(jsonString).getAsJsonObject();
+        } catch (JsonParseException e) {
+            reporter.printFatalErrorAndExit(
+                    "Invalid JSON string:\n" + jsonString);
+        }
+        // Append input paths.
+        JsonElement src = jsonObject.get("src");
+        if (src == null) {
+            reporter.printFatalErrorAndExit(
+                    "JSON Parse Exception: field \"src\" not found.");
+        }
+        argsList.add(src.getAsString());
+        // Append output path if given.
+        JsonElement out = jsonObject.get("out");
+        if (out != null) {
+            argsList.add("--output-path");
+            argsList.add(out.getAsString());
+        }
+
+        // If there are no other properties, return args array.
+        JsonElement properties = jsonObject.get("properties");
+        if (properties != null) {
+            // Get the remaining properties.
+            Set<Entry<String, JsonElement>> entrySet = properties
+                .getAsJsonObject()
+                .entrySet();
+            // Append the remaining properties to the args array.
+            for(Entry<String,JsonElement> entry : entrySet) {
+                String property = entry.getKey();
+                String value = entry.getValue().getAsString();
+
+                // Append option.
+                argsList.add("--" + property);
+                // Append argument for non-boolean options.
+                if (value != "true" || property == "threading") {
+                    argsList.add(value);
+                }
+            }
+        }
+
+        // Return as String[].
+        String[] args = argsList.toArray(new String[argsList.size()]);
+        return args;
+    }
 }

--- a/org.lflang/src/org/lflang/cli/CliBase.java
+++ b/org.lflang/src/org/lflang/cli/CliBase.java
@@ -169,7 +169,7 @@ public abstract class CliBase implements Runnable {
             io.callSystemExit(exitCode);
         // If args are already unpacked, invoke tool-specific logic.
         } else {
-            runTool();
+            doRun();
         }
     }
 
@@ -177,7 +177,7 @@ public abstract class CliBase implements Runnable {
      * The entrypoint of tool-specific logic.
      * Lfc and Lff have their own specific implementations for this method.
      */
-    public abstract void runTool();
+    public abstract void doRun();
 
     public static Injector getInjector(String toolName, Io io) {
         final ReportingBackend reporter 
@@ -325,7 +325,7 @@ public abstract class CliBase implements Runnable {
             jsonObject = JsonParser.parseString(jsonString).getAsJsonObject();
         } catch (JsonParseException e) {
             reporter.printFatalErrorAndExit(
-                    "Invalid JSON string:\n" + jsonString);
+                    String.format("Invalid JSON string:%n %s", jsonString));
         }
         // Append input paths.
         JsonElement src = jsonObject.get("src");

--- a/org.lflang/src/org/lflang/cli/CliBase.java
+++ b/org.lflang/src/org/lflang/cli/CliBase.java
@@ -63,7 +63,7 @@ public abstract class CliBase implements Runnable {
          @Parameters(
          arity = "1..",
          paramLabel = "FILES",
-         description = "Paths of the files to run Lingua Franca programs on.")
+         description = "Paths to one or more Lingua Franca programs.")
              protected List<Path> files;
 
          @Option(

--- a/org.lflang/src/org/lflang/cli/Lfc.java
+++ b/org.lflang/src/org/lflang/cli/Lfc.java
@@ -156,7 +156,7 @@ public class Lfc extends CliBase {
      * Load the resource, validate it, and, invoke the code generator.
      */
     @Override
-    public void run() {
+    public void runTool() {
         List<Path> paths = getInputPaths();
         final Path outputRoot = getOutputRoot();
         // Hard code the props based on the options we want.

--- a/org.lflang/src/org/lflang/cli/Lfc.java
+++ b/org.lflang/src/org/lflang/cli/Lfc.java
@@ -156,7 +156,7 @@ public class Lfc extends CliBase {
      * Load the resource, validate it, and, invoke the code generator.
      */
     @Override
-    public void runTool() {
+    public void doRun() {
         List<Path> paths = getInputPaths();
         final Path outputRoot = getOutputRoot();
         // Hard code the props based on the options we want.

--- a/org.lflang/src/org/lflang/cli/Lff.java
+++ b/org.lflang/src/org/lflang/cli/Lff.java
@@ -88,7 +88,7 @@ public class Lff extends CliBase {
      * Validates all paths and invokes the formatter on the input paths.
      */
     @Override
-    public void runTool() {
+    public void doRun() {
         List<Path> paths = getInputPaths();
         final Path outputRoot = getOutputRoot();
 

--- a/org.lflang/src/org/lflang/cli/Lff.java
+++ b/org.lflang/src/org/lflang/cli/Lff.java
@@ -88,7 +88,7 @@ public class Lff extends CliBase {
      * Validates all paths and invokes the formatter on the input paths.
      */
     @Override
-    public void run() {
+    public void runTool() {
         List<Path> paths = getInputPaths();
         final Path outputRoot = getOutputRoot();
 

--- a/test/Cpp/src/NativeListsAndTimes.lf
+++ b/test/Cpp/src/NativeListsAndTimes.lf
@@ -6,9 +6,7 @@ reactor Foo(
     y: time = 0,                // Units are missing but not required
     z = 1 msec,                 // Type is missing but not required
     p: int[]{1, 2, 3, 4},       // List of integers
-    q: {=  // list of time values
-        std::vector<reactor::Duration>
-    =}{1 msec, 2 msec, 3 msec},
+    q: {= std::vector<reactor::Duration> =}{1 msec, 2 msec, 3 msec},
     g: time[]{1 msec, 2 msec},  // List of time values
     g2: int[] = {}
 ) {


### PR DESCRIPTION
#### Objective
Allow properties to be passed into `lfc` through a JSON string or file as an alternative to CLI arguments.

#### Reason
To provide a JSON interface between `lingo` and `lfc`.

#### Tasks
- [x] Make options {input files, `--json`, `--json-files`} mutually exclusive.
- [x] Refactor run() (entry point of `CliBase.java`) to first check for `--json` and `--json-file` args, and if either are given, unpack args and recurse into run().
- [x] Implement method `jsonStringToArgs` to convert a JSON string to a Lingua Franca args array.
- [x] Add error handling for file reads and JSON indexing.
- [x] Add tests for `--json` and `--json-file`.