### PR TITLE
Replace sha256sum with shasum in CI actions

### DIFF
--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -15,15 +15,15 @@ runs:
         cat gradle.properties
         echo $JAVA_HOME
       shell: bash
-    - name: Create hash of Gradle configuration (Linux and macOS only)
+    - name: Create hash of Gradle configuration (macOS only)
       run: |
         echo "gradle-hash"="$(find . -type f \( -name "gradle.properties" -o -name "gradle-wrapper.properties" \) -exec cat {} + | shasum -a 256 | cut -d ' ' -f 1)" >> $GITHUB_ENV
-      if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
+      if: ${{ runner.os == 'macOS' }}
       shell: bash
-    - name: Create hash of Gradle configuration (Windows only)
+    - name: Create hash of Gradle configuration (Linux and Windows only)
       run: |
         echo "gradle-hash"="$(find . -type f \( -name "gradle.properties" -o -name "gradle-wrapper.properties" \) -exec cat {} + | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
-      if: ${{ runner.os == 'Windows'}}
+      if: ${{ runner.os == 'Windows' || runner.os == 'Linux' }}
       shell: bash
     - name: Cache
       uses: actions/cache@v3

--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -17,7 +17,9 @@ runs:
       shell: bash
     - name: Create hash of Gradle configuration
       run: |
-        echo "gradle-hash"="$(find . -type f \( -name "gradle.properties" -o -name "gradle-wrapper.properties" \) -exec cat {} + | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
+        echo "gradle-hash"="$(find . -type f \(
+          -name "gradle.properties" -o -name "gradle-wrapper.properties" \)
+          -exec cat {} + | shasum -a 256 | cut -d ' ' -f 1)" >> $GITHUB_ENV
       shell: bash
     - name: Cache
       uses: actions/cache@v3

--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -15,9 +15,15 @@ runs:
         cat gradle.properties
         echo $JAVA_HOME
       shell: bash
-    - name: Create hash of Gradle configuration
+    - name: Create hash of Gradle configuration (Linux and macOS only)
       run: |
         echo "gradle-hash"="$(find . -type f \( -name "gradle.properties" -o -name "gradle-wrapper.properties" \) -exec cat {} + | shasum -a 256 | cut -d ' ' -f 1)" >> $GITHUB_ENV
+      if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
+      shell: bash
+    - name: Create hash of Gradle configuration (Windows only)
+      run: |
+        echo "gradle-hash"="$(find . -type f \( -name "gradle.properties" -o -name "gradle-wrapper.properties" \) -exec cat {} + | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
+      if: ${{ runner.os == 'Windows'}}
       shell: bash
     - name: Cache
       uses: actions/cache@v3

--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -17,9 +17,7 @@ runs:
       shell: bash
     - name: Create hash of Gradle configuration
       run: |
-        echo "gradle-hash"="$(find . -type f \(
-          -name "gradle.properties" -o -name "gradle-wrapper.properties" \)
-          -exec cat {} + | shasum -a 256 | cut -d ' ' -f 1)" >> $GITHUB_ENV
+        echo "gradle-hash"="$(find . -type f \( -name "gradle.properties" -o -name "gradle-wrapper.properties" \) -exec cat {} + | shasum -a 256 | cut -d ' ' -f 1)" >> $GITHUB_ENV
       shell: bash
     - name: Cache
       uses: actions/cache@v3


### PR DESCRIPTION
I noticed that for any macOS CI action, in the Prepare Build Environment section there's an error that looks like
```
Run echo "gradle-hash"="$(find . -type f \( -name "gradle.properties" -o -name "gradle-wrapper.properties" \) -exec cat {} + | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
[56](https://github.com/lf-lang/lingua-franca/actions/runs/4669921848/jobs/8269011551#step:3:60)
/Users/runner/work/_temp/cf76cf63-b924-448a-9a60-8db61e686d90.sh: line 1: sha256sum: command not found
```
As a result of which all macOS build caches are stored and retrieved under the key `gradle-macOS-`, although it doesn't cause an error yet. This PR fixes the bug by replacing function `sha256sum` with `shasum`.
