### PR TITLE
Replaced all build option context getargs string with getkey (again)

### DIFF
--- a/org.lflang/src/org/lflang/federated/generator/FedGenerator.java
+++ b/org.lflang/src/org/lflang/federated/generator/FedGenerator.java
@@ -334,7 +334,7 @@ public class FedGenerator {
    * @param context Context of the build process.
    */
   private void processCLIArguments(LFGeneratorContext context) {
-    if (context.getArgs().containsKey("rti")) {
+    if (context.getArgs().containsKey(BuildParm.RTI.getKey())) {
       setFederationRTIProperties(context);
     }
   }

--- a/org.lflang/src/org/lflang/generator/GeneratorBase.java
+++ b/org.lflang/src/org/lflang/generator/GeneratorBase.java
@@ -48,6 +48,7 @@ import org.lflang.Target;
 import org.lflang.TargetConfig;
 import org.lflang.ast.ASTUtils;
 import org.lflang.ast.AstTransformation;
+import org.lflang.generator.LFGeneratorContext.BuildParm;
 import org.lflang.graph.InstantiationGraph;
 import org.lflang.lf.Connection;
 import org.lflang.lf.Instantiation;
@@ -236,7 +237,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
     // Configure the command factory
     commandFactory.setVerbose();
     if (Objects.equal(context.getMode(), LFGeneratorContext.Mode.STANDALONE)
-        && context.getArgs().containsKey("quiet")) {
+        && context.getArgs().containsKey(BuildParm.QUIET.getKey())) {
       commandFactory.setQuiet();
     }
 
@@ -294,7 +295,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
 
   /** Check if a clean was requested from the standalone compiler and perform the clean step. */
   protected void cleanIfNeeded(LFGeneratorContext context) {
-    if (context.getArgs().containsKey("clean")) {
+    if (context.getArgs().containsKey(BuildParm.CLEAN.getKey())) {
       try {
         context.getFileConfig().doClean();
       } catch (IOException e) {

--- a/org.lflang/src/org/lflang/generator/Validator.java
+++ b/org.lflang/src/org/lflang/generator/Validator.java
@@ -16,6 +16,7 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.lflang.ErrorReporter;
+import org.lflang.generator.LFGeneratorContext.BuildParm;
 import org.lflang.util.LFCommand;
 
 /**
@@ -91,7 +92,7 @@ public abstract class Validator {
    * @param context The context of the current build.
    */
   private boolean validationEnabled(LFGeneratorContext context) {
-    return context.getArgs().containsKey("lint") || validationEnabledByDefault(context);
+    return context.getArgs().containsKey(BuildParm.LINT.getKey()) || validationEnabledByDefault(context);
   }
 
   /**


### PR DESCRIPTION
This is supposed to be done in 81499a13 (this replaces https://github.com/lf-lang/lingua-franca/pull/1520#event-9316630760) yet it took a while and master was changed drastically. 

Fortunately, most of the conflicts arise from d872d4f where most of the magic strings were replaced, and I figured it would be a better idea to make a new branch and change accordingly.
