### PR TITLE
Fix error in programs with no main reactor

### DIFF
--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -1711,9 +1711,13 @@ public class ASTUtils {
       } else {
         inst.setName("");
       }
-
     } else {
       inst.setName(reactor.getName());
+    }
+    for (int i = 0; i < reactor.getTypeParms().size(); i++) {
+      Type t = LfFactory.eINSTANCE.createType();
+      t.setId("UNSPECIFIED_TYPE");
+      inst.getTypeArgs().add(t);
     }
     return inst;
   }


### PR DESCRIPTION
This error only occurs when using generics.

It is possibly a sign that `ReactorInstance` is being used to do too many different things. It is a little problematic to have to put in a dummy value in order to get things to work.

Closes #1824.