### PR TITLE
Submodule renamed to match repo name

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,8 @@
 	path = org.lflang/src/lib/c/reactor-c
 	url = https://github.com/lf-lang/reactor-c.git
 [submodule "org.lflang/src/lib/py/reactor-c-py"]
-	path = org.lflang/src/lib/py/reactor-c-py
-	url = https://github.com/lf-lang/reactor-c-py.git
+	path = org.lflang/src/lib/py/lf-python-support
+	url = https://github.com/lf-lang/lf-python-support.git
 [submodule "org.lflang/src/lib/cpp/reactor-cpp"]
 	path = org.lflang/src/lib/cpp/reactor-cpp
 	url = https://github.com/lf-lang/reactor-cpp

--- a/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
+++ b/org.lflang/src/org/lflang/generator/python/PythonGenerator.java
@@ -137,7 +137,7 @@ public class PythonGenerator extends CGenerator {
      *       FEDERATED_GENERIC_EXTENSION
      *   } generic_port_instance_struct;
      *
-     * See reactor-c-py/lib/pythontarget.h for details.
+     * See reactor-c/python/lib/pythontarget.h for details.
      */
     String genericPortType = "generic_port_instance_struct";
 
@@ -153,7 +153,7 @@ public class PythonGenerator extends CGenerator {
      * FEDERATED_CAPSULE_EXTENSION
      * } generic_action_instance_struct;
      *
-     * See reactor-c-py/lib/pythontarget.h for details.
+     * See reactor-c/python/lib/pythontarget.h for details.
      */
     String genericActionType = "generic_action_instance_struct";
 
@@ -672,7 +672,7 @@ public class PythonGenerator extends CGenerator {
             false
         );
         FileUtil.copyFromClassPath(
-            "/lib/py/reactor-c-py/LinguaFrancaBase",
+            "/lib/py/lf-python-support/LinguaFrancaBase",
             fileConfig.getSrcGenPath(),
             true,
             false


### PR DESCRIPTION
This PR is because the `reactor-c-py` submodule was renamed to reflect that it doesn't host a runtime implementation but only provides a support package.