### PR TITLE
Delete unnecessary complexity from `build-lf-cli`

### DIFF
--- a/lib/scripts/build.sh
+++ b/lib/scripts/build.sh
@@ -114,18 +114,4 @@ if [ "${OSTYPE}" = "msys" ]; then
 fi
 
 jar_path="$(get_jar_path)"
-
-if [ ! -f "${jar_path}" ] || ! "${find_cmd}" "${base}" \
-        -path "${src_pkg_path}" \
-        -prune -o \
-        -type f \
-        -newer "${jar_path}" \
-        -exec false {} +; then
-	# Rebuild.
-    1>&2 echo "Jar file is missing or out-of-date; starting rebuild..."
-	"${base}/gradlew" ${flags} -p "${base}" buildAll
-	# Update the timestamp in case the jar was not touched by Gradle.
-    touch -c -- "${jar_path}"
-else
-    echo "Already up-to-date."
-fi
+"${base}/gradlew" ${flags} -p "${base}" buildAll


### PR DESCRIPTION
I have not been able to get this script to detect changes in my file system. At first I thought this was a Gradle issue, but it is just a problem in the bash script.

If anyone wishes to make this mechanism work properly, then I will not stop them. However, Gradle is already supposed to detect when nothing needs to be rebuilt, so if we do it this way and something needs to be rebuilt, then we are just doing the same check twice, which is a waste of time. Furthermore, if nothing needed to be rebuilt, then we would not be running this script. Let us not make an incremental build system out of bash scripts.