### PR TITLE
Changes to workflow dispatch

### DIFF
--- a/.github/workflows/all-misc.yml
+++ b/.github/workflows/all-misc.yml
@@ -8,6 +8,7 @@ on:
       - master
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review, converted_to_draft]
+  merge_group:
 
 env:
   # 2020.11

--- a/.github/workflows/all-targets.yml
+++ b/.github/workflows/all-targets.yml
@@ -23,36 +23,26 @@ jobs:
 
   c:
     uses: ./.github/workflows/only-c.yml
-    with:
-      all: true
     needs: check-diff
     if: ${{  !github.event.pull_request.draft || needs.check-diff.outputs.changed-c == 1 }}
 
   cpp:
     uses: ./.github/workflows/only-cpp.yml
-    with:
-      all: true
     needs: check-diff
     if: ${{  !github.event.pull_request.draft || needs.check-diff.outputs.changed-cpp == 1 }}
 
   py:
     uses: ./.github/workflows/only-py.yml
-    with:
-      all: true
     needs: check-diff
     if: ${{  !github.event.pull_request.draft || needs.check-diff.outputs.changed-py == 1 }}
 
   rs:
     uses: ./.github/workflows/only-rs.yml
-    with:
-      all: true
     needs: check-diff
     if: ${{  !github.event.pull_request.draft || needs.check-diff.outputs.changed-rs == 1 }}
 
   ts:
     uses: ./.github/workflows/only-ts.yml
-    with:
-      all: true
     needs: check-diff
     if: ${{  !github.event.pull_request.draft || needs.check-diff.outputs.changed-ts == 1 }}
 

--- a/.github/workflows/all-targets.yml
+++ b/.github/workflows/all-targets.yml
@@ -8,6 +8,7 @@ on:
       - master
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review, converted_to_draft]
+  merge_group:
 
 env:
   # 2020.11

--- a/.github/workflows/only-c.yml
+++ b/.github/workflows/only-c.yml
@@ -3,10 +3,6 @@ name: C
 on:
   workflow_dispatch:
   workflow_call:
-    inputs:
-      all:
-        default: true
-        type: boolean
 
 env:
   # 2020.11
@@ -19,33 +15,28 @@ concurrency:
 jobs:
   # Run the C integration tests.
   default:
-    if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: ./.github/workflows/c-tests.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft  }}
 
   # Run the C benchmark tests.
   benchmarking:
-    if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@gradle
     with:
       target: "C"
 
   # Run the C Arduino integration tests.
   arduino:
-    if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: ./.github/workflows/c-arduino-tests.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft  }}
 
   # Run the C Zephyr integration tests.
   zephyr:
-    if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: ./.github/workflows/c-zephyr-tests.yml
 
   # Run the CCpp integration tests.
   ccpp:
-    if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: ./.github/workflows/c-tests.yml
     with:
       use-cpp: true

--- a/.github/workflows/only-cpp.yml
+++ b/.github/workflows/only-cpp.yml
@@ -3,10 +3,6 @@ name: C++
 on:
   workflow_dispatch:
   workflow_call:
-    inputs:
-      all:
-        default: true
-        type: boolean
 
 env:
   # 2020.11
@@ -19,19 +15,16 @@ concurrency:
 jobs:
   # Run the C++ benchmark tests.
   cpp-benchmark-tests:
-    if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@gradle
     with:
       target: "Cpp"
 
   # Run the C++ integration tests.
   cpp-tests:
-    if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: ./.github/workflows/cpp-tests.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft  }}
 
   # Run the C++ integration tests on ROS2.
   cpp-ros2-tests:
-    if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: ./.github/workflows/cpp-ros2-tests.yml

--- a/.github/workflows/only-py.yml
+++ b/.github/workflows/only-py.yml
@@ -3,10 +3,6 @@ name: Python
 on:
   workflow_dispatch:
   workflow_call:
-    inputs:
-      all:
-        default: true
-        type: boolean
 
 env:
   # 2020.11
@@ -20,6 +16,5 @@ jobs:
   # Run the Python integration tests.
   py-tests:
     uses: ./.github/workflows/py-tests.yml
-    if: ${{ inputs.all || github.event.pull_request.draft }}
     with:
       all-platforms: ${{ !github.event.pull_request.draft  }}

--- a/.github/workflows/only-rs.yml
+++ b/.github/workflows/only-rs.yml
@@ -3,10 +3,6 @@ name: Rust
 on:
   workflow_dispatch:
   workflow_call:
-    inputs:
-      all:
-        default: true
-        type: boolean
 
 env:
   # 2020.11
@@ -19,14 +15,12 @@ concurrency:
 jobs:
   # Run the Rust integration tests.
   rs-tests:
-    if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: ./.github/workflows/rs-tests.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft  }}
 
   # Run the Rust benchmark tests.
   rs-benchmark-tests:
-    if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@gradle
     with:
       target: "Rust"

--- a/.github/workflows/only-ts.yml
+++ b/.github/workflows/only-ts.yml
@@ -3,10 +3,6 @@ name: TypeScript
 on:
   workflow_dispatch:
   workflow_call:
-    inputs:
-      all:
-        default: true
-        type: boolean
 
 env:
   # 2020.11
@@ -19,14 +15,12 @@ concurrency:
 jobs:
   # Run the TypeScript benchmark tests.
   benchmarking:
-    if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@gradle
     with:
       target: "TS"
 
   # Run the TypeScript integration tests.
   ts-tests:
-    if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: ./.github/workflows/ts-tests.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft  }}


### PR DESCRIPTION
The current behavior in master is that workflows are skipped when manually triggered.

This PR also adds `merge-group` triggers to the main CI workflows in order to enable the merge queue that has now been activated on `master`.