### PR TITLE
Formatter: stop insertig a space after `interleaved`

### DIFF
--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -332,7 +332,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     //     variable=[Variable]) ')'
     if (!v.isInterleaved()) return MalleableString.anyOf(ToText.instance.doSwitch(v));
     return new Builder()
-        .append("interleaved ")
+        .append("interleaved")
         .append(list(false, ToText.instance.doSwitch(v)))
         .get();
   }

--- a/test/C/src/multiport/FullyConnectedAddressable.lf
+++ b/test/C/src/multiport/FullyConnectedAddressable.lf
@@ -47,8 +47,8 @@ reactor Node(num_nodes: size_t = 4, bank_index: int = 0) {
 
 main reactor(num_nodes: size_t = 4) {
   nodes1 = new[num_nodes] Node(num_nodes = num_nodes)
-  nodes1.out -> interleaved (nodes1.in)
+  nodes1.out -> interleaved(nodes1.in)
 
   nodes2 = new[num_nodes] Node(num_nodes = num_nodes)
-  interleaved (nodes2.out) -> nodes2.in
+  interleaved(nodes2.out) -> nodes2.in
 }

--- a/test/C/src/multiport/FullyConnectedAddressableAfter.lf
+++ b/test/C/src/multiport/FullyConnectedAddressableAfter.lf
@@ -5,8 +5,8 @@ import Node from "FullyConnectedAddressable.lf"
 
 main reactor(num_nodes: size_t = 4) {
   nodes1 = new[num_nodes] Node(num_nodes = num_nodes)
-  nodes1.out -> interleaved (nodes1.in) after 200 msec
+  nodes1.out -> interleaved(nodes1.in) after 200 msec
 
   nodes2 = new[num_nodes] Node(num_nodes = num_nodes)
-  interleaved (nodes2.out) -> nodes2.in after 400 msec
+  interleaved(nodes2.out) -> nodes2.in after 400 msec
 }

--- a/test/C/src/multiport/NestedInterleavedBanks.lf
+++ b/test/C/src/multiport/NestedInterleavedBanks.lf
@@ -18,7 +18,7 @@ reactor A(bank_index: int = 0, outer_bank_index: int = 0) {
 reactor B(bank_index: int = 0) {
   output[4] q: int
   a = new[2] A(outer_bank_index = bank_index)
-  interleaved (a.p) -> q
+  interleaved(a.p) -> q
 }
 
 reactor C {

--- a/test/Cpp/src/multiport/FullyConnectedAddressable.lf
+++ b/test/Cpp/src/multiport/FullyConnectedAddressable.lf
@@ -43,8 +43,8 @@ reactor Node(bank_index: size_t = 0, num_nodes: size_t = 4) {
 
 main reactor(num_nodes: size_t = 4) {
   nodes1 = new[num_nodes] Node(num_nodes = num_nodes)
-  nodes1.out -> interleaved (nodes1.in)
+  nodes1.out -> interleaved(nodes1.in)
 
   nodes2 = new[num_nodes] Node(num_nodes = num_nodes)
-  interleaved (nodes2.out) -> nodes2.in
+  interleaved(nodes2.out) -> nodes2.in
 }

--- a/test/Cpp/src/multiport/FullyConnectedAddressableAfter.lf
+++ b/test/Cpp/src/multiport/FullyConnectedAddressableAfter.lf
@@ -5,8 +5,8 @@ import Node from "FullyConnectedAddressable.lf"
 
 main reactor(num_nodes: size_t = 4) {
   nodes1 = new[num_nodes] Node(num_nodes = num_nodes)
-  nodes1.out -> interleaved (nodes1.in) after 200 msec
+  nodes1.out -> interleaved(nodes1.in) after 200 msec
 
   nodes2 = new[num_nodes] Node(num_nodes = num_nodes)
-  interleaved (nodes2.out) -> nodes2.in after 400 msec
+  interleaved(nodes2.out) -> nodes2.in after 400 msec
 }

--- a/test/Python/src/multiport/NestedInterleavedBanks.lf
+++ b/test/Python/src/multiport/NestedInterleavedBanks.lf
@@ -17,7 +17,7 @@ reactor A(bank_index = 0, outer_bank_index = 0) {
 reactor B(bank_index = 0) {
   output[4] q
   a = new[2] A(outer_bank_index = bank_index)
-  interleaved (a.p) -> q
+  interleaved(a.p) -> q
 }
 
 reactor C {

--- a/test/Rust/src/multiport/FullyConnectedAddressable.lf
+++ b/test/Rust/src/multiport/FullyConnectedAddressable.lf
@@ -45,8 +45,8 @@ reactor Node(bank_index: usize = 0, num_nodes: usize = 4) {
 
 main reactor(num_nodes: usize = 4) {
   nodes1 = new[num_nodes] Node(num_nodes = num_nodes)
-  nodes1.out -> interleaved (nodes1.inpt)
+  nodes1.out -> interleaved(nodes1.inpt)
 
   nodes2 = new[num_nodes] Node(num_nodes = num_nodes)
-  interleaved (nodes2.out) -> nodes2.inpt
+  interleaved(nodes2.out) -> nodes2.inpt
 }


### PR DESCRIPTION
I think we shouldn't insert a space after `interleaved`. It is intended to work more like a function call, modifying the ports in parentheses. The space in between creates a separation that could be confusing when reading the code.