### PR TITLE
More formatter fixes

### DIFF
--- a/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
+++ b/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
@@ -141,7 +141,37 @@ public class LffCliTest {
                     // baz
                     state grid2: SnakeGrid = {= SnakeGrid::new(grid_side, &snake) =}
                   }
-                  """));
+                  """),
+          List.of(
+              """
+                  target Cpp
+                  
+                  reactor ContextManager<Req, Resp, Ctx> {
+                  
+                  
+                     \s
+                  }
+                  
+                  reactor MACService {
+                    mul_cm = new ContextManager<loooooooooooooooooooooooooooooong, looooooooooooooong, loooooooooooooong>()
+                  }
+                  
+                  """,
+              """
+                  target Cpp
+                  
+                  reactor ContextManager<Req, Resp, Ctx> {
+                  }
+                  
+                  reactor MACService {
+                    mul_cm = new ContextManager<
+                      loooooooooooooooooooooooooooooong,
+                      looooooooooooooong,
+                      loooooooooooooong
+                    >()
+                  }
+                  """
+              ));
 
   LffTestFixture lffTester = new LffTestFixture();
 

--- a/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
+++ b/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
@@ -145,24 +145,24 @@ public class LffCliTest {
           List.of(
               """
                   target Cpp
-                  
+
                   reactor ContextManager<Req, Resp, Ctx> {
-                  
-                  
+
+
                      \s
                   }
-                  
+
                   reactor MACService {
                     mul_cm = new ContextManager<loooooooooooooooooooooooooooooong, looooooooooooooong, loooooooooooooong>()
                   }
-                  
+
                   """,
               """
                   target Cpp
-                  
+
                   reactor ContextManager<Req, Resp, Ctx> {
                   }
-                  
+
                   reactor MACService {
                     mul_cm = new ContextManager<
                       loooooooooooooooooooooooooooooong,
@@ -170,8 +170,7 @@ public class LffCliTest {
                       loooooooooooooong
                     >()
                   }
-                  """
-              ));
+                  """));
 
   LffTestFixture lffTester = new LffTestFixture();
 

--- a/core/src/main/java/org/lflang/ast/MalleableString.java
+++ b/core/src/main/java/org/lflang/ast/MalleableString.java
@@ -357,6 +357,14 @@ public abstract class MalleableString {
         String singleLineCommentPrefix) {
       this.width = width;
       keepCommentsOnSameLine = true;
+      // Multiple calls to optimizeChildren may be required because as parts of the textual
+      // representation are updated, the optimal representation of other parts may change.
+      // For example, if the text is wider than 100 characters, the line may only need to be
+      // broken in one place, but it will be broken in multiple places a second optimization pass
+      // is not made. This is a heuristic in the sense that two passes are not guaranteed to result
+      // in a fixed point, but since a subsequent call to the formatter will get the same AST and
+      // therefore have the same starting point, the formatter as a whole should still be
+      // idempotent.
       var everChanged = false;
       var changed =
           optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);

--- a/core/src/main/java/org/lflang/ast/MalleableString.java
+++ b/core/src/main/java/org/lflang/ast/MalleableString.java
@@ -42,8 +42,9 @@ public abstract class MalleableString {
    *     whole of this.
    * @param indentation The number of spaces used per level of indentation.
    * @param singleLineCommentPrefix The prefix that marks the start of a single-line comment.
+   * @return Whether the best representation changed.
    */
-  public abstract void findBestRepresentation(
+  public abstract boolean findBestRepresentation(
       Supplier<RenderResult> providedRender,
       ToLongFunction<RenderResult> badness,
       int width,
@@ -348,7 +349,7 @@ public abstract class MalleableString {
     }
 
     @Override
-    public void findBestRepresentation(
+    public boolean findBestRepresentation(
         Supplier<RenderResult> providedRender,
         ToLongFunction<RenderResult> badness,
         int width,
@@ -356,32 +357,37 @@ public abstract class MalleableString {
         String singleLineCommentPrefix) {
       this.width = width;
       keepCommentsOnSameLine = true;
-      optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
+      var everChanged = false;
+      var changed = optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
+      everChanged = changed;
+      if (changed) changed = optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
       if (components.stream()
           .noneMatch(
               it ->
                   it.render(indentation, singleLineCommentPrefix, false, null)
                       .unplacedComments
                       .findAny()
-                      .isPresent())) return;
+                      .isPresent())) return changed;
       long badnessTrue = badness.applyAsLong(providedRender.get());
       keepCommentsOnSameLine = false;
-      optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
+      changed = optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
+      everChanged |= changed;
       long badnessFalse = badness.applyAsLong(providedRender.get());
       keepCommentsOnSameLine = badnessTrue < badnessFalse;
-      optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
-      optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
+      if (changed) changed = optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
+      if (changed) optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
+      return everChanged;
     }
 
-    private void optimizeChildren(
+    private boolean optimizeChildren(
         Supplier<RenderResult> providedRender,
         ToLongFunction<RenderResult> badness,
         int width,
         int indentation,
         String singleLineCommentPrefix) {
-      components
+      return components
           .reverse()
-          .forEach(
+          .stream().anyMatch(
               it ->
                   it.findBestRepresentation(
                       providedRender, badness, width, indentation, singleLineCommentPrefix));
@@ -409,14 +415,14 @@ public abstract class MalleableString {
     }
 
     @Override
-    public void findBestRepresentation(
+    public boolean findBestRepresentation(
         Supplier<RenderResult> providedRender,
         ToLongFunction<RenderResult> badness,
         int width,
         int indentation,
         String singleLineCommentPrefix) {
       this.width = width;
-      nested.findBestRepresentation(
+      return nested.findBestRepresentation(
           providedRender, badness, width - indentation, indentation, singleLineCommentPrefix);
     }
 
@@ -462,12 +468,13 @@ public abstract class MalleableString {
     }
 
     @Override
-    public void findBestRepresentation(
+    public boolean findBestRepresentation(
         Supplier<RenderResult> providedRender,
         ToLongFunction<RenderResult> badness,
         int width,
         int indentation,
         String singleLineCommentPrefix) {
+      var initialChosenPossibility = getChosenPossibility();
       bestPossibility =
           Collections.min(
               getPossibilities(),
@@ -479,9 +486,10 @@ public abstract class MalleableString {
                 return Math.toIntExact(badnessA - badnessB);
               });
       if (bestPossibility instanceof MalleableString ms) {
-        ms.findBestRepresentation(
-            providedRender, badness, width, indentation, singleLineCommentPrefix);
+        if (ms.findBestRepresentation(
+            providedRender, badness, width, indentation, singleLineCommentPrefix)) return true;
       }
+      return getChosenPossibility() != initialChosenPossibility;
     }
 
     /** Return the best representation of this. */

--- a/core/src/main/java/org/lflang/ast/MalleableString.java
+++ b/core/src/main/java/org/lflang/ast/MalleableString.java
@@ -358,9 +358,12 @@ public abstract class MalleableString {
       this.width = width;
       keepCommentsOnSameLine = true;
       var everChanged = false;
-      var changed = optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
+      var changed =
+          optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
       everChanged = changed;
-      if (changed) changed = optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
+      if (changed)
+        changed =
+            optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
       if (components.stream()
           .noneMatch(
               it ->
@@ -370,12 +373,16 @@ public abstract class MalleableString {
                       .isPresent())) return changed;
       long badnessTrue = badness.applyAsLong(providedRender.get());
       keepCommentsOnSameLine = false;
-      changed = optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
+      changed =
+          optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
       everChanged |= changed;
       long badnessFalse = badness.applyAsLong(providedRender.get());
       keepCommentsOnSameLine = badnessTrue < badnessFalse;
-      if (changed) changed = optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
-      if (changed) optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
+      if (changed)
+        changed =
+            optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
+      if (changed)
+        optimizeChildren(providedRender, badness, width, indentation, singleLineCommentPrefix);
       return everChanged;
     }
 
@@ -385,9 +392,8 @@ public abstract class MalleableString {
         int width,
         int indentation,
         String singleLineCommentPrefix) {
-      return components
-          .reverse()
-          .stream().anyMatch(
+      return components.reverse().stream()
+          .anyMatch(
               it ->
                   it.findBestRepresentation(
                       providedRender, badness, width, indentation, singleLineCommentPrefix));

--- a/core/src/main/java/org/lflang/formatting2/LFFormatter.java
+++ b/core/src/main/java/org/lflang/formatting2/LFFormatter.java
@@ -7,6 +7,7 @@ package org.lflang.formatting2;
 import com.google.inject.Inject;
 import java.util.List;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.diagnostics.Severity;
 import org.eclipse.xtext.formatting2.FormatterRequest;
 import org.eclipse.xtext.formatting2.IFormatter2;
 import org.eclipse.xtext.formatting2.regionaccess.ITextReplacement;
@@ -24,13 +25,11 @@ public class LFFormatter implements IFormatter2 {
   @Override
   public List<ITextReplacement> format(FormatterRequest request) {
     // TODO: Use a CancelIndicator that actually cancels?
-    if (!request.getTextRegionAccess().getResource().getErrors().isEmpty()
-        || !validator
-            .validate(
-                request.getTextRegionAccess().getResource(),
-                CheckMode.ALL,
-                CancelIndicator.NullImpl)
-            .isEmpty()) {
+    if (validator
+        .validate(
+            request.getTextRegionAccess().getResource(), CheckMode.ALL, CancelIndicator.NullImpl)
+        .stream()
+        .anyMatch(it -> it.isSyntaxError() && it.getSeverity() == Severity.ERROR)) {
       return List.of();
     }
     ITextSegment documentRegion = request.getTextRegionAccess().regionForDocument();

--- a/test/C/src/federated/DistributedLogicalActionUpstreamLong.lf
+++ b/test/C/src/federated/DistributedLogicalActionUpstreamLong.lf
@@ -46,8 +46,7 @@ federated reactor {
   passThroughs7.out,
   passThroughs8.out,
   passThroughs9.out,
-  passThroughs10.out
-    ->
+  passThroughs10.out ->
     passThroughs1.in,
     passThroughs2.in,
     passThroughs3.in,

--- a/test/C/src/federated/DistributedPhysicalActionUpstreamLong.lf
+++ b/test/C/src/federated/DistributedPhysicalActionUpstreamLong.lf
@@ -71,8 +71,7 @@ federated reactor {
   passThroughs7.out,
   passThroughs8.out,
   passThroughs9.out,
-  passThroughs10.out
-    ->
+  passThroughs10.out ->
     passThroughs1.in,
     passThroughs2.in,
     passThroughs3.in,

--- a/test/C/src/modal_models/BanksModalStateReset.lf
+++ b/test/C/src/modal_models/BanksModalStateReset.lf
@@ -42,8 +42,7 @@ main reactor {
   reset2.mode_switch,
   reset2.count0,
   reset2.count1,
-  reset2.count2
-    -> test.events
+  reset2.count2 -> test.events
 
   // Trigger mode change (separately because of #1278)
   reaction(stepper) -> reset1.next {=

--- a/test/C/src/modal_models/ModalActions.lf
+++ b/test/C/src/modal_models/ModalActions.lf
@@ -87,8 +87,7 @@ main reactor {
   modal.action1_sched,
   modal.action1_exec,
   modal.action2_sched,
-  modal.action2_exec
-    -> test.events
+  modal.action2_exec -> test.events
 
   reaction(stepper) -> modal.next {= lf_set(modal.next, true); =}  // Trigger mode change
 }

--- a/test/C/src/modal_models/ModalStartupShutdown.lf
+++ b/test/C/src/modal_models/ModalStartupShutdown.lf
@@ -135,8 +135,7 @@ main reactor {
   modal.shutdown4,
   modal.startup5,
   modal.reset5,
-  modal.shutdown5
-    -> test.events
+  modal.shutdown5 -> test.events
 
   reaction(stepper) -> modal.next {= lf_set(modal.next, true); =}  // Trigger mode change
 }

--- a/test/Python/src/modal_models/BanksModalStateReset.lf
+++ b/test/Python/src/modal_models/BanksModalStateReset.lf
@@ -42,8 +42,7 @@ main reactor {
   reset2.mode_switch,
   reset2.count0,
   reset2.count1,
-  reset2.count2
-    -> test.events
+  reset2.count2 -> test.events
 
   # Trigger mode change (separately because of #1278)
   reaction(stepper) -> reset1.next {=

--- a/test/Python/src/modal_models/ModalActions.lf
+++ b/test/Python/src/modal_models/ModalActions.lf
@@ -87,8 +87,7 @@ main reactor {
   modal.action1_sched,
   modal.action1_exec,
   modal.action2_sched,
-  modal.action2_exec
-    -> test.events
+  modal.action2_exec -> test.events
 
   reaction(stepper) -> modal.next {= modal.next.set(True) =}  # Trigger mode change
 }

--- a/test/Python/src/modal_models/ModalStartupShutdown.lf
+++ b/test/Python/src/modal_models/ModalStartupShutdown.lf
@@ -135,8 +135,7 @@ main reactor {
   modal.shutdown4,
   modal.startup5,
   modal.reset5,
-  modal.shutdown5
-    -> test.events
+  modal.shutdown5 -> test.events
 
   reaction(stepper) -> modal.next {= modal.next.set(True) =}  # Trigger mode change
 }

--- a/test/TypeScript/src/DeadlineHandledAbove.lf
+++ b/test/TypeScript/src/DeadlineHandledAbove.lf
@@ -10,9 +10,7 @@ reactor Deadline(threshold: time = 100 msec) {
 
   reaction(x) -> deadline_violation {=
     util.requestErrorStop("ERROR: Deadline violation was not detected!")
-  =} deadline(
-    threshold
-  ) {=
+  =} deadline(threshold) {=
     console.log("Deadline violation detected.");
     deadline_violation = true;
   =}

--- a/test/TypeScript/src/SimpleDeadline.lf
+++ b/test/TypeScript/src/SimpleDeadline.lf
@@ -8,9 +8,7 @@ reactor Deadline(threshold: time = 100 msec) {
 
   reaction(x) -> deadlineViolation {=
     util.requestErrorStop("ERROR: Deadline violation was not detected!")
-  =} deadline(
-    threshold
-  ) {=
+  =} deadline(threshold) {=
     console.log("Deadline violation detected.");
     deadlineViolation = true;
   =}


### PR DESCRIPTION
This runs another pass of optimization. This is a heuristic, but it should not affect idempotency nor other correctness criteria. This can affect performance; however, I modified the formatter to keep track of whether anything has changed so that it knows whether further optimization passes have the potential to give any improved results, so in this common case the performance is not worse. When I ran it on my machine it did not seem much slower than before (around 30 seconds).

Also, when running the formatter from VS Code, we should go ahead even if there are warning or info messages, or syntax errors in the target code. If we can understand the AST, we can pretty-print it.