### PR TITLE
Bugfix in the federated launch script to let failures be reported correctly

### DIFF
--- a/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
+++ b/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
@@ -203,7 +203,7 @@ public class FedLauncherGenerator {
                 "# The errors are handled separately via trap.",
                 "for pid in \"${pids[@]}\"",
                 "do",
-                "    wait $pid",
+                "    wait $pid || exit $?",
                 "done",
                 "echo \"All done.\"",
                 "EXITED_SUCCESSFULLY=true")


### PR DESCRIPTION
This fixes another way tests can pass when they should be failing.

The behavior which apparently is currently in `master` is that if all federates terminate then the test passes, even if some federates terminated with nonzero exit code.