### PR TITLE
Gradle daemon brought down to free locks in Windows CI

### DIFF
--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -28,3 +28,9 @@ runs:
         key: gradle-${{ runner.os }}-${{ env.gradle-hash }}
         # restore-keys: |
         #   ${{ runner.os }}-gradle-
+    - name: Bring down Gradle daemon (Windows)
+      uses: webiny/action-post-run@3.0.0
+      id: post-run-command
+      with:
+        run: ./gradlew --stop
+      if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
Fixes #1670.