### PR TITLE
Improved line adjustment logic for federated programs

### DIFF
--- a/org.lflang/src/org/lflang/ast/ToLf.java
+++ b/org.lflang/src/org/lflang/ast/ToLf.java
@@ -219,7 +219,11 @@ public class ToLf extends LfSwitch<MalleableString> {
             .map(String::stripTrailing)
             .collect(Collectors.joining("\n"));
     MalleableString singleLineRepresentation =
-        MalleableString.anyOf(String.format("{= %s =}", content.strip()));
+        new Builder()
+            .append("{= ")
+            .append(content.strip())
+            .append(" =}")
+            .get();
     MalleableString multilineRepresentation =
         new Builder()
             .append(String.format("{=%n"))


### PR DESCRIPTION
This fixes a bug in which, when a reaction body of a federated reactor all fits on one line, it does not get a (correct) `CodeMap.Correspondence` tag. This issue was observed [here](https://github.com/lf-lang/lingua-franca/actions/runs/5030655964/jobs/9023219148?pr=1749).

It is bad that I had to modify ToLf to do this since the logic isn't really in ToLf. The problem was that the line adjustment relies on tagging the target code (without the fat braces), and the target code is not recorded separately from the fat braces if they are entered into the MalleableString machinery as all one string.