### PR TITLE
Check to avoid repeated CI runs

### DIFF
--- a/.github/scripts/check-diff.sh
+++ b/.github/scripts/check-diff.sh
@@ -3,7 +3,7 @@ changes() {
 }
 
 if changes | grep -q $1; then
-  echo "CHANGED_$2=1" >> $GITHUB_OUTPUT
+  echo "CHANGED_$2=${{ steps.check.outputs.should_skip != 'true' }}" >> $GITHUB_OUTPUT
 else
   echo "CHANGED_$2=0" >> $GITHUB_OUTPUT
 fi

--- a/.github/scripts/check-diff.sh
+++ b/.github/scripts/check-diff.sh
@@ -4,7 +4,7 @@ changes() {
   git diff --name-only HEAD $(git merge-base HEAD origin/master)
 }
 
-if changes | grep $1 | grep -q -v '^.*md\|txt$'; then
+if changes | grep "$1" | grep -q -v "^.*md\|txt$"; then
   echo "changed_$2=1" >> $GITHUB_OUTPUT
 else
   echo "changed_$2=0" >> $GITHUB_OUTPUT

--- a/.github/scripts/check-diff.sh
+++ b/.github/scripts/check-diff.sh
@@ -1,9 +1,11 @@
+#!/bin/bash
+
 changes() {
   git diff --name-only HEAD $(git merge-base HEAD origin/master)
 }
 
-if changes | grep -q $1; then
-  echo "CHANGED_$2=${{ steps.check.outputs.should_skip != 'true' }}" >> $GITHUB_OUTPUT
+if changes | grep $1 | grep -q -v '^.*md\|txt$'; then
+  echo "changed_$2=1" >> $GITHUB_OUTPUT
 else
-  echo "CHANGED_$2=0" >> $GITHUB_OUTPUT
+  echo "changed_$2=0" >> $GITHUB_OUTPUT
 fi

--- a/.github/workflows/all-misc.yml
+++ b/.github/workflows/all-misc.yml
@@ -28,19 +28,19 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft }}
-    if: ${{ needs.check-diff.outputs.skip_all != 'true' || needs.check-diff.outputs.build_anyway == 'true' }}
+    if: ${{ needs.check-diff.outputs.run_build == 'true' }}
 
   # Build the tools used for processing execution traces
   tracing:
     needs: check-diff
-    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_tracing == 'true') }}
+    if: ${{ needs.check-diff.outputs.run_tracing == 'true' }}
     uses: ./.github/workflows/build-trace-tools.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft }}
 
   # Run tests for the standalone compiler.
   cli:
-    if: ${{ needs.check-diff.outputs.skip_all != 'true' && !github.event.pull_request.draft }}
+    if: ${{ needs.check-diff.outputs.run_misc == 'true' }}
     needs: check-diff
     uses: ./.github/workflows/cli-tests.yml
     with:
@@ -48,7 +48,7 @@ jobs:
 
   # Run language server tests.
   lsp:
-    if: ${{ needs.check-diff.outputs.skip_all != 'true' && !github.event.pull_request.draft }}
+    if: ${{ needs.check-diff.outputs.run_misc == 'true' }}
     needs: check-diff
     uses: ./.github/workflows/lsp-tests.yml
     with:

--- a/.github/workflows/all-misc.yml
+++ b/.github/workflows/all-misc.yml
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft }}
-    if: ${{ needs.check-diff.outputs.skip_all != 'true' }}
+    if: ${{ needs.check-diff.outputs.skip_all != 'true' || needs.check-diff.outputs.build_anyway == 'true' }}
 
   # Build the tools used for processing execution traces
   tracing:

--- a/.github/workflows/all-misc.yml
+++ b/.github/workflows/all-misc.yml
@@ -19,8 +19,13 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
+  check-redundant:
+    uses: fkirc/skip-duplicate-actions@v5.3.0
+    if: ${{ github.ref == 'refs/heads/master' }}
+
   check-diff:
     uses: ./.github/workflows/check-diff.yml
+    needs: check-redundant
 
   # Test the Gradle build.
   building:

--- a/.github/workflows/all-misc.yml
+++ b/.github/workflows/all-misc.yml
@@ -33,14 +33,14 @@ jobs:
   # Build the tools used for processing execution traces
   tracing:
     needs: check-diff
-    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_tracing == 'true' }}
+    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (needs.check-diff.outputs.run_tracing == 'true' || !github.event.pull_request.draft) }}
     uses: ./.github/workflows/build-trace-tools.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft }}
 
   # Run tests for the standalone compiler.
   cli:
-    if: ${{ !github.event.pull_request.draft && needs.check-diff.outputs.skip_all != 'true' }}
+    if: ${{ needs.check-diff.outputs.skip_all != 'true' && !github.event.pull_request.draft }}
     needs: check-diff
     uses: ./.github/workflows/cli-tests.yml
     with:
@@ -48,7 +48,7 @@ jobs:
 
   # Run language server tests.
   lsp:
-    if: ${{ !github.event.pull_request.draft && needs.check-diff.outputs.skip_all != 'true' }}
+    if: ${{ needs.check-diff.outputs.skip_all != 'true' && !github.event.pull_request.draft }}
     needs: check-diff
     uses: ./.github/workflows/lsp-tests.yml
     with:

--- a/.github/workflows/all-misc.yml
+++ b/.github/workflows/all-misc.yml
@@ -21,32 +21,35 @@ concurrency:
 jobs:
   check-diff:
     uses: ./.github/workflows/check-diff.yml
-    needs: check-redundant
 
   # Test the Gradle build.
   building:
+    needs: check-diff
     uses: ./.github/workflows/build.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft }}
+    if: ${{ needs.check-diff.outputs.skip_all != 'true' }}
 
   # Build the tools used for processing execution traces
   tracing:
-    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.changed-tracing == 1 }}
-    uses: ./.github/workflows/build-trace-tools.yml
     needs: check-diff
+    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_tracing == 'true' }}
+    uses: ./.github/workflows/build-trace-tools.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft }}
 
   # Run tests for the standalone compiler.
   cli:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && needs.check-diff.outputs.skip_all != 'true' }}
+    needs: check-diff
     uses: ./.github/workflows/cli-tests.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft }}
 
   # Run language server tests.
   lsp:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && needs.check-diff.outputs.skip_all != 'true' }}
+    needs: check-diff
     uses: ./.github/workflows/lsp-tests.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/all-misc.yml
+++ b/.github/workflows/all-misc.yml
@@ -19,10 +19,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
-  check-redundant:
-    uses: fkirc/skip-duplicate-actions@v5.3.0
-    if: ${{ github.ref == 'refs/heads/master' }}
-
   check-diff:
     uses: ./.github/workflows/check-diff.yml
     needs: check-redundant

--- a/.github/workflows/all-misc.yml
+++ b/.github/workflows/all-misc.yml
@@ -33,7 +33,7 @@ jobs:
   # Build the tools used for processing execution traces
   tracing:
     needs: check-diff
-    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (needs.check-diff.outputs.run_tracing == 'true' || !github.event.pull_request.draft) }}
+    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_tracing == 'true') }}
     uses: ./.github/workflows/build-trace-tools.yml
     with:
       all-platforms: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/all-targets.yml
+++ b/.github/workflows/all-targets.yml
@@ -25,29 +25,29 @@ jobs:
   c:
     uses: ./.github/workflows/only-c.yml
     needs: check-diff
-    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_c == 'true' }}
+    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_c == 'true') }}
 
   cpp:
     uses: ./.github/workflows/only-cpp.yml
     needs: check-diff
-    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_cpp == 'true' }}
+    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_cpp == 'true') }}
 
   py:
     uses: ./.github/workflows/only-py.yml
     needs: check-diff
-    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_py == 'true' }}
+    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_py == 'true') }}
 
   rs:
     uses: ./.github/workflows/only-rs.yml
     needs: check-diff
-    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_rs == 'true' }}
+    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_rs == 'true') }}
 
   ts:
     uses: ./.github/workflows/only-ts.yml
     needs: check-diff
-    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_ts == 'true' }}
+    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_ts == 'true') }}
 
   serialization:
-    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_c == 'true' || needs.check-diff.outputs.run_py == 'true' || needs.check-diff.outputs.run_ts == 'true' }}
+    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_c == 'true' || needs.check-diff.outputs.run_py == 'true' || needs.check-diff.outputs.run_ts == 'true') }}
     needs: check-diff
     uses: ./.github/workflows/serialization-tests.yml

--- a/.github/workflows/all-targets.yml
+++ b/.github/workflows/all-targets.yml
@@ -25,29 +25,29 @@ jobs:
   c:
     uses: ./.github/workflows/only-c.yml
     needs: check-diff
-    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_c == 'true') }}
+    if: ${{ needs.check-diff.outputs.run_c == 'true' }}
 
   cpp:
     uses: ./.github/workflows/only-cpp.yml
     needs: check-diff
-    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_cpp == 'true') }}
+    if: ${{ needs.check-diff.outputs.run_cpp == 'true' }}
 
   py:
     uses: ./.github/workflows/only-py.yml
     needs: check-diff
-    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_py == 'true') }}
+    if: ${{ needs.check-diff.outputs.run_py == 'true' || needs.check-diff.outputs.run_c == 'true' }}
 
   rs:
     uses: ./.github/workflows/only-rs.yml
     needs: check-diff
-    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_rs == 'true') }}
+    if: ${{ needs.check-diff.outputs.run_rs == 'true' }}
 
   ts:
     uses: ./.github/workflows/only-ts.yml
     needs: check-diff
-    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_ts == 'true') }}
+    if: ${{ needs.check-diff.outputs.run_ts == 'true' }}
 
   serialization:
-    if: ${{ needs.check-diff.outputs.skip_all != 'true' && (!github.event.pull_request.draft || needs.check-diff.outputs.run_c == 'true' || needs.check-diff.outputs.run_py == 'true' || needs.check-diff.outputs.run_ts == 'true') }}
+    if: ${{ needs.check-diff.outputs.run_c == 'true' || needs.check-diff.outputs.run_py == 'true' || needs.check-diff.outputs.run_ts == 'true' }}
     needs: check-diff
     uses: ./.github/workflows/serialization-tests.yml

--- a/.github/workflows/all-targets.yml
+++ b/.github/workflows/all-targets.yml
@@ -25,29 +25,29 @@ jobs:
   c:
     uses: ./.github/workflows/only-c.yml
     needs: check-diff
-    if: ${{  !github.event.pull_request.draft || needs.check-diff.outputs.changed-c == 1 }}
+    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_c == 'true' }}
 
   cpp:
     uses: ./.github/workflows/only-cpp.yml
     needs: check-diff
-    if: ${{  !github.event.pull_request.draft || needs.check-diff.outputs.changed-cpp == 1 }}
+    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_cpp == 'true' }}
 
   py:
     uses: ./.github/workflows/only-py.yml
     needs: check-diff
-    if: ${{  !github.event.pull_request.draft || needs.check-diff.outputs.changed-py == 1 }}
+    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_py == 'true' }}
 
   rs:
     uses: ./.github/workflows/only-rs.yml
     needs: check-diff
-    if: ${{  !github.event.pull_request.draft || needs.check-diff.outputs.changed-rs == 1 }}
+    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_rs == 'true' }}
 
   ts:
     uses: ./.github/workflows/only-ts.yml
     needs: check-diff
-    if: ${{  !github.event.pull_request.draft || needs.check-diff.outputs.changed-ts == 1 }}
+    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_ts == 'true' }}
 
   serialization:
-    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.changed-c == 1 || needs.check-diff.outputs.changed-py == 1 || needs.check-diff.outputs.changed-ts == 1 }}
+    if: ${{ !github.event.pull_request.draft || needs.check-diff.outputs.run_c == 'true' || needs.check-diff.outputs.run_py == 'true' || needs.check-diff.outputs.run_ts == 'true' }}
     needs: check-diff
     uses: ./.github/workflows/serialization-tests.yml

--- a/.github/workflows/all-targets.yml
+++ b/.github/workflows/all-targets.yml
@@ -19,13 +19,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
-  check-redundant:
-    uses: fkirc/skip-duplicate-actions@v5.3.0
-    if: ${{ github.ref == 'refs/heads/master' }}
-
   check-diff:
     uses: ./.github/workflows/check-diff.yml
-    needs: check-redundant
 
   c:
     uses: ./.github/workflows/only-c.yml

--- a/.github/workflows/all-targets.yml
+++ b/.github/workflows/all-targets.yml
@@ -19,8 +19,13 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
+  check-redundant:
+    uses: fkirc/skip-duplicate-actions@v5.3.0
+    if: ${{ github.ref == 'refs/heads/master' }}
+
   check-diff:
     uses: ./.github/workflows/check-diff.yml
+    needs: check-redundant
 
   c:
     uses: ./.github/workflows/only-c.yml

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -35,7 +35,7 @@ jobs:
       changed_rs: ${{ steps.do.outputs.changed_rs }}
       changed_ts: ${{ steps.do.outputs.changed_ts }}
       changed_tracing: ${{ steps.do.outputs.changed_tracing }}
-      skip_all: ${{ steps.duplicate.outputs.should_skip == 'true' || steps.do.outputs.changed_any == 0 }}
+      skip_all: ${{ steps.duplicate.outputs.should_skip == 'true' && steps.do.outputs.changed_any == 0 }}
     steps:
       - name: Check out lingua-franca repository
         uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
           ./check-diff.sh "lflang/generator/rust\|resources/lib/rs\|test/Rust" rs
           ./check-diff.sh "lflang/generator/ts\|resources/lib/ts\|test/TypeScript" ts
           ./check-diff.sh "util/tracing" tracing
-          ./check-diff.sh ".+" any
+          ./check-diff.sh "" any
         shell: bash
         working-directory: .github/scripts
       - id: summarize

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -67,32 +67,32 @@ jobs:
         run: |
           echo '## Summary' > $GITHUB_STEP_SUMMARY
       - id: skip-redundant
-        name: "Explain skipping checks due to a prior run"
+        name: "Report skipping checks due to a prior run"
         run: |
           echo ":tada: A successful prior run has been found:" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.duplicate.outputs.skipped_by }}" >> $GITHUB_STEP_SUMMARY
-          echo ":heavy_check_mark: Skipping all tests. Only building." >> $GITHUB_STEP_SUMMARY
+          echo ":heavy_check_mark: Skipping all tests." >> $GITHUB_STEP_SUMMARY
         if: ${{ steps.duplicate.outputs.should_skip == 'true' }}
       - id: skip-ignore
-        name: "Explain skipping checks due to inconsequential changes"
+        name: "Report skipping checks due to inconsequential changes"
         run: |
           echo ":octopus: The detected changes did not affect any code." >> $GITHUB_STEP_SUMMARY
           echo ":heavy_check_mark: Skipping tests. Only building." >> $GITHUB_STEP_SUMMARY
         if: ${{ steps.duplicate.outputs.should_skip != 'true' && steps.do.outputs.changed_any == 0 }}
       - id: run-some
-        name: "Explain running some checks"
+        name: "Report running some checks"
         run: |
           echo ":octopus: No successful prior run has been found." >> $GITHUB_STEP_SUMMARY
-        if: ${{ steps.duplicate.outputs.should_skip != 'true' }}
-      - id: ready-mode
+          if: ${{ steps.duplicate.outputs.should_skip != 'true' && steps.do.outputs.changed_any != 0}}
+      - id: run-ready-mode
         name: 'Report on full test run'
         run: |
           echo ":hourglass: Performing all tests." >> $GITHUB_STEP_SUMMARY
-        if: ${{ !github.event.pull_request.draft }}
-      - id: draft-mode
+        if: ${{ steps.duplicate.outputs.should_skip != 'true' && steps.do.outputs.changed_any != 0 && !github.event.pull_request.draft}}
+      - id: run-draft-mode
         name: 'Report on partial test run'
         run: |
-          echo ":heavy_check_mark: Performing tests affected by detected changes." >> $GITHUB_STEP_SUMMARY
+          echo ":hourglass: Performing tests affected by detected changes." >> $GITHUB_STEP_SUMMARY
           echo '|         | running                                   |' >> $GITHUB_STEP_SUMMARY
           echo '|---------|-------------------------------------------|' >> $GITHUB_STEP_SUMMARY
           echo '| c       | `${{ steps.do.outputs.changed_c == 1 }}`       |' >> $GITHUB_STEP_SUMMARY
@@ -101,4 +101,4 @@ jobs:
           echo '| rs      | `${{ steps.do.outputs.changed_rs == 1 }}`      |' >> $GITHUB_STEP_SUMMARY
           echo '| ts      | `${{ steps.do.outputs.changed_ts == 1 }}`      |' >> $GITHUB_STEP_SUMMARY
           echo '| tracing | `${{ steps.do.outputs.changed_tracing == 1 }}` |' >> $GITHUB_STEP_SUMMARY
-        if: ${{ github.event.pull_request.draft }}
+        if: ${{ steps.duplicate.outputs.should_skip != 'true' && steps.do.outputs.changed_any != 0 && github.event.pull_request.draft}}

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -83,7 +83,7 @@ jobs:
         name: "Report running some checks"
         run: |
           echo ":octopus: No successful prior run has been found." >> $GITHUB_STEP_SUMMARY
-          if: ${{ steps.duplicate.outputs.should_skip != 'true' && steps.do.outputs.changed_any != 0}}
+        if: ${{ steps.duplicate.outputs.should_skip != 'true' && steps.do.outputs.changed_any != 0}}
       - id: run-ready-mode
         name: 'Report on full test run'
         run: |

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -35,7 +35,7 @@ jobs:
       changed_rs: ${{ steps.do.outputs.changed_rs }}
       changed_ts: ${{ steps.do.outputs.changed_ts }}
       changed_tracing: ${{ steps.do.outputs.changed_tracing }}
-      skip_all: ${{ steps.duplicate.outputs.should_skip }}
+      skip_all: ${{ steps.duplicate.outputs.should_skip == 'true' || steps.do.outputs.changed_any == 0 }}
     steps:
       - name: Check out lingua-franca repository
         uses: actions/checkout@v3
@@ -55,6 +55,7 @@ jobs:
           ./check-diff.sh "lflang/generator/rust\|resources/lib/rs\|test/Rust" rs
           ./check-diff.sh "lflang/generator/ts\|resources/lib/ts\|test/TypeScript" ts
           ./check-diff.sh "util/tracing" tracing
+          ./check-diff.sh "*" any
         shell: bash
         working-directory: .github/scripts
       - id: summarize

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -55,7 +55,7 @@ jobs:
           ./check-diff.sh "lflang/generator/rust\|resources/lib/rs\|test/Rust" rs
           ./check-diff.sh "lflang/generator/ts\|resources/lib/ts\|test/TypeScript" ts
           ./check-diff.sh "util/tracing" tracing
-          ./check-diff.sh "*" any
+          ./check-diff.sh ".+" any
         shell: bash
         working-directory: .github/scripts
       - id: summarize

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -3,48 +3,91 @@ name: Check diff from master
 on:
   workflow_call:
     outputs:
-      changed-c:
-        value: ${{ jobs.check.outputs.changed-c }}
-      changed-cpp:
-        value: ${{ jobs.check.outputs.changed-cpp }}
-      changed-py:
-        value: ${{ jobs.check.outputs.changed-py }}
-      changed-rs:
-        value: ${{ jobs.check.outputs.changed-rs }}
-      changed-ts:
-        value: ${{ jobs.check.outputs.changed-ts }}
-      changed-tracing:
-        value: ${{ jobs.check.outputs.changed-tracing }}
+      run_c:
+        description: 'Return true if C tests should be run'
+        value: ${{ jobs.check.outputs.changed_c == 1 && jobs.check.outputs.skip_all != 'true' }}
+      run_cpp:
+        description: 'Return true if C++ tests should be run'
+        value: ${{ jobs.check.outputs.changed_cpp == 1 && jobs.check.outputs.skip_all != 'true' }}
+      run_py:
+        description: 'Return true if Python tests should be run'
+        value: ${{ (jobs.check.outputs.changed_py == 1 || jobs.check.outputs.changed_c == 1) && jobs.check.outputs.skip_all != 'true' }}
+      run_rs:
+        description: 'Return true if Rust tests should be run'
+        value: ${{ jobs.check.outputs.changed_rs == 1 && jobs.check.outputs.skip_all != 'true' }}
+      run_ts:
+        description: 'Return true if TypeScript tests should be run'
+        value: ${{ jobs.check.outputs.changed_ts == 1 && jobs.check.outputs.skip_all != 'true' }}
+      run_tracing:
+        description: 'Return true if tracing tests should be run'
+        value: ${{ jobs.check.outputs.changed_tracing == 1 && jobs.check.outputs.skip_all != 'true' }}
+      skip_all:
+        description: 'Return true if tests should not be run'
+        value: ${{ jobs.check.outputs.skip_all == 'true' }}
 
 jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
-      changed-c: ${{ steps.do.outputs.CHANGED_C }}
-      changed-cpp: ${{ steps.do.outputs.CHANGED_CPP }}
-      changed-py: ${{ steps.do.outputs.CHANGED_PY }}
-      changed-rs: ${{ steps.do.outputs.CHANGED_RS }}
-      changed-ts: ${{ steps.do.outputs.CHANGED_TS }}
-      changed-tracing: ${{ steps.do.outputs.CHANGED_TRACING }}
+      changed_c: ${{ steps.do.outputs.changed_c }}
+      changed_cpp: ${{ steps.do.outputs.changed_cpp }}
+      changed_py: ${{ steps.do.outputs.changed_py }}
+      changed_rs: ${{ steps.do.outputs.changed_rs }}
+      changed_ts: ${{ steps.do.outputs.changed_ts }}
+      changed_tracing: ${{ steps.do.outputs.changed_tracing }}
+      skip_all: ${{ steps.duplicate.outputs.should_skip }}
     steps:
-    - name: Check out lingua-franca repository
-      uses: actions/checkout@v3
-      with:
-        repository: lf-lang/lingua-franca
-        submodules: true
-        fetch-depth: 0
-    - name: Check for redundant runs
-      id: check
-      uses: fkirc/skip-duplicate-actions@v5.3.0
-      if: ${{ github.ref == 'refs/heads/master' }}
-    - id: do
-      run: |
-        wget https://raw.githubusercontent.com/lf-lang/lingua-franca/master/.github/scripts/check-diff.sh
-        source check-diff.sh "core/src/main/java/org/lflang/generator/c\|core/src/main/resources/lib/c\|core/src/main/resources/lib/platform\|test/C" C
-        source check-diff.sh "core/src/main/kotlin/org/lflang/generator/cpp\|core/src/main/resources/lib/cpp\|test/Cpp" CPP
-        source check-diff.sh "core/src/main/java/org/lflang/generator/python\|core/src/main/resources/lib/py\|test/Python" PY
-        source check-diff.sh "core/src/main/kotlin/org/lflang/generator/rust\|core/src/main/java/org/lflang/generator/rust\|core/src/main/resources/lib/rs\|test/Rust" RS
-        source check-diff.sh "core/src/main/kotlin/org/lflang/generator/ts\|core/src/main/java/org/lflang/generator/ts\|core/src/main/resources/lib/ts\|test/TypeScript" TS
-        source check-diff.sh "util/tracing" TRACING
-      shell: bash
-      if: ${{ steps.check.outputs.should_skip != 'true' }}
+      - name: Check out lingua-franca repository
+        uses: actions/checkout@v3
+        with:
+          repository: lf-lang/lingua-franca
+          submodules: true
+          fetch-depth: 0
+      - name: Check for redundant runs
+        id: duplicate
+        uses: fkirc/skip-duplicate-actions@v5.3.0
+      - id: do
+        name: Check which targets have changes
+        run: |
+          ./check-diff.sh "lflang/generator/c\|resources/lib/c\|resources/lib/platform\|test/C" c
+          ./check-diff.sh "lflang/generator/cpp\|resources/lib/cpp\|test/Cpp" cpp
+          ./check-diff.sh "lflang/generator/python\|resources/lib/py\|test/Python" py
+          ./check-diff.sh "lflang/generator/rust\|resources/lib/rs\|test/Rust" rs
+          ./check-diff.sh "lflang/generator/ts\|resources/lib/ts\|test/TypeScript" ts
+          ./check-diff.sh "util/tracing" tracing
+        shell: bash
+        working-directory: .github/scripts
+      - id: summarize
+        name: "Create summary"
+        run: |
+          echo '## Summary' > $GITHUB_STEP_SUMMARY
+      - id: skip-all
+        name: "Explain skipping all checks"
+        run: |
+          echo ":tada: A successful prior run has been found:" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.duplicate.outputs.skipped_by }}" >> $GITHUB_STEP_SUMMARY
+          echo ":heavy_check_mark: Skipping tests." >> $GITHUB_STEP_SUMMARY
+        if: ${{ steps.do.outputs.skip_all == 'true' }}
+      - id: run-some
+        name: "Explain running some checks"
+        run: |
+          echo ":hourglass: No successful prior run has been found." >> $GITHUB_STEP_SUMMARY
+        if: ${{ steps.do.outputs.skip_all != 'true' }}
+      - id: ready-mode
+        name: 'Report on full test run'
+        run: |
+          echo ":heavy_check_mark: Performing all tests." >> $GITHUB_STEP_SUMMARY
+        if: ${{ !github.event.pull_request.draft }}
+      - id: draft-mode
+        name: 'Report on partial test run'
+        run: |
+          echo ":heavy_check_mark: Performing tests affected by detected changes." >> $GITHUB_STEP_SUMMARY
+          echo '|         | running                                   |' >> $GITHUB_STEP_SUMMARY
+          echo '|---------|-------------------------------------------|' >> $GITHUB_STEP_SUMMARY
+          echo '| c       | `${{ steps.do.outputs.changed_c == 1 }}`       |' >> $GITHUB_STEP_SUMMARY
+          echo '| cpp     | `${{ steps.do.outputs.changed_cpp == 1 }}`     |' >> $GITHUB_STEP_SUMMARY
+          echo '| py      | `${{ steps.do.outputs.changed_py == 1 }}`      |' >> $GITHUB_STEP_SUMMARY
+          echo '| rs      | `${{ steps.do.outputs.changed_rs == 1 }}`      |' >> $GITHUB_STEP_SUMMARY
+          echo '| ts      | `${{ steps.do.outputs.changed_ts == 1 }}`      |' >> $GITHUB_STEP_SUMMARY
+          echo '| tracing | `${{ steps.do.outputs.changed_tracing == 1 }}` |' >> $GITHUB_STEP_SUMMARY
+        if: ${{ github.event.pull_request.draft }}

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -66,29 +66,33 @@ jobs:
         name: "Create summary"
         run: |
           echo '## Summary' > $GITHUB_STEP_SUMMARY
+      - id: should-skip
+        name: "Determine whether to skip checks"
+        run: |
+          echo "skip=${{ steps.duplicate.outputs.should_skip == 'true' && github.event.action != 'ready_for_review' }}" >> $GITHUB_OUTPUT
       - id: skip-redundant
         name: "Report on skipping checks (prior run found)"
         run: |
           echo ":tada: A successful prior run has been found:" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.duplicate.outputs.skipped_by }}" >> $GITHUB_STEP_SUMMARY
           echo ":heavy_check_mark: Skipping all tests." >> $GITHUB_STEP_SUMMARY
-        if: ${{ steps.duplicate.outputs.should_skip == 'true' }}
+        if: ${{ steps.should-skip.outputs.skip == 'true' }}
       - id: skip-ignore
         name: "Report skipping checks due to inconsequential changes"
         run: |
           echo ":octopus: The detected changes did not affect any code." >> $GITHUB_STEP_SUMMARY
           echo ":heavy_check_mark: Skipping tests. Only building." >> $GITHUB_STEP_SUMMARY
-        if: ${{ steps.duplicate.outputs.should_skip != 'true' && steps.do.outputs.changed_any == 0 }}
+        if: ${{ steps.should-skip.outputs.skip != 'true' && steps.do.outputs.changed_any == 0 }}
       - id: run-some
         name: "Report on running checks (no prior run found)"
         run: |
           echo ":octopus: No successful prior run has been found." >> $GITHUB_STEP_SUMMARY
-        if: ${{ steps.duplicate.outputs.should_skip != 'true' && steps.do.outputs.changed_any != 0}}
+        if: ${{ steps.should-skip.outputs.skip != 'true' && steps.do.outputs.changed_any != 0}}
       - id: run-ready-mode
         name: 'Report on full test run'
         run: |
           echo ":hourglass: Performing all tests." >> $GITHUB_STEP_SUMMARY
-        if: ${{ steps.duplicate.outputs.should_skip != 'true' && steps.do.outputs.changed_any != 0 && !github.event.pull_request.draft}}
+        if: ${{ steps.should-skip.outputs.skip != 'true' && steps.do.outputs.changed_any != 0 && !github.event.pull_request.draft}}
       - id: run-draft-mode
         name: 'Report on partial test run'
         run: |
@@ -101,4 +105,4 @@ jobs:
           echo '| rs      | `${{ steps.do.outputs.changed_rs == 1 }}`      |' >> $GITHUB_STEP_SUMMARY
           echo '| ts      | `${{ steps.do.outputs.changed_ts == 1 }}`      |' >> $GITHUB_STEP_SUMMARY
           echo '| tracing | `${{ steps.do.outputs.changed_tracing == 1 }}` |' >> $GITHUB_STEP_SUMMARY
-        if: ${{ steps.duplicate.outputs.should_skip != 'true' && steps.do.outputs.changed_any != 0 && github.event.pull_request.draft}}
+        if: ${{ steps.should-skip.outputs.skip != 'true' && steps.do.outputs.changed_any != 0 && github.event.pull_request.draft}}

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -3,43 +3,43 @@ name: Check diff from master
 on:
   workflow_call:
     outputs:
-      build_anyway:
-        description: 'Return true if building is still needed when skipping tests'
-        value: ${{ jobs.check.outputs.build_anyway == 1 }}
       run_c:
         description: 'Return true if C tests should be run'
-        value: ${{ jobs.check.outputs.changed_c == 1 && jobs.check.outputs.skip_all != 'true' }}
+        value: ${{ jobs.check.outputs.run_c == 'true' && jobs.check.outputs.skip != 'true' }}
       run_cpp:
         description: 'Return true if C++ tests should be run'
-        value: ${{ jobs.check.outputs.changed_cpp == 1 && jobs.check.outputs.skip_all != 'true' }}
+        value: ${{ jobs.check.outputs.run_cpp == 'true' && jobs.check.outputs.skip != 'true' }}
       run_py:
         description: 'Return true if Python tests should be run'
-        value: ${{ (jobs.check.outputs.changed_py == 1 || jobs.check.outputs.changed_c == 1) && jobs.check.outputs.skip_all != 'true' }}
+        value: ${{ jobs.check.outputs.run_py == 'true' && jobs.check.outputs.skip != 'true' }}
       run_rs:
         description: 'Return true if Rust tests should be run'
-        value: ${{ jobs.check.outputs.changed_rs == 1 && jobs.check.outputs.skip_all != 'true' }}
+        value: ${{ jobs.check.outputs.run_rs == 'true' && jobs.check.outputs.skip != 'true' }}
       run_ts:
         description: 'Return true if TypeScript tests should be run'
-        value: ${{ jobs.check.outputs.changed_ts == 1 && jobs.check.outputs.skip_all != 'true' }}
+        value: ${{ jobs.check.outputs.run_ts == 'true' && jobs.check.outputs.skip != 'true' }}
       run_tracing:
         description: 'Return true if tracing tests should be run'
-        value: ${{ jobs.check.outputs.changed_tracing == 1 && jobs.check.outputs.skip_all != 'true' }}
-      skip_all:
-        description: 'Return true if tests should not be run'
-        value: ${{ jobs.check.outputs.skip_all == 'true' }}
+        value: ${{ jobs.check.outputs.run_tracing == 'true' && jobs.check.outputs.skip != 'true' }}
+      run_build:
+        description: 'Return true if the build should be run'
+        value: ${{ jobs.check.outputs.skip != 'true' }}
+      run_misc:
+            description: 'Return true if the build should be run'
+            value: ${{ jobs.check.outputs.run_misc == 'true' && jobs.check.outputs.skip != 'true' }}
 
 jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
-      build_anyway: ${{ steps.skip-ignore.outputs.changed_build }}  
-      changed_c: ${{ steps.do.outputs.changed_c }}
-      changed_cpp: ${{ steps.do.outputs.changed_cpp }}
-      changed_py: ${{ steps.do.outputs.changed_py }}
-      changed_rs: ${{ steps.do.outputs.changed_rs }}
-      changed_ts: ${{ steps.do.outputs.changed_ts }}
-      changed_tracing: ${{ steps.do.outputs.changed_tracing }}
-      skip_all: ${{ steps.duplicate.outputs.should_skip == 'true' && steps.do.outputs.changed_any == 0 }}
+      skip: ${{ steps.duplicate.outputs.should_skip == 'true' }}
+      run_c: ${{ steps.do.outputs.changed_c == 1 || !github.event.pull_request.draft }}
+      run_cpp: ${{ steps.do.outputs.changed_cpp == 1 || !github.event.pull_request.draft }}
+      run_misc: ${{ steps.do.outputs.changed_any == 1 || !github.event.pull_request.draft }}
+      run_py: ${{ steps.do.outputs.changed_py == 1 || !github.event.pull_request.draft }}
+      run_rs: ${{ steps.do.outputs.changed_rs == 1 || !github.event.pull_request.draft }}
+      run_ts: ${{ steps.do.outputs.changed_ts == 1|| !github.event.pull_request.draft }}
+      run_tracing: ${{ steps.do.outputs.changed_tracing == 1 || !github.event.pull_request.draft }}
     steps:
       - name: Check out lingua-franca repository
         uses: actions/checkout@v3
@@ -67,28 +67,27 @@ jobs:
         run: |
           echo '## Summary' > $GITHUB_STEP_SUMMARY
       - id: skip-redundant
-        name: "Explain skipping all checks due to a prior run"
+        name: "Explain skipping checks due to a prior run"
         run: |
           echo ":tada: A successful prior run has been found:" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.duplicate.outputs.skipped_by }}" >> $GITHUB_STEP_SUMMARY
-          echo ":heavy_check_mark: Skipping all tests." >> $GITHUB_STEP_SUMMARY
-        if: ${{ steps.do.outputs.skip_all == 'true' }}
+          echo ":heavy_check_mark: Skipping all tests. Only building." >> $GITHUB_STEP_SUMMARY
+        if: ${{ steps.duplicate.outputs.should_skip == 'true' }}
       - id: skip-ignore
-        name: "Explain skipping all checks due to inconsequential changes"
+        name: "Explain skipping checks due to inconsequential changes"
         run: |
-          echo "The detected changes did not affect any code." >> $GITHUB_STEP_SUMMARY
-          echo ":heavy_check_mark: Skipping tests. Only running build." >> $GITHUB_STEP_SUMMARY
-          echo "build_anyway=1" >> $GITHUB_OUTPUT
-        if: ${{ steps.do.outputs.skip_all != 'true' && steps.do.outputs.changed_any == 0 }}
+          echo ":octopus: The detected changes did not affect any code." >> $GITHUB_STEP_SUMMARY
+          echo ":heavy_check_mark: Skipping tests. Only building." >> $GITHUB_STEP_SUMMARY
+        if: ${{ steps.duplicate.outputs.should_skip != 'true' && steps.do.outputs.changed_any == 0 }}
       - id: run-some
         name: "Explain running some checks"
         run: |
-          echo ":hourglass: No successful prior run has been found." >> $GITHUB_STEP_SUMMARY
-        if: ${{ steps.do.outputs.skip_all != 'true' }}
+          echo ":octopus: No successful prior run has been found." >> $GITHUB_STEP_SUMMARY
+        if: ${{ steps.duplicate.outputs.should_skip != 'true' }}
       - id: ready-mode
         name: 'Report on full test run'
         run: |
-          echo ":heavy_check_mark: Performing all tests." >> $GITHUB_STEP_SUMMARY
+          echo ":hourglass: Performing all tests." >> $GITHUB_STEP_SUMMARY
         if: ${{ !github.event.pull_request.draft }}
       - id: draft-mode
         name: 'Report on partial test run'

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -86,7 +86,7 @@ jobs:
       - id: run-some
         name: "Report on running checks (no prior run found)"
         run: |
-          echo ":octopus: No successful prior run has been found." >> $GITHUB_STEP_SUMMARY
+          echo ":octopus: No (complete) successful prior run has been found." >> $GITHUB_STEP_SUMMARY
         if: ${{ steps.should-skip.outputs.skip != 'true' && steps.do.outputs.changed_any != 0}}
       - id: run-ready-mode
         name: 'Report on full test run'

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -96,7 +96,7 @@ jobs:
       - id: run-draft-mode
         name: 'Report on partial test run'
         run: |
-          echo ":hourglass: Performing tests affected by detected changes." >> $GITHUB_STEP_SUMMARY
+          echo ":hourglass: Performing tests potentially affected by detected changes." >> $GITHUB_STEP_SUMMARY
           echo '|         | running                                   |' >> $GITHUB_STEP_SUMMARY
           echo '|---------|-------------------------------------------|' >> $GITHUB_STEP_SUMMARY
           echo '| c       | `${{ steps.do.outputs.changed_c == 1 }}`       |' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -32,7 +32,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
-      skip: ${{ steps.duplicate.outputs.should_skip == 'true' }}
+      skip: ${{ steps.should-skip.outputs.skip == 'true' }}
       run_c: ${{ steps.do.outputs.changed_c == 1 || !github.event.pull_request.draft }}
       run_cpp: ${{ steps.do.outputs.changed_cpp == 1 || !github.event.pull_request.draft }}
       run_misc: ${{ steps.do.outputs.changed_any == 1 || !github.event.pull_request.draft }}

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -25,8 +25,8 @@ on:
         description: 'Return true if the build should be run'
         value: ${{ jobs.check.outputs.skip != 'true' }}
       run_misc:
-            description: 'Return true if the build should be run'
-            value: ${{ jobs.check.outputs.run_misc == 'true' && jobs.check.outputs.skip != 'true' }}
+        description: 'Return true if the build should be run'
+        value: ${{ jobs.check.outputs.run_misc == 'true' && jobs.check.outputs.skip != 'true' }}
 
 jobs:
   check:
@@ -67,7 +67,7 @@ jobs:
         run: |
           echo '## Summary' > $GITHUB_STEP_SUMMARY
       - id: skip-redundant
-        name: "Report skipping checks due to a prior run"
+        name: "Report on skipping checks (prior run found)"
         run: |
           echo ":tada: A successful prior run has been found:" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.duplicate.outputs.skipped_by }}" >> $GITHUB_STEP_SUMMARY
@@ -80,7 +80,7 @@ jobs:
           echo ":heavy_check_mark: Skipping tests. Only building." >> $GITHUB_STEP_SUMMARY
         if: ${{ steps.duplicate.outputs.should_skip != 'true' && steps.do.outputs.changed_any == 0 }}
       - id: run-some
-        name: "Report running some checks"
+        name: "Report on running checks (no prior run found)"
         run: |
           echo ":octopus: No successful prior run has been found." >> $GITHUB_STEP_SUMMARY
         if: ${{ steps.duplicate.outputs.should_skip != 'true' && steps.do.outputs.changed_any != 0}}

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -33,6 +33,10 @@ jobs:
         repository: lf-lang/lingua-franca
         submodules: true
         fetch-depth: 0
+    - name: Check for redundant runs
+      id: check
+      uses: fkirc/skip-duplicate-actions@v5.3.0
+      if: ${{ github.ref == 'refs/heads/master' }}
     - id: do
       run: |
         wget https://raw.githubusercontent.com/lf-lang/lingua-franca/master/.github/scripts/check-diff.sh
@@ -43,3 +47,4 @@ jobs:
         source check-diff.sh "core/src/main/kotlin/org/lflang/generator/ts\|core/src/main/java/org/lflang/generator/ts\|core/src/main/resources/lib/ts\|test/TypeScript" TS
         source check-diff.sh "util/tracing" TRACING
       shell: bash
+      if: ${{ steps.check.outputs.should_skip != 'true' }}

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -3,6 +3,9 @@ name: Check diff from master
 on:
   workflow_call:
     outputs:
+      build_anyway:
+        description: 'Return true if building is still needed when skipping tests'
+        value: ${{ jobs.check.outputs.build_anyway == 1 }}
       run_c:
         description: 'Return true if C tests should be run'
         value: ${{ jobs.check.outputs.changed_c == 1 && jobs.check.outputs.skip_all != 'true' }}
@@ -29,6 +32,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
+      build_anyway: ${{ steps.skip-ignore.outputs.changed_build }}  
       changed_c: ${{ steps.do.outputs.changed_c }}
       changed_cpp: ${{ steps.do.outputs.changed_cpp }}
       changed_py: ${{ steps.do.outputs.changed_py }}
@@ -62,13 +66,20 @@ jobs:
         name: "Create summary"
         run: |
           echo '## Summary' > $GITHUB_STEP_SUMMARY
-      - id: skip-all
-        name: "Explain skipping all checks"
+      - id: skip-redundant
+        name: "Explain skipping all checks due to a prior run"
         run: |
           echo ":tada: A successful prior run has been found:" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.duplicate.outputs.skipped_by }}" >> $GITHUB_STEP_SUMMARY
-          echo ":heavy_check_mark: Skipping tests." >> $GITHUB_STEP_SUMMARY
+          echo ":heavy_check_mark: Skipping all tests." >> $GITHUB_STEP_SUMMARY
         if: ${{ steps.do.outputs.skip_all == 'true' }}
+      - id: skip-ignore
+        name: "Explain skipping all checks due to inconsequential changes"
+        run: |
+          echo "The detected changes did not affect any code." >> $GITHUB_STEP_SUMMARY
+          echo ":heavy_check_mark: Skipping tests. Only running build." >> $GITHUB_STEP_SUMMARY
+          echo "build_anyway=1" >> $GITHUB_OUTPUT
+        if: ${{ steps.do.outputs.skip_all != 'true' && steps.do.outputs.changed_any == 0 }}
       - id: run-some
         name: "Explain running some checks"
         run: |

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -59,7 +59,7 @@ jobs:
           ./check-diff.sh "lflang/generator/rust\|resources/lib/rs\|test/Rust" rs
           ./check-diff.sh "lflang/generator/ts\|resources/lib/ts\|test/TypeScript" ts
           ./check-diff.sh "util/tracing" tracing
-          ./check-diff.sh "" any
+          ./check-diff.sh ".*" any
         shell: bash
         working-directory: .github/scripts
       - id: summarize

--- a/.github/workflows/only-c.yml
+++ b/.github/workflows/only-c.yml
@@ -21,7 +21,7 @@ jobs:
 
   # Run the C benchmark tests.
   benchmarking:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@gradle
+    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
     with:
       target: "C"
 

--- a/.github/workflows/only-cpp.yml
+++ b/.github/workflows/only-cpp.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   # Run the C++ benchmark tests.
   cpp-benchmark-tests:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@gradle
+    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
     with:
       target: "Cpp"
 

--- a/.github/workflows/only-rs.yml
+++ b/.github/workflows/only-rs.yml
@@ -21,6 +21,6 @@ jobs:
 
   # Run the Rust benchmark tests.
   rs-benchmark-tests:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@gradle
+    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
     with:
       target: "Rust"

--- a/.github/workflows/only-ts.yml
+++ b/.github/workflows/only-ts.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   # Run the TypeScript benchmark tests.
   benchmarking:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@gradle
+    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
     with:
       target: "TS"
 


### PR DESCRIPTION
This PR intends to change the CI workflows in the following ways:
 - when a previous run can be found that already pass all the checks, checks are skipped
 - when `.txt` or `.md` files are checked in, we don't run tests, we just build (which includes doing a Spotless check)
 - a summary is added to let users better understand what is happening (and why)

We will probably have to get this merged in order to see whether it really works as expected...