### PR TITLE
Debugging ts CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,89 +37,90 @@ jobs:
 #   needs: cancel
 
   # Run the unit tests.
-  unit-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/unit-tests.yml@master
-    needs: cancel
+  # unit-tests:
+  #   uses: lf-lang/lingua-franca/.github/workflows/unit-tests.yml@master
+  #   needs: cancel
 
   # Run tests for the standalone compiler.
-  cli-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/cli-tests.yml@master
-    needs: cancel
+  # cli-tests:
+  #   uses: lf-lang/lingua-franca/.github/workflows/cli-tests.yml@master
+  #   needs: cancel
 
   # Run the C benchmark tests.
-  c-benchmark-tests:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
-    with:
-      target: 'C'
-    needs: cancel
+  # c-benchmark-tests:
+  #   uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
+  #   with:
+  #     target: 'C'
+  #   needs: cancel
 
   # Run language server tests.
-  lsp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@master
-    needs: cancel
+  # lsp-tests:
+  #   uses: lf-lang/lingua-franca/.github/workflows/lsp-tests.yml@master
+  #   needs: cancel
 
   # Run the C integration tests.
-  c-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@master
-    needs: cancel
+  # c-tests:
+  #   uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@master
+  #   needs: cancel
   
   # Run the C Arduino integration tests.
-  c-arduino-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-arduino-tests.yml@master
-    needs: cancel
+  # c-arduino-tests:
+  #   uses: lf-lang/lingua-franca/.github/workflows/c-arduino-tests.yml@master
+  #   needs: cancel
   
   # Run the C Zephyr integration tests.
-  c-zephyr-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@master
-    needs: cancel
+  # c-zephyr-tests:
+  #   uses: lf-lang/lingua-franca/.github/workflows/c-zephyr-tests.yml@master
+  #   needs: cancel
 
   # Run the CCpp integration tests.
-  ccpp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@master
-    with:
-      use-cpp: true
-    needs: cancel
+  # ccpp-tests:
+  #   uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@master
+  #   with:
+  #     use-cpp: true
+  #   needs: cancel
 
   # Run the C++ benchmark tests.
-  cpp-benchmark-tests:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
-    with:
-      target: 'Cpp'
-    needs: cancel
+  # cpp-benchmark-tests:
+  #   uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
+  #   with:
+  #     target: 'Cpp'
+  #   needs: cancel
 
   # Run the C++ integration tests.
-  cpp-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/cpp-tests.yml@master
-    needs: cancel
+  # cpp-tests:
+  #   uses: lf-lang/lingua-franca/.github/workflows/cpp-tests.yml@master
+  #   needs: cancel
 
   # Run the C++ integration tests on ROS2.
-  cpp-ros2-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/cpp-ros2-tests.yml@master
-    needs: cancel
+  # cpp-ros2-tests:
+  #   uses: lf-lang/lingua-franca/.github/workflows/cpp-ros2-tests.yml@master
+  #   needs: cancel
 
   # Run the Python integration tests.
-  py-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/py-tests.yml@master
-    needs: cancel
+  # py-tests:
+  #   uses: lf-lang/lingua-franca/.github/workflows/py-tests.yml@master
+  #   needs: cancel
 
   # Run the Rust integration tests.
-  rs-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/rs-tests.yml@master
-    needs: cancel
+  # rs-tests:
+  #   uses: lf-lang/lingua-franca/.github/workflows/rs-tests.yml@master
+  #   needs: cancel
 
   # Run the Rust benchmark tests.
-  rs-benchmark-tests:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
-    with:
-      target: 'Rust'
-    needs: cancel
+  # rs-benchmark-tests:
+  #   uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
+  #   with:
+  #     target: 'Rust'
+  #   needs: cancel
 
   # Run the TypeScript integration tests.
   ts-tests:
+    uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@debug-ts-in-ci
     uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@master
     needs: cancel
 
   # Run the serialization tests
-  serialization-tests:
-    uses: lf-lang/lingua-franca/.github/workflows/serialization-tests.yml@master
-    needs: cancel
+  # serialization-tests:
+  #   uses: lf-lang/lingua-franca/.github/workflows/serialization-tests.yml@master
+  #   needs: cancel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
   # Run the TypeScript integration tests.
   ts-tests:
     uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@debug-ts-in-ci
-    uses: lf-lang/lingua-franca/.github/workflows/ts-tests.yml@master
     needs: cancel
 
   # Run the serialization tests

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           brew install coreutils
         if: ${{ runner.os == 'macOS' }}
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - name: Perform TypeScript tests
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="git://github.com/lf-lang/reactor-ts.git#master"


### PR DESCRIPTION
Currently, CI cannot catch errors in reactor-ts. This PR is for finding the ssh connection string for CI ([reference link](https://github.com/marketplace/actions/debugging-with-ssh)).