### PR TITLE
Make `uniqueName` thread-safe

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/TypeParameterizedReactor.java
+++ b/core/src/main/java/org/lflang/generator/c/TypeParameterizedReactor.java
@@ -94,7 +94,7 @@ public record TypeParameterizedReactor(Reactor reactor, Map<String, Type> typeAr
    * Return a name that is unique to this TypeParameterizedReactor (up to structural equality) and
    * that is prefixed with exactly one underscore and that does not contain any upper-case letters.
    */
-  public String uniqueName() {
+  public synchronized String uniqueName() {
     String name = reactor.getName().toLowerCase();
     if (uniqueNames.containsKey(this)) return uniqueNames.get(this);
     if (nameCounts.containsKey(name)) {


### PR DESCRIPTION
Addresses [this CI failure](https://github.com/lf-lang/reactor-c/actions/runs/5123102899/jobs/9302210809).