### PR TITLE
Amortize slow LFF startup time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,15 +16,15 @@ spotless {
         endWithNewline()
     }
 
-//    format 'linguaFranca', {
-//        addStep(LfFormatStep.create(project.projectDir))
-//        target 'test/*/src/**/*.lf' // you have to set the target manually
-//        targetExclude 'test/**/failing/**'
-//    }
+    format 'linguaFranca', {
+        addStep(LfFormatStep.create())
+        target 'test/*/src/**/*.lf' // you have to set the target manually
+        targetExclude 'test/**/failing/**'
+    }
 
 }
 
-//spotlessLinguaFranca.dependsOn(":org.lflang:cli:lff:installDist")
+spotlessLinguaFranca.dependsOn(":org.lflang:cli:lff:installDist")
 
 
 distributions {

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,11 @@ spotless {
         target 'test/*/src/**/*.lf' // you have to set the target manually
         targetExclude 'test/**/failing/**'
     }
-
 }
 
-spotlessLinguaFranca.dependsOn(":org.lflang:cli:lff:installDist")
-
+// Make the LF formatting task depend on lff
+spotlessLinguaFranca.dependsOn(':org.lflang:cli:lff:installDist')
+spotlessLinguaFranca.inputs.files(tasks.getByPath(':org.lflang:cli:lff:installDist').outputs)
 
 distributions {
     clitools {

--- a/buildSrc/src/main/java/lfformat/LfFormatStep.java
+++ b/buildSrc/src/main/java/lfformat/LfFormatStep.java
@@ -1,23 +1,15 @@
 package lfformat;
 
-import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.Reader;
-import java.io.Serializable;
 import java.io.Writer;
-import java.lang.ProcessBuilder.Redirect;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
@@ -41,6 +33,7 @@ public final class LfFormatStep {
     // The use of the static keyword here is a workaround for serialization difficulties.
     /** The path to the lingua-franca repository. */
     private static Path projectRoot;
+
     private static Step instance;
 
     private static Process formatter;
@@ -56,16 +49,19 @@ public final class LfFormatStep {
 
     private Step() throws IOException {
       initializeFormatter();
-      Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-        try {
-          writer.close();
-          formatter.waitFor();
-          reader.close();
-          error.close();
-        } catch (IOException | InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-      }));
+      Runtime.getRuntime()
+          .addShutdownHook(
+              new Thread(
+                  () -> {
+                    try {
+                      writer.close();
+                      formatter.waitFor();
+                      reader.close();
+                      error.close();
+                    } catch (IOException | InterruptedException e) {
+                      throw new RuntimeException(e);
+                    }
+                  }));
     }
 
     @Override
@@ -114,14 +110,14 @@ public final class LfFormatStep {
       error = new BufferedReader(new InputStreamReader(formatter.getErrorStream()));
     }
 
-//    /** Run the formatter on the given file and return the resulting process handle. */
-//    private Process runFormatter(File file) throws IOException {
-//      // It looks silly to invoke Java from Java, but it is necessary in
-//      // order to break the circularity of needing the program to be built
-//      // in order for it to be built.
-//      var formatter = getFormatter();
-//      return formatter;
-//    }
+    //    /** Run the formatter on the given file and return the resulting process handle. */
+    //    private Process runFormatter(File file) throws IOException {
+    //      // It looks silly to invoke Java from Java, but it is necessary in
+    //      // order to break the circularity of needing the program to be built
+    //      // in order for it to be built.
+    //      var formatter = getFormatter();
+    //      return formatter;
+    //    }
 
     @SuppressWarnings("NullableProblems")
     @Override

--- a/buildSrc/src/main/java/lfformat/LfFormatStep.java
+++ b/buildSrc/src/main/java/lfformat/LfFormatStep.java
@@ -1,11 +1,18 @@
 package lfformat;
 
+import com.diffplug.spotless.FormatterFunc;
 import com.diffplug.spotless.FormatterStep;
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
 import java.io.Serializable;
+import java.io.Writer;
+import java.lang.ProcessBuilder.Redirect;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
@@ -27,32 +34,44 @@ public final class LfFormatStep {
   }
 
   /** Implement LF-specific formatting functionality. */
-  public static class Step implements FormatterStep, Serializable {
+  public static class Step implements FormatterStep {
     // The use of the static keyword here is a workaround for serialization difficulties.
     /** The path to the lingua-franca repository. */
     private static Path projectRoot;
+
+    private static Process formatter;
+    private static Writer writer;
+
+    private static BufferedReader reader;
+    private static BufferedReader error;
 
     @Override
     public String format(
         @SuppressWarnings("NullableProblems") String rawUnix,
         @SuppressWarnings("NullableProblems") File file)
         throws IOException, InterruptedException {
-      Process p = runFormatter(file);
       StringBuilder output = new StringBuilder();
-      BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
-      String line;
-      while ((line = in.readLine()) != null) {
-        output.append(line).append("\n");
+      getFormatter();
+      try {
+        writer.write(file.getAbsoluteFile().toString().strip() + "\n");
+        writer.flush();
+      } catch (IOException e) {
+        getFormatter().waitFor();
+        error.lines().forEach(System.out::println);
+        formatter = null;
+        throw new RuntimeException("Failed to format " + file + ".\nPlease ensure that this file passes validator checks.");
       }
-      int returnCode = p.waitFor();
-      if (returnCode != 0) {
-        throw new RuntimeException("Failed to reformat file. Exit code: " + returnCode + " Output: " + output.toString());
+      String line = reader.readLine();
+      while (line != null && !line.endsWith("\0")) {
+        if (!output.isEmpty()) output.append("\n");
+        output.append(line);
+        line = reader.readLine();
       }
       return output.toString();
     }
 
-    /** Run the formatter on the given file and return the resulting process handle. */
-    private Process runFormatter(File file) throws IOException {
+    private static Process getFormatter() throws IOException {
+      if (formatter != null) return formatter;
       final Path lffPath =
           Path.of(
               "org.lflang",
@@ -63,16 +82,26 @@ public final class LfFormatStep {
               "lff",
               "bin",
               "lff");
-      // It looks silly to invoke Java from Java, but it is necessary in
-      // order to break the circularity of needing the program to be built
-      // in order for it to be built.
-      return new ProcessBuilder(
-              List.of(
-                  lffPath.toString(),
-                  "--dry-run",
-                  file.getAbsoluteFile().toString()))
+      formatter = new ProcessBuilder(
+          List.of(
+              lffPath.toString(),
+              "--dry-run",
+              "--stdin"))
           .start();
+      writer = new BufferedWriter(new OutputStreamWriter(formatter.getOutputStream()));
+      reader = new BufferedReader(new InputStreamReader(formatter.getInputStream()));
+      error = new BufferedReader(new InputStreamReader(formatter.getErrorStream()));
+      return formatter;
     }
+
+//    /** Run the formatter on the given file and return the resulting process handle. */
+//    private Process runFormatter(File file) throws IOException {
+//      // It looks silly to invoke Java from Java, but it is necessary in
+//      // order to break the circularity of needing the program to be built
+//      // in order for it to be built.
+//      var formatter = getFormatter();
+//      return formatter;
+//    }
 
     @SuppressWarnings("NullableProblems")
     @Override

--- a/buildSrc/src/main/java/lfformat/LfFormatStep.java
+++ b/buildSrc/src/main/java/lfformat/LfFormatStep.java
@@ -74,7 +74,7 @@ public final class LfFormatStep {
       } catch (IOException e) {
         formatter.waitFor();
         error.lines().forEach(System.out::println);
-        formatter = null;
+        initializeFormatter();
         throw new RuntimeException("Failed to format " + file + ".\nPlease ensure that this file passes validator checks.");
       }
       String line = reader.readLine();

--- a/buildSrc/src/main/java/lfformat/LfFormatStep.java
+++ b/buildSrc/src/main/java/lfformat/LfFormatStep.java
@@ -67,7 +67,7 @@ public final class LfFormatStep {
     @Override
     public String format(
         @SuppressWarnings("NullableProblems") String rawUnix,
-        @SuppressWarnings("NullableProblems") File file)
+        File file)
         throws IOException, InterruptedException {
       StringBuilder output = new StringBuilder();
       try {
@@ -109,15 +109,6 @@ public final class LfFormatStep {
       reader = new BufferedReader(new InputStreamReader(formatter.getInputStream()));
       error = new BufferedReader(new InputStreamReader(formatter.getErrorStream()));
     }
-
-    //    /** Run the formatter on the given file and return the resulting process handle. */
-    //    private Process runFormatter(File file) throws IOException {
-    //      // It looks silly to invoke Java from Java, but it is necessary in
-    //      // order to break the circularity of needing the program to be built
-    //      // in order for it to be built.
-    //      var formatter = getFormatter();
-    //      return formatter;
-    //    }
 
     @SuppressWarnings("NullableProblems")
     @Override

--- a/buildSrc/src/main/java/lfformat/LfFormatStep.java
+++ b/buildSrc/src/main/java/lfformat/LfFormatStep.java
@@ -65,9 +65,7 @@ public final class LfFormatStep {
     }
 
     @Override
-    public String format(
-        @SuppressWarnings("NullableProblems") String rawUnix,
-        File file)
+    public String format(@SuppressWarnings("NullableProblems") String rawUnix, File file)
         throws IOException, InterruptedException {
       StringBuilder output = new StringBuilder();
       try {

--- a/org.lflang/cli/base/src/main/java/org/lflang/cli/CliBase.java
+++ b/org.lflang/cli/base/src/main/java/org/lflang/cli/CliBase.java
@@ -24,7 +24,6 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.xtext.util.CancelIndicator;
-import org.eclipse.xtext.util.RuntimeIOException;
 import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.IResourceValidator;
 import org.eclipse.xtext.validation.Issue;
@@ -180,7 +179,7 @@ public abstract class CliBase implements Runnable {
       try {
         line = reader.readLine();
       } catch (IOException e) {
-        throw new RuntimeIOException(e);
+        throw new RuntimeException(e);
       }
       if (line == null) return List.of();
       return List.of(Path.of(line));

--- a/org.lflang/cli/base/src/main/java/org/lflang/cli/CliBase.java
+++ b/org.lflang/cli/base/src/main/java/org/lflang/cli/CliBase.java
@@ -7,7 +7,6 @@ import com.google.gson.JsonParser;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
-
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -186,8 +185,7 @@ public abstract class CliBase implements Runnable {
       if (line == null) return List.of();
       return List.of(Path.of(line));
     } else {
-      paths =
-          topLevelArg.files.stream().map(io.getWd()::resolve).collect(Collectors.toList());
+      paths = topLevelArg.files.stream().map(io.getWd()::resolve).collect(Collectors.toList());
     }
 
     for (Path path : paths) {

--- a/org.lflang/cli/lff/src/main/java/org/lflang/cli/Lff.java
+++ b/org.lflang/cli/lff/src/main/java/org/lflang/cli/Lff.java
@@ -80,20 +80,23 @@ public class Lff extends CliBase {
   /** Validates all paths and invokes the formatter on the input paths. */
   @Override
   public void doRun() {
-    List<Path> paths = getInputPaths();
-    final Path outputRoot = getOutputRoot();
+    List<Path> paths;
+    do {
+      paths = getInputPaths();
+      final Path outputRoot = getOutputRoot();
 
-    try {
-      // Format all files defined by the list of paths.
-      formatAllFiles(paths, outputRoot);
+      try {
+        // Format all files defined by the list of paths.
+        formatAllFiles(paths, outputRoot);
 
-      exitIfCollectedErrors();
-      if (!dryRun || verbose) {
-        reporter.printInfo("Done formatting.");
+        exitIfCollectedErrors();
+        if (!dryRun || verbose) {
+          reporter.printInfo("Done formatting.");
+        }
+      } catch (RuntimeException e) {
+        reporter.printFatalErrorAndExit("An unexpected error occurred:", e);
       }
-    } catch (RuntimeException e) {
-      reporter.printFatalErrorAndExit("An unexpected error occurred:", e);
-    }
+    } while (stdinMode() && !paths.isEmpty());
   }
 
   /*
@@ -155,7 +158,8 @@ public class Lff extends CliBase {
         FormattingUtils.render(resource.getContents().get(0), lineLength);
 
     if (dryRun) {
-      io.getOut().print(formattedFileContents);
+      io.getOut().println(formattedFileContents);
+      io.getOut().println("\0");
     } else {
       try {
         FileUtil.writeToFile(formattedFileContents, outputPath, true);


### PR DESCRIPTION
Fixes #1342.

Benefits of correctly incorporating LFF into Spotless include:
- uniform framework for formatting tests in this repository, including spotlessCheck, for which we have not implemented an analogue
- use of Spotless's [PaddedCell](https://github.com/diffplug/spotless/blob/main/PADDEDCELL.md) features
- use of Spotless's ability to run only on changed files (I have verified that using the Spotless task is empirically much faster when only one file has been modified since the last formatter run)

This solution works by giving the formatter the ability to listen in its input stream for the paths that it needs to format. This lets us use one instance of the formatter for the entire lifetime of the calling Gradle daemon.

To my knowledge, Spotless does not provide an API for releasing resources used by the formatting step across multiple invocations of the formatter. However the JVM does provide a shutdown hook, which I think is an acceptable though imperfect way to release the formatter. I have verified on Ubuntu that the formatter subprocess does indeed terminate when the enclosing Gradle daemon is killed with a SIGKILL.