### PR TITLE
Check spotless formatting in CI

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,4 +1,4 @@
-name: Test the automatic code formatting task
+name: Check if all files are formatted correctly with spotless
 
 on:
   workflow_call:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,9 @@ jobs:
     uses: lf-lang/lingua-franca/.github/workflows/build-trace-tools.yml@master
     needs: cancel
 
-# Check that automatic code formatting works.
-# TODO: Uncomment after fed-gen is merged.
-# format:
-#   uses: lf-lang/lingua-franca/.github/workflows/format.yml@master
-#   needs: cancel
+  check-format:
+    uses: lf-lang/lingua-franca/.github/workflows/check-format.yml@ci-check-formatting
+    needs: cancel
 
   # Run the unit tests.
   unit-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
- 
+
 ## [v0.4.0](https://github.com/lf-lang/lingua-franca/tree/v0.4.0) (2023-03-01)
 
 **Highlights**
@@ -207,7 +207,7 @@ This release includes substantial changes under the hood and brings a lot of new
 - Fix problem with merging of reaction plans [\#28](https://github.com/lf-lang/reactor-rs/pull/28) ([oowekyala](https://github.com/oowekyala))
 
 
- 
+
 ## [v0.3.0](https://github.com/lf-lang/lingua-franca/tree/v0.3.0) (2022-07-22)
 
 **Highlights**
@@ -309,7 +309,7 @@ This release adds broader support for methods (C and Python), syntax for annotat
 - Increased coverage of unit tests in bank.ts, multiport.ts and port.ts [\#100](https://github.com/lf-lang/reactor-ts/pull/100) ([goekberk](https://github.com/goekberk))
 
 
- 
+
 ## [v0.2.1](https://github.com/lf-lang/lingua-franca/tree/v0.2.1) (2022-06-01)
 
 **Highlights:**
@@ -373,7 +373,7 @@ This release includes bug fixes related to IDE tooling and federated execution. 
 - Do not create the temporary dependency link if a connection between f… [\#1085](https://github.com/lf-lang/lingua-franca/pull/1085) ([edwardalee](https://github.com/edwardalee))
 - Replace Value with Expression in the grammar [\#1023](https://github.com/lf-lang/lingua-franca/pull/1023) ([cmnrd](https://github.com/cmnrd))
 - Scale back LSP tests [\#944](https://github.com/lf-lang/lingua-franca/pull/944) ([petervdonovan](https://github.com/petervdonovan))
- 
+
 ## [v0.2.0](https://github.com/lf-lang/lingua-franca/tree/v0.2.0) (2022-05-01)
 
 **Highlights:**
@@ -415,7 +415,7 @@ This release brings the minimum version requirement of Java to 17, which is a lo
 - Java configuration bumped to version 17 [\#1094](https://github.com/lf-lang/lingua-franca/pull/1094) ([lhstrh](https://github.com/lhstrh))
 - Add validation tests for ports in main or federated reactor [\#1091](https://github.com/lf-lang/lingua-franca/pull/1091) ([housengw](https://github.com/housengw))
 - Update and add federated execution tests for TypeScript target [\#1062](https://github.com/lf-lang/lingua-franca/pull/1062) ([hokeun](https://github.com/hokeun))
- 
+
 ## [v0.1.0](https://github.com/lf-lang/lingua-franca/tree/v0.1.0) (2022-04-11)
 
 **Highlights:**
@@ -631,7 +631,7 @@ The `lfc` command line application is suitable for:
 #### System Requirements
 - Java 11 or up ([download from Oracle](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html))
 - Various target-specific dependencies, documented [here](https://github.com/icyphy/lingua-franca/blob/7473ae1549c2b2aeed8f5469675f328d3984cb2c/REQUIREMENTS.md)
- 
+
 #### IDE Features
 - code generation
 - diagram synthesis

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ You can work on the Lingua Franca code base in your favorite editor and build us
 Please refer to our handbook for specific instructions for setting up a development environment in [IntelliJ](https://www.lf-lang.org/docs/handbook/intellij) or [Eclipse](https://www.lf-lang.org/docs/handbook/eclipse-oomph).
 
 ### Writing tests
-An integral part of contributing code is writing tests. 
+An integral part of contributing code is writing tests.
 
 **Unit tests** for the compiler are located in the `org.lflang.tests` package and are implemented using the JUnit test framework. These tests are invoked using Gradle. For example, to run all the tests in the `org.lflang.tests.compiler` package, use the following command:
 ```
@@ -137,9 +137,9 @@ In Java, instances of collection classes may be read-only. They will throw an ex
 
 ```
 /* Assume the returned list is unmodifiable */
-List<String> contents = container.getListOfContents(); 
+List<String> contents = container.getListOfContents();
 /* You can iterate on the list, get an item, but not set/add/remove. To make local modifications, make a copy:*/
-contents = new ArrayList<>(contents); 
+contents = new ArrayList<>(contents);
 /* Now the list is modifiable, but changes do not affect the `container` object */
 contents.add("extra");
 

--- a/README.md
+++ b/README.md
@@ -19,5 +19,3 @@ Lingua Franca (LF) is a polyglot coordination language for concurrent and possib
 See [lf-lang.org](https://lf-lang.org) for installation instructions and documentation. See also the [wiki](https://github.com/icyphy/lingua-franca/wiki) for further information on ongoing projects.
 
 See our [Publications and Presentations](https://www.lf-lang.org/publications-and-presentations).
-
-

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -20,7 +20,7 @@ With Java (>= 11), you should also be able to use the provided Eclipse IDE produ
 
 However, to compile the generated code and to create a binary (which is done by default), each target language in Lingua Franca has an additional set of requirements, which are listed in this section. We also include a list of tested operating systems in the format of a compact table below.
 
-**Note:** Compiling the generated code is generally automatically done in the Eclipse IDE or while using the `lfc` command line tool. This default behavior can be disabled, however, using the [no-compile](https://github.com/icyphy/lingua-franca/wiki/target-specification#no-compile) target property in your Lingua Franca program or by using the `-n` argument for the `lfc` command line tool (see [Command Line Tools](https://github.com/icyphy/lingua-franca/wiki/Command-Line-Tools)). 
+**Note:** Compiling the generated code is generally automatically done in the Eclipse IDE or while using the `lfc` command line tool. This default behavior can be disabled, however, using the [no-compile](https://github.com/icyphy/lingua-franca/wiki/target-specification#no-compile) target property in your Lingua Franca program or by using the `-n` argument for the `lfc` command line tool (see [Command Line Tools](https://github.com/icyphy/lingua-franca/wiki/Command-Line-Tools)).
 
 
 ### Supported Operating Systems
@@ -34,7 +34,7 @@ However, to compile the generated code and to create a binary (which is done by 
 ### Dependencies
 
 **C:**
-  - A C compiler (e.g., gcc >= 7, clang, or MSVC >= 14.20) 
+  - A C compiler (e.g., gcc >= 7, clang, or MSVC >= 14.20)
   - CMAKE >= 3.13 (follow https://cmake.org/install/ for installation instructions)
   - **Windows Only:** Visual Studio >= 2019 and Windows SDK >= 10.0.18362.0
   - **Programs using Protocol Buffers:** protoc-c 1.3.3 - see https://github.com/icyphy/lingua-franca/wiki/Protobufs.

--- a/org.lflang.tests/src/org/lflang/tests/compiler/RoundTripTests.java
+++ b/org.lflang.tests/src/org/lflang/tests/compiler/RoundTripTests.java
@@ -5,7 +5,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.extensions.InjectionExtension;
@@ -58,10 +57,5 @@ public class RoundTripTests {
             "The reformatted version of %s was not equivalent to the original file.%n"
                 + "Formatted file:%n%s%n%n",
             file, squishedTestCase));
-    final String normalTestCase = FormattingUtils.render(originalModel);
-    Assertions.assertEquals(
-        Files.readString(file).replaceAll("\\r\\n?", "\n"),
-        normalTestCase,
-        "File is not formatted properly, or formatter is bugged. Check " + file);
   }
 }


### PR DESCRIPTION
Since we now formatted all the code with spotless, we should make sure that it stays this way. This PR re-enables the CI check that ensures that everything is correctly formatted.