### PR TITLE
Inherit preambles

### DIFF
--- a/org.lflang/src/org/lflang/ASTUtils.java
+++ b/org.lflang/src/org/lflang/ASTUtils.java
@@ -81,6 +81,7 @@ import org.lflang.lf.Output;
 import org.lflang.lf.Parameter;
 import org.lflang.lf.ParameterReference;
 import org.lflang.lf.Port;
+import org.lflang.lf.Preamble;
 import org.lflang.lf.Reaction;
 import org.lflang.lf.Reactor;
 import org.lflang.lf.ReactorDecl;
@@ -375,6 +376,18 @@ public class ASTUtils {
     /** A list of all ports of {@code definition}, in an unspecified order. */
     public static List<Port> allPorts(Reactor definition) {
         return Stream.concat(ASTUtils.allInputs(definition).stream(), ASTUtils.allOutputs(definition).stream()).toList();
+    }
+
+    /**
+     * Given a reactor class, return a list of all its preambles,
+     * which includes preambles of base classes that it extends.
+     * If the base classes include a cycle, where X extends Y and Y extends X,
+     * then return only the input defined in the base class.
+     * The returned list may be empty.
+     * @param definition Reactor class definition.
+     */
+    public static List<Preamble> allPreambles(Reactor definition) {
+        return ASTUtils.collectElements(definition, featurePackage.getReactor_Preambles());
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -1078,7 +1078,7 @@ public class CGenerator extends GeneratorBase {
      * @param reactor The given reactor
      */
     protected void generateUserPreamblesForReactor(Reactor reactor, CodeBuilder src) {
-        for (Preamble p : convertToEmptyListIfNull(reactor.getPreambles())) {
+        for (Preamble p : ASTUtils.allPreambles(reactor)) {
             src.pr("// *********** From the preamble, verbatim:");
             src.prSourceLineNumber(p.getCode());
             src.pr(toText(p.getCode()));

--- a/test/C/src/PreambleInherited.lf
+++ b/test/C/src/PreambleInherited.lf
@@ -1,0 +1,17 @@
+/**
+ * Check that preamble is inherited.
+ * Success is just compiling and running.
+ */
+target C
+reactor A {
+    preamble {=
+        #define FOO 2
+    =}
+    reaction(startup) {=
+        printf("FOO: %d\n", FOO);
+    =}
+}
+reactor B extends A {}
+main reactor {
+    b = new B()
+}

--- a/test/C/src/PreambleInherited.lf
+++ b/test/C/src/PreambleInherited.lf
@@ -1,17 +1,17 @@
-/**
- * Check that preamble is inherited.
- * Success is just compiling and running.
- */
+/** Check that preamble is inherited. Success is just compiling and running. */
 target C
+
 reactor A {
     preamble {=
         #define FOO 2
     =}
-    reaction(startup) {=
-        printf("FOO: %d\n", FOO);
-    =}
+
+    reaction(startup) {= printf("FOO: %d\n", FOO); =}
 }
-reactor B extends A {}
+
+reactor B extends A {
+}
+
 main reactor {
     b = new B()
 }


### PR DESCRIPTION
This PR addresses the first problem in #1712, where a preamble of base-class reactor was not inherited by a subclass of the reactor. It adds the test mentioned in the issue.