### PR TITLE
Avoid directly using global variables in tests

### DIFF
--- a/test/C/src/Alignment.lf
+++ b/test/C/src/Alignment.lf
@@ -81,14 +81,14 @@ reactor Destination {
         if (ok->is_present && in->is_present) {
             lf_print("Destination: Input %d is prime at tag (%lld, %d).",
                 in->value,
-                current_tag.time - start_time, current_tag.microstep
+                current_tag.time - lf_time_start(), current_tag.microstep
             );
         }
         if (lf_tag_compare(current_tag, self->last_invoked) <= 0) {
             lf_print_error_and_exit("Invoked at tag (%lld, %d), "
                 "but previously invoked at tag (%lld, %d).",
-                current_tag.time - start_time, current_tag.microstep,
-                self->last_invoked.time - start_time, self->last_invoked.microstep
+                current_tag.time - lf_time_start(), current_tag.microstep,
+                self->last_invoked.time - lf_time_start(), self->last_invoked.microstep
             );
         }
         self->last_invoked = current_tag;

--- a/test/C/src/Alignment.lf
+++ b/test/C/src/Alignment.lf
@@ -77,6 +77,7 @@ reactor Destination {
     state last_invoked: tag_t = {= NEVER_TAG_INITIALIZER =}
 
     reaction(ok, in) {=
+        tag_t current_tag = lf_tag();
         if (ok->is_present && in->is_present) {
             lf_print("Destination: Input %d is prime at tag (%lld, %d).",
                 in->value,

--- a/test/C/src/DelayString.lf
+++ b/test/C/src/DelayString.lf
@@ -27,7 +27,6 @@ reactor DelayString2(delay: time = 100 msec) {
 
 reactor Test {
     input in: string
-    state start_time: time = 0
 
     reaction(in) {=
         printf("Received: %s.\n", in->value);

--- a/test/C/src/RequestStop.lf
+++ b/test/C/src/RequestStop.lf
@@ -4,7 +4,7 @@ target C
 
 main reactor {
     reaction(shutdown) {=
-        tag_t current_time = lf_tag();
+        tag_t current_tag = lf_tag();
         lf_print("Shutdown invoked at tag (%lld, %d). Calling lf_request_stop(), which should have no effect.",
             current_tag.time - lf_time_start(), current_tag.microstep
         );

--- a/test/C/src/Starvation.lf
+++ b/test/C/src/Starvation.lf
@@ -21,13 +21,13 @@ reactor SuperDenseSender(number_of_iterations: int = 10) {
 
     reaction(shutdown) {=
         tag_t current_tag = lf_tag();
-        if (current_tag.time == start_time
+        if (current_tag.time == lf_time_start()
             && current_tag.microstep == self->number_of_iterations + 1) {
             printf("SUCCESS: Sender successfully detected starvation.\n");
         } else {
             fprintf(stderr, "ERROR: Failed to properly enforce starvation at sender. "
                             "Shutting down at tag (%lld, %u).\n",
-                             current_tag.time - start_time,
+                             current_tag.time - lf_time_start(),
                              current_tag.microstep);
             exit(1);
         }
@@ -41,19 +41,19 @@ reactor SuperDenseReceiver(number_of_iterations: int = 10) {
         tag_t current_tag = lf_tag();
         printf("Received %d at tag (%lld, %u).\n",
                 in->value,
-                current_tag.time - start_time,
+                current_tag.time - lf_time_start(),
                 current_tag.microstep);
     =}
 
     reaction(shutdown) {=
         tag_t current_tag = lf_tag();
-        if (current_tag.time == start_time
+        if (current_tag.time == lf_time_start()
             && current_tag.microstep == self->number_of_iterations + 1) {
             printf("SUCCESS: Receiver successfully detected starvation.\n");
         } else {
             fprintf(stderr, "ERROR: Failed to properly enforce starvation at receiver. "
                             "Shutting down at tag (%lld, %u).\n",
-                             current_tag.time - start_time,
+                             current_tag.time - lf_time_start(),
                              current_tag.microstep);
             exit(1);
         }

--- a/test/C/src/Timeout.lf
+++ b/test/C/src/Timeout.lf
@@ -27,6 +27,7 @@ reactor Consumer {
     =}
 
     reaction(shutdown) {=
+        tag_t current_tag = lf_tag();
         printf("Shutdown invoked at tag (%lld, %u).\n", current_tag.time - lf_time_start(), current_tag.microstep);
         if (lf_tag_compare(current_tag,
             (tag_t) { .time = MSEC(11) + lf_time_start(), .microstep = 0}) == 0 &&

--- a/test/C/src/TimeoutZero.lf
+++ b/test/C/src/TimeoutZero.lf
@@ -28,6 +28,7 @@ reactor Consumer {
     =}
 
     reaction(shutdown) {=
+        tag_t current_tag = lf_tag();
         printf("Shutdown invoked at tag (%lld, %u).\n", current_tag.time - lf_time_start(), current_tag.microstep);
         if (lf_tag_compare(current_tag,
             (tag_t) { .time = MSEC(0) + lf_time_start(), .microstep = 0}) == 0 &&

--- a/test/C/src/concurrent/StarvationThreaded.lf
+++ b/test/C/src/concurrent/StarvationThreaded.lf
@@ -22,13 +22,13 @@ reactor SuperDenseSender(number_of_iterations: int = 10) {
 
     reaction(shutdown) {=
         tag_t current_tag = lf_tag();
-        if (current_tag.time == start_time
+        if (current_tag.time == lf_time_start()
             && current_tag.microstep == self->number_of_iterations + 1) {
             printf("SUCCESS: Sender successfully detected starvation.\n");
         } else {
             fprintf(stderr, "ERROR: Failed to properly enforce starvation at sender. "
                             "Shutting down at tag (%lld, %u).\n",
-                             current_tag.time - start_time,
+                             current_tag.time - lf_time_start(),
                              current_tag.microstep);
             exit(1);
         }
@@ -42,19 +42,19 @@ reactor SuperDenseReceiver(number_of_iterations: int = 10) {
         tag_t current_tag = lf_tag();
         printf("Received %d at tag (%lld, %u).\n",
                 in->value,
-                current_tag.time - start_time,
+                current_tag.time - lf_time_start(),
                 current_tag.microstep);
     =}
 
     reaction(shutdown) {=
         tag_t current_tag = lf_tag();
-        if (current_tag.time == start_time
+        if (current_tag.time == lf_time_start()
             && current_tag.microstep == self->number_of_iterations + 1) {
             printf("SUCCESS: Receiver successfully detected starvation.\n");
         } else {
             fprintf(stderr, "ERROR: Failed to properly enforce starvation at receiver. "
                             "Shutting down at tag (%lld, %u).\n",
-                             current_tag.time - start_time,
+                             current_tag.time - lf_time_start(),
                              current_tag.microstep);
             exit(1);
         }

--- a/test/C/src/concurrent/TimeoutThreaded.lf
+++ b/test/C/src/concurrent/TimeoutThreaded.lf
@@ -28,6 +28,7 @@ reactor Consumer {
     =}
 
     reaction(shutdown) {=
+        tag_t current_tag = lf_tag();
         printf("Shutdown invoked at tag (%lld, %u).\n", current_tag.time - lf_time_start(), current_tag.microstep);
         if (lf_tag_compare(current_tag,
             (tag_t) { .time = MSEC(11) + lf_time_start(), .microstep = 0}) == 0 &&
@@ -35,7 +36,7 @@ reactor Consumer {
             printf("SUCCESS: successfully enforced timeout.\n");
         } else {
             fprintf(stderr,"ERROR: Shutdown invoked at tag (%llu, %d). Failed to enforce timeout.\n",
-                            current_tag.time - start_time, current_tag.microstep);
+                            current_tag.time - lf_time_start(), current_tag.microstep);
             exit(1);
         }
     =}

--- a/test/C/src/concurrent/TimeoutZeroThreaded.lf
+++ b/test/C/src/concurrent/TimeoutZeroThreaded.lf
@@ -19,7 +19,7 @@ reactor Consumer {
         if (lf_tag_compare(current_tag,
                          (tag_t) { .time = MSEC(0) + lf_time_start(), .microstep = 0}) > 0) {
             fprintf(stderr,"ERROR: Tag (%lld, %d) received. Failed to enforce timeout.\n",
-                            current_tag.time - start_time, current_tag.microstep);
+                            current_tag.time - lf_time_start(), current_tag.microstep);
             exit(1);
         } else if (lf_tag_compare(current_tag,
                          (tag_t) { .time = MSEC(0) + lf_time_start(), .microstep = 0}) == 0) {
@@ -28,6 +28,7 @@ reactor Consumer {
     =}
 
     reaction(shutdown) {=
+        tag_t current_tag = lf_tag();
         printf("Shutdown invoked at tag (%lld, %u).\n", current_tag.time - lf_time_start(), current_tag.microstep);
         if (lf_tag_compare(current_tag,
             (tag_t) { .time = MSEC(0) + lf_time_start(), .microstep = 0}) == 0 &&
@@ -35,7 +36,7 @@ reactor Consumer {
             printf("SUCCESS: successfully enforced timeout.\n");
         } else {
             fprintf(stderr,"ERROR: Shutdown invoked at tag (%llu, %d). Failed to enforce timeout.\n",
-                            current_tag.time - start_time, current_tag.microstep);
+                            current_tag.time - lf_time_start(), current_tag.microstep);
             exit(1);
         }
     =}

--- a/test/C/src/federated/DecentralizedP2PUnbalancedTimeout.lf
+++ b/test/C/src/federated/DecentralizedP2PUnbalancedTimeout.lf
@@ -36,7 +36,7 @@ reactor Destination {
         tag_t current_tag = lf_tag();
         if (x->value != self->s) {
             lf_print_error_and_exit("At tag (%lld, %u) expected %d and got %d.",
-                current_tag.time - start_time, current_tag.microstep, self->s, x->value
+                current_tag.time - lf_time_start(), current_tag.microstep, self->s, x->value
             );
         }
         self->s++;

--- a/test/C/src/federated/DistributedCountDecentralizedLate.lf
+++ b/test/C/src/federated/DistributedCountDecentralizedLate.lf
@@ -38,7 +38,7 @@ reactor Print {
     =} STP(0) {=
         tag_t current_tag = lf_tag();
         printf("At tag (%lld, %u), message has violated the STP offset by (%lld, %u).\n",
-                current_tag.time - start_time, current_tag.microstep,
+                current_tag.time - lf_time_start(), current_tag.microstep,
                 current_tag.time - in->intended_tag.time,
                 current_tag.microstep - in->intended_tag.microstep);
         self->success_stp_violation++;

--- a/test/C/src/federated/DistributedNetworkOrder.lf
+++ b/test/C/src/federated/DistributedNetworkOrder.lf
@@ -46,7 +46,7 @@ reactor Receiver {
 
     reaction(in) {=
         tag_t current_tag = lf_tag();
-        if (current_tag.time == (start_time + MSEC(10))) {
+        if (current_tag.time == (lf_time_start() + MSEC(10))) {
             if (current_tag.microstep == 0 && in->value == 1) {
                 self->success++;
             } else if (current_tag.microstep == 1 && in->value == 2) {

--- a/test/C/src/federated/LoopDistributedDouble.lf
+++ b/test/C/src/federated/LoopDistributedDouble.lf
@@ -60,7 +60,7 @@ reactor Looper(incr: int = 1, delay: time = 0 msec) {
         tag_t current_tag = lf_tag();
         lf_print("Received %d at logical time (%lld, %d).",
             in->value,
-            current_tag.time - start_time, current_tag.microstep
+            current_tag.time - lf_time_start(), current_tag.microstep
         );
     =}
 
@@ -68,13 +68,14 @@ reactor Looper(incr: int = 1, delay: time = 0 msec) {
         tag_t current_tag = lf_tag();
         lf_print("Received %d on in2 at logical time (%lld, %d).",
             in2->value,
-            current_tag.time - start_time, current_tag.microstep
+            current_tag.time - lf_time_start(), current_tag.microstep
         );
     =}
 
     reaction(t) {=
+        tag_t current_tag = lf_tag();
         lf_print("Timer triggered at logical time (%lld, %d).",
-            current_tag.time - start_time, current_tag.microstep
+            current_tag.time - lf_time_start(), current_tag.microstep
         );
     =}
 

--- a/test/C/src/federated/LoopDistributedDouble.lf
+++ b/test/C/src/federated/LoopDistributedDouble.lf
@@ -57,6 +57,7 @@ reactor Looper(incr: int = 1, delay: time = 0 msec) {
     =}
 
     reaction(in) {=
+        tag_t current_tag = lf_tag();
         lf_print("Received %d at logical time (%lld, %d).",
             in->value,
             current_tag.time - start_time, current_tag.microstep
@@ -64,6 +65,7 @@ reactor Looper(incr: int = 1, delay: time = 0 msec) {
     =}
 
     reaction(in2) {=
+        tag_t current_tag = lf_tag();
         lf_print("Received %d on in2 at logical time (%lld, %d).",
             in2->value,
             current_tag.time - start_time, current_tag.microstep

--- a/test/C/src/federated/PhysicalSTP.lf
+++ b/test/C/src/federated/PhysicalSTP.lf
@@ -16,7 +16,6 @@ reactor Print(STP_offset_param: time = 0) {
     reaction(in) {=
         interval_t elapsed_time = lf_time_logical_elapsed();
         lf_print("At time %lld, received %d", elapsed_time, in->value);
-        // lf_print("Physical time of arrival is %lld.", in->physical_time_of_arrival - start_time);
         if (in->value != self->c) {
             lf_print_error_and_exit("Expected to receive %d.", self->c);
         }

--- a/test/C/src/federated/failing/DistributedNetworkOrderDecentralized.lf
+++ b/test/C/src/federated/failing/DistributedNetworkOrderDecentralized.lf
@@ -35,7 +35,7 @@ reactor Receiver {
 
     reaction(in) {=
         tag_t current_tag = lf_tag();
-        if (current_tag.time == (start_time + MSEC(10))) {
+        if (current_tag.time == (lf_time_start() + MSEC(10))) {
             if (current_tag.microstep == 0 && in->value == 1) {
                 self->success++;
             } else if (current_tag.microstep == 1 && in->value == 2) {


### PR DESCRIPTION
This PR replaces the use of global variables `start_time` and `current_tag` with function calls that are meant to be part of the API.  This is part of a broader cleanup of the C target that is happening in `docs` branch of reactor-c, but these changes have no dependence on that branch and should be merged before that branch is merge.