### PR TITLE
Adjustments for running the LF compiler in Epoch

### DIFF
--- a/cli/base/src/main/java/org/lflang/cli/CliBase.java
+++ b/cli/base/src/main/java/org/lflang/cli/CliBase.java
@@ -262,7 +262,7 @@ public abstract class CliBase implements Runnable {
       if (uri != null) {
         try {
           path = FileUtil.toPath(uri);
-        } catch (IOException e) {
+        } catch (IllegalArgumentException e) {
           reporter.printError("Unable to convert '" + uri + "' to path." + e);
         }
       }

--- a/cli/base/src/main/java/org/lflang/cli/StandaloneIssueAcceptor.java
+++ b/cli/base/src/main/java/org/lflang/cli/StandaloneIssueAcceptor.java
@@ -1,7 +1,6 @@
 package org.lflang.cli;
 
 import com.google.inject.Inject;
-import java.io.IOException;
 import java.nio.file.Path;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
@@ -53,7 +52,7 @@ public class StandaloneIssueAcceptor implements ValidationMessageAcceptor {
     Path file = null;
     try {
       file = FileUtil.toPath(diagnostic.getUriToProblem());
-    } catch (IOException e) {
+    } catch (IllegalArgumentException e) {
       // just continue with null
     }
     return file;

--- a/core/src/main/java/org/lflang/ModelInfo.java
+++ b/core/src/main/java/org/lflang/ModelInfo.java
@@ -28,7 +28,6 @@ package org.lflang;
 import static org.eclipse.xtext.xbase.lib.IterableExtensions.filter;
 import static org.eclipse.xtext.xbase.lib.IteratorExtensions.toIterable;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;

--- a/core/src/main/java/org/lflang/ModelInfo.java
+++ b/core/src/main/java/org/lflang/ModelInfo.java
@@ -153,7 +153,7 @@ public class ModelInfo {
   private String getName(Reactor r) {
     return r.getName() != null
         ? r.getName()
-        : FileUtil.nameWithoutExtension(Path.of(model.eResource().getURI().toFileString()));
+        : FileUtil.nameWithoutExtension(FileUtil.toPath(model.eResource().getURI()));
   }
 
   public Set<NamedInstance<?>> topologyCycles() {

--- a/core/src/main/java/org/lflang/TargetProperty.java
+++ b/core/src/main/java/org/lflang/TargetProperty.java
@@ -26,7 +26,6 @@
 package org.lflang;
 
 import com.google.common.collect.ImmutableList;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.LinkedList;

--- a/core/src/main/java/org/lflang/TargetProperty.java
+++ b/core/src/main/java/org/lflang/TargetProperty.java
@@ -717,7 +717,7 @@ public enum TargetProperty {
         Path referencePath;
         try {
           referencePath = FileUtil.toPath(value.eResource().getURI()).toAbsolutePath();
-        } catch (IOException e) {
+        } catch (IllegalArgumentException e) {
           err.reportError(value, "Invalid path? " + e.getMessage());
           throw new RuntimeIOException(e);
         }

--- a/core/src/main/java/org/lflang/federated/generator/FedTargetConfig.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedTargetConfig.java
@@ -9,6 +9,7 @@ import org.lflang.TargetConfig;
 import org.lflang.TargetProperty;
 import org.lflang.generator.GeneratorUtils;
 import org.lflang.generator.LFGeneratorContext;
+import org.lflang.util.FileUtil;
 
 /**
  * Subclass of TargetConfig with a specialized constructor for creating configurations for
@@ -67,9 +68,9 @@ public class FedTargetConfig extends TargetConfig {
   }
 
   private Path getRelativePath(Resource source, Resource target) {
-    return Path.of(source.getURI().toFileString())
+    return FileUtil.toPath(source.getURI())
         .getParent()
-        .relativize(Path.of(target.getURI().toFileString()).getParent());
+        .relativize(FileUtil.toPath(target.getURI()).getParent());
   }
 
   /** Method for the removal of things that should not appear in the target config of a federate. */

--- a/core/src/main/java/org/lflang/generator/LanguageServerErrorReporter.java
+++ b/core/src/main/java/org/lflang/generator/LanguageServerErrorReporter.java
@@ -15,6 +15,7 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.lflang.ErrorReporter;
+import org.lflang.util.FileUtil;
 
 /**
  * Report diagnostics to the language client.
@@ -159,7 +160,7 @@ public class LanguageServerErrorReporter implements ErrorReporter {
 
   /** Return the file on which the current validation process was triggered. */
   private Path getMainFile() {
-    return Path.of(parseRoot.eResource().getURI().toFileString());
+    return FileUtil.toPath(parseRoot.eResource().getURI());
   }
 
   /**

--- a/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
@@ -30,7 +30,7 @@ public class CReactorHeaderFileGenerator {
   /** Return the path to the user-visible header file that would be generated for {@code r}. */
   public static Path outputPath(TypeParameterizedReactor tpr) {
     return Path.of(
-            Path.of(tpr.reactor().eResource().getURI().toFileString())
+            FileUtil.toPath(tpr.reactor().eResource().getURI())
                 .getFileName()
                 .toString()
                 .replaceFirst("[.][^.]+$", ""))

--- a/core/src/main/java/org/lflang/util/FileUtil.java
+++ b/core/src/main/java/org/lflang/util/FileUtil.java
@@ -55,36 +55,36 @@ public class FileUtil {
    *
    * @param r Any {@code Resource}.
    * @return The name of the file associated with the given resource, excluding its file extension.
-   * @throws IOException If the resource has an invalid URI.
+   * @throws IllegalArgumentException If the resource has an invalid URI.
    */
-  public static String nameWithoutExtension(Resource r) throws IOException {
+  public static String nameWithoutExtension(Resource r) {
     return nameWithoutExtension(toPath(r));
   }
 
   /**
    * Return a java.nio.Path object corresponding to the given URI.
    *
-   * @throws IOException If the given URI is invalid.
+   * @throws IllegalArgumentException If the given URI is invalid.
    */
-  public static Path toPath(URI uri) throws IOException {
+  public static Path toPath(URI uri) {
     return Paths.get(toIPath(uri).toFile().getAbsolutePath());
   }
 
   /**
    * Return a java.nio.Path object corresponding to the given Resource.
    *
-   * @throws IOException If the given resource has an invalid URI.
+   * @throws IllegalArgumentException If the given resource has an invalid URI.
    */
-  public static Path toPath(Resource resource) throws IOException {
+  public static Path toPath(Resource resource) {
     return toPath(resource.getURI());
   }
 
   /**
    * Return an org.eclipse.core.runtime.Path object corresponding to the given URI.
    *
-   * @throws IOException If the given URI is invalid.
+   * @throws IllegalArgumentException If the given URI is invalid.
    */
-  public static IPath toIPath(URI uri) throws IOException {
+  public static IPath toIPath(URI uri) {
     if (uri.isPlatform()) {
       IPath path = new org.eclipse.core.runtime.Path(uri.toPlatformString(true));
       if (path.segmentCount() == 1) {
@@ -98,7 +98,7 @@ public class FileUtil {
     } else if (uri.isFile()) {
       return new org.eclipse.core.runtime.Path(uri.toFileString());
     } else {
-      throw new IOException("Unrecognized file protocol in URI " + uri);
+      throw new IllegalArgumentException("Unrecognized file protocol in URI " + uri);
     }
   }
 
@@ -822,7 +822,7 @@ public class FileUtil {
   }
 
   /** Get the iResource corresponding to the provided resource if it can be found. */
-  public static IResource getIResource(Resource r) throws IOException {
+  public static IResource getIResource(Resource r) {
     return getIResource(FileUtil.toPath(r).toFile().toURI());
   }
 


### PR DESCRIPTION
- Fixed access to URIs which caused NPEs in Epoch. Eclipse does not use file URIs but platform URIs hence `toFileString` will return null.
- Improved Exception handling for URI conversion. Methods no longer throw IOExceptions beause there are no IO operations involved, instead IllegalArgumentException if the URI is malformed.