### PR TITLE
New `--check` flag for `lff`

### DIFF
--- a/cli/base/src/main/kotlin/org/lflang/cli/ReportingUtil.kt
+++ b/cli/base/src/main/kotlin/org/lflang/cli/ReportingUtil.kt
@@ -204,6 +204,8 @@ class ReportingBackend constructor(
     /** *Absolute* path to lines. */
     private val fileCache = mutableMapOf<Path, List<String>?>()
 
+    private var errorsOccurred = false
+
     private fun getLines(path: Path?): List<String>? =
         if (path == null) null
         else fileCache.computeIfAbsent(path.toAbsolutePath()) {
@@ -225,16 +227,18 @@ class ReportingBackend constructor(
         io.callSystemExit(1)
     }
 
-    /** Print a fatal error message to [Io.err] and exit with code 1. */
+    /** Print a fatal error message to [Io.err]. */
     @JvmOverloads
     fun printFatalError(message: String, cause: Throwable? = null) {
         io.err.println(header + colors.redAndBold("fatal error: ") + colors.bold(message))
         cause?.printStackTrace(io.err)
+        errorsOccurred = true
     }
 
     /** Print an error message to [Io.err]. */
     fun printError(message: String) {
         io.err.println(header + colors.redAndBold("error: ") + message)
+        errorsOccurred = true
     }
 
     /** Print a warning message to [Io.err]. */
@@ -415,6 +419,16 @@ class ReportingBackend constructor(
                 repeatChar('^', max(rangeLen, 1))
                 append(' ').append(message)
             }
+        }
+    }
+
+
+    /** Exit and return an error code if any errors were reported. */
+    fun exit() {
+        if (errorsOccurred) {
+            io.callSystemExit(1)
+        } else {
+            io.callSystemExit(0)
         }
     }
 

--- a/cli/lff/src/main/java/org/lflang/cli/Lff.java
+++ b/cli/lff/src/main/java/org/lflang/cli/Lff.java
@@ -156,11 +156,13 @@ public class Lff extends CliBase {
             ? path // Format in place.
             : outputRoot.resolve(inputRoot.relativize(path)).normalize();
 
+    Path relativePath = io.getWd().relativize(path);
+
     final Resource resource = getResource(path);
     // Skip file if not an LF file.
     if (resource == null) {
       if (verbose) {
-        reporter.printInfo("Skipped " + path + ": not an LF file");
+        reporter.printInfo("Skipped " + relativePath + ": not an LF file");
       }
       return;
     }
@@ -205,7 +207,7 @@ public class Lff extends CliBase {
     // the position of the issue may be wrong in the formatted file.
     // issueCollector.getAllIssues().forEach(reporter::printIssue);
     if (verbose) {
-      String msg = "Formatted " + io.getWd().relativize(path);
+      String msg = "Formatted " + relativePath;
       if (path != outputPath) {
         msg += " -> " + io.getWd().relativize(outputPath);
       }

--- a/cli/lff/src/main/java/org/lflang/cli/Lff.java
+++ b/cli/lff/src/main/java/org/lflang/cli/Lff.java
@@ -157,24 +157,26 @@ public class Lff extends CliBase {
     final String formattedFileContents =
         FormattingUtils.render(resource.getContents().get(0), lineLength);
 
-    if (dryRun) {
-      io.getOut().println(formattedFileContents);
-      io.getOut().println("\0");
-    } else {
-      try {
+    try {
+      if (dryRun) {
+        io.getOut().println(formattedFileContents);
+        io.getOut().println("\0");
+      } else {
         FileUtil.writeToFile(formattedFileContents, outputPath, true);
-      } catch (IOException e) {
-        if (e instanceof FileAlreadyExistsException) {
-          // Only happens if a subdirectory is named with
-          // ".lf" at the end.
-          reporter.printFatalErrorAndExit(
-              "Error writing to "
-                  + outputPath
-                  + ": file already exists. Make sure that no file or"
-                  + " directory within provided input paths have the"
-                  + " same relative paths.");
-        }
       }
+    } catch (FileAlreadyExistsException e) {
+      // Only happens if a subdirectory is named with
+      // ".lf" at the end.
+      reporter.printFatalErrorAndExit(
+          "Error writing to "
+              + outputPath
+              + ": file already exists. Make sure that no file or"
+              + " directory within provided input paths have the"
+              + " same relative paths.");
+    } catch (IOException e) {
+      reporter.printFatalErrorAndExit(
+          "An unknown I/O exception occurred while processing " + outputPath);
+      e.printStackTrace();
     }
 
     if (!ignoreErrors) {

--- a/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
+++ b/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
@@ -150,6 +150,26 @@ public class LffCliTest {
     dirChecker(tempDir).checkContentsOf("out/File.lf", equalTo(FILE_AFTER_REFORMAT));
   }
 
+  @Test
+  public void testCheckAndDryRun(@TempDir Path tempDir) {
+    lffTester.run(tempDir, "foo.lf", "--check", "--dry-run").checkFailed();
+    lffTester.run(tempDir, "foo.lf", "-c", "-d").checkFailed();
+  }
+
+  @Test
+  public void testCheck(@TempDir Path tempDir) throws IOException {
+    dirBuilder(tempDir).file("src/a/File.lf", FILE_BEFORE_REFORMAT);
+    dirBuilder(tempDir).file("src/b/File.lf", FILE_AFTER_REFORMAT);
+
+    lffTester.run(tempDir, "src/a/File.lf", "--check").checkFailed();
+    lffTester.run(tempDir, "src/a/File.lf", "-c").checkFailed();
+    lffTester.run(tempDir, "src/b/File.lf", "--check").checkOk();
+    lffTester.run(tempDir, "src/b/File.lf", "-c").checkOk();
+
+    dirChecker(tempDir).checkContentsOf("src/a/File.lf", equalTo(FILE_BEFORE_REFORMAT));
+    dirChecker(tempDir).checkContentsOf("src/b/File.lf", equalTo(FILE_AFTER_REFORMAT));
+  }
+
   static class LffTestFixture extends CliToolTestFixture {
 
     @Override

--- a/core/src/main/java/org/lflang/util/FileUtil.java
+++ b/core/src/main/java/org/lflang/util/FileUtil.java
@@ -870,6 +870,21 @@ public class FileUtil {
   }
 
   /**
+   * Check if the content of a file is equal to a given string.
+   *
+   * @param text The text to compare with.
+   * @param path The file to compare with.
+   * @return true, if the given text is identical to the file content.
+   */
+  public static boolean isSame(String text, Path path) throws IOException {
+    if (Files.isRegularFile(path)) {
+      final byte[] bytes = text.getBytes();
+      return Arrays.equals(bytes, Files.readAllBytes(path));
+    }
+    return false;
+  }
+
+  /**
    * Write text to a file.
    *
    * @param text The text to be written.
@@ -879,14 +894,10 @@ public class FileUtil {
    */
   public static void writeToFile(String text, Path path, boolean skipIfUnchanged)
       throws IOException {
-    Files.createDirectories(path.getParent());
-    final byte[] bytes = text.getBytes();
-    if (skipIfUnchanged && Files.isRegularFile(path)) {
-      if (Arrays.equals(bytes, Files.readAllBytes(path))) {
-        return;
-      }
+    if (!skipIfUnchanged || !isSame(text, path)) {
+      Files.createDirectories(path.getParent());
+      Files.write(path, text.getBytes());
     }
-    Files.write(path, text.getBytes());
   }
 
   /**


### PR DESCRIPTION
This implements a `--check` option for lff. In this check mode, lff reports all files that it would reformat as errors and only returns with a zero exit code if it would not change any files.