### PR TITLE
Generic params as arguments

### DIFF
--- a/org.lflang/src/org/lflang/ast/ASTUtils.java
+++ b/org.lflang/src/org/lflang/ast/ASTUtils.java
@@ -63,8 +63,6 @@ import org.lflang.TimeValue;
 import org.lflang.generator.CodeMap;
 import org.lflang.generator.InvalidSourceException;
 import org.lflang.generator.ReactorInstance;
-import org.lflang.generator.c.CUtil;
-import org.lflang.generator.c.TypeParameterizedReactor;
 import org.lflang.lf.Action;
 import org.lflang.lf.Assignment;
 import org.lflang.lf.Code;
@@ -407,20 +405,6 @@ public class ASTUtils {
    */
   public static List<Instantiation> allInstantiations(Reactor definition) {
     return ASTUtils.collectElements(definition, featurePackage.getReactor_Instantiations());
-  }
-
-  /**
-   * Given a reactor Class, return a set of include names for interacting reactors which includes
-   * all instantiations of base class that it extends.
-   *
-   * @param r Reactor Class
-   */
-  public static HashSet<String> allIncludes(Reactor r) {
-    var set = new HashSet<String>();
-    for (var i : allInstantiations(r)) {
-      set.add(CUtil.getName(new TypeParameterizedReactor(i)));
-    }
-    return set;
   }
 
   /*

--- a/org.lflang/src/org/lflang/generator/ReactorInstance.java
+++ b/org.lflang/src/org/lflang/generator/ReactorInstance.java
@@ -795,7 +795,7 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
     this.reporter = reporter;
     this.reactorDeclaration = definition.getReactorClass();
     this.reactorDefinition = ASTUtils.toDefinition(reactorDeclaration);
-    this.tpr = new TypeParameterizedReactor(definition);
+    this.tpr = new TypeParameterizedReactor(definition, parent == null ? null : parent.tpr);
 
     // check for recursive instantiation
     var currentParent = parent;

--- a/org.lflang/src/org/lflang/generator/c/CGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CGenerator.java
@@ -40,10 +40,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -89,7 +87,6 @@ import org.lflang.lf.Reaction;
 import org.lflang.lf.Reactor;
 import org.lflang.lf.ReactorDecl;
 import org.lflang.lf.StateVar;
-import org.lflang.lf.Type;
 import org.lflang.lf.Variable;
 import org.lflang.util.ArduinoUtil;
 import org.lflang.util.FileUtil;
@@ -1035,9 +1032,7 @@ public class CGenerator extends GeneratorBase {
     src.pr("#include \"include/" + CReactorHeaderFileGenerator.outputPath(tpr) + "\"");
     src.pr("#include \"" + headerName + "\"");
     tpr.doDefines(src);
-    CUtil.allIncludes(tpr).stream()
-        .map(name -> "#include \"" + name + ".h\"")
-        .forEach(header::pr);
+    CUtil.allIncludes(tpr).stream().map(name -> "#include \"" + name + ".h\"").forEach(header::pr);
   }
 
   private void generateReactorClassBody(

--- a/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
@@ -372,7 +372,8 @@ public class CReactionGenerator {
       structs.put(definition, structBuilder);
     }
     String inputStructType =
-        CGenerator.variableStructType(input, new TypeParameterizedReactor(definition, container), false);
+        CGenerator.variableStructType(
+            input, new TypeParameterizedReactor(definition, container), false);
     String defName = definition.getName();
     String defWidth = generateWidthVariable(defName);
     String inputName = input.getName();

--- a/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CReactionGenerator.java
@@ -202,7 +202,8 @@ public class CReactionGenerator {
                 reactionInitialization,
                 fieldsForStructsForContainedReactors,
                 effect.getContainer(),
-                (Input) variable);
+                (Input) variable,
+                tpr);
           } else if (variable instanceof Watchdog) {
             reactionInitialization.pr(generateWatchdogVariablesInReaction(effect));
           } else {
@@ -363,14 +364,15 @@ public class CReactionGenerator {
       CodeBuilder builder,
       Map<Instantiation, CodeBuilder> structs,
       Instantiation definition,
-      Input input) {
+      Input input,
+      TypeParameterizedReactor container) {
     CodeBuilder structBuilder = structs.get(definition);
     if (structBuilder == null) {
       structBuilder = new CodeBuilder();
       structs.put(definition, structBuilder);
     }
     String inputStructType =
-        CGenerator.variableStructType(input, new TypeParameterizedReactor(definition), false);
+        CGenerator.variableStructType(input, new TypeParameterizedReactor(definition, container), false);
     String defName = definition.getName();
     String defWidth = generateWidthVariable(defName);
     String inputName = input.getName();
@@ -461,7 +463,7 @@ public class CReactionGenerator {
       Output output = (Output) port.getVariable();
       String portStructType =
           CGenerator.variableStructType(
-              output, new TypeParameterizedReactor(port.getContainer()), false);
+              output, new TypeParameterizedReactor(port.getContainer(), tpr), false);
 
       CodeBuilder structBuilder = structs.get(port.getContainer());
       if (structBuilder == null) {
@@ -773,7 +775,7 @@ public class CReactionGenerator {
           (effect.getContainer() == null)
               ? CGenerator.variableStructType(output, tpr, false)
               : CGenerator.variableStructType(
-                  output, new TypeParameterizedReactor(effect.getContainer()), false);
+                  output, new TypeParameterizedReactor(effect.getContainer(), tpr), false);
       if (!ASTUtils.isMultiport(output)) {
         // Output port is not a multiport.
         return outputStructType + "* " + outputName + " = &self->_lf_" + outputName + ";";

--- a/org.lflang/src/org/lflang/generator/c/CReactorHeaderFileGenerator.java
+++ b/org.lflang/src/org/lflang/generator/c/CReactorHeaderFileGenerator.java
@@ -150,7 +150,7 @@ public class CReactorHeaderFileGenerator {
                                 reactor.reactor().getInstantiations().stream()
                                     .filter(
                                         instantiation ->
-                                            new TypeParameterizedReactor(instantiation)
+                                            new TypeParameterizedReactor(instantiation, reactor)
                                                 .equals(it.r))
                                     .findAny()
                                     .orElseThrow(),
@@ -184,7 +184,7 @@ public class CReactorHeaderFileGenerator {
                     ? new PortVariable(
                         tv,
                         it.getContainer() != null
-                            ? new TypeParameterizedReactor(it.getContainer())
+                            ? new TypeParameterizedReactor(it.getContainer(), reactorOfReaction)
                             : reactorOfReaction,
                         it.getContainer())
                     : null)

--- a/org.lflang/src/org/lflang/generator/c/CUtil.java
+++ b/org.lflang/src/org/lflang/generator/c/CUtil.java
@@ -498,9 +498,9 @@ public class CUtil {
    */
   public static String selfType(TypeParameterizedReactor reactor) {
     if (reactor.reactor().isMain()) {
-      return "_" + CUtil.getName(reactor) + "_main_self_t";
+      return CUtil.getName(reactor) + "_main_self_t";
     }
-    return "_" + CUtil.getName(reactor) + "_self_t";
+    return CUtil.getName(reactor) + "_self_t";
   }
 
   /** Construct a unique type for the "self" struct of the class of the given reactor. */

--- a/org.lflang/src/org/lflang/generator/c/CUtil.java
+++ b/org.lflang/src/org/lflang/generator/c/CUtil.java
@@ -28,6 +28,7 @@ package org.lflang.generator.c;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -36,6 +37,7 @@ import org.lflang.ErrorReporter;
 import org.lflang.FileConfig;
 import org.lflang.InferredType;
 import org.lflang.TargetConfig;
+import org.lflang.ast.ASTUtils;
 import org.lflang.generator.ActionInstance;
 import org.lflang.generator.GeneratorCommandFactory;
 import org.lflang.generator.LFGeneratorContext;
@@ -554,7 +556,19 @@ public class CUtil {
         + "_trigger";
   }
 
-  //////////////////////////////////////////////////////
+    /**
+     * Given a reactor Class, return a set of include names for interacting reactors which includes
+     * all instantiations of base class that it extends.
+     */
+    public static HashSet<String> allIncludes(TypeParameterizedReactor tpr) {
+      var set = new HashSet<String>();
+      for (var i : ASTUtils.allInstantiations(tpr.reactor())) {
+        set.add(getName(new TypeParameterizedReactor(i, tpr)));
+      }
+      return set;
+    }
+
+    //////////////////////////////////////////////////////
   //// FIXME: Not clear what the strategy is with the following inner interface.
   // The {@code ReportCommandErrors} interface allows the
   // method runBuildCommand to call a protected

--- a/org.lflang/src/org/lflang/generator/c/CUtil.java
+++ b/org.lflang/src/org/lflang/generator/c/CUtil.java
@@ -137,7 +137,7 @@ public class CUtil {
    * (to allow for instantiations that have the same name as the main reactor or the .lf file).
    */
   public static String getName(TypeParameterizedReactor reactor) {
-    String name = reactor.reactor().getName().toLowerCase() + reactor.hashCode();
+    String name = reactor.uniqueName();
     if (reactor.reactor().isMain()) {
       return name + "_main";
     }

--- a/org.lflang/src/org/lflang/generator/c/CUtil.java
+++ b/org.lflang/src/org/lflang/generator/c/CUtil.java
@@ -556,19 +556,19 @@ public class CUtil {
         + "_trigger";
   }
 
-    /**
-     * Given a reactor Class, return a set of include names for interacting reactors which includes
-     * all instantiations of base class that it extends.
-     */
-    public static HashSet<String> allIncludes(TypeParameterizedReactor tpr) {
-      var set = new HashSet<String>();
-      for (var i : ASTUtils.allInstantiations(tpr.reactor())) {
-        set.add(getName(new TypeParameterizedReactor(i, tpr)));
-      }
-      return set;
+  /**
+   * Given a reactor Class, return a set of include names for interacting reactors which includes
+   * all instantiations of base class that it extends.
+   */
+  public static HashSet<String> allIncludes(TypeParameterizedReactor tpr) {
+    var set = new HashSet<String>();
+    for (var i : ASTUtils.allInstantiations(tpr.reactor())) {
+      set.add(getName(new TypeParameterizedReactor(i, tpr)));
     }
+    return set;
+  }
 
-    //////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////
   //// FIXME: Not clear what the strategy is with the following inner interface.
   // The {@code ReportCommandErrors} interface allows the
   // method runBuildCommand to call a protected

--- a/org.lflang/src/org/lflang/generator/c/TypeParameterizedReactor.java
+++ b/org.lflang/src/org/lflang/generator/c/TypeParameterizedReactor.java
@@ -18,6 +18,9 @@ import org.lflang.lf.Type;
  */
 public record TypeParameterizedReactor(Reactor reactor, Map<String, Type> typeArgs) {
 
+  private static final Map<TypeParameterizedReactor, String> uniqueNames = new HashMap<>();
+  private static final Map<String, Integer> nameCounts = new HashMap<>();
+
   /**
    * Construct the TPR corresponding to the given instantiation which syntactically appears within
    * the definition corresponding to {@code parent}.
@@ -84,9 +87,22 @@ public record TypeParameterizedReactor(Reactor reactor, Map<String, Type> typeAr
     return InferredType.fromAST(resolveType(t.astType));
   }
 
+  public String uniqueName() {
+    if (uniqueNames.containsKey(this)) return uniqueNames.get(this);
+    if (nameCounts.containsKey(reactor.getName())) {
+      int currentCount = nameCounts.get(reactor.getName());
+      nameCounts.put(reactor.getName(), currentCount + 1);
+      uniqueNames.put(this, reactor.getName() + currentCount);
+      return uniqueName();
+    }
+    nameCounts.put(reactor.getName(), 1);
+    uniqueNames.put(this, reactor.getName());
+    return uniqueName();
+  }
+
   @Override
   public int hashCode() {
-    return Math.abs(reactor.hashCode() * 31 + typeArgs.hashCode());
+    return reactor.hashCode() * 31 + typeArgs.hashCode();
   }
 
   @Override

--- a/org.lflang/src/org/lflang/generator/c/TypeParameterizedReactor.java
+++ b/org.lflang/src/org/lflang/generator/c/TypeParameterizedReactor.java
@@ -88,15 +88,16 @@ public record TypeParameterizedReactor(Reactor reactor, Map<String, Type> typeAr
   }
 
   public String uniqueName() {
+    String name = reactor.getName().toLowerCase();
     if (uniqueNames.containsKey(this)) return uniqueNames.get(this);
-    if (nameCounts.containsKey(reactor.getName())) {
-      int currentCount = nameCounts.get(reactor.getName());
-      nameCounts.put(reactor.getName(), currentCount + 1);
-      uniqueNames.put(this, "_" + reactor.getName() + currentCount);
+    if (nameCounts.containsKey(name)) {
+      int currentCount = nameCounts.get(name);
+      nameCounts.put(name, currentCount + 1);
+      uniqueNames.put(this, "_" + name + currentCount);
       return uniqueName();
     }
-    nameCounts.put(reactor.getName(), 1);
-    uniqueNames.put(this, "_" + reactor.getName());
+    nameCounts.put(name, 1);
+    uniqueNames.put(this, "_" + name);
     return uniqueName();
   }
 

--- a/org.lflang/src/org/lflang/generator/c/TypeParameterizedReactor.java
+++ b/org.lflang/src/org/lflang/generator/c/TypeParameterizedReactor.java
@@ -24,9 +24,10 @@ public record TypeParameterizedReactor(Reactor reactor, Map<String, Type> typeAr
   /**
    * Construct the TPR corresponding to the given instantiation which syntactically appears within
    * the definition corresponding to {@code parent}.
+   *
    * @param i An instantiation of the TPR to be constructed.
    * @param parent The reactor in which {@code i} appears, or {@code null} if type variables are
-   * permitted instead of types in this TPR.
+   *     permitted instead of types in this TPR.
    */
   public TypeParameterizedReactor(Instantiation i, TypeParameterizedReactor parent) {
     this(
@@ -34,12 +35,14 @@ public record TypeParameterizedReactor(Reactor reactor, Map<String, Type> typeAr
         addTypeArgs(i, ASTUtils.toDefinition(i.getReactorClass()), parent));
   }
 
-  private static Map<String, Type> addTypeArgs(Instantiation instantiation, Reactor r, TypeParameterizedReactor parent) {
+  private static Map<String, Type> addTypeArgs(
+      Instantiation instantiation, Reactor r, TypeParameterizedReactor parent) {
     HashMap<String, Type> ret = new HashMap<>();
     if (instantiation.getTypeArgs() != null) {
       for (int i = 0; i < r.getTypeParms().size(); i++) {
         var arg = instantiation.getTypeArgs().get(i);
-        ret.put(r.getTypeParms().get(i).getLiteral(), parent == null ? arg : parent.resolveType(arg));
+        ret.put(
+            r.getTypeParms().get(i).getLiteral(), parent == null ? arg : parent.resolveType(arg));
       }
     }
     return ret;

--- a/org.lflang/src/org/lflang/generator/c/TypeParameterizedReactor.java
+++ b/org.lflang/src/org/lflang/generator/c/TypeParameterizedReactor.java
@@ -92,11 +92,11 @@ public record TypeParameterizedReactor(Reactor reactor, Map<String, Type> typeAr
     if (nameCounts.containsKey(reactor.getName())) {
       int currentCount = nameCounts.get(reactor.getName());
       nameCounts.put(reactor.getName(), currentCount + 1);
-      uniqueNames.put(this, reactor.getName() + currentCount);
+      uniqueNames.put(this, "_" + reactor.getName() + currentCount);
       return uniqueName();
     }
     nameCounts.put(reactor.getName(), 1);
-    uniqueNames.put(this, reactor.getName());
+    uniqueNames.put(this, "_" + reactor.getName());
     return uniqueName();
   }
 

--- a/org.lflang/src/org/lflang/generator/c/TypeParameterizedReactor.java
+++ b/org.lflang/src/org/lflang/generator/c/TypeParameterizedReactor.java
@@ -90,6 +90,10 @@ public record TypeParameterizedReactor(Reactor reactor, Map<String, Type> typeAr
     return InferredType.fromAST(resolveType(t.astType));
   }
 
+  /**
+   * Return a name that is unique to this TypeParameterizedReactor (up to structural equality) and
+   * that is prefixed with exactly one underscore and that does not contain any upper-case letters.
+   */
   public String uniqueName() {
     String name = reactor.getName().toLowerCase();
     if (uniqueNames.containsKey(this)) return uniqueNames.get(this);

--- a/org.lflang/src/org/lflang/generator/c/TypeParameterizedReactor.java
+++ b/org.lflang/src/org/lflang/generator/c/TypeParameterizedReactor.java
@@ -18,17 +18,25 @@ import org.lflang.lf.Type;
  */
 public record TypeParameterizedReactor(Reactor reactor, Map<String, Type> typeArgs) {
 
-  public TypeParameterizedReactor(Instantiation i) {
+  /**
+   * Construct the TPR corresponding to the given instantiation which syntactically appears within
+   * the definition corresponding to {@code parent}.
+   * @param i An instantiation of the TPR to be constructed.
+   * @param parent The reactor in which {@code i} appears, or {@code null} if type variables are
+   * permitted instead of types in this TPR.
+   */
+  public TypeParameterizedReactor(Instantiation i, TypeParameterizedReactor parent) {
     this(
         ASTUtils.toDefinition(i.getReactorClass()),
-        addTypeArgs(i, ASTUtils.toDefinition(i.getReactorClass())));
+        addTypeArgs(i, ASTUtils.toDefinition(i.getReactorClass()), parent));
   }
 
-  private static Map<String, Type> addTypeArgs(Instantiation instantiation, Reactor r) {
+  private static Map<String, Type> addTypeArgs(Instantiation instantiation, Reactor r, TypeParameterizedReactor parent) {
     HashMap<String, Type> ret = new HashMap<>();
     if (instantiation.getTypeArgs() != null) {
       for (int i = 0; i < r.getTypeParms().size(); i++) {
-        ret.put(r.getTypeParms().get(i).getLiteral(), instantiation.getTypeArgs().get(i));
+        var arg = instantiation.getTypeArgs().get(i);
+        ret.put(r.getTypeParms().get(i).getLiteral(), parent == null ? arg : parent.resolveType(arg));
       }
     }
     return ret;

--- a/org.lflang/src/org/lflang/validation/LFValidator.java
+++ b/org.lflang/src/org/lflang/validation/LFValidator.java
@@ -221,7 +221,7 @@ public class LFValidator extends BaseLFValidator {
     var portType = ((Port) port.getVariable()).getType();
     return port.getContainer() == null
         ? portType
-        : new TypeParameterizedReactor(port.getContainer()).resolveType(portType);
+        : new TypeParameterizedReactor(port.getContainer(), null).resolveType(portType);
   }
 
   @Check(CheckType.FAST)

--- a/test/C/src/generics/ParameterAsArgument.lf
+++ b/test/C/src/generics/ParameterAsArgument.lf
@@ -1,0 +1,29 @@
+target C;
+
+// Hash issue
+// Header name mismatch
+reactor bundle <In, Out> {
+}
+
+reactor Child<T1, In, Out> {
+    state k: T1
+    input in:In;
+    output out:Out;
+    reaction(in) {=
+        int a = in->value;
+        printf("Got %d\n", a);
+    =}
+}
+
+reactor Super<T1, T2, T3, In, Out> {
+    input in:In;
+    output out:Out;
+    state t1:T1;
+    c = new Child<T3, In, Out>();
+    in -> c.in;
+    c.out -> out;
+}
+
+main reactor {
+    cc = new Super<long, double, char, int, float>();
+}

--- a/test/C/src/generics/ParameterAsArgument.lf
+++ b/test/C/src/generics/ParameterAsArgument.lf
@@ -1,14 +1,13 @@
-target C;
+target C
 
-// Hash issue
-// Header name mismatch
-reactor bundle <In, Out> {
+reactor bundle<In, Out> {  // Hash issue Header name mismatch
 }
 
 reactor Child<T1, In, Out> {
     state k: T1
-    input in:In;
-    output out:Out;
+    input in: In
+    output out: Out
+
     reaction(in) {=
         int a = in->value;
         printf("Got %d\n", a);
@@ -16,17 +15,16 @@ reactor Child<T1, In, Out> {
 }
 
 reactor Super<T1, T2, T3, In, Out> {
-    input in:In;
-    output out:Out;
-    state t1:T1;
-    c = new Child<T3, In, Out>();
-    in -> c.in;
-    c.out -> out;
+    input in: In
+    output out: Out
+    state t1: T1
+    c = new Child<T3, In, Out>()
+    in -> c.in
+    c.out -> out
 }
 
 main reactor {
-    reaction(startup) -> cc.in {=
-        lf_set(cc.in, 42);
-    =}
-    cc = new Super<long, double, char, int, float>();
+    cc = new Super<long, double, char, int, float>()
+
+    reaction(startup) -> cc.in {= lf_set(cc.in, 42); =}
 }

--- a/test/C/src/generics/ParameterAsArgument.lf
+++ b/test/C/src/generics/ParameterAsArgument.lf
@@ -25,5 +25,8 @@ reactor Super<T1, T2, T3, In, Out> {
 }
 
 main reactor {
+    reaction(startup) -> cc.in {=
+        lf_set(cc.in, 42);
+    =}
     cc = new Super<long, double, char, int, float>();
 }

--- a/test/C/src/generics/ParameterAsArgument.lf
+++ b/test/C/src/generics/ParameterAsArgument.lf
@@ -1,8 +1,5 @@
 target C
 
-reactor bundle<In, Out> {  // Hash issue Header name mismatch
-}
-
 reactor Child<T1, In, Out> {
     state k: T1
     input in: In


### PR DESCRIPTION
Allow parameters of generic reactors to syntactically appear as arguments of contained reactors.