### PR TITLE
Fix build error in serialization tests in master

### DIFF
--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -28,7 +28,7 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
       - name: Perform TypeScript tests
         run: |
-          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="git://github.com/lf-lang/reactor-ts.git#master"
+          ./gradlew test --tests org.lflang.tests.runtime.TypeScriptTest.* -Druntime="git://github.com/lf-lang/reactor-ts.git#minor-reorg"
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:

--- a/org.lflang/src/lib/ts/package.json
+++ b/org.lflang/src/lib/ts/package.json
@@ -2,7 +2,7 @@
     "name": "LinguaFrancaDefault",
     "type": "commonjs",
     "dependencies": {
-        "@lf-lang/reactor-ts": "git://github.com/lf-lang/reactor-ts.git#master",
+        "@lf-lang/reactor-ts": "git://github.com/lf-lang/reactor-ts.git#minor-reorg",
         "command-line-args": "^5.1.1",
         "command-line-usage": "^6.1.3"
     },

--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -334,7 +334,7 @@ class TSGenerator(
             // first build reactor-ts (pnpm does this automatically).
             if (devMode) {
                 val rtPath = path.resolve("node_modules").resolve("@lf-lang").resolve("reactor-ts")
-                val buildRuntime = commandFactory.createCommand("npm", listOf("run", "prepublish"), rtPath)
+                val buildRuntime = commandFactory.createCommand("npm", listOf("run", "build"), rtPath)
                 if (buildRuntime.run(context.cancelIndicator) != 0) {
                     errorReporter.reportError(
                         GeneratorUtils.findTargetDecl(resource),


### PR DESCRIPTION
When in dev mode, we may point to a git URL instead of a published version on reactor-ts. If `pnpm` is not available and we fall back to `npm`, we need to cd into the `node_modules` and make sure that the `.js` sources get built. This used to happen by invoking `npm run prepublish` but that was removed due to a deprecation notice. We should be able to run `npm run build` instead, but that does not appear to work...