### PR TITLE
Fedsd compatibility with pandas 2.0

### DIFF
--- a/util/tracing/visualization/fedsd.py
+++ b/util/tracing/visualization/fedsd.py
@@ -51,15 +51,6 @@ parser.add_argument('-f','--federates', nargs='+', action='append',
                     help='List of the federates csv trace files.')
 
 
-''' Clock synchronization error '''
-''' FIXME: There should be a value for each communicating pair '''
-clock_sync_error = 0
-
-''' Bound on the network latency '''
-''' FIXME: There should be a value for each communicating pair '''
-network_latency = 100000000 # That is 100us
-
-
 def load_and_process_csv_file(csv_file) :
     '''
     Loads and processes the csv entries, based on the type of the actor (if RTI
@@ -141,11 +132,6 @@ if __name__ == '__main__':
     trace_df = trace_df.sort_values(by=['physical_time'])
     trace_df = trace_df.reset_index(drop=True)
 
-    # FIXME: For now, we need to remove the rows with negative physical time values...
-    # Until the reason behinf such values is investigated. The negative physical
-    # time is when federates are still in the process of joining
-    # trace_df = trace_df[trace_df['physical_time'] >= 0]
-
     # Add the Y column and initialize it with the padding value 
     trace_df['y1'] = math.ceil(padding * 3 / 2) # Or set a small shift
 
@@ -213,9 +199,7 @@ if __name__ == '__main__':
                 trace_df.loc[index, 'arrow'] = 'dot'
             else:
                 # If there is one or more matching rows, then consider 
-                # the first one, since it is an out -> in arrow, and  
-                # since it is the closet in time
-                # FIXME: What other possible choices to consider?
+                # the first one
                 if (inout == 'out'):
                     matching_index = matching_df.index[0]
                     matching_row = matching_df.loc[matching_index]

--- a/util/tracing/visualization/fedsd.py
+++ b/util/tracing/visualization/fedsd.py
@@ -134,7 +134,7 @@ if __name__ == '__main__':
                 x_coor[fed_id] = (padding * 2) + (spacing * (len(actors)-1))
                 fed_df['x1'] = x_coor[fed_id]
                 # Append into trace_df
-                trace_df = trace_df.append(fed_df, sort=False, ignore_index=True)
+                trace_df = pd.concat([trace_df, fed_df])
                 fed_df = fed_df[0:0]
     
     # Sort all traces by physical time and then reset the index


### PR DESCRIPTION
This PR fixes [issue #1834](https://github.com/lf-lang/lingua-franca/issues/1834).
It also makes `fedsd` correctly match non-tagged messages, which enables the visualization of exchanged messages within physical connections.