### PR TITLE
Validator rules to check if target suppports federation or inheritance

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -281,7 +281,7 @@ public class LinguaFrancaValidationTest {
     public void disallowUnderscoreReactorDef() throws Exception {
         String testCase = """
                 target TypeScript;
-                main reactor __Foo {
+                reactor __Foo {
                 }
             """;
         validator.assertError(parseWithoutError(testCase), LfPackage.eINSTANCE.getReactor(), null,

--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -821,7 +821,7 @@ public class LinguaFrancaValidationTest {
                     reactor B extends A{}
                 """.formatted(target));
 
-            if(target.supportsInheritance()) {
+            if (target.supportsInheritance()) {
                 validator.assertNoIssues(model);
             } else {
                 validator.assertError(model, LfPackage.eINSTANCE.getReactor(), null,
@@ -838,7 +838,7 @@ public class LinguaFrancaValidationTest {
                     federated reactor {}
                 """.formatted(target));
 
-            if(target.supportsFederated()) {
+            if (target.supportsFederated()) {
                 validator.assertNoIssues(model);
             } else {
                 validator.assertError(model, LfPackage.eINSTANCE.getReactor(), null,

--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -137,7 +137,7 @@ public class LinguaFrancaValidationTest {
 
         Model model_error_1 = parser.parse("""
                 target Cpp;
-                main reactor Preamble {
+                reactor Preamble {
                 }
             """);
 
@@ -145,7 +145,7 @@ public class LinguaFrancaValidationTest {
                 target Cpp;
                 reactor Preamble {
                 }
-                main reactor Main {
+                main reactor {
                 }
             """);
 

--- a/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -812,6 +812,41 @@ public class LinguaFrancaValidationTest {
         }
     }
 
+    @Test
+    public void testInheritanceSupport() throws Exception {
+        for (Target target : Target.values()) {
+            Model model = parseWithoutError("""
+                    target %s
+                    reactor A{}
+                    reactor B extends A{}
+                """.formatted(target));
+
+            if(target.supportsInheritance()) {
+                validator.assertNoIssues(model);
+            } else {
+                validator.assertError(model, LfPackage.eINSTANCE.getReactor(), null,
+                    "The " + target.getDisplayName() + " target does not support reactor inheritance.");
+            }
+        }
+    }
+
+    @Test
+    public void testFederationSupport() throws Exception {
+        for (Target target : Target.values()) {
+            Model model = parseWithoutError("""
+                    target %s
+                    federated reactor {}
+                """.formatted(target));
+
+            if(target.supportsFederated()) {
+                validator.assertNoIssues(model);
+            } else {
+                validator.assertError(model, LfPackage.eINSTANCE.getReactor(), null,
+                    "The " + target.getDisplayName() + " target does not support federated execution.");
+            }
+        }
+    }
+
 
     /**
      * Tests for state and parameter declarations, including native lists.

--- a/org.lflang/src/org/lflang/Target.java
+++ b/org.lflang/src/org/lflang/Target.java
@@ -463,6 +463,16 @@ public enum Target {
     }
 
     /**
+     * Return true if the target supports reactor inheritance (extends keyword).
+     */
+    public boolean supportsInheritance() {
+        return switch (this) {
+            case C, CCPP, Python -> true;
+            default -> false;
+        };
+    }
+
+    /**
      * Return true if the target supports multiports and banks
      * of reactors.
      */

--- a/org.lflang/src/org/lflang/Target.java
+++ b/org.lflang/src/org/lflang/Target.java
@@ -463,6 +463,16 @@ public enum Target {
     }
 
     /**
+     * Return true if the target supports federated execution.
+     */
+    public boolean supportsFederated() {
+        return switch (this) {
+            case C, CCPP, Python, TS -> true;
+            default -> false;
+        };
+    }
+
+    /**
      * Return true if the target supports reactor inheritance (extends keyword).
      */
     public boolean supportsInheritance() {

--- a/org.lflang/src/org/lflang/validation/LFValidator.java
+++ b/org.lflang/src/org/lflang/validation/LFValidator.java
@@ -984,7 +984,7 @@ public class LFValidator extends BaseLFValidator {
         }
 
         if (reactor.isFederated()) {
-            if(!target.supportsFederated()) {
+            if (!target.supportsFederated()) {
                 error("The " + target.getDisplayName() + " target does not support federated execution.",
                     Literals.REACTOR__FEDERATED);
             }

--- a/org.lflang/src/org/lflang/validation/LFValidator.java
+++ b/org.lflang/src/org/lflang/validation/LFValidator.java
@@ -971,6 +971,11 @@ public class LFValidator extends BaseLFValidator {
         if (reactor.isFederated()) {
             FedValidator.validateFederatedReactor(reactor, this.errorReporter);
         }
+
+        if (!reactor.getSuperClasses().isEmpty() && !target.supportsInheritance()) {
+            error("The " + target.name() + " target does not support reactor inheritance.",
+                  Literals.REACTOR__SUPER_CLASSES);
+        }
     }
 
     /**

--- a/org.lflang/src/org/lflang/validation/LFValidator.java
+++ b/org.lflang/src/org/lflang/validation/LFValidator.java
@@ -969,11 +969,16 @@ public class LFValidator extends BaseLFValidator {
         }
 
         if (reactor.isFederated()) {
+            if(!target.supportsFederated()) {
+                error("The " + target.getDisplayName() + " target does not support federated execution.",
+                    Literals.REACTOR__FEDERATED);
+            }
+
             FedValidator.validateFederatedReactor(reactor, this.errorReporter);
         }
 
         if (!reactor.getSuperClasses().isEmpty() && !target.supportsInheritance()) {
-            error("The " + target.name() + " target does not support reactor inheritance.",
+            error("The " + target.getDisplayName() + " target does not support reactor inheritance.",
                   Literals.REACTOR__SUPER_CLASSES);
         }
     }

--- a/org.lflang/src/org/lflang/validation/LFValidator.java
+++ b/org.lflang/src/org/lflang/validation/LFValidator.java
@@ -852,29 +852,22 @@ public class LFValidator extends BaseLFValidator {
     // FIXME: improve error message.
     }
 
-    @Check(CheckType.FAST)
-    public void checkReactor(Reactor reactor) throws IOException {
-        Set<Reactor> superClasses = ASTUtils.superClasses(reactor);
-        if (superClasses == null) {
-            error(
-                    "Problem with superclasses: Either they form a cycle or are not defined",
-                    Literals.REACTOR_DECL__NAME
-            );
-            // Continue checks, but without any superclasses.
-            superClasses = new LinkedHashSet<>();
-        }
+    public void checkReactorName(Reactor reactor) throws IOException {
         String name = FileUtil.nameWithoutExtension(reactor.eResource());
-        if (reactor.getName() == null) {
-            if (!reactor.isFederated() && !reactor.isMain()) {
+
+        // Check for illegal names.
+        if(reactor.getName() != null) {
+            checkName(reactor.getName(), Literals.REACTOR_DECL__NAME);
+
+            // C++ reactors may not be called 'preamble'
+            if (this.target == Target.CPP && name.equalsIgnoreCase("preamble")) {
                 error(
-                    "Reactor must be named.",
+                    "Reactor cannot be named '" + name + "'",
                     Literals.REACTOR_DECL__NAME
                 );
-                // Prevent NPE in tests below.
-                return;
             }
         }
-        TreeIterator<EObject> iter = reactor.eResource().getAllContents();
+
         if (reactor.isFederated() || reactor.isMain()) {
             if(reactor.getName() != null && !reactor.getName().equals(name)) {
                 // Make sure that if the name is given, it matches the expected name.
@@ -883,38 +876,55 @@ public class LFValidator extends BaseLFValidator {
                     Literals.REACTOR_DECL__NAME
                 );
             }
+        } else {
+            // Not federated or main.
+            if (reactor.getName() == null) {
+                error(
+                    "Reactor must be named.",
+                    Literals.REACTOR_DECL__NAME
+                );
+            } else {
+                TreeIterator<EObject> iter = reactor.eResource().getAllContents();
+                int nMain = countMainOrFederated(iter);
+                if (nMain > 0 && reactor.getName().equals(name)) {
+                    error(
+                        "Name conflict with main reactor.",
+                        Literals.REACTOR_DECL__NAME
+                    );
+                }
+            }
+        }
+    }
+
+    @Check(CheckType.FAST)
+    public void checkReactor(Reactor reactor) throws IOException {
+        checkReactorName(reactor);
+
+        if (reactor.isFederated() || reactor.isMain()) {
             // Do not allow multiple main/federated reactors.
+            TreeIterator<EObject> iter = reactor.eResource().getAllContents();
             int nMain = countMainOrFederated(iter);
             if (nMain > 1) {
                 EAttribute attribute = Literals.REACTOR__MAIN;
                 if (reactor.isFederated()) {
-                   attribute = Literals.REACTOR__FEDERATED;
+                    attribute = Literals.REACTOR__FEDERATED;
                 }
                 error(
                     "Multiple definitions of main or federated reactor.",
                     attribute
                 );
             }
-        } else {
-            // Not federated or main.
-            int nMain = countMainOrFederated(iter);
-            if (nMain > 0 && reactor.getName().equals(name)) {
-                error(
-                    "Name conflict with main reactor.",
-                    Literals.REACTOR_DECL__NAME
-                );
-            }
         }
 
-        // Check for illegal names.
-        checkName(reactor.getName(), Literals.REACTOR_DECL__NAME);
 
-        // C++ reactors may not be called 'preamble'
-        if (this.target == Target.CPP && reactor.getName().equalsIgnoreCase("preamble")) {
+        Set<Reactor> superClasses = ASTUtils.superClasses(reactor);
+        if (superClasses == null) {
             error(
-                "Reactor cannot be named '" + reactor.getName() + "'",
-                Literals.REACTOR_DECL__NAME
+                    "Problem with superclasses: Either they form a cycle or are not defined",
+                    Literals.REACTOR_DECL__NAME
             );
+            // Continue checks, but without any superclasses.
+            superClasses = new LinkedHashSet<>();
         }
 
         if (reactor.getHost() != null) {
@@ -932,6 +942,11 @@ public class LFValidator extends BaseLFValidator {
         variables.addAll(reactor.getOutputs());
         variables.addAll(reactor.getActions());
         variables.addAll(reactor.getTimers());
+
+        if (!reactor.getSuperClasses().isEmpty() && !target.supportsInheritance()) {
+            error("The " + target.getDisplayName() + " target does not support reactor inheritance.",
+                Literals.REACTOR__SUPER_CLASSES);
+        }
 
         // Perform checks on super classes.
         for (Reactor superClass : superClasses) {
@@ -975,11 +990,6 @@ public class LFValidator extends BaseLFValidator {
             }
 
             FedValidator.validateFederatedReactor(reactor, this.errorReporter);
-        }
-
-        if (!reactor.getSuperClasses().isEmpty() && !target.supportsInheritance()) {
-            error("The " + target.getDisplayName() + " target does not support reactor inheritance.",
-                  Literals.REACTOR__SUPER_CLASSES);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/lf-lang/lingua-franca/issues/1652.

This also updates the checkReactor rule in order to mitigate potential exception and avoid weird control flow (i.e. returning from a nested if).