### PR TITLE
Fix warnings reported on CliBase.

### DIFF
--- a/org.lflang/src/org/lflang/cli/CliBase.java
+++ b/org.lflang/src/org/lflang/cli/CliBase.java
@@ -285,6 +285,7 @@ public abstract class CliBase implements Runnable {
     if (src == null) {
       reporter.printFatalErrorAndExit("JSON Parse Exception: field \"src\" not found.");
     }
+    assert src != null;
     argsList.add(src.getAsString());
     // Append output path if given.
     JsonElement out = jsonObject.get("out");
@@ -306,14 +307,12 @@ public abstract class CliBase implements Runnable {
         // Append option.
         argsList.add("--" + property);
         // Append argument for non-boolean options.
-        if (value != "true" || property == "threading") {
+        if (!value.equals("true") || property.equals("threading")) {
           argsList.add(value);
         }
       }
     }
 
-    // Return as String[].
-    String[] args = argsList.toArray(new String[argsList.size()]);
-    return args;
+    return argsList.toArray(new String[0]);
   }
 }


### PR DESCRIPTION
The comparison of strings to string literals looks like a critical error which I think would have been caught by sufficient tests.

One of these warnings is incorrect, but we might as well silence it with an assertion.

The warning about toArray is merely a matter of best practice. A human couldn't be expected to know about this, but the warning emitted by IntelliJ is correct.

I'm not sure I have time to add tests for this at the moment or to do a close second read of this code but we also don't want to leave wrong code sitting around.