### PR TITLE
Mechanism for printing execution statistics

### DIFF
--- a/org.lflang.tests/src/org/lflang/tests/cli/LfcCliTest.java
+++ b/org.lflang.tests/src/org/lflang/tests/cli/LfcCliTest.java
@@ -76,6 +76,7 @@ public class LfcCliTest {
                 "logging": "info",
                 "lint": true,
                 "no-compile": true,
+                "print-statistics": true,
                 "quiet": true,
                 "rti": "path/to/rti",
                 "runtime-version": "rs",
@@ -228,6 +229,7 @@ public class LfcCliTest {
                 assertEquals(properties.getProperty(BuildParm.LOGGING.getKey()), "info");
                 assertEquals(properties.getProperty(BuildParm.LINT.getKey()), "true");
                 assertEquals(properties.getProperty(BuildParm.NO_COMPILE.getKey()), "true");
+                assertEquals(properties.getProperty(BuildParm.PRINT_STATISTICS.getKey()), "true");
                 assertEquals(properties.getProperty(BuildParm.QUIET.getKey()), "true");
                 assertEquals(properties.getProperty(BuildParm.RTI.getKey()),
                         "path" + File.separator + "to" + File.separator + "rti");
@@ -256,6 +258,7 @@ public class LfcCliTest {
             "--logging", "info",
             "--lint",
             "--no-compile",
+            "--print-statistics",
             "--quiet",
             "--rti", "path/to/rti",
             "--runtime-version", "rs",

--- a/org.lflang/src/org/lflang/TargetConfig.java
+++ b/org.lflang/src/org/lflang/TargetConfig.java
@@ -40,6 +40,7 @@ import org.lflang.TargetProperty.LogLevel;
 import org.lflang.TargetProperty.Platform;
 import org.lflang.TargetProperty.SchedulerOption;
 import org.lflang.TargetProperty.UnionType;
+import org.lflang.generator.LFGeneratorContext.BuildParm;
 import org.lflang.generator.rust.RustTargetConfig;
 import org.lflang.lf.KeyValuePair;
 import org.lflang.lf.TargetDecl;
@@ -136,6 +137,9 @@ public class TargetConfig {
         if (cliArgs.containsKey(TargetProperty.KEEPALIVE.description)) {
             this.keepalive = Boolean.parseBoolean(
                 cliArgs.getProperty(TargetProperty.KEEPALIVE.description));
+        }
+        if (cliArgs.containsKey(BuildParm.PRINT_STATISTICS.getKey())) {
+            this.printStatistics = true;
         }
     }
 
@@ -268,6 +272,11 @@ public class TargetConfig {
      * of defining platform (either a string or dictionary of values)
      */
     public PlatformOptions platformOptions = new PlatformOptions();
+
+    /**
+     * If true, instruct the runtime to collect and print execution statistics.
+     */
+    public boolean printStatistics = false;
 
     /**
      * List of proto files to be processed by the code generator.

--- a/org.lflang/src/org/lflang/TargetProperty.java
+++ b/org.lflang/src/org/lflang/TargetProperty.java
@@ -480,6 +480,16 @@ public enum TargetProperty {
             }),
 
     /**
+     * Directive to instruct the runtime to collect and print execution statistics.
+     */
+    PRINT_STATISTICS("print-statistics", PrimitiveType.BOOLEAN,
+        Arrays.asList(Target.CPP),
+        (config) -> ASTUtils.toElement(config.printStatistics),
+        (config, value, err) -> {
+            config.printStatistics = ASTUtils.toBoolean(value);
+        }),
+
+    /**
      * Directive for specifying .proto files that need to be compiled and their
      * code included in the sources.
      */

--- a/org.lflang/src/org/lflang/cli/Lfc.java
+++ b/org.lflang/src/org/lflang/cli/Lfc.java
@@ -98,6 +98,12 @@ public class Lfc extends CliBase {
     private boolean noCompile;
 
     @Option(
+        names = {"--print-statistics"},
+        arity = "0",
+        description = "Instruct the runtime to collect and print statistics.")
+    private boolean printStatistics;
+
+    @Option(
         names = {"-q", "--quiet"},
         arity = "0",
         description = 
@@ -263,6 +269,10 @@ public class Lfc extends CliBase {
                     logging + ": Invalid log level.");
             }
             props.setProperty(BuildParm.LOGGING.getKey(), logging);
+        }
+
+        if(printStatistics) {
+            props.setProperty(BuildParm.PRINT_STATISTICS.getKey(), "true");
         }
 
         if (noCompile) {

--- a/org.lflang/src/org/lflang/generator/LFGeneratorContext.java
+++ b/org.lflang/src/org/lflang/generator/LFGeneratorContext.java
@@ -1,15 +1,12 @@
 package org.lflang.generator;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.generator.IFileSystemAccess2;
 import org.eclipse.xtext.generator.IGeneratorContext;
-import org.eclipse.xtext.util.RuntimeIOException;
 
 import org.lflang.ErrorReporter;
 import org.lflang.FileConfig;
@@ -37,6 +34,7 @@ public interface LFGeneratorContext extends IGeneratorContext {
         LINT("Enable or disable linting of generated code."),
         NO_COMPILE("Do not invoke target compiler."),
         OUTPUT_PATH("Specify the root output directory."),
+        PRINT_STATISTICS("Instruct the runtime to collect and print statistics."),
         QUIET("Suppress output of the target compiler and other commands"),
         RTI("Specify the location of the RTI."),
         RUNTIME_VERSION("Specify the version of the runtime library used for compiling LF programs."),

--- a/org.lflang/src/org/lflang/generator/cpp/CppStandaloneGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppStandaloneGenerator.kt
@@ -165,6 +165,7 @@ class CppStandaloneGenerator(generator: CppGenerator) :
                 "-DCMAKE_INSTALL_PREFIX=${outPath.toUnixString()}",
                 "-DCMAKE_INSTALL_BINDIR=${outPath.relativize(fileConfig.binPath).toUnixString()}",
                 "-DREACTOR_CPP_VALIDATE=${if (targetConfig.noRuntimeValidation) "OFF" else "ON"}",
+                "-DREACTOR_CPP_PRINT_STATISTICS=${if (targetConfig.printStatistics) "ON" else "OFF"}",
                 "-DREACTOR_CPP_TRACE=${if (targetConfig.tracing != null) "ON" else "OFF"}",
                 "-DREACTOR_CPP_LOG_LEVEL=${targetConfig.logLevel.severity}",
                 "-DLF_SRC_PKG_PATH=${fileConfig.srcPkgPath}",


### PR DESCRIPTION
This adds the `print-statistics` target property and pulls in https://github.com/lf-lang/reactor-cpp/pull/47. If `print-statistics` is true, the compiled program will print an output like the following when the program terminates.

```
[INFO]  -----------------------------------------------------------
[INFO]  Program statistics:
[INFO]    - number of reactors:    4
[INFO]    - number of connections: 4
[INFO]    - number of reactions    9
[INFO]    - number of actions:     11
[INFO]    - number of ports:       8
[INFO]  Execution statistics:
[INFO]    - processed events:      12000015
[INFO]    - triggered actions:     12000021
[INFO]    - processed reactions:   36000039
[INFO]    - set ports:             24000024
[INFO]    - scheduled actions:     12000021
[INFO]  -----------------------------------------------------------
```