### PR TITLE
Preamble file level

### DIFF
--- a/org.lflang/src/org/lflang/ASTUtils.java
+++ b/org.lflang/src/org/lflang/ASTUtils.java
@@ -81,6 +81,7 @@ import org.lflang.lf.Output;
 import org.lflang.lf.Parameter;
 import org.lflang.lf.ParameterReference;
 import org.lflang.lf.Port;
+import org.lflang.lf.Preamble;
 import org.lflang.lf.Reaction;
 import org.lflang.lf.Reactor;
 import org.lflang.lf.ReactorDecl;
@@ -375,6 +376,18 @@ public class ASTUtils {
     /** A list of all ports of {@code definition}, in an unspecified order. */
     public static List<Port> allPorts(Reactor definition) {
         return Stream.concat(ASTUtils.allInputs(definition).stream(), ASTUtils.allOutputs(definition).stream()).toList();
+    }
+
+    /**
+     * Given a reactor class, return a list of all its preambles,
+     * which includes preambles of base classes that it extends.
+     * If the base classes include a cycle, where X extends Y and Y extends X,
+     * then return only the input defined in the base class.
+     * The returned list may be empty.
+     * @param definition Reactor class definition.
+     */
+    public static List<Preamble> allPreambles(Reactor definition) {
+        return ASTUtils.collectElements(definition, featurePackage.getReactor_Preambles());
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -1078,7 +1078,7 @@ public class CGenerator extends GeneratorBase {
      * @param reactor The given reactor
      */
     protected void generateUserPreamblesForReactor(Reactor reactor, CodeBuilder src) {
-        for (Preamble p : convertToEmptyListIfNull(reactor.getPreambles())) {
+        for (Preamble p : ASTUtils.allPreambles(reactor)) {
             src.pr("// *********** From the preamble, verbatim:");
             src.prSourceLineNumber(p.getCode());
             src.pr(toText(p.getCode()));

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -1983,8 +1983,11 @@ public class CGenerator extends GeneratorBase {
         var guard = "TOP_LEVEL_PREAMBLE_" + reactor.eContainer().hashCode() + "_H";
         builder.pr("#ifndef " + guard);
         builder.pr("#define " + guard);
+        // Reactors that are instantiated by the specified reactor need to have
+        // their file-level preambles included.  This needs to also include file-level
+        // preambles of base classes of those reactors.
         Stream.concat(Stream.of(reactor), ASTUtils.allNestedClasses(reactor))
-            .flatMap(it -> ((Model) it.eContainer()).getPreambles().stream())
+            .flatMap(it -> ASTUtils.allFileLevelPreambles(it).stream())
             .collect(Collectors.toSet())
             .forEach(it -> builder.pr(toText(it.getCode())));
         for (String file : targetConfig.protoFiles) {

--- a/test/C/src/PreambleFileLevel.lf
+++ b/test/C/src/PreambleFileLevel.lf
@@ -1,0 +1,14 @@
+/**
+ * Test for ensuring that file-level preambles are inherited when a file is
+ * imported.
+ */
+target C
+
+import FileLevelPreamble from "lib/FileLevelPreamble.lf"
+
+reactor B extends FileLevelPreamble {
+}
+
+main reactor {
+    b = new B()
+}

--- a/test/C/src/PreambleInherited.lf
+++ b/test/C/src/PreambleInherited.lf
@@ -1,0 +1,17 @@
+/**
+ * Check that preamble is inherited.
+ * Success is just compiling and running.
+ */
+target C
+reactor A {
+    preamble {=
+        #define FOO 2
+    =}
+    reaction(startup) {=
+        printf("FOO: %d\n", FOO);
+    =}
+}
+reactor B extends A {}
+main reactor {
+    b = new B()
+}

--- a/test/C/src/PreambleInherited.lf
+++ b/test/C/src/PreambleInherited.lf
@@ -1,17 +1,17 @@
-/**
- * Check that preamble is inherited.
- * Success is just compiling and running.
- */
+/** Check that preamble is inherited. Success is just compiling and running. */
 target C
+
 reactor A {
     preamble {=
         #define FOO 2
     =}
-    reaction(startup) {=
-        printf("FOO: %d\n", FOO);
-    =}
+
+    reaction(startup) {= printf("FOO: %d\n", FOO); =}
 }
-reactor B extends A {}
+
+reactor B extends A {
+}
+
 main reactor {
     b = new B()
 }

--- a/test/C/src/lib/FileLevelPreamble.lf
+++ b/test/C/src/lib/FileLevelPreamble.lf
@@ -1,0 +1,13 @@
+/**
+ * Test for ensuring that file-level preambles are inherited when a file is
+ * imported.
+ */
+target C
+
+preamble {=
+    #define FOO 2
+=}
+
+reactor FileLevelPreamble {
+    reaction(startup) {= printf("FOO: %d\n", FOO); =}
+}


### PR DESCRIPTION
This fixes the problems identified in #1712, where reactor-level preambles were not inherited and file-level preambles for base classes are not included in the generated code.