### PR TITLE
Prohibit reactor classes in the same file with the same name, up to case differences

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/compiler/TargetConfigTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/TargetConfigTests.java
@@ -94,7 +94,7 @@ class TargetConfigTests {
         generator.doGenerate(resource, fileAccess, context);
 
         String lfSrc = Files.readAllLines(
-            ((FedFileConfig)context.getFileConfig()).getSrcPath().resolve("a.lf")
+            ((FedFileConfig)context.getFileConfig()).getSrcPath().resolve("__a.lf")
         ).stream().reduce("\n", String::concat);
         Model federate = parser.parse(lfSrc);
         assertHasTargetProperty(federate, "tracing");

--- a/org.lflang.tests/src/org/lflang/tests/compiler/TargetConfigTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/TargetConfigTests.java
@@ -94,7 +94,7 @@ class TargetConfigTests {
         generator.doGenerate(resource, fileAccess, context);
 
         String lfSrc = Files.readAllLines(
-            ((FedFileConfig)context.getFileConfig()).getSrcPath().resolve("__a.lf")
+            ((FedFileConfig)context.getFileConfig()).getSrcPath().resolve("federate__a.lf")
         ).stream().reduce("\n", String::concat);
         Model federate = parser.parse(lfSrc);
         assertHasTargetProperty(federate, "tracing");

--- a/org.lflang/src/org/lflang/ModelInfo.java
+++ b/org.lflang/src/org/lflang/ModelInfo.java
@@ -160,7 +160,7 @@ public class ModelInfo {
     }
 
     private String getName(Reactor r) {
-        return r.getName() == null ? r.getName() : FileUtil.nameWithoutExtension(Path.of(model.eResource().getURI().toFileString()));
+        return r.getName() != null ? r.getName() : FileUtil.nameWithoutExtension(Path.of(model.eResource().getURI().toFileString()));
     }
 
     public Set<NamedInstance<?>> topologyCycles() {

--- a/org.lflang/src/org/lflang/ModelInfo.java
+++ b/org.lflang/src/org/lflang/ModelInfo.java
@@ -28,6 +28,7 @@ package org.lflang;
 import static org.eclipse.xtext.xbase.lib.IterableExtensions.filter;
 import static org.eclipse.xtext.xbase.lib.IteratorExtensions.toIterable;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -47,6 +48,7 @@ import org.lflang.lf.Parameter;
 import org.lflang.lf.ParameterReference;
 import org.lflang.lf.Reactor;
 import org.lflang.lf.STP;
+import org.lflang.util.FileUtil;
 
 
 /**
@@ -146,15 +148,19 @@ public class ModelInfo {
         var reactorNames = new HashSet<>();
         var bad = new ArrayList<>();
         for (var reactor : model.getReactors()) {
-            var lowerName = reactor.getName().toLowerCase();
+            var lowerName = getName(reactor).toLowerCase();
             if (reactorNames.contains(lowerName)) bad.add(lowerName);
             reactorNames.add(lowerName);
         }
         for (var badName : bad) {
-            model.getReactors().stream().filter(it -> it.getName()
-                .toLowerCase().equals(badName))
+            model.getReactors().stream()
+                .filter(it -> getName(it).toLowerCase().equals(badName))
                 .forEach(it -> reporter.reportError(it, "Multiple reactors have the same name up to case differences."));
         }
+    }
+
+    private String getName(Reactor r) {
+        return r.getName() == null ? r.getName() : FileUtil.nameWithoutExtension(Path.of(model.eResource().getURI().toFileString()));
     }
 
     public Set<NamedInstance<?>> topologyCycles() {

--- a/org.lflang/src/org/lflang/federated/generator/FedEmitter.java
+++ b/org.lflang/src/org/lflang/federated/generator/FedEmitter.java
@@ -51,9 +51,6 @@ public class FedEmitter {
                                + " in directory "
                                + fileConfig.getSrcPath());
 
-        Path lfFilePath = fileConfig.getSrcPath().resolve(
-            "__" + fedName + ".lf");
-
         String federateCode = String.join(
             "\n",
             new FedTargetEmitter().generateTarget(context, numOfFederates, federate, fileConfig, errorReporter, rtiConfig),
@@ -67,11 +64,17 @@ public class FedEmitter {
             )
         );
         Map<Path, CodeMap> codeMapMap = new HashMap<>();
+        var lfFilePath = lfFilePath(fileConfig, federate);
         try (var srcWriter = Files.newBufferedWriter(lfFilePath)) {
             var codeMap = CodeMap.fromGeneratedCode(federateCode);
             codeMapMap.put(lfFilePath, codeMap);
             srcWriter.write(codeMap.getGeneratedCode());
         }
         return codeMapMap;
+    }
+
+    public static Path lfFilePath(FedFileConfig fileConfig, FederateInstance federate) {
+        return fileConfig.getSrcPath().resolve(
+            "__" + federate.name + ".lf");
     }
 }

--- a/org.lflang/src/org/lflang/federated/generator/FedEmitter.java
+++ b/org.lflang/src/org/lflang/federated/generator/FedEmitter.java
@@ -74,7 +74,6 @@ public class FedEmitter {
     }
 
     public static Path lfFilePath(FedFileConfig fileConfig, FederateInstance federate) {
-        return fileConfig.getSrcPath().resolve(
-            "__" + federate.name + ".lf");
+        return fileConfig.getSrcPath().resolve(federate.name + ".lf");
     }
 }

--- a/org.lflang/src/org/lflang/federated/generator/FedEmitter.java
+++ b/org.lflang/src/org/lflang/federated/generator/FedEmitter.java
@@ -52,7 +52,7 @@ public class FedEmitter {
                                + fileConfig.getSrcPath());
 
         Path lfFilePath = fileConfig.getSrcPath().resolve(
-            fedName + ".lf");
+            "__" + fedName + ".lf");
 
         String federateCode = String.join(
             "\n",

--- a/org.lflang/src/org/lflang/federated/generator/FedGenerator.java
+++ b/org.lflang/src/org/lflang/federated/generator/FedGenerator.java
@@ -286,7 +286,7 @@ public class FedGenerator {
             final int id = i;
             compileThreadPool.execute(() -> {
                 Resource res = rs.getResource(URI.createFileURI(
-                    fileConfig.getSrcPath().resolve(fed.name + ".lf").toAbsolutePath().toString()
+                    FedEmitter.lfFilePath(fileConfig, fed).toAbsolutePath().toString()
                 ), true);
                 FileConfig subFileConfig = LFGenerator.createFileConfig(res, fileConfig.getSrcGenPath(), true);
                 ErrorReporter subContextErrorReporter = new LineAdjustingErrorReporter(threadSafeErrorReporter, lf2lfCodeMapMap);

--- a/org.lflang/src/org/lflang/federated/generator/FederateInstance.java
+++ b/org.lflang/src/org/lflang/federated/generator/FederateInstance.java
@@ -97,8 +97,8 @@ public class FederateInstance { // why does this not extend ReactorInstance?
      * @param errorReporter The error reporter
      */
     public FederateInstance(
-            Instantiation instantiation, 
-            int id, 
+            Instantiation instantiation,
+            int id,
             int bankIndex,
             TargetConfig targetConfig,
             ErrorReporter errorReporter) {
@@ -107,9 +107,9 @@ public class FederateInstance { // why does this not extend ReactorInstance?
         this.bankIndex = bankIndex;
         this.errorReporter = errorReporter;
         this.targetConfig = targetConfig;
-        
+
         if (instantiation != null) {
-            this.name = instantiation.getName();
+            this.name = "__" + instantiation.getName();
             // If the instantiation is in a bank, then we have to append
             // the bank index to the name.
             if (instantiation.getWidthSpec() != null) {
@@ -120,18 +120,18 @@ public class FederateInstance { // why does this not extend ReactorInstance?
 
     /////////////////////////////////////////////
     //// Public Fields
-    
+
     /**
      * The position within a bank of reactors for this federate.
      * This is 0 if the instantiation is not a bank of reactors.
      */
     public int bankIndex = 0;
-    
+
     /**
      * A list of outputs that can be triggered directly or indirectly by physical actions.
      */
     public Set<Expression> outputsConnectedToPhysicalActions = new LinkedHashSet<>();
-    
+
     /**
      * The host, if specified using the 'at' keyword.
      */
@@ -150,7 +150,7 @@ public class FederateInstance { // why does this not extend ReactorInstance?
      * A list of individual connections between federates
      */
     public Set<FedConnectionInstance> connections = new HashSet<>();
-    
+
     /**
      * Map from the federates that this federate receives messages from
      * to the delays on connections from that federate. The delay set
@@ -158,17 +158,17 @@ public class FederateInstance { // why does this not extend ReactorInstance?
      * from the federate instance that has no delay.
      */
     public Map<FederateInstance, Set<Expression>> dependsOn = new LinkedHashMap<>();
-    
+
     /**
      * The directory, if specified using the 'at' keyword.
      */
     public String dir = null;
-    
+
     /**
      * The port, if specified using the 'at' keyword.
      */
     public int port = 0;
-    
+
     /**
      * Map from the federates that this federate sends messages to
      * to the delays on connections to that federate. The delay set
@@ -176,12 +176,12 @@ public class FederateInstance { // why does this not extend ReactorInstance?
      * from the federate instance that has no delay.
      */
     public Map<FederateInstance, Set<Expression>> sendsTo = new LinkedHashMap<>();
-    
+
     /**
      * The user, if specified using the 'at' keyword.
      */
     public String user = null;
-    
+
     /**
      * The integer ID of this federate.
      */
@@ -194,7 +194,7 @@ public class FederateInstance { // why does this not extend ReactorInstance?
      * this instance if the instantiation is of a bank of reactors.
      */
     public String name = "Unnamed";
-    
+
     /**
      * List of networkMessage actions. Each of these handles a message
      *  received from another federate over the network. The ID of
@@ -202,7 +202,7 @@ public class FederateInstance { // why does this not extend ReactorInstance?
      *  The sending federate needs to specify this ID.
      */
     public List<Action> networkMessageActions = new ArrayList<>();
-    
+
     /**
      * A set of federates with which this federate has an inbound connection
      * There will only be one physical connection even if federate A has defined multiple
@@ -211,7 +211,7 @@ public class FederateInstance { // why does this not extend ReactorInstance?
      * to help the receiver distinguish different events.
      */
     public Set<FederateInstance> inboundP2PConnections = new LinkedHashSet<>();
-    
+
     /**
      * A list of federate with which this federate has an outbound physical connection.
      * There will only be one physical connection even if federate A has defined multiple
@@ -220,29 +220,29 @@ public class FederateInstance { // why does this not extend ReactorInstance?
      * scheduling the appropriate action.
      */
     public Set<FederateInstance> outboundP2PConnections = new LinkedHashSet<>();
-    
+
     /**
      * A list of triggers for network input control reactions. This is used to trigger
      * all the input network control reactions that might be nested in a hierarchy.
      */
     public List<Action> networkInputControlReactionsTriggers = new ArrayList<>();
-    
+
     /**
      * The trigger that triggers the output control reaction of this
      * federate.
-     * 
+     *
      * The network output control reactions send a PORT_ABSENT message for a network output port,
      * if it is absent at the current tag, to notify all downstream federates that no value will
      * be present on the given network port, allowing input control reactions on those federates
      * to stop blocking.
      */
     public Variable networkOutputControlReactionsTrigger = null;
-    
+
     /**
      * Indicates whether the federate is remote or local
      */
     public boolean isRemote = false;
-    
+
     /**
      * List of generated network reactions (network receivers,
      * network input control reactions, network senders, and network output control
@@ -389,16 +389,16 @@ public class FederateInstance { // why does this not extend ReactorInstance?
                 }
             }
         }
-        
-        return false;        
+
+        return false;
     }
 
-    /** 
+    /**
      * Return true if the specified reaction should be included in the code generated for this
      * federate at the top-level. This means that if the reaction is triggered by or
      * sends data to a port of a contained reactor, then that reaction
      * is in the federate. Otherwise, return false.
-     * 
+     *
      * NOTE: This method assumes that it will not be called with reaction arguments
      * that are within other federates. It should only be called on reactions that are
      * either at the top level or within this federate. For this reason, for any reaction
@@ -411,7 +411,7 @@ public class FederateInstance { // why does this not extend ReactorInstance?
 
         assert reactor != null;
         if (!reactor.getReactions().contains(reaction)) return false;
-        
+
         if (networkReactions.contains(reaction)) {
             // Reaction is a network reaction that belongs to this federate
             return true;
@@ -421,15 +421,15 @@ public class FederateInstance { // why does this not extend ReactorInstance?
         if (reactionBankIndex >= 0 && this.bankIndex >= 0 && reactionBankIndex != this.bankIndex) {
             return false;
         }
-        
+
         // If this has been called before, then the result of the
         // following check is cached.
         if (excludeReactions != null) {
             return !excludeReactions.contains(reaction);
         }
-        
+
         indexExcludedTopLevelReactions(reactor);
-       
+
         return !excludeReactions.contains(reaction);
     }
 
@@ -462,17 +462,17 @@ public class FederateInstance { // why does this not extend ReactorInstance?
         return false;
     }
 
-    /** 
+    /**
      * Return true if the specified reactor instance or any parent
      * reactor instance is contained by this federate.
      * If the specified instance is the top-level reactor, return true
      * (the top-level reactor belongs to all federates).
      * If this federate instance is a singleton, then return true if the
      * instance is non null.
-     * 
+     *
      * NOTE: If the instance is bank within the top level, then this
      * returns true even though only one of the bank members is in the federate.
-     * 
+     *
      * @param instance The reactor instance.
      * @return True if this federate contains the reactor instance
      */
@@ -496,7 +496,7 @@ public class FederateInstance { // why does this not extend ReactorInstance?
      * federatedReactor) that don't belong to this federate
      * instance. This index is put in the excludeReactions
      * class variable.
-     * 
+     *
      * @param federatedReactor The top-level federated reactor
      */
     private void indexExcludedTopLevelReactions(Reactor federatedReactor) {
@@ -537,7 +537,7 @@ public class FederateInstance { // why does this not extend ReactorInstance?
             }
         }
     }
-    
+
     /**
      * Return true if all members of 'varRefs' belong to this federate.
      *
@@ -564,7 +564,7 @@ public class FederateInstance { // why does this not extend ReactorInstance?
         }
         return inFederate;
     }
-     
+
     /**
      * Find output ports that are connected to a physical action trigger upstream
      * in the same reactor. Return a list of such outputs paired with the minimum delay
@@ -596,7 +596,7 @@ public class FederateInstance { // why does this not extend ReactorInstance?
                                  .filter(e -> e.getValue().contains(null))
                                  .map(Map.Entry::getKey).toList();
     }
-    
+
     @Override
     public String toString() {
         return "Federate " + id + ": "
@@ -605,21 +605,21 @@ public class FederateInstance { // why does this not extend ReactorInstance?
 
     /////////////////////////////////////////////
     //// Private Fields
-     
+
     /**
      * Cached result of analysis of which reactions to exclude from main.
      */
     private Set<Reaction> excludeReactions = null;
-    
+
     /**
      * An error reporter
      */
     private final ErrorReporter errorReporter;
-    
+
     /**
      * Find the nearest (shortest) path to a physical action trigger from this
      * 'reaction' in terms of minimum delay.
-     * 
+     *
      * @param reaction The reaction to start with
      * @return The minimum delay found to the nearest physical action and
      *  TimeValue.MAX_VALUE otherwise
@@ -646,7 +646,7 @@ public class FederateInstance { // why does this not extend ReactorInstance?
                         }
                     }
                 }
-                
+
             } else if (trigger.getDefinition() instanceof Output) {
                 // Outputs of contained reactions
                 PortInstance outputInstance = (PortInstance) trigger;
@@ -660,7 +660,7 @@ public class FederateInstance { // why does this not extend ReactorInstance?
         }
         return minDelay;
     }
-    
+
     // TODO: Put this function into a utils file instead
     private <T> List<T> convertToEmptyListIfNull(List<T> list) {
         return list == null ? new ArrayList<>() : list;

--- a/org.lflang/src/org/lflang/federated/generator/FederateInstance.java
+++ b/org.lflang/src/org/lflang/federated/generator/FederateInstance.java
@@ -25,7 +25,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package org.lflang.federated.generator;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -40,17 +39,13 @@ import org.eclipse.emf.ecore.EObject;
 
 import org.lflang.ASTUtils;
 import org.lflang.ErrorReporter;
-import org.lflang.FileConfig;
-import org.lflang.Target;
 import org.lflang.TargetConfig;
 import org.lflang.TimeValue;
 import org.lflang.federated.serialization.SupportedSerializers;
 import org.lflang.generator.ActionInstance;
-import org.lflang.generator.GeneratorUtils;
 import org.lflang.generator.PortInstance;
 import org.lflang.generator.ReactionInstance;
 import org.lflang.generator.ReactorInstance;
-import org.lflang.generator.SubContext;
 import org.lflang.generator.TriggerInstance;
 import org.lflang.lf.Action;
 import org.lflang.lf.ActionOrigin;
@@ -109,12 +104,12 @@ public class FederateInstance { // why does this not extend ReactorInstance?
         this.targetConfig = targetConfig;
 
         if (instantiation != null) {
-            this.name = "__" + instantiation.getName();
             // If the instantiation is in a bank, then we have to append
             // the bank index to the name.
             if (instantiation.getWidthSpec() != null) {
                 this.name = instantiation.getName() + "__" + bankIndex;
             }
+            name = "federate__" + name;
         }
     }
 

--- a/org.lflang/src/org/lflang/federated/generator/FederateInstance.java
+++ b/org.lflang/src/org/lflang/federated/generator/FederateInstance.java
@@ -107,9 +107,10 @@ public class FederateInstance { // why does this not extend ReactorInstance?
             // If the instantiation is in a bank, then we have to append
             // the bank index to the name.
             if (instantiation.getWidthSpec() != null) {
-                this.name = instantiation.getName() + "__" + bankIndex;
+                this.name = "federate__" + instantiation.getName() + "__" + bankIndex;
+            } else {
+                this.name = "federate__" + instantiation.getName();
             }
-            name = "federate__" + name;
         }
     }
 

--- a/org.lflang/src/org/lflang/generator/DockerGenerator.java
+++ b/org.lflang/src/org/lflang/generator/DockerGenerator.java
@@ -43,7 +43,7 @@ public abstract class DockerGenerator {
         var dockerFilePath = context.getFileConfig().getSrcGenPath().resolve("Dockerfile");
         var dockerFileContent = generateDockerFileContent();
 
-        return new DockerData(name, dockerFilePath, dockerFileContent);
+        return new DockerData(name.replace("_", ""), dockerFilePath, dockerFileContent);
     }
 
     public static DockerGenerator dockerGeneratorFactory(LFGeneratorContext context) {

--- a/org.lflang/src/org/lflang/generator/ReactorInstance.java
+++ b/org.lflang/src/org/lflang/generator/ReactorInstance.java
@@ -323,7 +323,8 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
     @Override
     public String uniqueID() {
        if (this.isMainOrFederated()) {
-          return super.uniqueID() + "_main";
+           if (reactorDefinition.isFederated()) return "__" + super.uniqueID() + "_main";
+           return super.uniqueID() + "_main";
        }
        return super.uniqueID();
     }

--- a/org.lflang/src/org/lflang/generator/ReactorInstance.java
+++ b/org.lflang/src/org/lflang/generator/ReactorInstance.java
@@ -323,7 +323,7 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
     @Override
     public String uniqueID() {
        if (this.isMainOrFederated()) {
-           if (reactorDefinition.isFederated()) return "__" + super.uniqueID() + "_main";
+           if (reactorDefinition.isFederated() && !super.uniqueID().startsWith("federate__")) return "federate__" + super.uniqueID() + "_main";
            return super.uniqueID() + "_main";
        }
        return super.uniqueID();


### PR DESCRIPTION
Fixes #1702.

The core issue in #1702 is that we consider reactor classes to have distinct names using a **case-sensitive** comparison, but we want to generate files corresponding to the reactor classes that will be compared **case-insensitively** on macOS.

We can't just mangle these file names because users might refer to them in their code.

Therefore, we should avoid creating reactor classes whose names are the same, up to case differences.