### PR TITLE
Make USER_THREADS possible to specify in platform options

### DIFF
--- a/org.lflang/src/org/lflang/TargetConfig.java
+++ b/org.lflang/src/org/lflang/TargetConfig.java
@@ -478,6 +478,11 @@ public class TargetConfig {
          * port values depending on the infrastructure you use to flash the boards.
          */
         public boolean flash = false;
+
+        /** 
+         * The int value is used to determine the number of needed threads for the user application in Zephyr. 
+         */
+        public int userThreads = 0;
     }   
 
     /**

--- a/org.lflang/src/org/lflang/TargetProperty.java
+++ b/org.lflang/src/org/lflang/TargetProperty.java
@@ -432,6 +432,9 @@ public enum TargetProperty {
                         case PORT:
                             pair.setValue(ASTUtils.toElement(config.platformOptions.port));
                             break;
+                        case USERTHREADS:
+                            pair.setValue(ASTUtils.toElement(config.platformOptions.userThreads));
+                            break;
                     }
                     kvp.getPairs().add(pair);
                 }
@@ -471,6 +474,9 @@ public enum TargetProperty {
                                 break;
                             case PORT:
                                 config.platformOptions.port = ASTUtils.elementToSingleString(entry.getValue());
+                                break;
+                            case USERTHREADS:
+                                config.platformOptions.userThreads = ASTUtils.toInteger(entry.getValue());
                                 break;
                             default:
                                 break;
@@ -1659,7 +1665,8 @@ public enum TargetProperty {
         BAUDRATE("baud-rate", PrimitiveType.NON_NEGATIVE_INTEGER),
         BOARD("board", PrimitiveType.STRING),
         FLASH("flash", PrimitiveType.BOOLEAN),
-        PORT("port", PrimitiveType.STRING);
+        PORT("port", PrimitiveType.STRING),
+        USERTHREADS("user_threads", PrimitiveType.NON_NEGATIVE_INTEGER);
 
         public final PrimitiveType type;
 

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -1962,6 +1962,14 @@ public class CGenerator extends GeneratorBase {
             System.out.println("To enable compilation for the Arduino platform, you must specify the fully-qualified board name (FQBN) in the target property. For example, platform: {name: arduino, board: arduino:avr:leonardo}. Entering \"no-compile\" mode and generating target code only.");
             targetConfig.noCompile = true;
         }
+
+        if (targetConfig.platformOptions.platform == Platform.ZEPHYR && targetConfig.platformOptions.userThreads >= 0) {
+            targetConfig.compileDefinitions.put(
+                "USER_THREADS",
+                String.valueOf(targetConfig.platformOptions.userThreads)
+            );
+        }
+
         if (targetConfig.threading) {  // FIXME: This logic is duplicated in CMake
             pickScheduler();
             // FIXME: this and pickScheduler should be combined.


### PR DESCRIPTION
In reference to this PR: https://github.com/lf-lang/reactor-c/pull/194

USER_THREADS can now be specified under platform options in target properties:

platform: {
       name: Zephyr,
       user_threads: 3
}