### PR TITLE
Bugfixes in handling of `files` target property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
     with:
       target: 'C'
       benchmarks-ref: main
-      compiler-ref: master
     needs: cancel
 
   # Run language server tests.

--- a/org.lflang/src/org/lflang/generator/GeneratorBase.java
+++ b/org.lflang/src/org/lflang/generator/GeneratorBase.java
@@ -350,7 +350,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
      * @param fileConfig The fileConfig used to make the copy and resolve paths.
      */
     protected void copyUserFiles(TargetConfig targetConfig, FileConfig fileConfig) {
-        FileUtil.copyFilesOrDirectories(targetConfig.files, this.context.getFileConfig().getSrcGenPath(), fileConfig, errorReporter);
+        FileUtil.copyFilesOrDirectoryContents(targetConfig.files, this.context.getFileConfig().getSrcGenPath(), fileConfig, errorReporter);
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/GeneratorBase.java
+++ b/org.lflang/src/org/lflang/generator/GeneratorBase.java
@@ -350,12 +350,8 @@ public abstract class GeneratorBase extends AbstractLFValidator {
      * @param fileConfig The fileConfig used to make the copy and resolve paths.
      */
     protected void copyUserFiles(TargetConfig targetConfig, FileConfig fileConfig) {
-        FileUtil.copyFilesOrDirectories(
-            targetConfig.files,
-            this.context.getFileConfig().getSrcGenPath(),
-            fileConfig,
-            errorReporter,
-            false);
+        var dst = this.context.getFileConfig().getSrcGenPath();
+        FileUtil.copyFilesOrDirectories(targetConfig.files, dst, fileConfig, errorReporter, false);
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/GeneratorBase.java
+++ b/org.lflang/src/org/lflang/generator/GeneratorBase.java
@@ -350,7 +350,12 @@ public abstract class GeneratorBase extends AbstractLFValidator {
      * @param fileConfig The fileConfig used to make the copy and resolve paths.
      */
     protected void copyUserFiles(TargetConfig targetConfig, FileConfig fileConfig) {
-        FileUtil.copyFilesOrDirectoryContents(targetConfig.files, this.context.getFileConfig().getSrcGenPath(), fileConfig, errorReporter);
+        FileUtil.copyFilesOrDirectories(
+            targetConfig.files,
+            this.context.getFileConfig().getSrcGenPath(),
+            fileConfig,
+            errorReporter,
+            false);
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/GeneratorBase.java
+++ b/org.lflang/src/org/lflang/generator/GeneratorBase.java
@@ -350,7 +350,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
      * @param fileConfig The fileConfig used to make the copy and resolve paths.
      */
     protected void copyUserFiles(TargetConfig targetConfig, FileConfig fileConfig) {
-        FileUtil.copyFiles(targetConfig.files, this.context.getFileConfig().getSrcGenPath(), fileConfig, errorReporter);
+        FileUtil.copyFilesOrDirectories(targetConfig.files, this.context.getFileConfig().getSrcGenPath(), fileConfig, errorReporter);
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -830,7 +830,8 @@ public class CGenerator extends GeneratorBase {
         // Must use class variable to determine destination!
         var destination = this.fileConfig.getSrcGenPath();
 
-        FileUtil.copyFilesOrDirectoryContents(targetConfig.cmakeIncludes, destination, fileConfig, errorReporter);
+        // NOTE: All entries should be files, but we are not checking this.
+        FileUtil.copyFilesOrDirectories(targetConfig.cmakeIncludes, destination, fileConfig, errorReporter, true);
 
         // FIXME: Unclear what the following does, but it does not appear to belong here.
         if (!StringExtensions.isNullOrEmpty(targetConfig.fedSetupPreamble)) {
@@ -886,7 +887,8 @@ public class CGenerator extends GeneratorBase {
         FileUtil.copyFromClassPath(
             fileConfig.getRuntimeIncludePath(),
             fileConfig.getIncludePath(),
-            false
+            false,
+            true
         );
         for (Reactor r : reactors) {
             CReactorHeaderFileGenerator.doGenerate(
@@ -964,13 +966,15 @@ public class CGenerator extends GeneratorBase {
         } else {
             FileUtil.copyFromClassPath(
                 "/lib/c/reactor-c/core",
-                dest.resolve("core"),
-                true
+                dest,
+                true,
+                false
             );
             FileUtil.copyFromClassPath(
                 "/lib/c/reactor-c/lib",
-                dest.resolve("lib"),
-                true
+                dest,
+                true,
+                false
             );
         }
 
@@ -978,16 +982,17 @@ public class CGenerator extends GeneratorBase {
         if (targetConfig.platformOptions.platform == Platform.ZEPHYR) {
             FileUtil.copyFromClassPath(
                 "/lib/platform/zephyr/boards",
-                fileConfig.getSrcGenPath().resolve("boards"),
+                fileConfig.getSrcGenPath(),
+                false,
                 false
             );
-            FileUtil.copyFromClassPath(
+            FileUtil.copySingleFileFromClasspath(
                 "/lib/platform/zephyr/prj_lf.conf",
                 fileConfig.getSrcGenPath(),
                 true
             );
 
-            FileUtil.copyFromClassPath(
+            FileUtil.copySingleFileFromClasspath(
                 "/lib/platform/zephyr/Kconfig",
                 fileConfig.getSrcGenPath(),
                 true

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -983,13 +983,13 @@ public class CGenerator extends GeneratorBase {
                 false,
                 false
             );
-            FileUtil.copyFileFromClasspath(
+            FileUtil.copyFileFromClassPath(
                 "/lib/platform/zephyr/prj_lf.conf",
                 fileConfig.getSrcGenPath(),
                 true
             );
 
-            FileUtil.copyFileFromClasspath(
+            FileUtil.copyFileFromClassPath(
                 "/lib/platform/zephyr/Kconfig",
                 fileConfig.getSrcGenPath(),
                 true

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -983,13 +983,13 @@ public class CGenerator extends GeneratorBase {
                 false,
                 false
             );
-            FileUtil.copySingleFileFromClasspath(
+            FileUtil.copyFileFromClasspath(
                 "/lib/platform/zephyr/prj_lf.conf",
                 fileConfig.getSrcGenPath(),
                 true
             );
 
-            FileUtil.copySingleFileFromClasspath(
+            FileUtil.copyFileFromClasspath(
                 "/lib/platform/zephyr/Kconfig",
                 fileConfig.getSrcGenPath(),
                 true

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -983,13 +983,13 @@ public class CGenerator extends GeneratorBase {
             );
             FileUtil.copyFromClassPath(
                 "/lib/platform/zephyr/prj_lf.conf",
-                fileConfig.getSrcGenPath().resolve("prj_lf.conf"),
+                fileConfig.getSrcGenPath(),
                 true
             );
 
             FileUtil.copyFromClassPath(
                 "/lib/platform/zephyr/Kconfig",
-                fileConfig.getSrcGenPath().resolve("Kconfig"),
+                fileConfig.getSrcGenPath(),
                 true
             );
         }

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -828,7 +828,6 @@ public class CGenerator extends GeneratorBase {
         // Must use class variable to determine destination!
         var destination = this.fileConfig.getSrcGenPath();
 
-        // NOTE: All entries should be files, but we are not checking this.
         FileUtil.copyFilesOrDirectories(targetConfig.cmakeIncludes, destination, fileConfig, errorReporter, true);
 
         // FIXME: Unclear what the following does, but it does not appear to belong here.

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -883,7 +883,7 @@ public class CGenerator extends GeneratorBase {
     /** Generate user-visible header files for all reactors instantiated. */
     private void generateHeaders() throws IOException {
         FileUtil.deleteDirectory(fileConfig.getIncludePath());
-        FileUtil.copyDirectoryFromClassPath(
+        FileUtil.copyFromClassPath(
             fileConfig.getRuntimeIncludePath(),
             fileConfig.getIncludePath(),
             false
@@ -962,12 +962,12 @@ public class CGenerator extends GeneratorBase {
         if (coreLib != null) {
             FileUtil.copyDirectory(Path.of(coreLib), dest, true);
         } else {
-            FileUtil.copyDirectoryFromClassPath(
+            FileUtil.copyFromClassPath(
                 "/lib/c/reactor-c/core",
                 dest.resolve("core"),
                 true
             );
-            FileUtil.copyDirectoryFromClassPath(
+            FileUtil.copyFromClassPath(
                 "/lib/c/reactor-c/lib",
                 dest.resolve("lib"),
                 true
@@ -976,18 +976,18 @@ public class CGenerator extends GeneratorBase {
 
         // For the Zephyr target, copy default config and board files.
         if (targetConfig.platformOptions.platform == Platform.ZEPHYR) {
-            FileUtil.copyDirectoryFromClassPath(
+            FileUtil.copyFromClassPath(
                 "/lib/platform/zephyr/boards",
                 fileConfig.getSrcGenPath().resolve("boards"),
                 false
             );
-            FileUtil.copyFileFromClassPath(
+            FileUtil.copyFromClassPath(
                 "/lib/platform/zephyr/prj_lf.conf",
                 fileConfig.getSrcGenPath().resolve("prj_lf.conf"),
                 true
             );
 
-            FileUtil.copyFileFromClassPath(
+            FileUtil.copyFromClassPath(
                 "/lib/platform/zephyr/Kconfig",
                 fileConfig.getSrcGenPath().resolve("Kconfig"),
                 true

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -906,7 +906,7 @@ public class CGenerator extends GeneratorBase {
                 },
                 this::generateTopLevelPreambles);
         }
-        FileUtil.copyDirectory(fileConfig.getIncludePath(), fileConfig.getSrcGenPath(), false);
+        FileUtil.copyDirectoryContents(fileConfig.getIncludePath(), fileConfig.getSrcGenPath().resolve("include"), false);
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -830,7 +830,7 @@ public class CGenerator extends GeneratorBase {
         // Must use class variable to determine destination!
         var destination = this.fileConfig.getSrcGenPath();
 
-        FileUtil.copyFiles(targetConfig.cmakeIncludes, destination, fileConfig, errorReporter);
+        FileUtil.copyFilesOrDirectories(targetConfig.cmakeIncludes, destination, fileConfig, errorReporter);
 
         // FIXME: Unclear what the following does, but it does not appear to belong here.
         if (!StringExtensions.isNullOrEmpty(targetConfig.fedSetupPreamble)) {
@@ -904,7 +904,7 @@ public class CGenerator extends GeneratorBase {
                 },
                 this::generateTopLevelPreambles);
         }
-        FileUtil.copyDirectory(fileConfig.getIncludePath(), fileConfig.getSrcGenPath().resolve("include"), false);
+        FileUtil.copyDirectoryContents(fileConfig.getIncludePath(), fileConfig.getSrcGenPath().resolve("include"), false);
     }
 
     /**
@@ -960,7 +960,7 @@ public class CGenerator extends GeneratorBase {
         Path dest = fileConfig.getSrcGenPath();
         if (targetConfig.platformOptions.platform == Platform.ARDUINO) dest = dest.resolve("src");
         if (coreLib != null) {
-            FileUtil.copyDirectory(Path.of(coreLib), dest, true);
+            FileUtil.copyDirectoryContents(Path.of(coreLib), dest, true);
         } else {
             FileUtil.copyFromClassPath(
                 "/lib/c/reactor-c/core",

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -830,7 +830,7 @@ public class CGenerator extends GeneratorBase {
         // Must use class variable to determine destination!
         var destination = this.fileConfig.getSrcGenPath();
 
-        FileUtil.copyFilesOrDirectories(targetConfig.cmakeIncludes, destination, fileConfig, errorReporter);
+        FileUtil.copyFilesOrDirectoryContents(targetConfig.cmakeIncludes, destination, fileConfig, errorReporter);
 
         // FIXME: Unclear what the following does, but it does not appear to belong here.
         if (!StringExtensions.isNullOrEmpty(targetConfig.fedSetupPreamble)) {

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -906,7 +906,7 @@ public class CGenerator extends GeneratorBase {
                 },
                 this::generateTopLevelPreambles);
         }
-        FileUtil.copyDirectoryContents(fileConfig.getIncludePath(), fileConfig.getSrcGenPath().resolve("include"), false);
+        FileUtil.copyDirectory(fileConfig.getIncludePath(), fileConfig.getSrcGenPath(), false);
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -425,8 +425,6 @@ public class CGenerator extends GeneratorBase {
                     "LF programs with a CCpp target are currently not supported on Windows. " +
                     "Exiting code generation."
                 );
-                // FIXME: The incompatibility between our C runtime code and the
-                //  Visual Studio compiler is extensive.
                 return false;
             }
         }

--- a/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
@@ -27,7 +27,6 @@
 package org.lflang.generator.cpp
 
 import org.eclipse.emf.ecore.resource.Resource
-import org.lflang.ErrorReporter
 import org.lflang.Target
 import org.lflang.generator.CodeMap
 import org.lflang.generator.GeneratorBase
@@ -127,9 +126,9 @@ class CppGenerator(
         // copy static library files over to the src-gen directory
         val genIncludeDir = srcGenPath.resolve("__include__")
         listOf("lfutil.hh", "time_parser.hh").forEach {
-            FileUtil.copyFileFromClassPath("$libDir/$it", genIncludeDir.resolve(it), true)
+            FileUtil.copyFromClassPath("$libDir/$it", genIncludeDir.resolve(it), true)
         }
-        FileUtil.copyFileFromClassPath(
+        FileUtil.copyFromClassPath(
             "$libDir/3rd-party/cxxopts.hpp",
             genIncludeDir.resolve("CLI").resolve("cxxopts.hpp"),
             true
@@ -140,7 +139,7 @@ class CppGenerator(
             if (targetConfig.runtimeVersion != null) {
                 fetchReactorCpp()
             } else {
-                FileUtil.copyDirectoryFromClassPath(
+                FileUtil.copyFromClassPath(
                     "$libDir/reactor-cpp",
                     fileConfig.srcGenBasePath.resolve("reactor-cpp-default"),
                     true

--- a/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
@@ -126,13 +126,12 @@ class CppGenerator(
         // copy static library files over to the src-gen directory
         val genIncludeDir = srcGenPath.resolve("__include__")
         listOf("lfutil.hh", "time_parser.hh").forEach {
-            FileUtil.copyFromClassPath("$libDir/$it", genIncludeDir, true)
+            FileUtil.copySingleFileFromClasspath("$libDir/$it", genIncludeDir, true)
         }
-        FileUtil.copyFromClassPath(
+        FileUtil.copySingleFileFromClasspath(
             "$libDir/3rd-party/cxxopts.hpp",
             genIncludeDir.resolve("CLI"),
-            true
-        )
+            true)
 
         // copy or download reactor-cpp
         if (targetConfig.externalRuntimePath == null) {
@@ -142,6 +141,7 @@ class CppGenerator(
                 FileUtil.copyFromClassPath(
                     "$libDir/reactor-cpp",
                     fileConfig.srcGenBasePath.resolve("reactor-cpp-default"),
+                    true,
                     true
                 )
             }

--- a/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
@@ -126,9 +126,9 @@ class CppGenerator(
         // copy static library files over to the src-gen directory
         val genIncludeDir = srcGenPath.resolve("__include__")
         listOf("lfutil.hh", "time_parser.hh").forEach {
-            FileUtil.copyFileFromClasspath("$libDir/$it", genIncludeDir, true)
+            FileUtil.copyFileFromClassPath("$libDir/$it", genIncludeDir, true)
         }
-        FileUtil.copyFileFromClasspath(
+        FileUtil.copyFileFromClassPath(
             "$libDir/3rd-party/cxxopts.hpp",
             genIncludeDir.resolve("CLI"),
             true)

--- a/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
@@ -126,11 +126,11 @@ class CppGenerator(
         // copy static library files over to the src-gen directory
         val genIncludeDir = srcGenPath.resolve("__include__")
         listOf("lfutil.hh", "time_parser.hh").forEach {
-            FileUtil.copyFromClassPath("$libDir/$it", genIncludeDir.resolve(it), true)
+            FileUtil.copyFromClassPath("$libDir/$it", genIncludeDir, true)
         }
         FileUtil.copyFromClassPath(
             "$libDir/3rd-party/cxxopts.hpp",
-            genIncludeDir.resolve("CLI").resolve("cxxopts.hpp"),
+            genIncludeDir.resolve("CLI"),
             true
         )
 

--- a/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
@@ -126,9 +126,9 @@ class CppGenerator(
         // copy static library files over to the src-gen directory
         val genIncludeDir = srcGenPath.resolve("__include__")
         listOf("lfutil.hh", "time_parser.hh").forEach {
-            FileUtil.copySingleFileFromClasspath("$libDir/$it", genIncludeDir, true)
+            FileUtil.copyFileFromClasspath("$libDir/$it", genIncludeDir, true)
         }
-        FileUtil.copySingleFileFromClasspath(
+        FileUtil.copyFileFromClasspath(
             "$libDir/3rd-party/cxxopts.hpp",
             genIncludeDir.resolve("CLI"),
             true)

--- a/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 
@@ -56,7 +55,6 @@ import org.lflang.generator.c.CCmakeGenerator;
 import org.lflang.generator.c.CGenerator;
 import org.lflang.generator.c.CUtil;
 import org.lflang.lf.Action;
-import org.lflang.lf.Code;
 import org.lflang.lf.Input;
 import org.lflang.lf.Model;
 import org.lflang.lf.Output;
@@ -661,17 +659,17 @@ public class PythonGenerator extends CGenerator {
     @Override
     protected void copyTargetFiles() throws IOException {
         super.copyTargetFiles();
-        FileUtil.copyDirectoryFromClassPath(
+        FileUtil.copyFromClassPath(
             "/lib/py/reactor-c-py/include",
             fileConfig.getSrcGenPath().resolve("include"),
             true
         );
-        FileUtil.copyDirectoryFromClassPath(
+        FileUtil.copyFromClassPath(
             "/lib/py/reactor-c-py/lib",
             fileConfig.getSrcGenPath().resolve("lib"),
             true
         );
-        FileUtil.copyDirectoryFromClassPath(
+        FileUtil.copyFromClassPath(
             "/lib/py/reactor-c-py/LinguaFrancaBase",
             fileConfig.getSrcGenPath().resolve("LinguaFrancaBase"),
             true

--- a/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
@@ -661,18 +661,21 @@ public class PythonGenerator extends CGenerator {
         super.copyTargetFiles();
         FileUtil.copyFromClassPath(
             "/lib/py/reactor-c-py/include",
-            fileConfig.getSrcGenPath().resolve("include"),
-            true
+            fileConfig.getSrcGenPath(),
+            true,
+            false
         );
         FileUtil.copyFromClassPath(
             "/lib/py/reactor-c-py/lib",
-            fileConfig.getSrcGenPath().resolve("lib"),
-            true
+            fileConfig.getSrcGenPath(),
+            true,
+            false
         );
         FileUtil.copyFromClassPath(
             "/lib/py/reactor-c-py/LinguaFrancaBase",
-            fileConfig.getSrcGenPath().resolve("LinguaFrancaBase"),
-            true
+            fileConfig.getSrcGenPath(),
+            true,
+            false
         );
     }
 

--- a/org.lflang/src/org/lflang/generator/rust/RustEmitter.kt
+++ b/org.lflang/src/org/lflang/generator/rust/RustEmitter.kt
@@ -73,7 +73,7 @@ object RustEmitter : RustEmitterBase() {
         for (modPath in gen.crate.modulesToIncludeInMain) {
             val target = fileConfig.srcGenPath.resolve("src").resolve(modPath.fileName)
             if (Files.isDirectory(modPath)) {
-                FileUtil.copyDirectory(modPath, target)
+                FileUtil.copyDirectoryContents(modPath, target)
             } else {
                 FileUtil.copyFile(modPath, target)
             }

--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -235,7 +235,7 @@ class TSGenerator(
                     "No '" + configFile + "' exists in " + fileConfig.srcPath +
                             ". Using default configuration."
                 )
-                FileUtil.copyFileFromClassPath("$LIB_PATH/$configFile", configFileDest)
+                FileUtil.copyFromClassPath("$LIB_PATH/$configFile", configFileDest, true)
             }
         }
     }

--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -38,7 +38,6 @@ import org.lflang.scoping.LFGlobalScopeProvider
 import org.lflang.util.FileUtil
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
 import java.util.*
 
 private const val NO_NPM_MESSAGE = "The TypeScript target requires npm >= 6.14.4. " +
@@ -61,18 +60,12 @@ class TSGenerator(
 
 
     val fileConfig: TSFileConfig = context.fileConfig as TSFileConfig
-    var devMode = false;
+    private var devMode = false
 
     companion object {
 
         /** Path to the TS lib directory (relative to class path)  */
         const val LIB_PATH = "/lib/ts"
-
-        /**
-         * Names of the configuration files to check for and copy to the generated
-         * source package root if they cannot be found in the source directory.
-         */
-        val CONFIG_FILES = arrayOf("package.json", "tsconfig.json", ".eslintrc.json")
 
         const val RUNTIME_URL = "git://github.com/lf-lang/reactor-ts.git"
 
@@ -223,21 +216,11 @@ class TSGenerator(
      * as the source file, copy a default version from $LIB_PATH/.
      */
     private fun copyConfigFiles() {
-        for (configFile in CONFIG_FILES) {
-            val configFileDest = fileConfig.srcGenPath.resolve(configFile)
-            val configFileInSrc = fileConfig.srcPath.resolve(configFile)
-            if (configFileInSrc.toFile().exists()) {
-                println("Copying $configFileInSrc to $configFileDest")
-                Files.createDirectories(configFileDest.parent)
-                Files.copy(configFileInSrc, configFileDest, StandardCopyOption.REPLACE_EXISTING)
-            } else {
-                println(
-                    "No '" + configFile + "' exists in " + fileConfig.srcPath +
-                            ". Using default configuration."
-                )
-                FileUtil.copyFromClassPath("$LIB_PATH/$configFile", configFileDest, true)
-            }
-        }
+        FileUtil.copyFromClassPath(
+            LIB_PATH,
+            fileConfig.srcGenPath,
+            true
+        )
     }
 
 

--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -181,8 +181,6 @@ class TSGenerator(
         val manifest = fileConfig.srcGenPath.resolve("package.json");
         val rtRegex = Regex("(\"@lf-lang/reactor-ts\")(.+)")
         if (rtPath != null) rtPath = formatRuntimePath(rtPath)
-        // FIXME: do better CLI arg validation upstream
-        // https://github.com/lf-lang/lingua-franca/issues/1429
         if (rtPath != null || rtVersion != null) {
             devMode = true;
         }

--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -220,12 +220,7 @@ class TSGenerator(
      * as the source file, copy a default version from $LIB_PATH/.
      */
     private fun copyConfigFiles() {
-        FileUtil.copyFromClassPath(
-            LIB_PATH,
-            fileConfig.srcGenPath,
-            true,
-            true
-        )
+        FileUtil.copyFromClassPath(LIB_PATH, fileConfig.srcGenPath, true, true)
         for (configFile in CONFIG_FILES) {
             var override = FileUtil.findAndCopyFile(configFile, fileConfig.srcGenPath, fileConfig);
             if (override != null) {

--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -217,6 +217,7 @@ class TSGenerator(
         FileUtil.copyFromClassPath(
             LIB_PATH,
             fileConfig.srcGenPath,
+            true,
             true
         )
     }

--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -38,7 +38,6 @@ import org.lflang.scoping.LFGlobalScopeProvider
 import org.lflang.util.FileUtil
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
 import java.util.*
 
 private const val NO_NPM_MESSAGE = "The TypeScript target requires npm >= 6.14.4. " +
@@ -228,17 +227,11 @@ class TSGenerator(
             true
         )
         for (configFile in CONFIG_FILES) {
-            val configFileInSrc = fileConfig.srcPath.resolve(configFile)
-            if (configFileInSrc.toFile().exists()) {
-                val configFileDest = fileConfig.srcGenPath.resolve(configFile)
-                println("Copying $configFileInSrc to $configFileDest")
-                Files.copy(configFileInSrc, configFileDest, StandardCopyOption.REPLACE_EXISTING)
+            var override = FileUtil.findAndCopyFile(configFile, fileConfig.srcGenPath, fileConfig);
+            if (override != null) {
+                System.out.println("Using user-provided '" + override + "'");
             } else {
-                println(
-                    "No '" + configFile + "' exists in " + fileConfig.srcPath +
-                            ". Using default configuration."
-                )
-                FileUtil.copyFileFromClassPath("$LIB_PATH/$configFile", fileConfig.srcGenPath, true)
+                System.out.println("Using default '" + configFile + "'");
             }
         }
     }

--- a/org.lflang/src/org/lflang/util/FileUtil.java
+++ b/org.lflang/src/org/lflang/util/FileUtil.java
@@ -531,8 +531,8 @@ public class FileUtil {
     }
 
     /**
-     * Given a connection to a JAR file that points to an entry that is a directory, copy all entries
-     * located in that directory or its subdirectories into the given {@code dstDir}.
+     * Given a connection to a JAR file that points to an entry that is a directory, recursively copy
+     * all entries located in that directory into the given {@code dstDir}.
      * <p>
      * If {@code contentsOnly} is true, only the contents of the directory will be copied into the
      * destination directory (not the directory itself). The directory will be copied as a whole,

--- a/org.lflang/src/org/lflang/util/FileUtil.java
+++ b/org.lflang/src/org/lflang/util/FileUtil.java
@@ -278,31 +278,40 @@ public class FileUtil {
         Path dstDir,
         FileConfig fileConfig,
         ErrorReporter errorReporter,
-        boolean contentsOnly
+        boolean fileEntriesOnly
     ) {
         for (String fileOrDirectory : entries) {
             var path = Paths.get(fileOrDirectory);
             var found = FileUtil.findInPackage(path, fileConfig);
             if (found != null) {
                 try {
-                    FileUtil.copyFromFileSystem(found, dstDir, contentsOnly);
+                    if (fileEntriesOnly) {
+                        FileUtil.copyFile(found, dstDir.resolve(path.getFileName()));
+                    } else {
+                        FileUtil.copyFromFileSystem(found, dstDir, false);
+                    }
                     System.out.println("Copied '" + fileOrDirectory + "' from the file system.");
                 } catch (IOException e) {
                     errorReporter.reportError(
-                        "Unable to copy '" + fileOrDirectory + "' from the file system."
+                        "Unable to copy '" + fileOrDirectory + "' from the file system. Reason: " + e.toString()
                     );
                 }
             } else {
                 try {
-                    FileUtil.copyFromClassPath(
-                        fileOrDirectory,
-                        dstDir,
-                        false,
-                        contentsOnly
-                    );
+                    if (fileEntriesOnly) {
+                          copySingleFileFromClasspath(fileOrDirectory, dstDir, false);
+                    } else {
+                        FileUtil.copyFromClassPath(
+                            fileOrDirectory,
+                            dstDir,
+                            false,
+                            false
+                        );
+                    }
+
                 } catch(IOException e) {
                     errorReporter.reportError(
-                        "Unable to copy '" + fileOrDirectory + "' from the class path."
+                        "Unable to copy '" + fileOrDirectory + "' from the class path. Reason: " + e.toString()
                     );
                 }
                 System.out.println("Copied '" + fileOrDirectory + "' from the class path.");

--- a/org.lflang/src/org/lflang/util/FileUtil.java
+++ b/org.lflang/src/org/lflang/util/FileUtil.java
@@ -299,7 +299,7 @@ public class FileUtil {
             } else {
                 try {
                     if (fileEntriesOnly) {
-                          copyFileFromClasspath(fileOrDirectory, dstDir, false);
+                          copyFileFromClassPath(fileOrDirectory, dstDir, false);
                     } else {
                         FileUtil.copyFromClassPath(
                             fileOrDirectory,
@@ -389,7 +389,7 @@ public class FileUtil {
      * not be changed.
      * @throws IOException If the operation failed.
      */
-    public static void copyFileFromClasspath(final String entry, final Path dstDir, final boolean skipIfUnchanged) throws IOException {
+    public static void copyFileFromClassPath(final String entry, final Path dstDir, final boolean skipIfUnchanged) throws IOException {
         final URL resource = FileConfig.class.getResource(entry);
 
         if (resource == null) {

--- a/org.lflang/src/org/lflang/util/FileUtil.java
+++ b/org.lflang/src/org/lflang/util/FileUtil.java
@@ -398,7 +398,7 @@ public class FileUtil {
 
         final URLConnection connection = resource.openConnection();
         if (connection instanceof JarURLConnection) {
-            if (!copySingleFileFromJar((JarURLConnection) connection, dstDir, skipIfUnchanged)) {
+            if (!copyFileFromJar((JarURLConnection) connection, dstDir, skipIfUnchanged)) {
                 throw new IOException("'" + entry + "' is not a file");
             }
         } else {
@@ -487,7 +487,7 @@ public class FileUtil {
      *      * not be changed.
      * @throws IOException If the operation fails.
      */
-    private static void copySingleFileFromJar(JarFile jar, String srcFile, Path dstDir, boolean skipIfUnchanged) throws IOException {
+    private static void copyFileFromJar(JarFile jar, String srcFile, Path dstDir, boolean skipIfUnchanged) throws IOException {
         var entry = jar.getJarEntry(srcFile);
         var filename = Paths.get(entry.getName()).getFileName();
         InputStream is = jar.getInputStream(entry);
@@ -524,10 +524,10 @@ public class FileUtil {
         final boolean contentsOnly
     ) throws IOException {
 
-        if (copySingleFileFromJar(connection, dstDir, skipIfUnchanged)) {
+        if (copyFileFromJar(connection, dstDir, skipIfUnchanged)) {
             return true;
         }
-        return copyMultipleFilesFromJar(connection, dstDir, skipIfUnchanged, contentsOnly);
+        return copyDirectoryFromJar(connection, dstDir, skipIfUnchanged, contentsOnly);
     }
 
     /**
@@ -544,7 +544,7 @@ public class FileUtil {
      * @return
      * @throws IOException
      */
-    private static boolean copyMultipleFilesFromJar(JarURLConnection connection,
+    private static boolean copyDirectoryFromJar(JarURLConnection connection,
         Path dstDir,
         final boolean skipIfUnchanged,
         final boolean contentsOnly) throws IOException {
@@ -586,7 +586,7 @@ public class FileUtil {
      * {@code false} if the connection entry is not a file and the copy operation was aborted.
      * @throws IOException If the operation failed.
      */
-    private static boolean copySingleFileFromJar(
+    private static boolean copyFileFromJar(
         JarURLConnection connection,
         Path dstDir,
         final boolean skipIfUnchanged
@@ -597,7 +597,7 @@ public class FileUtil {
         if (!isFileInJar(connection)) {
             return false;
         }
-        copySingleFileFromJar(jar, source, dstDir, skipIfUnchanged);
+        copyFileFromJar(jar, source, dstDir, skipIfUnchanged);
 
         return true;
     }

--- a/org.lflang/src/org/lflang/util/FileUtil.java
+++ b/org.lflang/src/org/lflang/util/FileUtil.java
@@ -337,41 +337,41 @@ public class FileUtil {
     }
 
     /**
-     *  Lookup a directory in the classpath and copy its contents to a destination path
-     *  in the filesystem.
+     *  Look up the given entry in the classpath. If it is a file, copy it into the destination
+     *  directory. If it is a directory, copy its contents to the destination directory.
      *
      *  This also creates new directories for any directories on the destination
      *  path that do not yet exist.
      *
-     *  @param source The source directory as a path relative to the classpath.
-     *  @param destination The file system path that the source directory is copied to.
+     *  @param entry The entry to be found on the class path and copied to the given destination.
+     *  @param dstDir The file system path that found files are to be copied to.
      *  @param skipIfUnchanged If true, don't overwrite the file if its content would not be changed
      *  @throws IOException If the given source cannot be copied.
      */
-    public static void copyFromClassPath(final String source, final Path destination, final boolean skipIfUnchanged) throws IOException {
-        final URL resource = FileConfig.class.getResource(source);
+    public static void copyFromClassPath(final String entry, final Path dstDir, final boolean skipIfUnchanged) throws IOException {
+        final URL resource = FileConfig.class.getResource(entry);
 
         if (resource == null) {
-            throw new TargetResourceNotFoundException(source);
+            throw new TargetResourceNotFoundException(entry);
         }
 
         final URLConnection connection = resource.openConnection();
         if (connection instanceof JarURLConnection) {
-            boolean copiedFiles = copyFromJar((JarURLConnection) connection, destination, skipIfUnchanged);
+            boolean copiedFiles = copyFromJar((JarURLConnection) connection, dstDir, skipIfUnchanged);
             if (!copiedFiles) {
-                throw new TargetResourceNotFoundException(source);
+                throw new TargetResourceNotFoundException(entry);
             }
         } else {
             try {
                 Path path = Paths.get(FileLocator.toFileURL(resource).toURI());
                 if (path.toFile().isDirectory()) {
-                    copyDirectoryContents(path, destination, skipIfUnchanged);
+                    copyDirectoryContents(path, dstDir, skipIfUnchanged);
                 } else {
-                    copyFile(path, destination.resolve(path.getFileName()), skipIfUnchanged);
+                    copyFile(path, dstDir.resolve(path.getFileName()), skipIfUnchanged);
                 }
             } catch(URISyntaxException e) {
                 // This should never happen as toFileURL should always return a valid URL
-                throw new IOException("Unexpected error while resolving " + source + " on the classpath");
+                throw new IOException("Unexpected error while resolving " + entry + " on the classpath");
             }
         }
     }

--- a/org.lflang/src/org/lflang/util/FileUtil.java
+++ b/org.lflang/src/org/lflang/util/FileUtil.java
@@ -299,7 +299,7 @@ public class FileUtil {
             } else {
                 try {
                     if (fileEntriesOnly) {
-                          copySingleFileFromClasspath(fileOrDirectory, dstDir, false);
+                          copyFileFromClasspath(fileOrDirectory, dstDir, false);
                     } else {
                         FileUtil.copyFromClassPath(
                             fileOrDirectory,
@@ -389,7 +389,7 @@ public class FileUtil {
      * not be changed.
      * @throws IOException If the operation failed.
      */
-    public static void copySingleFileFromClasspath(final String entry, final Path dstDir, final boolean skipIfUnchanged) throws IOException {
+    public static void copyFileFromClasspath(final String entry, final Path dstDir, final boolean skipIfUnchanged) throws IOException {
         final URL resource = FileConfig.class.getResource(entry);
 
         if (resource == null) {


### PR DESCRIPTION
Resources identified by some string and to be looked up relative to a source file, a package, or on the class path, could be files or directories, and there is no way to tell what it is until a matching entry has been found. Therefore, it is most convenient if we provide a lookup mechanism that will work with strings, regardless of whether they point to files or directories. PR https://github.com/lf-lang/lingua-franca/pull/1700 that was merged recently, attempted to furnish this API, but introduces some bugs. This PR fixes those bugs and tries to make the public APIs a bit more friendly improves the documentation.

One issue is that file interactions are different depending on whether tests are executed through JUnit or using `lfc`. We need to add a few unit tests to get full coverage of `FileUtil`, but we should merge this in first because it address the current CI failure on `master`.