### PR TITLE
Bugfix in integration tests and fixed ROS2 tests 

### DIFF
--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -69,7 +69,8 @@ jobs:
       - id: should-skip
         name: "Determine whether to skip checks"
         run: |
-          echo "skip=${{ steps.duplicate.outputs.should_skip == 'true' && github.event.action != 'ready_for_review' }}" >> $GITHUB_OUTPUT
+          echo "skip=${{ steps.duplicate.outputs.should_skip == 'true' && github.event.action != 'ready_for_review' && github.event.sender.login != 'github-merge-queue' }}" >> $GITHUB_OUTPUT
+          echo "(Run initiated by ${{ github.event.sender.login }} )"
       - id: skip-redundant
         name: "Report on skipping checks (prior run found)"
         run: |

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -70,7 +70,7 @@ jobs:
         name: "Determine whether to skip checks"
         run: |
           echo ${{ github.ref_name }}
-          if echo ${{ github.ref_name }} | grep 'gh-readonly-queues'; then
+          if echo ${{ github.ref_name }} | grep 'gh-readonly-queue'; then
             echo "Don't skip, because this is a merge queue commit."
             echo "skip=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -69,8 +69,14 @@ jobs:
       - id: should-skip
         name: "Determine whether to skip checks"
         run: |
-          echo "skip=${{ steps.duplicate.outputs.should_skip == 'true' && github.event.action != 'ready_for_review' && github.event.sender.login != 'github-merge-queue' }}" >> $GITHUB_OUTPUT
-          echo "(Run initiated by ${{ github.event.sender.login }} )"
+          echo ${{ github.ref_name }}
+          if echo ${{ github.ref_name }} | grep 'gh-readonly-queues'; then
+            echo "Don't skip, because this is a merge queue commit."
+            echo "skip=false" >> $GITHUB_OUTPUT
+          else
+            echo "skip=${{ steps.duplicate.outputs.should_skip == 'true' && github.event.action != 'ready_for_review' }}" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
       - id: skip-redundant
         name: "Report on skipping checks (prior run found)"
         run: |

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CppRos2Test.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CppRos2Test.java
@@ -3,7 +3,6 @@ package org.lflang.tests.runtime;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.lflang.Target;
-import org.lflang.ast.ASTUtils;
 import org.lflang.lf.Element;
 import org.lflang.lf.LfFactory;
 import org.lflang.tests.TestBase;
@@ -30,7 +29,10 @@ public class CppRos2Test extends TestBase {
     runTestsForTargets(
         Message.DESC_ROS2,
         it -> true,
-        it -> ASTUtils.addTargetProperty(it.getFileConfig().resource, "ros2", trueLiteral),
+        it -> {
+          it.getContext().getTargetConfig().ros2 = true;
+          return true;
+        },
         TestLevel.EXECUTION,
         true);
   }

--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -266,28 +266,6 @@ public class ASTUtils {
   }
 
   /**
-   * Add a new target property to the given resource. This also creates a config object if the
-   * resource does not yey have one.
-   *
-   * @param resource The resource to modify
-   * @param name Name of the property to add
-   * @param value Value to be assigned to the property
-   */
-  public static boolean addTargetProperty(
-      final Resource resource, final String name, final Element value) {
-    var config = targetDecl(resource).getConfig();
-    if (config == null) {
-      config = LfFactory.eINSTANCE.createKeyValuePairs();
-      targetDecl(resource).setConfig(config);
-    }
-    final var newProperty = LfFactory.eINSTANCE.createKeyValuePair();
-    newProperty.setName(name);
-    newProperty.setValue(value);
-    config.getPairs().add(newProperty);
-    return true;
-  }
-
-  /**
    * Return true if the connection involves multiple ports on the left or right side of the
    * connection, or if the port on the left or right of the connection involves a bank of reactors
    * or a multiport.

--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppFileConfig.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppFileConfig.kt
@@ -49,7 +49,8 @@ class CppFileConfig(resource: Resource, srcGenBasePath: Path, useHierarchicalBin
         this.outPath.resolve("build"),
         this.outPath.resolve("lib"),
         this.outPath.resolve("include"),
-        this.outPath.resolve("share")
+        this.outPath.resolve("share"),
+        this.outPath.resolve("install")
     )
 
     /** Relative path to the directory where all source files for this resource should be generated in. */

--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppPlatformGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppPlatformGenerator.kt
@@ -22,4 +22,14 @@ abstract class CppPlatformGenerator(protected val generator: CppGenerator) {
     abstract fun generatePlatformFiles()
 
     abstract fun doCompile(context: LFGeneratorContext, onlyGenerateBuildFiles: Boolean = false): Boolean
+
+    protected val cmakeArgs: List<String>
+        get() = listOf(
+            "-DCMAKE_BUILD_TYPE=${targetConfig.cmakeBuildType}",
+            "-DREACTOR_CPP_VALIDATE=${if (targetConfig.noRuntimeValidation) "OFF" else "ON"}",
+            "-DREACTOR_CPP_PRINT_STATISTICS=${if (targetConfig.printStatistics) "ON" else "OFF"}",
+            "-DREACTOR_CPP_TRACE=${if (targetConfig.tracing != null) "ON" else "OFF"}",
+            "-DREACTOR_CPP_LOG_LEVEL=${targetConfig.logLevel.severity}",
+            "-DLF_SRC_PKG_PATH=${fileConfig.srcPkgPath}",
+        )
 }

--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppRos2Generator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppRos2Generator.kt
@@ -54,8 +54,7 @@ class CppRos2Generator(generator: CppGenerator) : CppPlatformGenerator(generator
                 packageGenerator.reactorCppName,
                 "--cmake-args",
                 "-DLF_REACTOR_CPP_SUFFIX=${packageGenerator.reactorCppSuffix}",
-                "-DLF_SRC_PKG_PATH=${fileConfig.srcPkgPath}"
-            ),
+            ) + cmakeArgs,
             fileConfig.outPath
         )
         val returnCode = colconCommand?.run(context.cancelIndicator);

--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppRos2NodeGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppRos2NodeGenerator.kt
@@ -79,7 +79,7 @@ class CppRos2NodeGenerator(
             |}
             |
             |$nodeName::~$nodeName() {
-            |  if (lf_env->phase() == reactor::Environment::Phase::Execution) { 
+            |  if (lf_env->phase() == reactor::Phase::Execution) {
             |    lf_env->async_shutdown();
             |  }
             |  lf_shutdown_thread.join();

--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppStandaloneGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppStandaloneGenerator.kt
@@ -160,15 +160,10 @@ class CppStandaloneGenerator(generator: CppGenerator) :
 
     private fun createCmakeCommand(buildPath: Path, outPath: Path): LFCommand {
         val cmd = commandFactory.createCommand(
-            "cmake", listOf(
-                "-DCMAKE_BUILD_TYPE=${targetConfig.cmakeBuildType}",
+            "cmake",
+            cmakeArgs + listOf(
                 "-DCMAKE_INSTALL_PREFIX=${outPath.toUnixString()}",
                 "-DCMAKE_INSTALL_BINDIR=${outPath.relativize(fileConfig.binPath).toUnixString()}",
-                "-DREACTOR_CPP_VALIDATE=${if (targetConfig.noRuntimeValidation) "OFF" else "ON"}",
-                "-DREACTOR_CPP_PRINT_STATISTICS=${if (targetConfig.printStatistics) "ON" else "OFF"}",
-                "-DREACTOR_CPP_TRACE=${if (targetConfig.tracing != null) "ON" else "OFF"}",
-                "-DREACTOR_CPP_LOG_LEVEL=${targetConfig.logLevel.severity}",
-                "-DLF_SRC_PKG_PATH=${fileConfig.srcPkgPath}",
                 fileConfig.srcGenBasePath.toUnixString()
             ),
             buildPath


### PR DESCRIPTION
This PR fixes a bug in our integration tests that prevented the C++ ROS2 tests from actually being compiled with the ROS2 flag. Effectively, we did not run any of the ROS2 tests for a while. Since a few small bugs crept into the ROS2 support in the meantime, this PR also fixes the problems in the ROS2 code generation and pulls in https://github.com/lf-lang/reactor-cpp/pull/50.