### PR TITLE
More formatter fixes

### DIFF
--- a/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
+++ b/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
@@ -119,7 +119,7 @@ public class LffCliTest {
                   }
 
                   main reactor {
-                    az_f = new Filter(period = 100, b = {0.229019233988375, 0.421510777305010})
+                    az_f = new Filter(period=100, b = {0.229019233988375, 0.421510777305010})
                   }
                   """),
           List.of(
@@ -165,10 +165,9 @@ public class LffCliTest {
 
                   reactor MACService {
                     mul_cm = new ContextManager<
-                      loooooooooooooooooooooooooooooong,
-                      looooooooooooooong,
-                      loooooooooooooong
-                    >()
+                        loooooooooooooooooooooooooooooong,
+                        looooooooooooooong,
+                        loooooooooooooong>()
                   }
                   """));
 

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -489,7 +489,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     }
     msb.append("state ").append(object.getName());
     msb.append(typeAnnotationFor(object.getType()));
-    if (object.getInit() != null) msb.append(doSwitch(object.getInit()));
+    if (object.getInit() != null) msb.append(doSwitch(object.getInit()).transform(ToLf::whitespaceInitializer));
 
     return msb.get();
   }
@@ -886,7 +886,8 @@ public class ToLf extends LfSwitch<MalleableString> {
     // ));
     Builder msb = new Builder();
     msb.append(object.getLhs().getName());
-    msb.append(doSwitch(object.getRhs()));
+    var rhs = doSwitch(object.getRhs());
+    msb.append(rhs.transform(conditionalWhitespaceInitializer(MalleableString.anyOf(""), rhs)));
     return msb.get();
   }
 
@@ -907,12 +908,12 @@ public class ToLf extends LfSwitch<MalleableString> {
     if (shouldOutputAsAssignment(init)) {
       Expression expr = ASTUtils.asSingleExpr(init);
       Objects.requireNonNull(expr);
-      return new Builder().append(" = ").append(doSwitch(expr)).get();
+      return new Builder().append("=").append(doSwitch(expr)).get();
     }
     if (ASTUtils.getTarget(init) == Target.C) {
       // This turns C array initializers into a braced expression.
       // C++ variants are not converted.
-      return new Builder().append(" = ").append(bracedListExpression(init.getExprs())).get();
+      return new Builder().append("=").append(bracedListExpression(init.getExprs())).get();
     }
     String prefix;
     String suffix;
@@ -935,11 +936,23 @@ public class ToLf extends LfSwitch<MalleableString> {
     // )?
     var builder = new Builder();
     addAttributes(builder, object::getAttributes);
+    var annotation = typeAnnotationFor(object.getType());
+    var init = doSwitch(object.getInit());
     return builder
         .append(object.getName())
-        .append(typeAnnotationFor(object.getType()))
-        .append(doSwitch(object.getInit()))
+        .append(annotation)
+        .append(init.transform(conditionalWhitespaceInitializer(annotation, init)))
         .get();
+  }
+
+  /** Ensure that equals signs are surrounded by spaces if neither the text before nor the text after has spaces and is not a string. */
+  private static Function<String, String> conditionalWhitespaceInitializer(MalleableString before, MalleableString after) {
+    return it -> before.isEmpty() && !(after.toString().contains(" ") || after.toString().startsWith("\"")) ? it : whitespaceInitializer(it);
+  }
+
+  /** Ensure that equals signs are surrounded by spaces. */
+  private static String whitespaceInitializer(String s) {
+    return s.replaceAll("(?<! )=(?! )", " = ");
   }
 
   @Override

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -100,7 +100,7 @@ public class ToLf extends LfSwitch<MalleableString> {
   @Override
   public MalleableString caseArraySpec(ArraySpec spec) {
     if (spec.isOfVariableLength()) return MalleableString.anyOf("[]");
-    return list("", "[", "]", false, false, spec.getLength());
+    return list("", "[", "]", false, false, true, spec.getLength());
   }
 
   @Override
@@ -308,7 +308,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     } else if (type.getId() != null) {
       msb.append(type.getId()); // TODO: Multiline dottedName?
       if (type.getTypeArgs() != null) {
-        msb.append(list(", ", "<", ">", true, false, type.getTypeArgs()));
+        msb.append(list(", ", "<", ">", true, false, true, type.getTypeArgs()));
       }
       msb.append("*".repeat(type.getStars().size()));
     }
@@ -362,7 +362,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     return new Builder()
         .append("import ")
         // TODO: This is a place where we can use conditional parentheses.
-        .append(list(", ", "", "", false, true, object.getReactorClasses()))
+        .append(list(", ", "", "", false, true, true, object.getReactorClasses()))
         .append(" from \"")
         .append(object.getImportURI())
         .append("\"")
@@ -444,7 +444,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     if (object.isRealtime()) msb.append("realtime ");
     msb.append("reactor");
     if (object.getName() != null) msb.append(" ").append(object.getName());
-    msb.append(list(", ", "<", ">", true, false, object.getTypeParms()));
+    msb.append(list(", ", "<", ">", true, false, true, object.getTypeParms()));
     msb.append(list(true, object.getParameters()));
     if (object.getHost() != null) msb.append(" at ").append(doSwitch(object.getHost()));
     if (object.getSuperClasses() != null && !object.getSuperClasses().isEmpty()) {
@@ -619,7 +619,7 @@ public class ToLf extends LfSwitch<MalleableString> {
       msb.append("reaction");
     }
     msb.append(list(true, object.getTriggers()));
-    msb.append(list(", ", " ", "", true, false, object.getSources()));
+    msb.append(list(", ", " ", "", true, false, true, object.getSources()));
     if (!object.getEffects().isEmpty()) {
       List<Mode> allModes = ASTUtils.allModes(ASTUtils.getEnclosingReactor(object));
       msb.append(" -> ", " ->\n")
@@ -737,7 +737,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     msb.append(object.getName()).append(" = new");
     if (object.getWidthSpec() != null) msb.append(doSwitch(object.getWidthSpec()));
     msb.append(" ").append(object.getReactorClass().getName());
-    msb.append(list(", ", "<", ">", true, false, object.getTypeArgs()));
+    msb.append(list(", ", "<", ">", true, false, true, object.getTypeArgs()));
     msb.append(list(false, object.getParameters()));
     // TODO: Delete the following case when the corresponding feature is removed
     if (object.getHost() != null) msb.append(" at ").append(doSwitch(object.getHost())).append(";");
@@ -788,10 +788,10 @@ public class ToLf extends LfSwitch<MalleableString> {
 
   private MalleableString minimallyDelimitedList(List<? extends EObject> items) {
     return MalleableString.anyOf(
-        list(", ", " ", "", true, true, items),
+        list(", ", " ", "", true, true, true, items),
         new Builder()
             .append(String.format("%n"))
-            .append(list(String.format(",%n"), "", "", true, true, items).indent())
+            .append(list(String.format(",%n"), "", "", true, true, true, items).indent())
             .get());
   }
 
@@ -809,7 +809,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     }
     return new Builder()
         .append("{\n")
-        .append(list(",\n", "", "\n", true, true, object.getPairs()).indent())
+        .append(list(",\n", "", "\n", true, true, false, object.getPairs()).indent())
         .append("}")
         .get();
   }
@@ -829,7 +829,7 @@ public class ToLf extends LfSwitch<MalleableString> {
   private MalleableString bracedListExpression(List<Expression> items) {
     // Note that this strips the trailing comma. There is no way
     // to implement trailing commas with the current set of list() methods AFAIU.
-    return list(", ", "{", "}", false, false, items);
+    return list(", ", "{", "}", false, false, true, items);
   }
 
   @Override
@@ -845,7 +845,7 @@ public class ToLf extends LfSwitch<MalleableString> {
   @Override
   public MalleableString caseArray(Array object) {
     // '[' elements+=Element (',' (elements+=Element))* ','? ']'
-    return list(", ", "[", "]", false, false, object.getElements());
+    return list(", ", "[", "]", false, false, true, object.getElements());
   }
 
   @Override
@@ -924,7 +924,7 @@ public class ToLf extends LfSwitch<MalleableString> {
       prefix = "(";
       suffix = ")";
     }
-    return list(", ", prefix, suffix, false, false, init.getExprs());
+    return list(", ", prefix, suffix, false, false, true, init.getExprs());
   }
 
   @Override
@@ -961,7 +961,7 @@ public class ToLf extends LfSwitch<MalleableString> {
   public MalleableString caseWidthSpec(WidthSpec object) {
     // ofVariableLength?='[]' | '[' (terms+=WidthTerm) ('+' terms+=WidthTerm)* ']';
     if (object.isOfVariableLength()) return MalleableString.anyOf("[]");
-    return list(" + ", "[", "]", false, false, object.getTerms());
+    return list(" + ", "[", "]", false, false, true, object.getTerms());
   }
 
   @Override
@@ -1025,6 +1025,7 @@ public class ToLf extends LfSwitch<MalleableString> {
       String suffix,
       boolean nothingIfEmpty,
       boolean whitespaceRigid,
+      boolean suffixSameLine,
       List<E> items) {
     return list(
         separator,
@@ -1032,6 +1033,7 @@ public class ToLf extends LfSwitch<MalleableString> {
         suffix,
         nothingIfEmpty,
         whitespaceRigid,
+        suffixSameLine,
         (Object[]) items.toArray(EObject[]::new));
   }
 
@@ -1041,9 +1043,10 @@ public class ToLf extends LfSwitch<MalleableString> {
       String suffix,
       boolean nothingIfEmpty,
       boolean whitespaceRigid,
+      boolean suffixSameLine,
       Object... items) {
-    if (nothingIfEmpty && Arrays.stream(items).allMatch(Objects::isNull)) {
-      return MalleableString.anyOf("");
+    if (Arrays.stream(items).allMatch(Objects::isNull)) {
+      return MalleableString.anyOf(nothingIfEmpty ? "" : prefix + suffix);
     }
     MalleableString rigid =
         Arrays.stream(items)
@@ -1057,21 +1060,22 @@ public class ToLf extends LfSwitch<MalleableString> {
                 })
             .collect(new Joiner(separator, prefix, suffix));
     if (whitespaceRigid) return rigid;
+    var rigidList = list(separator.strip() + "\n", "", suffixSameLine ? "" : "\n", nothingIfEmpty, true, suffixSameLine, items);
     return MalleableString.anyOf(
         rigid,
         new Builder()
             .append(prefix.stripTrailing() + "\n")
-            .append(list(separator.strip() + "\n", "", "\n", nothingIfEmpty, true, items).indent())
+            .append(suffixSameLine ? rigidList.indent().indent() : rigidList.indent())
             .append(suffix.stripLeading())
             .get());
   }
 
   private <E extends EObject> MalleableString list(boolean nothingIfEmpty, EList<E> items) {
-    return list(", ", "(", ")", nothingIfEmpty, false, items);
+    return list(", ", "(", ")", nothingIfEmpty, false, true, items);
   }
 
   private MalleableString list(boolean nothingIfEmpty, Object... items) {
-    return list(", ", "(", ")", nothingIfEmpty, false, items);
+    return list(", ", "(", ")", nothingIfEmpty, false, true, items);
   }
 
   private MalleableString typeAnnotationFor(Type type) {

--- a/test/C/src/ArrayAsParameter.lf
+++ b/test/C/src/ArrayAsParameter.lf
@@ -40,7 +40,7 @@ reactor Print {
 }
 
 main reactor ArrayAsParameter {
-  s = new Source(sequence = {1, 2, 3, 4}, n_sequence = 4)
+  s = new Source(sequence = {1, 2, 3, 4}, n_sequence=4)
   p = new Print()
   s.out -> p.in
 }

--- a/test/C/src/ArrayFree.lf
+++ b/test/C/src/ArrayFree.lf
@@ -24,7 +24,7 @@ main reactor ArrayFree {
   s = new Source()
   c = new Free()
   c2 = new Scale()
-  p = new Print(scale = 2)
+  p = new Print(scale=2)
   s.out -> c.in
   s.out -> c2.in
   c2.out -> p.in

--- a/test/C/src/ArrayFreeMultiple.lf
+++ b/test/C/src/ArrayFreeMultiple.lf
@@ -40,7 +40,7 @@ main reactor ArrayFreeMultiple {
   s = new Source()
   c = new Free()
   c2 = new Scale()
-  p = new Print(scale = 2)
+  p = new Print(scale=2)
   s.out -> c.in
   s.out -> c2.in
   c2.out -> p.in

--- a/test/C/src/ArrayParallel.lf
+++ b/test/C/src/ArrayParallel.lf
@@ -12,9 +12,9 @@ import Source, Print from "ArrayPrint.lf"
 main reactor ArrayParallel {
   s = new Source()
   c1 = new Scale()
-  c2 = new Scale(scale = 3)
-  p1 = new Print(scale = 2)
-  p2 = new Print(scale = 3)
+  c2 = new Scale(scale=3)
+  p1 = new Print(scale=2)
+  p2 = new Print(scale=3)
   s.out -> c1.in
   s.out -> c2.in
   c1.out -> p1.in

--- a/test/C/src/ArrayScale.lf
+++ b/test/C/src/ArrayScale.lf
@@ -23,7 +23,7 @@ reactor Scale(scale: int = 2) {
 main reactor ArrayScale {
   s = new Source()
   c = new Scale()
-  p = new Print(scale = 2)
+  p = new Print(scale=2)
   s.out -> c.in
   c.out -> p.in
 }

--- a/test/C/src/CountSelf.lf
+++ b/test/C/src/CountSelf.lf
@@ -23,6 +23,6 @@ reactor CountSelf2(delay: time = 100 msec) {
 
 main reactor {
   d = new CountSelf2()
-  t = new TestCount(num_inputs = 11, start = 0)
+  t = new TestCount(num_inputs=11, start=0)
   d.out -> t.in
 }

--- a/test/C/src/CountTest.lf
+++ b/test/C/src/CountTest.lf
@@ -9,6 +9,6 @@ import TestCount from "lib/TestCount.lf"
 
 main reactor CountTest {
   count = new Count()
-  test = new TestCount(num_inputs = 4)
+  test = new TestCount(num_inputs=4)
   count.out -> test.in
 }

--- a/test/C/src/Hello.lf
+++ b/test/C/src/Hello.lf
@@ -46,7 +46,7 @@ reactor Reschedule(period: time = 2 sec, message: string = "Hello C") {
 }
 
 reactor Inside(period: time = 1 sec, message: string = "Composite default message.") {
-  third_instance = new Reschedule(period = period, message = message)
+  third_instance = new Reschedule(period=period, message=message)
 }
 
 main reactor Hello {

--- a/test/C/src/NativeListsAndTimes.lf
+++ b/test/C/src/NativeListsAndTimes.lf
@@ -2,13 +2,13 @@ target C
 
 // This test passes if it is successfully compiled into valid target code.
 main reactor(
-  x: int = 0,
-  y: time = 0,                  // Units are missing but not required
-  z = 1 msec,                   // Type is missing but not required
-  p: int[] = {1, 2, 3, 4},      // List of integers
-  q: interval_t[] = {1 msec, 2 msec, 3 msec},  // list of time values
-  g: time[] = {1 msec, 2 msec}  // List of time values
-) {
+    x: int = 0,
+    y: time = 0,                  // Units are missing but not required
+    z = 1 msec,                   // Type is missing but not required
+    p: int[] = {1, 2, 3, 4},      // List of integers
+    q: interval_t[] = {1 msec, 2 msec, 3 msec},  // list of time values
+    // List of time values
+    g: time[] = {1 msec, 2 msec}) {
   state s: time = y  // Reference to explicitly typed time parameter
   state t: time = z  // Reference to implicitly typed time parameter
   state v: bool      // Uninitialized boolean state variable

--- a/test/C/src/ParameterHierarchy.lf
+++ b/test/C/src/ParameterHierarchy.lf
@@ -12,13 +12,13 @@ reactor Deep(p0: int = 0) {
 }
 
 reactor Intermediate(p1: int = 10) {
-  a0 = new Deep(p0 = p1)
+  a0 = new Deep(p0=p1)
 }
 
 reactor Another(p2: int = 20) {
-  a1 = new Intermediate(p1 = p2)
+  a1 = new Intermediate(p1=p2)
 }
 
 main reactor ParameterHierarchy {
-  a2 = new Another(p2 = 42)
+  a2 = new Another(p2=42)
 }

--- a/test/C/src/RepeatedInheritance.lf
+++ b/test/C/src/RepeatedInheritance.lf
@@ -33,7 +33,7 @@ reactor A extends B, C {
 main reactor {
   c = new Count()
   a = new A()
-  t = new TestCount(start = 4, stride = 4, num_inputs = 6)
+  t = new TestCount(start=4, stride=4, num_inputs=6)
   (c.out)+ -> a.a, a.b, a.c, a.d
   a.out -> t.in
 }

--- a/test/C/src/Stride.lf
+++ b/test/C/src/Stride.lf
@@ -30,7 +30,7 @@ reactor Display {
 }
 
 main reactor Stride {
-  c = new Count(stride = 2)
+  c = new Count(stride=2)
   d = new Display()
   c.y -> d.x
 }

--- a/test/C/src/StructParallel.lf
+++ b/test/C/src/StructParallel.lf
@@ -48,9 +48,9 @@ reactor Print(scale: int = 2) {
 main reactor StructParallel {
   s = new Source()
   c1 = new Print()
-  c2 = new Print(scale = 3)
-  p1 = new Check(expected = 84)
-  p2 = new Check(expected = 126)
+  c2 = new Print(scale=3)
+  p1 = new Check(expected=84)
+  p2 = new Check(expected=126)
   s.out -> c1.in
   s.out -> c2.in
   c1.out -> p1.in

--- a/test/C/src/StructScale.lf
+++ b/test/C/src/StructScale.lf
@@ -58,7 +58,7 @@ reactor Print(scale: int = 2) {
 main reactor StructScale {
   s = new Source()
   c = new Print()
-  p = new TestInput(expected = 84)
+  p = new TestInput(expected=84)
   s.out -> c.in
   c.out -> p.in
 }

--- a/test/C/src/TimeLimit.lf
+++ b/test/C/src/TimeLimit.lf
@@ -40,7 +40,7 @@ reactor Destination {
 
 main reactor TimeLimit(period: time = 1 sec) {
   timer stop(10 sec)
-  c = new Clock(period = period)
+  c = new Clock(period=period)
   d = new Destination()
   c.y -> d.x
 

--- a/test/C/src/concurrent/HelloThreaded.lf
+++ b/test/C/src/concurrent/HelloThreaded.lf
@@ -46,7 +46,7 @@ reactor Reschedule(period: time = 2 sec, message: string = "Hello C") {
 }
 
 reactor Inside(period: time = 1 sec, message: string = "Composite default message.") {
-  third_instance = new Reschedule(period = period, message = message)
+  third_instance = new Reschedule(period=period, message=message)
 }
 
 main reactor HelloThreaded {

--- a/test/C/src/concurrent/ScheduleAt.lf
+++ b/test/C/src/concurrent/ScheduleAt.lf
@@ -23,36 +23,34 @@ reactor Scheduler {
   state microstep_delay_list: uint32_t[] = {0, 1, 1, 2, 2, 0, 0, 1, 1, 0, 2, 3, 3, 4, 4, 5}
 
   state times: int[] = {
-    0,
-    0,
-    0,
-    0,
-    0,
-    400 msec,
-    400 msec,
-    400 msec,
-    400 msec,  // List of the corresponding times. Size = 16
-    800 msec,
-    800 msec,
-    800 msec,
-    800 msec,
-    900 msec,
-    900 msec,
-    900 msec
-  }
+      0,
+      0,
+      0,
+      0,
+      0,
+      400 msec,
+      400 msec,
+      400 msec,
+      400 msec,  // List of the corresponding times. Size = 16
+      800 msec,
+      800 msec,
+      800 msec,
+      800 msec,
+      900 msec,
+      900 msec,
+      900 msec}
   // Size = 9
   state action_hit_list_microstep: int[] = {1, 2, 0, 1, 0, 2, 3, 4, 5}
   state action_hit_list_times: int[] = {
-    0,
-    0,
-    400 msec,
-    400 msec,
-    800 msec,
-    800 msec,
-    800 msec,
-    900 msec,
-    900 msec
-  }
+      0,
+      0,
+      400 msec,
+      400 msec,
+      800 msec,
+      800 msec,
+      800 msec,
+      900 msec,
+      900 msec}
   // Size = 9
   state action_hit_list_index: int = 0
 

--- a/test/C/src/concurrent/Threaded.lf
+++ b/test/C/src/concurrent/Threaded.lf
@@ -59,6 +59,6 @@ main reactor(width: int = 4) {
   a = new Source()
   t = new[width] TakeTime()
   (a.out)+ -> t.in
-  b = new Destination(width = width)
+  b = new Destination(width=width)
   t.out -> b.in
 }

--- a/test/C/src/concurrent/ThreadedMultiport.lf
+++ b/test/C/src/concurrent/ThreadedMultiport.lf
@@ -61,9 +61,9 @@ reactor Destination(width: int = 4, iterations: int = 100000000) {
 }
 
 main reactor ThreadedMultiport(width: int = 4, iterations: int = 100000000) {
-  a = new Source(width = width)
-  t = new[width] Computation(iterations = iterations)
-  b = new Destination(width = width, iterations = iterations)
+  a = new Source(width=width)
+  t = new[width] Computation(iterations=iterations)
+  b = new Destination(width=width, iterations=iterations)
   a.out -> t.in
   t.out -> b.in
 }

--- a/test/C/src/concurrent/ThreadedThreaded.lf
+++ b/test/C/src/concurrent/ThreadedThreaded.lf
@@ -59,6 +59,6 @@ main reactor ThreadedThreaded(width: int = 4) {
   a = new Source()
   t = new[width] TakeTime()
   (a.out)+ -> t.in
-  b = new Destination(width = width)
+  b = new Destination(width=width)
   t.out -> b.in
 }

--- a/test/C/src/concurrent/TimeLimitThreaded.lf
+++ b/test/C/src/concurrent/TimeLimitThreaded.lf
@@ -40,7 +40,7 @@ reactor Destination {
 
 main reactor(period: time = 1 sec) {
   timer stop(10 sec)
-  c = new Clock(period = period)
+  c = new Clock(period=period)
   d = new Destination()
   c.y -> d.x
 

--- a/test/C/src/concurrent/Tracing.lf
+++ b/test/C/src/concurrent/Tracing.lf
@@ -93,6 +93,6 @@ main reactor(width: int = 4) {
   a = new Source()
   t = new[width] TakeTime()
   (a.out)+ -> t.in
-  b = new Destination(width = width)
+  b = new Destination(width=width)
   t.out -> b.in
 }

--- a/test/C/src/federated/ChainWithDelay.lf
+++ b/test/C/src/federated/ChainWithDelay.lf
@@ -14,7 +14,7 @@ import TestCount from "../lib/TestCount.lf"
 federated reactor {
   c = new Count(period = 1 msec)
   i = new InternalDelay(delay = 500 usec)
-  t = new TestCount(num_inputs = 3)
+  t = new TestCount(num_inputs=3)
   c.out -> i.in
   i.out -> t.in
 }

--- a/test/C/src/federated/DecentralizedP2PComm.lf
+++ b/test/C/src/federated/DecentralizedP2PComm.lf
@@ -41,8 +41,8 @@ reactor Platform(start: int = 0, expected_start: int = 0, stp_offset_param: time
 }
 
 federated reactor DecentralizedP2PComm {
-  a = new Platform(expected_start = 100, stp_offset_param = 10 msec)
-  b = new Platform(start = 100, stp_offset_param = 10 msec)
+  a = new Platform(expected_start=100, stp_offset_param = 10 msec)
+  b = new Platform(start=100, stp_offset_param = 10 msec)
   a.out -> b.in
   b.out -> a.in
 }

--- a/test/C/src/federated/DecentralizedP2PUnbalancedTimeout.lf
+++ b/test/C/src/federated/DecentralizedP2PUnbalancedTimeout.lf
@@ -46,7 +46,7 @@ reactor Destination {
 }
 
 federated reactor(period: time = 10 usec) {
-  c = new Clock(period = period)
+  c = new Clock(period=period)
   d = new Destination()
   c.y -> d.x
 }

--- a/test/C/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
+++ b/test/C/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
@@ -44,7 +44,7 @@ reactor Destination {
 }
 
 federated reactor(period: time = 10 usec) {
-  c = new Clock(period = period)
+  c = new Clock(period=period)
   d = new Destination()
   c.y ~> d.x
 }

--- a/test/C/src/federated/DistributedCountPhysicalAfterDelay.lf
+++ b/test/C/src/federated/DistributedCountPhysicalAfterDelay.lf
@@ -44,7 +44,7 @@ reactor Print {
 }
 
 federated reactor at localhost {
-  c = new Count(offset = 200 msec, period = 0)
+  c = new Count(offset = 200 msec, period=0)
   p = new Print()
   c.out ~> p.in after 400 msec  // Indicating a 'physical' connection with a 400 msec after delay.
 }

--- a/test/C/src/federated/DistributedLogicalActionUpstreamLong.lf
+++ b/test/C/src/federated/DistributedLogicalActionUpstreamLong.lf
@@ -23,7 +23,7 @@ reactor WithLogicalAction {
 
 federated reactor {
   a = new WithLogicalAction()
-  test = new TestCount(num_inputs = 21)
+  test = new TestCount(num_inputs=21)
 
   passThroughs1 = new PassThrough()
   passThroughs2 = new PassThrough()

--- a/test/C/src/federated/DistributedLoopedActionDecentralized.lf
+++ b/test/C/src/federated/DistributedLoopedActionDecentralized.lf
@@ -75,13 +75,12 @@ reactor Receiver(take_a_break_after: int = 10, break_interval: time = 400 msec) 
 }
 
 reactor STPReceiver(
-  take_a_break_after: int = 10,
-  break_interval: time = 400 msec,
-  stp_offset: time = 0
-) {
+    take_a_break_after: int = 10,
+    break_interval: time = 400 msec,
+    stp_offset: time = 0) {
   input in: int
   state last_time_updated_stp: time = 0
-  receiver = new Receiver(take_a_break_after = 10, break_interval = 400 msec)
+  receiver = new Receiver(take_a_break_after=10, break_interval = 400 msec)
   timer t(0, 1 msec)  // Force advancement of logical time
 
   reaction(in) -> receiver.in {=
@@ -110,8 +109,8 @@ reactor STPReceiver(
 }
 
 federated reactor DistributedLoopedActionDecentralized {
-  sender = new Sender(take_a_break_after = 10, break_interval = 400 msec)
-  stpReceiver = new STPReceiver(take_a_break_after = 10, break_interval = 400 msec)
+  sender = new Sender(take_a_break_after=10, break_interval = 400 msec)
+  stpReceiver = new STPReceiver(take_a_break_after=10, break_interval = 400 msec)
 
   sender.out -> stpReceiver.in
 }

--- a/test/C/src/federated/DistributedPhysicalActionUpstream.lf
+++ b/test/C/src/federated/DistributedPhysicalActionUpstream.lf
@@ -51,7 +51,7 @@ federated reactor {
   a = new WithPhysicalAction()
   m1 = new PassThrough()
   m2 = new PassThrough()
-  test = new TestCount(num_inputs = 14)
+  test = new TestCount(num_inputs=14)
   a.out -> m1.in
   m1.out -> m2.in
   m2.out -> test.in

--- a/test/C/src/federated/DistributedPhysicalActionUpstreamLong.lf
+++ b/test/C/src/federated/DistributedPhysicalActionUpstreamLong.lf
@@ -48,7 +48,7 @@ reactor WithPhysicalAction {
 
 federated reactor {
   a = new WithPhysicalAction()
-  test = new TestCount(num_inputs = 19)
+  test = new TestCount(num_inputs=19)
 
   passThroughs1 = new PassThrough()
   passThroughs2 = new PassThrough()

--- a/test/C/src/federated/DistributedStop.lf
+++ b/test/C/src/federated/DistributedStop.lf
@@ -62,8 +62,8 @@ reactor Sender {
 }
 
 reactor Receiver(
-  stp_offset: time = 10 msec  // Used in the decentralized variant of the test
-) {
+    // Used in the decentralized variant of the test
+    stp_offset: time = 10 msec) {
   input in: int
   state reaction_invoked_correctly: bool = false
 

--- a/test/C/src/federated/LevelPattern.lf
+++ b/test/C/src/federated/LevelPattern.lf
@@ -37,7 +37,7 @@ reactor A {
 
 federated reactor {
   c = new Count()
-  test = new TestCount(num_inputs = 2)
+  test = new TestCount(num_inputs=2)
   b = new A()
   t = new Through()
 

--- a/test/C/src/federated/LoopDistributedCentralized.lf
+++ b/test/C/src/federated/LoopDistributedCentralized.lf
@@ -43,7 +43,7 @@ reactor Looper(incr: int = 1, delay: time = 0 msec) {
 
 federated reactor LoopDistributedCentralized(delay: time = 0) {
   left = new Looper()
-  right = new Looper(incr = -1)
+  right = new Looper(incr=-1)
   left.out -> right.in
   right.out -> left.in
 }

--- a/test/C/src/federated/LoopDistributedCentralized2.lf
+++ b/test/C/src/federated/LoopDistributedCentralized2.lf
@@ -70,7 +70,7 @@ reactor Looper2(incr: int = 1, delay: time = 0 msec) {
 
 federated reactor(delay: time = 0) {
   left = new Looper()
-  right = new Looper2(incr = -1)
+  right = new Looper2(incr=-1)
   left.out -> right.in
   right.out -> left.in
 }

--- a/test/C/src/federated/LoopDistributedCentralizedPhysicalAction.lf
+++ b/test/C/src/federated/LoopDistributedCentralizedPhysicalAction.lf
@@ -67,7 +67,7 @@ reactor Looper(incr: int = 1, delay: time = 0 msec) {
 
 federated reactor(delay: time = 0) {
   left = new Looper()
-  right = new Looper(incr = -1)
+  right = new Looper(incr=-1)
   left.out -> right.in
   right.out -> left.in
 }

--- a/test/C/src/federated/LoopDistributedCentralizedPrecedence.lf
+++ b/test/C/src/federated/LoopDistributedCentralizedPrecedence.lf
@@ -50,7 +50,7 @@ reactor Looper(incr: int = 1, delay: time = 0 msec) {
 
 federated reactor(delay: time = 0) {
   left = new Looper()
-  right = new Looper(incr = -1)
+  right = new Looper(incr=-1)
   left.out -> right.in
   right.out -> left.in
 }

--- a/test/C/src/federated/LoopDistributedCentralizedPrecedenceHierarchy.lf
+++ b/test/C/src/federated/LoopDistributedCentralizedPrecedenceHierarchy.lf
@@ -37,7 +37,7 @@ reactor Looper(incr: int = 1, delay: time = 0 msec) {
   state count: int = 0
   timer t(0, 1 sec)
 
-  c = new Contained(incr = incr)
+  c = new Contained(incr=incr)
   in -> c.in
 
   reaction(t) -> out {=
@@ -63,7 +63,7 @@ reactor Looper(incr: int = 1, delay: time = 0 msec) {
 
 federated reactor(delay: time = 0) {
   left = new Looper()
-  right = new Looper(incr = -1)
+  right = new Looper(incr=-1)
   left.out -> right.in
   right.out -> left.in
 }

--- a/test/C/src/federated/LoopDistributedDecentralized.lf
+++ b/test/C/src/federated/LoopDistributedDecentralized.lf
@@ -74,7 +74,7 @@ reactor Looper(incr: int = 1, delay: time = 0 msec, stp_offset: time = 0) {
 
 federated reactor LoopDistributedDecentralized(delay: time = 0) {
   left = new Looper(stp_offset = 900 usec)
-  right = new Looper(incr = -1, stp_offset = 2400 usec)
+  right = new Looper(incr=-1, stp_offset = 2400 usec)
   left.out -> right.in
   right.out -> left.in
 }

--- a/test/C/src/federated/LoopDistributedDouble.lf
+++ b/test/C/src/federated/LoopDistributedDouble.lf
@@ -90,7 +90,7 @@ reactor Looper(incr: int = 1, delay: time = 0 msec) {
 
 federated reactor(delay: time = 0) {
   left = new Looper()
-  right = new Looper(incr = -1)
+  right = new Looper(incr=-1)
   left.out -> right.in
   right.out -> left.in
   right.out2 -> left.in2

--- a/test/C/src/federated/ParallelDestinations.lf
+++ b/test/C/src/federated/ParallelDestinations.lf
@@ -16,8 +16,8 @@ reactor Source {
 
 federated reactor {
   s = new Source()
-  t1 = new TestCount(num_inputs = 3)
-  t2 = new TestCount(num_inputs = 3)
+  t1 = new TestCount(num_inputs=3)
+  t2 = new TestCount(num_inputs=3)
 
   s.out -> t1.in, t2.in
 }

--- a/test/C/src/federated/ParallelSources.lf
+++ b/test/C/src/federated/ParallelSources.lf
@@ -9,8 +9,8 @@ import TestCount from "../lib/TestCount.lf"
 reactor Destination {
   input[2] in: int
 
-  t1 = new TestCount(num_inputs = 3)
-  t2 = new TestCount(num_inputs = 3)
+  t1 = new TestCount(num_inputs=3)
+  t2 = new TestCount(num_inputs=3)
 
   in -> t1.in, t2.in
 }

--- a/test/C/src/federated/ParallelSourcesMultiport.lf
+++ b/test/C/src/federated/ParallelSourcesMultiport.lf
@@ -17,9 +17,9 @@ reactor Source {
 reactor Destination1 {
   input[3] in: int
 
-  t1 = new TestCount(num_inputs = 3)
-  t2 = new TestCount(num_inputs = 3)
-  t3 = new TestCount(num_inputs = 3)
+  t1 = new TestCount(num_inputs=3)
+  t2 = new TestCount(num_inputs=3)
+  t3 = new TestCount(num_inputs=3)
 
   in -> t1.in, t2.in, t3.in
 }
@@ -28,7 +28,7 @@ federated reactor {
   s1 = new Source()
   s2 = new Source()
   d1 = new Destination1()
-  t4 = new TestCount(num_inputs = 3)
+  t4 = new TestCount(num_inputs=3)
 
   s1.out, s2.out -> d1.in, t4.in
 }

--- a/test/C/src/federated/PingPongDistributed.lf
+++ b/test/C/src/federated/PingPongDistributed.lf
@@ -21,8 +21,8 @@ target C
 import Ping, Pong from "PingPongDistributedPhysical.lf"
 
 federated reactor(count: int = 10) {
-  ping = new Ping(count = count)
-  pong = new Pong(expected = count)
+  ping = new Ping(count=count)
+  pong = new Pong(expected=count)
   ping.send -> pong.receive
   pong.send -> ping.receive
 }

--- a/test/C/src/federated/PingPongDistributedPhysical.lf
+++ b/test/C/src/federated/PingPongDistributedPhysical.lf
@@ -70,8 +70,8 @@ reactor Pong(expected: int = 10) {
 }
 
 federated reactor(count: int = 10) {
-  ping = new Ping(count = count)
-  pong = new Pong(expected = count)
+  ping = new Ping(count=count)
+  pong = new Pong(expected=count)
   ping.send ~> pong.receive
   pong.send ~> ping.receive
 }

--- a/test/C/src/generics/TypeCheck.lf
+++ b/test/C/src/generics/TypeCheck.lf
@@ -39,6 +39,6 @@ reactor TestCount<T>(start: int = 1, num_inputs: int = 1) {
 
 main reactor {
   count = new Count<int>()
-  testcount = new TestCount<int>(num_inputs = 4)
+  testcount = new TestCount<int>(num_inputs=4)
   count.out -> testcount.in
 }

--- a/test/C/src/modal_models/ModalAfter.lf
+++ b/test/C/src/modal_models/ModalAfter.lf
@@ -19,8 +19,8 @@ reactor Modal {
   output consumed2: int
 
   initial mode One {
-    producer1 = new Producer(mode_id = 1)
-    consumer1 = new Consumer(mode_id = 1)
+    producer1 = new Producer(mode_id=1)
+    consumer1 = new Consumer(mode_id=1)
     producer1.product -> produced1
     producer1.product -> consumer1.product after 500 msec
     consumer1.report -> consumed1
@@ -32,8 +32,8 @@ reactor Modal {
   }
 
   mode Two {
-    producer2 = new Producer(mode_id = 2)
-    consumer2 = new Consumer(mode_id = 2)
+    producer2 = new Producer(mode_id=2)
+    consumer2 = new Consumer(mode_id=2)
     producer2.product -> produced2
     producer2.product -> consumer2.product after 500 msec
     consumer2.report -> consumed2

--- a/test/C/src/modal_models/util/TraceTesting.lf
+++ b/test/C/src/modal_models/util/TraceTesting.lf
@@ -2,11 +2,10 @@
 target C
 
 reactor TraceTesting(
-  events_size: int = 0,
-  trace_size: int = 0,
-  trace: int[] = 0,
-  training: bool = false
-) {
+    events_size: int = 0,
+    trace_size: int = 0,
+    trace: int[] = 0,
+    training: bool = false) {
   input[events_size] events: int
 
   state last_reaction_time: int = 0

--- a/test/C/src/multiport/BankIndexInitializer.lf
+++ b/test/C/src/multiport/BankIndexInitializer.lf
@@ -36,6 +36,6 @@ reactor Sink(width: int = 4) {
 
 main reactor(width: int = 4) {
   source = new[width] Source(value = {= table[bank_index] =})
-  sink = new Sink(width = width)
+  sink = new Sink(width=width)
   source.out -> sink.in
 }

--- a/test/C/src/multiport/BankMulticast.lf
+++ b/test/C/src/multiport/BankMulticast.lf
@@ -17,7 +17,7 @@ reactor Foo {
   c = new Count()
   c.out -> out
 
-  d = new TestCount(num_inputs = 4)
+  d = new TestCount(num_inputs=4)
   in -> d.in
 }
 
@@ -33,6 +33,6 @@ reactor Bar {
 main reactor {
   bar = new Bar()
 
-  d = new[4] TestCount(num_inputs = 4)
+  d = new[4] TestCount(num_inputs=4)
   bar.out -> d.in
 }

--- a/test/C/src/multiport/BankToBankMultiport.lf
+++ b/test/C/src/multiport/BankToBankMultiport.lf
@@ -43,7 +43,7 @@ reactor Destination(width: int = 1) {
 }
 
 main reactor BankToBankMultiport(bank_width: int = 4) {
-  a = new[bank_width] Source(width = 4)
-  b = new[bank_width] Destination(width = 4)
+  a = new[bank_width] Source(width=4)
+  b = new[bank_width] Destination(width=4)
   a.out -> b.in
 }

--- a/test/C/src/multiport/BankToBankMultiportAfter.lf
+++ b/test/C/src/multiport/BankToBankMultiportAfter.lf
@@ -43,7 +43,7 @@ reactor Destination(width: int = 1) {
 }
 
 main reactor(bank_width: int = 4) {
-  a = new[bank_width] Source(width = 4)
-  b = new[bank_width] Destination(width = 4)
+  a = new[bank_width] Source(width=4)
+  b = new[bank_width] Destination(width=4)
   a.out -> b.in after 200 msec
 }

--- a/test/C/src/multiport/BankToMultiport.lf
+++ b/test/C/src/multiport/BankToMultiport.lf
@@ -34,6 +34,6 @@ reactor Sink(width: int = 4) {
 
 main reactor BankToMultiport(width: int = 5) {
   source = new[width] Source()
-  sink = new Sink(width = width)
+  sink = new Sink(width=width)
   source.out -> sink.in
 }

--- a/test/C/src/multiport/BroadcastMultipleAfter.lf
+++ b/test/C/src/multiport/BroadcastMultipleAfter.lf
@@ -37,9 +37,9 @@ reactor Destination(bank_index: int = 0) {
 }
 
 main reactor {
-  a1 = new Source(value = 1)
-  a2 = new Source(value = 2)
-  a3 = new Source(value = 3)
+  a1 = new Source(value=1)
+  a2 = new Source(value=2)
+  a3 = new Source(value=3)
   b = new[9] Destination()
   (a1.out, a2.out, a3.out)+ -> b.in after 1 sec
 }

--- a/test/C/src/multiport/FullyConnected.lf
+++ b/test/C/src/multiport/FullyConnected.lf
@@ -36,6 +36,6 @@ reactor Node(num_nodes: size_t = 4, bank_index: int = 0) {
 }
 
 main reactor(num_nodes: size_t = 4) {
-  nodes = new[num_nodes] Node(num_nodes = num_nodes)
+  nodes = new[num_nodes] Node(num_nodes=num_nodes)
   (nodes.out)+ -> nodes.in
 }

--- a/test/C/src/multiport/FullyConnectedAddressable.lf
+++ b/test/C/src/multiport/FullyConnectedAddressable.lf
@@ -46,9 +46,9 @@ reactor Node(num_nodes: size_t = 4, bank_index: int = 0) {
 }
 
 main reactor(num_nodes: size_t = 4) {
-  nodes1 = new[num_nodes] Node(num_nodes = num_nodes)
+  nodes1 = new[num_nodes] Node(num_nodes=num_nodes)
   nodes1.out -> interleaved(nodes1.in)
 
-  nodes2 = new[num_nodes] Node(num_nodes = num_nodes)
+  nodes2 = new[num_nodes] Node(num_nodes=num_nodes)
   interleaved(nodes2.out) -> nodes2.in
 }

--- a/test/C/src/multiport/FullyConnectedAddressableAfter.lf
+++ b/test/C/src/multiport/FullyConnectedAddressableAfter.lf
@@ -4,9 +4,9 @@ target C
 import Node from "FullyConnectedAddressable.lf"
 
 main reactor(num_nodes: size_t = 4) {
-  nodes1 = new[num_nodes] Node(num_nodes = num_nodes)
+  nodes1 = new[num_nodes] Node(num_nodes=num_nodes)
   nodes1.out -> interleaved(nodes1.in) after 200 msec
 
-  nodes2 = new[num_nodes] Node(num_nodes = num_nodes)
+  nodes2 = new[num_nodes] Node(num_nodes=num_nodes)
   interleaved(nodes2.out) -> nodes2.in after 400 msec
 }

--- a/test/C/src/multiport/MultiportFromBank.lf
+++ b/test/C/src/multiport/MultiportFromBank.lf
@@ -36,7 +36,7 @@ reactor Destination(port_width: int = 3) {
 }
 
 main reactor MultiportFromBank(width: int = 4) {
-  a = new[width] Source(check_override = 1)
-  b = new Destination(port_width = width)
+  a = new[width] Source(check_override=1)
+  b = new Destination(port_width=width)
   a.out -> b.in
 }

--- a/test/C/src/multiport/MultiportFromBankHierarchy.lf
+++ b/test/C/src/multiport/MultiportFromBankHierarchy.lf
@@ -9,12 +9,12 @@ import Source, Destination from "MultiportFromBank.lf"
 
 reactor Container(port_width: int = 3) {
   output[port_width] out: int
-  s = new[port_width] Source(check_override = 1)
+  s = new[port_width] Source(check_override=1)
   s.out -> out
 }
 
 main reactor(width: int = 4) {
-  a = new Container(port_width = width)
-  b = new Destination(port_width = width)
+  a = new Container(port_width=width)
+  b = new Destination(port_width=width)
   a.out -> b.in
 }

--- a/test/C/src/multiport/MultiportFromBankHierarchyAfter.lf
+++ b/test/C/src/multiport/MultiportFromBankHierarchyAfter.lf
@@ -9,7 +9,7 @@ import Destination from "MultiportFromBank.lf"
 import Container from "MultiportFromBankHierarchy.lf"
 
 main reactor MultiportFromBankHierarchyAfter {
-  a = new Container(port_width = 4)
-  b = new Destination(port_width = 4)
+  a = new Container(port_width=4)
+  b = new Destination(port_width=4)
   a.out -> b.in after 1 sec
 }

--- a/test/C/src/multiport/MultiportFromHierarchy.lf
+++ b/test/C/src/multiport/MultiportFromHierarchy.lf
@@ -44,18 +44,18 @@ reactor Destination(width: int = 3) {
 
 reactor Container(width: int = 3) {
   output[width] out: int
-  src = new InsideContainer(width = width)
+  src = new InsideContainer(width=width)
   src.out -> out
 }
 
 reactor InsideContainer(width: int = 3) {
   output[width] out: int
-  src = new Source(width = width)
+  src = new Source(width=width)
   src.out -> out
 }
 
 main reactor MultiportFromHierarchy(width: int = 4) {
-  a = new Container(width = width)
-  b = new Destination(width = width)
+  a = new Container(width=width)
+  b = new Destination(width=width)
   a.out -> b.in
 }

--- a/test/C/src/multiport/MultiportFromReaction.lf
+++ b/test/C/src/multiport/MultiportFromReaction.lf
@@ -33,7 +33,7 @@ reactor Destination(width: int = 1) {
 main reactor MultiportFromReaction(width: int = 4) {
   timer t(0, 200 msec)
   state s: int = 0
-  b = new Destination(width = width)
+  b = new Destination(width=width)
 
   reaction(t) -> b.in {=
     for(int i = 0; i < b.in_width; i++) {

--- a/test/C/src/multiport/MultiportInParameterized.lf
+++ b/test/C/src/multiport/MultiportInParameterized.lf
@@ -55,7 +55,7 @@ main reactor {
   t2 = new Computation()
   t3 = new Computation()
   t4 = new Computation()
-  b = new Destination(width = 4)
+  b = new Destination(width=4)
   a.out -> t1.in
   a.out -> t2.in
   a.out -> t3.in

--- a/test/C/src/multiport/MultiportMutableInput.lf
+++ b/test/C/src/multiport/MultiportMutableInput.lf
@@ -43,7 +43,7 @@ reactor Scale(scale: int = 2) {
 main reactor {
   s = new Source()
   c = new Scale()
-  p = new Print(scale = 2)
+  p = new Print(scale=2)
   s.out -> c.in
   c.out -> p.in
 }

--- a/test/C/src/multiport/MultiportMutableInputArray.lf
+++ b/test/C/src/multiport/MultiportMutableInputArray.lf
@@ -71,7 +71,7 @@ reactor Scale(scale: int = 2) {
 main reactor {
   s = new Source()
   c = new Scale()
-  p = new Print(scale = 2)
+  p = new Print(scale=2)
   s.out -> c.in
   c.out -> p.in
 }

--- a/test/C/src/multiport/MultiportToBank.lf
+++ b/test/C/src/multiport/MultiportToBank.lf
@@ -48,7 +48,7 @@ reactor Destination(bank_index: int = 0) {
 }
 
 main reactor MultiportToBank(width: int = 3) {
-  a = new Source(width = width)
+  a = new Source(width=width)
   b = new[width] Destination()
   a.out -> b.in
 }

--- a/test/C/src/multiport/MultiportToBankAfter.lf
+++ b/test/C/src/multiport/MultiportToBankAfter.lf
@@ -41,7 +41,7 @@ reactor Destination(bank_index: int = 0) {
 }
 
 main reactor(width: int = 3) {
-  a = new Source(width = width)
+  a = new Source(width=width)
   b = new[width] Destination()
   a.out -> b.in after 1 sec  // Width of the bank of delays will be inferred.
 }

--- a/test/C/src/multiport/MultiportToBankHierarchy.lf
+++ b/test/C/src/multiport/MultiportToBankHierarchy.lf
@@ -44,7 +44,7 @@ reactor Container(width: int = 2) {
 }
 
 main reactor MultiportToBankHierarchy(width: int = 3) {
-  a = new Source(width = width)
-  b = new Container(width = width)
+  a = new Source(width=width)
+  b = new Container(width=width)
   a.out -> b.in
 }

--- a/test/C/src/multiport/MultiportToHierarchy.lf
+++ b/test/C/src/multiport/MultiportToHierarchy.lf
@@ -50,7 +50,7 @@ reactor Container(width: int = 4) {
 }
 
 main reactor MultiportToHierarchy(width: int = 4) {
-  a = new Source(width = width)
-  b = new Container(width = width)
+  a = new Source(width=width)
+  b = new Container(width=width)
   a.out -> b.in
 }

--- a/test/C/src/multiport/MultiportToMultiport.lf
+++ b/test/C/src/multiport/MultiportToMultiport.lf
@@ -46,7 +46,7 @@ reactor Destination(width: int = 1) {
 }
 
 main reactor MultiportToMultiport(width: int = 4) {
-  a = new Source(width = width)
-  b = new Destination(width = width)
+  a = new Source(width=width)
+  b = new Destination(width=width)
   a.out -> b.in
 }

--- a/test/C/src/multiport/MultiportToMultiport2.lf
+++ b/test/C/src/multiport/MultiportToMultiport2.lf
@@ -30,8 +30,8 @@ reactor Destination(width: int = 2) {
 }
 
 main reactor MultiportToMultiport2(width1: int = 3, width2: int = 2, width3: int = 5) {
-  a1 = new Source(width = width1)
-  a2 = new Source(width = width2)
-  b = new Destination(width = width3)
+  a1 = new Source(width=width1)
+  a2 = new Source(width=width2)
+  b = new Destination(width=width3)
   a1.out, a2.out -> b.in
 }

--- a/test/C/src/multiport/MultiportToMultiport2After.lf
+++ b/test/C/src/multiport/MultiportToMultiport2After.lf
@@ -34,8 +34,8 @@ reactor Destination(width: int = 2) {
 }
 
 main reactor MultiportToMultiport2After {
-  a1 = new Source(width = 3)
-  a2 = new Source(width = 2)
-  b = new Destination(width = 5)
+  a1 = new Source(width=3)
+  a2 = new Source(width=2)
+  b = new Destination(width=5)
   a1.out, a2.out -> b.in after 1 sec
 }

--- a/test/C/src/multiport/MultiportToMultiportParameter.lf
+++ b/test/C/src/multiport/MultiportToMultiportParameter.lf
@@ -46,7 +46,7 @@ reactor Destination(width: int = 1) {
 }
 
 main reactor(width: int = 4) {
-  a = new Source(width = width)
-  b = new Destination(width = width)
+  a = new Source(width=width)
+  b = new Destination(width=width)
   a.out -> b.in
 }

--- a/test/C/src/multiport/MultiportToPort.lf
+++ b/test/C/src/multiport/MultiportToPort.lf
@@ -40,6 +40,6 @@ reactor Destination(expected: int = 0) {
 main reactor MultiportToPort {
   a = new Source()
   b1 = new Destination()
-  b2 = new Destination(expected = 1)
+  b2 = new Destination(expected=1)
   a.out -> b1.in, b2.in
 }

--- a/test/C/src/multiport/MultiportToReaction.lf
+++ b/test/C/src/multiport/MultiportToReaction.lf
@@ -19,7 +19,7 @@ reactor Source(width: int = 1) {
 
 main reactor MultiportToReaction {
   state s: int = 6
-  b = new Source(width = 4)
+  b = new Source(width=4)
 
   reaction(b.out) {=
     int sum = 0;

--- a/test/C/src/multiport/NestedBanks.lf
+++ b/test/C/src/multiport/NestedBanks.lf
@@ -15,7 +15,7 @@ main reactor {
 
 reactor A(bank_index: int = 0) {
   output[4] x: int
-  b = new[2] B(a_bank_index = bank_index)
+  b = new[2] B(a_bank_index=bank_index)
   b.y -> x
 }
 
@@ -31,8 +31,8 @@ reactor B(a_bank_index: int = 0, bank_index: int = 0) {
 
 reactor C(bank_index: int = 0) {
   input[2] z: int
-  f = new F(c_bank_index = bank_index)
-  g = new G(c_bank_index = bank_index)
+  f = new F(c_bank_index=bank_index)
+  g = new G(c_bank_index=bank_index)
   z -> f.w, g.s
 }
 

--- a/test/C/src/multiport/NestedInterleavedBanks.lf
+++ b/test/C/src/multiport/NestedInterleavedBanks.lf
@@ -17,7 +17,7 @@ reactor A(bank_index: int = 0, outer_bank_index: int = 0) {
 
 reactor B(bank_index: int = 0) {
   output[4] q: int
-  a = new[2] A(outer_bank_index = bank_index)
+  a = new[2] A(outer_bank_index=bank_index)
   interleaved(a.p) -> q
 }
 

--- a/test/C/src/multiport/ReactionToContainedBank.lf
+++ b/test/C/src/multiport/ReactionToContainedBank.lf
@@ -10,7 +10,7 @@ main reactor ReactionToContainedBank(width: int = 2) {
   timer t(0, 100 msec)
   state count: int = 1
 
-  test = new[width] TestCount(num_inputs = 11)
+  test = new[width] TestCount(num_inputs=11)
 
   reaction(t) -> test.in {=
     for (int i = 0; i < self->width; i++) {

--- a/test/C/src/multiport/ReactionToContainedBank2.lf
+++ b/test/C/src/multiport/ReactionToContainedBank2.lf
@@ -10,7 +10,7 @@ reactor ReactionToContainedBank(width: int = 2) {
   timer t(0, 100 msec)
   state count: int = 1
 
-  test = new[width] TestCount(num_inputs = 11)
+  test = new[width] TestCount(num_inputs=11)
 
   reaction(t) -> test.in {=
     for (int i = 0; i < self->width; i++) {
@@ -21,6 +21,6 @@ reactor ReactionToContainedBank(width: int = 2) {
 }
 
 main reactor(width: int = 2) {
-  a = new ReactionToContainedBank(width = width)
-  b = new ReactionToContainedBank(width = 4)
+  a = new ReactionToContainedBank(width=width)
+  b = new ReactionToContainedBank(width=4)
 }

--- a/test/C/src/multiport/ReactionToContainedBankMultiport.lf
+++ b/test/C/src/multiport/ReactionToContainedBankMultiport.lf
@@ -10,7 +10,7 @@ main reactor(width: int = 2) {
   timer t(0, 100 msec)
   state count: int = 1
 
-  test = new[width] TestCountMultiport(num_inputs = 11, width = width)
+  test = new[width] TestCountMultiport(num_inputs=11, width=width)
 
   reaction(t) -> test.in {=
     for (int i = 0; i < self->width; i++) {

--- a/test/C/src/multiport/ReactionsToNested.lf
+++ b/test/C/src/multiport/ReactionsToNested.lf
@@ -24,8 +24,8 @@ reactor T(expected: int = 0) {
 
 reactor D {
   input[2] y: int
-  t1 = new T(expected = 42)
-  t2 = new T(expected = 43)
+  t1 = new T(expected=42)
+  t2 = new T(expected=43)
   y -> t1.z, t2.z
 }
 

--- a/test/C/src/multiport/Sparse.lf
+++ b/test/C/src/multiport/Sparse.lf
@@ -44,7 +44,7 @@ reactor SparseSink(width: int = 20) {
 }
 
 main reactor(width: int = 20) {
-  s = new SparseSource(width = width)
-  d = new SparseSink(width = width)
+  s = new SparseSource(width=width)
+  d = new SparseSink(width=width)
   s.out -> d.in
 }

--- a/test/C/src/multiport/SparseFallback.lf
+++ b/test/C/src/multiport/SparseFallback.lf
@@ -47,7 +47,7 @@ reactor SparseSink(width: int = 20) {
 }
 
 main reactor(width: int = 10) {
-  s = new SparseSource(width = width)
-  d = new SparseSink(width = width)
+  s = new SparseSource(width=width)
+  d = new SparseSink(width=width)
   s.out -> d.in
 }

--- a/test/C/src/no_inlining/CountHierarchy.lf
+++ b/test/C/src/no_inlining/CountHierarchy.lf
@@ -11,7 +11,7 @@ reactor Timer(m: time = 0, n: time = 0) {
 }
 
 main reactor {
-  t = new Timer(m = 0, n = 1 msec)
+  t = new Timer(m=0, n = 1 msec)
 
   state count: int
 

--- a/test/C/src/no_inlining/MultiportToReactionNoInlining.lf
+++ b/test/C/src/no_inlining/MultiportToReactionNoInlining.lf
@@ -21,7 +21,7 @@ reactor Source(width: int = 1) {
 
 main reactor {
   state s: int = 6
-  b = new Source(width = 4)
+  b = new Source(width=4)
 
   reaction(b.out) named check
 

--- a/test/C/src/target/CMakeInclude.lf
+++ b/test/C/src/target/CMakeInclude.lf
@@ -3,9 +3,8 @@
  */
 target C {
   cmake-include: [
-    "../include/mlib-cmake-extension.cmake",
-    "../include/foo-cmake-compile-definition.txt"
-  ],
+      "../include/mlib-cmake-extension.cmake",
+      "../include/foo-cmake-compile-definition.txt"],
   timeout: 0 sec
 }
 

--- a/test/C/src/token/TokenMutable.lf
+++ b/test/C/src/token/TokenMutable.lf
@@ -12,10 +12,10 @@ import TokenSource, TokenPrint, TokenScale from "lib/Token.lf"
 
 main reactor {
   s = new TokenSource()
-  g2 = new TokenScale(scale = 2)
-  g3 = new TokenScale(scale = 3)
-  p2 = new TokenPrint(scale = 2)
-  p3 = new TokenPrint(scale = 3)
+  g2 = new TokenScale(scale=2)
+  g3 = new TokenScale(scale=3)
+  p2 = new TokenPrint(scale=2)
+  p3 = new TokenPrint(scale=3)
   s.out -> g2.in
   s.out -> g3.in
   g2.out -> p2.in

--- a/test/C/src/token/TokenSourceScalePrint.lf
+++ b/test/C/src/token/TokenSourceScalePrint.lf
@@ -12,8 +12,8 @@ import TokenSource, TokenPrint, TokenScale from "lib/Token.lf"
 
 main reactor {
   s = new TokenSource()
-  g2 = new TokenScale(scale = 2)
-  p2 = new TokenPrint(scale = 2)
+  g2 = new TokenScale(scale=2)
+  p2 = new TokenPrint(scale=2)
   s.out -> g2.in
   g2.out -> p2.in
 }

--- a/test/Cpp/src/ArrayParallel.lf
+++ b/test/Cpp/src/ArrayParallel.lf
@@ -9,9 +9,9 @@ import Source, Print from "ArrayPrint.lf"
 main reactor ArrayParallel {
   s = new Source()
   c1 = new Scale()
-  c2 = new Scale(scale = 3)
-  p1 = new Print(scale = 2)
-  p2 = new Print(scale = 3)
+  c2 = new Scale(scale=3)
+  p1 = new Print(scale=2)
+  p2 = new Print(scale=3)
   s.out -> c1.in
   s.out -> c2.in
   c1.out -> p1.in

--- a/test/Cpp/src/ArrayScale.lf
+++ b/test/Cpp/src/ArrayScale.lf
@@ -23,8 +23,8 @@ reactor Scale(scale: int = 2) {
 
 main reactor ArrayScale {
   s = new Source()
-  c = new Scale(scale = 2)
-  p = new Print(scale = 2)
+  c = new Scale(scale=2)
+  p = new Print(scale=2)
   s.out -> c.in
   c.out -> p.in
 }

--- a/test/Cpp/src/Hello.lf
+++ b/test/Cpp/src/Hello.lf
@@ -36,7 +36,7 @@ reactor HelloCpp(period: time = 2 sec, message: {= std::string =} = "Hello C++")
 }
 
 reactor Inside(period: time = 1 sec, message: std::string = "Composite default message.") {
-  third_instance = new HelloCpp(period = period, message = message)
+  third_instance = new HelloCpp(period=period, message=message)
 }
 
 main reactor Hello {

--- a/test/Cpp/src/NativeListsAndTimes.lf
+++ b/test/Cpp/src/NativeListsAndTimes.lf
@@ -2,14 +2,13 @@ target Cpp
 
 // This test passes if it is successfully compiled into valid target code.
 reactor Foo(
-  x: int = 0,
-  y: time = 0,                // Units are missing but not required
-  z = 1 msec,                 // Type is missing but not required
-  p: int[]{1, 2, 3, 4},       // List of integers
-  q: {= std::vector<reactor::Duration> =}{1 msec, 2 msec, 3 msec},
-  g: time[]{1 msec, 2 msec},  // List of time values
-  g2: int[] = {}
-) {
+    x: int = 0,
+    y: time = 0,                // Units are missing but not required
+    z = 1 msec,                 // Type is missing but not required
+    p: int[]{1, 2, 3, 4},       // List of integers
+    q: {= std::vector<reactor::Duration> =}{1 msec, 2 msec, 3 msec},
+    g: time[]{1 msec, 2 msec},  // List of time values
+    g2: int[] = {}) {
   state s: time = y  // Reference to explicitly typed time parameter
   state t: time = z  // Reference to implicitly typed time parameter
   state v: bool      // Uninitialized boolean state variable

--- a/test/Cpp/src/ParameterHierarchy.lf
+++ b/test/Cpp/src/ParameterHierarchy.lf
@@ -19,7 +19,7 @@ reactor Deep(p: int = 0) {
 }
 
 reactor Intermediate(p: int = 10) {
-  a = new Deep(p = p)
+  a = new Deep(p=p)
 }
 
 reactor Another(p: int = 20) {
@@ -27,5 +27,5 @@ reactor Another(p: int = 20) {
 }
 
 main reactor ParameterHierarchy {
-  a = new Intermediate(p = 42)
+  a = new Intermediate(p=42)
 }

--- a/test/Cpp/src/ParameterizedState.lf
+++ b/test/Cpp/src/ParameterizedState.lf
@@ -12,5 +12,5 @@ reactor Foo(bar: int = 4) {
 }
 
 main reactor ParameterizedState {
-  a = new Foo(bar = 42)
+  a = new Foo(bar=42)
 }

--- a/test/Cpp/src/ParametersOutOfOrder.lf
+++ b/test/Cpp/src/ParametersOutOfOrder.lf
@@ -12,5 +12,5 @@ reactor Foo(a: int = 0, b: std::string = "", c: float = 0.0) {
 }
 
 main reactor {
-  foo = new Foo(c = 3.14, b = "bar", a = 42)
+  foo = new Foo(c=3.14, b="bar", a=42)
 }

--- a/test/Cpp/src/Stride.lf
+++ b/test/Cpp/src/Stride.lf
@@ -23,7 +23,7 @@ reactor Display {
 }
 
 main reactor Stride {
-  c = new Count(stride = 2)
+  c = new Count(stride=2)
   d = new Display()
   c.y -> d.x
 }

--- a/test/Cpp/src/StructParallel.lf
+++ b/test/Cpp/src/StructParallel.lf
@@ -13,9 +13,9 @@ public preamble {=
 main reactor {
   s = new Source()
   c1 = new Scale()
-  c2 = new Scale(scale = 3)
-  p1 = new Print(expected_value = 84)
-  p2 = new Print(expected_value = 126)
+  c2 = new Scale(scale=3)
+  p1 = new Print(expected_value=84)
+  p2 = new Print(expected_value=126)
   s.out -> c1.in
   s.out -> c2.in
   c1.out -> p1.in

--- a/test/Cpp/src/StructScale.lf
+++ b/test/Cpp/src/StructScale.lf
@@ -23,7 +23,7 @@ reactor Scale(scale: int = 2) {
 main reactor StructScale {
   s = new Source()
   c = new Scale()
-  p = new Print(expected_value = 84)
+  p = new Print(expected_value=84)
   s.out -> c.in
   c.out -> p.in
 }

--- a/test/Cpp/src/TimeLimit.lf
+++ b/test/Cpp/src/TimeLimit.lf
@@ -40,7 +40,7 @@ reactor Destination {
 
 main reactor TimeLimit(period: time = 1 sec) {
   timer stop(10 sec)
-  c = new Clock(period = period)
+  c = new Clock(period=period)
   d = new Destination()
   c.y -> d.x
 

--- a/test/Cpp/src/Timeout_Test.lf
+++ b/test/Cpp/src/Timeout_Test.lf
@@ -38,7 +38,7 @@ reactor Consumer {
 
 main reactor Timeout_Test {
   consumer = new Consumer()
-  producer = new Sender(take_a_break_after = 10, break_interval = 1 msec)
+  producer = new Sender(take_a_break_after=10, break_interval = 1 msec)
 
   producer.out -> consumer.in
 }

--- a/test/Cpp/src/concurrent/HelloThreaded.lf
+++ b/test/Cpp/src/concurrent/HelloThreaded.lf
@@ -36,7 +36,7 @@ reactor HelloCpp(period: time = 2 sec, message: {= std::string =} = "Hello C++")
 }
 
 reactor Inside(period: time = 1 sec, message: {= std::string =} = "Composite default message.") {
-  third_instance = new HelloCpp(period = period, message = message)
+  third_instance = new HelloCpp(period=period, message=message)
 }
 
 main reactor {

--- a/test/Cpp/src/concurrent/TimeLimitThreaded.lf
+++ b/test/Cpp/src/concurrent/TimeLimitThreaded.lf
@@ -41,7 +41,7 @@ reactor Destination {
 
 main reactor(period: time = 1 sec) {
   timer stop(10 sec)
-  c = new Clock(period = period)
+  c = new Clock(period=period)
   d = new Destination()
   c.y -> d.x
 

--- a/test/Cpp/src/enclave/EnclaveBank.lf
+++ b/test/Cpp/src/enclave/EnclaveBank.lf
@@ -4,11 +4,10 @@ target Cpp {
 }
 
 reactor Node(
-  bank_index: size_t = 0,
-  id: std::string = {= "node" + std::to_string(bank_index) =},
-  period: time = 500 msec,
-  duration: time = 10 msec
-) {
+    bank_index: size_t = 0,
+    id: std::string = {= "node" + std::to_string(bank_index) =},
+    period: time = 500 msec,
+    duration: time = 10 msec) {
   logical action a: void
 
   reaction(startup, a) -> a {=
@@ -23,7 +22,7 @@ reactor Node(
 }
 
 main reactor {
-  slow = new Node(id = "slow", period = 1 sec, duration = 500 msec)
+  slow = new Node(id="slow", period = 1 sec, duration = 500 msec)
   @enclave
   nodes = new[2] Node()
 }

--- a/test/Cpp/src/enclave/EnclaveBankEach.lf
+++ b/test/Cpp/src/enclave/EnclaveBankEach.lf
@@ -4,11 +4,10 @@ target Cpp {
 }
 
 reactor Node(
-  bank_index: size_t = 0,
-  id: std::string = {= "node" + std::to_string(bank_index) =},
-  period: {= reactor::Duration =} = {= 100ms * (bank_index+1) =},
-  duration: {= reactor::Duration =} = {= 50ms + 100ms * bank_index =}
-) {
+    bank_index: size_t = 0,
+    id: std::string = {= "node" + std::to_string(bank_index) =},
+    period: {= reactor::Duration =} = {= 100ms * (bank_index+1) =},
+    duration: {= reactor::Duration =} = {= 50ms + 100ms * bank_index =}) {
   logical action a: void
 
   reaction(startup, a) -> a {=
@@ -23,7 +22,7 @@ reactor Node(
 }
 
 main reactor {
-  slow = new Node(id = "slow", period = {= 1s =}, duration = {= 700ms =})
+  slow = new Node(id="slow", period = {= 1s =}, duration = {= 700ms =})
   @enclave(each = true)
   nodes = new[2] Node()
 }

--- a/test/Cpp/src/enclave/EnclaveHelloWorld.lf
+++ b/test/Cpp/src/enclave/EnclaveHelloWorld.lf
@@ -5,8 +5,8 @@ reactor Hello(msg: std::string = "World") {
 }
 
 main reactor(msg1: std::string = "World", msg2: std::string = "Enclave") {
-  hello1 = new Hello(msg = msg1)
+  hello1 = new Hello(msg=msg1)
 
   @enclave
-  hello2 = new Hello(msg = msg2)
+  hello2 = new Hello(msg=msg2)
 }

--- a/test/Cpp/src/enclave/EnclaveHierarchy.lf
+++ b/test/Cpp/src/enclave/EnclaveHierarchy.lf
@@ -18,20 +18,20 @@ reactor Node(id: std::string = "node", period: time = 100 msec, duration: time =
 
 reactor MiddleNode {
   @enclave
-  inner = new Node(id = "inner", period = 1 sec, duration = 400 msec)
+  inner = new Node(id="inner", period = 1 sec, duration = 400 msec)
 
-  middle = new Node(id = "middle", period = 200 msec, duration = 70 msec)
+  middle = new Node(id="middle", period = 200 msec, duration = 70 msec)
 }
 
 reactor OuterNode {
   @enclave
   middle = new MiddleNode()
 
-  outer = new Node(id = "outer", period = 500 msec, duration = 200 msec)
+  outer = new Node(id="outer", period = 500 msec, duration = 200 msec)
 }
 
 main reactor {
   outer = new OuterNode()
   @enclave
-  node = new Node(id = "node", period = 2 sec, duration = 500 msec)
+  node = new Node(id="node", period = 2 sec, duration = 500 msec)
 }

--- a/test/Cpp/src/enclave/EnclaveMultiportToPort.lf
+++ b/test/Cpp/src/enclave/EnclaveMultiportToPort.lf
@@ -43,6 +43,6 @@ main reactor {
   @enclave
   b1 = new Destination()
   @enclave
-  b2 = new Destination(expected = 1)
+  b2 = new Destination(expected=1)
   a.out -> b1.in, b2.in
 }

--- a/test/Cpp/src/enclave/EnclaveMultiportToPort2.lf
+++ b/test/Cpp/src/enclave/EnclaveMultiportToPort2.lf
@@ -42,6 +42,6 @@ main reactor {
   a = new Source()
   @enclave
   b1 = new Destination()
-  b2 = new Destination(expected = 1)
+  b2 = new Destination(expected=1)
   a.out -> b1.in, b2.in
 }

--- a/test/Cpp/src/multiport/BankToBankMultiport.lf
+++ b/test/Cpp/src/multiport/BankToBankMultiport.lf
@@ -45,7 +45,7 @@ reactor Destination(width: size_t = 1) {
 }
 
 main reactor(bank_width: size_t = 4) {
-  a = new[bank_width] Source(width = 4)
-  b = new[bank_width] Destination(width = 4)
+  a = new[bank_width] Source(width=4)
+  b = new[bank_width] Destination(width=4)
   a.out -> b.in
 }

--- a/test/Cpp/src/multiport/BankToBankMultiportAfter.lf
+++ b/test/Cpp/src/multiport/BankToBankMultiportAfter.lf
@@ -53,7 +53,7 @@ reactor Destination(width: size_t = 1) {
 }
 
 main reactor(bank_width: size_t = 4) {
-  a = new[bank_width] Source(width = 4)
-  b = new[bank_width] Destination(width = 4)
+  a = new[bank_width] Source(width=4)
+  b = new[bank_width] Destination(width=4)
   a.out -> b.in after 200 msec
 }

--- a/test/Cpp/src/multiport/BroadcastMultipleAfter.lf
+++ b/test/Cpp/src/multiport/BroadcastMultipleAfter.lf
@@ -36,9 +36,9 @@ reactor Sink(bank_index: size_t = 0) {
 }
 
 main reactor {
-  source1 = new Source(value = 1)
-  source2 = new Source(value = 2)
-  source3 = new Source(value = 3)
+  source1 = new Source(value=1)
+  source2 = new Source(value=2)
+  source3 = new Source(value=3)
   sink = new[9] Sink()
   (source1.out, source2.out, source3.out)+ -> sink.in after 1 sec
 }

--- a/test/Cpp/src/multiport/FullyConnected.lf
+++ b/test/Cpp/src/multiport/FullyConnected.lf
@@ -37,6 +37,6 @@ reactor Node(bank_index: size_t = 0, num_nodes: size_t = 4) {
 }
 
 main reactor(num_nodes: size_t = 4) {
-  nodes = new[num_nodes] Node(num_nodes = num_nodes)
+  nodes = new[num_nodes] Node(num_nodes=num_nodes)
   (nodes.out)+ -> nodes.in
 }

--- a/test/Cpp/src/multiport/FullyConnectedAddressable.lf
+++ b/test/Cpp/src/multiport/FullyConnectedAddressable.lf
@@ -42,9 +42,9 @@ reactor Node(bank_index: size_t = 0, num_nodes: size_t = 4) {
 }
 
 main reactor(num_nodes: size_t = 4) {
-  nodes1 = new[num_nodes] Node(num_nodes = num_nodes)
+  nodes1 = new[num_nodes] Node(num_nodes=num_nodes)
   nodes1.out -> interleaved(nodes1.in)
 
-  nodes2 = new[num_nodes] Node(num_nodes = num_nodes)
+  nodes2 = new[num_nodes] Node(num_nodes=num_nodes)
   interleaved(nodes2.out) -> nodes2.in
 }

--- a/test/Cpp/src/multiport/FullyConnectedAddressableAfter.lf
+++ b/test/Cpp/src/multiport/FullyConnectedAddressableAfter.lf
@@ -4,9 +4,9 @@ target Cpp
 import Node from "FullyConnectedAddressable.lf"
 
 main reactor(num_nodes: size_t = 4) {
-  nodes1 = new[num_nodes] Node(num_nodes = num_nodes)
+  nodes1 = new[num_nodes] Node(num_nodes=num_nodes)
   nodes1.out -> interleaved(nodes1.in) after 200 msec
 
-  nodes2 = new[num_nodes] Node(num_nodes = num_nodes)
+  nodes2 = new[num_nodes] Node(num_nodes=num_nodes)
   interleaved(nodes2.out) -> nodes2.in after 400 msec
 }

--- a/test/Cpp/src/multiport/MultiportFromBank.lf
+++ b/test/Cpp/src/multiport/MultiportFromBank.lf
@@ -37,6 +37,6 @@ reactor Destination(port_width: size_t = 2) {
 
 main reactor(width: size_t = 4) {
   a = new[width] Source()
-  b = new Destination(port_width = width)
+  b = new Destination(port_width=width)
   a.out -> b.in
 }

--- a/test/Cpp/src/multiport/MultiportToHierarchy.lf
+++ b/test/Cpp/src/multiport/MultiportToHierarchy.lf
@@ -51,7 +51,7 @@ reactor Container(width: size_t = 4) {
 }
 
 main reactor MultiportToHierarchy(width: size_t = 4) {
-  a = new Source(width = width)
-  b = new Container(width = width)
+  a = new Source(width=width)
+  b = new Container(width=width)
   a.out -> b.in
 }

--- a/test/Cpp/src/multiport/MultiportToMultiport2.lf
+++ b/test/Cpp/src/multiport/MultiportToMultiport2.lf
@@ -29,8 +29,8 @@ reactor Destination(width: size_t = 2) {
 }
 
 main reactor MultiportToMultiport2 {
-  a1 = new Source(width = 3)
-  a2 = new Source(width = 2)
-  b = new Destination(width = 5)
+  a1 = new Source(width=3)
+  a2 = new Source(width=2)
+  b = new Destination(width=5)
   a1.out, a2.out -> b.in
 }

--- a/test/Cpp/src/multiport/MultiportToMultiport2After.lf
+++ b/test/Cpp/src/multiport/MultiportToMultiport2After.lf
@@ -35,8 +35,8 @@ reactor Destination(width: size_t = 2) {
 }
 
 main reactor {
-  a1 = new Source(width = 3)
-  a2 = new Source(width = 2)
-  b = new Destination(width = 5)
+  a1 = new Source(width=3)
+  a2 = new Source(width=2)
+  b = new Destination(width=5)
   a1.out, a2.out -> b.in after 1 sec
 }

--- a/test/Cpp/src/multiport/MultiportToPort.lf
+++ b/test/Cpp/src/multiport/MultiportToPort.lf
@@ -40,6 +40,6 @@ reactor Destination(expected: int = 0) {
 main reactor MultiportToPort {
   a = new Source()
   b1 = new Destination()
-  b2 = new Destination(expected = 1)
+  b2 = new Destination(expected=1)
   a.out -> b1.in, b2.in
 }

--- a/test/Cpp/src/multiport/WidthGivenByCode.lf
+++ b/test/Cpp/src/multiport/WidthGivenByCode.lf
@@ -18,8 +18,8 @@ reactor Foo(a: size_t = 8, b: size_t = 2) {
 
 main reactor {
   foo1 = new Foo()
-  foo2 = new Foo(a = 10, b = 3)
-  foo3 = new Foo(a = 9, b = 9)
+  foo2 = new Foo(a=10, b=3)
+  foo3 = new Foo(a=9, b=9)
   foo_bank = new[{= 42 =}] Foo()
 
   reaction(startup) foo_bank.out {=

--- a/test/Cpp/src/target/BraceAndParenInitialization.lf
+++ b/test/Cpp/src/target/BraceAndParenInitialization.lf
@@ -1,11 +1,11 @@
 target Cpp
 
 reactor Foo(
-  param_list_1: std::vector<int>(4, 2),  // list containing [2,2,2,2]
-  param_list_2: std::vector<int>{4, 2},  // list containing [4,2]
-  param_list_3: std::vector<int>(4, 2),  // list containing [2,2,2,2]
-  param_list_4: std::vector<int>{4, 2}   // list containing [4,2]
-) {
+    param_list_1: std::vector<int>(4, 2),  // list containing [2,2,2,2]
+    param_list_2: std::vector<int>{4, 2},  // list containing [4,2]
+    param_list_3: std::vector<int>(4, 2),  // list containing [2,2,2,2]
+    // list containing [4,2]
+    param_list_4: std::vector<int>{4, 2}) {
   state state_list_1: std::vector<int>(6, 42)  // list containing [42,42,42,42,42,42]
   state state_list_2: std::vector<int>{6, 42}  // list containing [6,42]
 

--- a/test/Cpp/src/target/CMakeInclude.lf
+++ b/test/Cpp/src/target/CMakeInclude.lf
@@ -3,9 +3,8 @@
  */
 target Cpp {
   cmake-include: [
-    "../include/mlib-cmake-extension.cmake",
-    "../include/bar-cmake-compile-definition.txt"
-  ],
+      "../include/mlib-cmake-extension.cmake",
+      "../include/bar-cmake-compile-definition.txt"],
   timeout: 0 sec
 }
 

--- a/test/Cpp/src/target/CliParserGenericArguments.lf
+++ b/test/Cpp/src/target/CliParserGenericArguments.lf
@@ -43,20 +43,19 @@ private preamble {=
 =}
 
 main reactor CliParserGenericArguments(
-  int_value: int = 10,
-  signed_value: signed = -10,
-  unsigned_value: unsigned = 11,
-  long_value: long = -100,
-  unsigned_long_value: {= unsigned_long =} = 42,
-  long_long_value: {= long_long =} = -42,
-  ull_value: {= uns_long_long =} = 42,
-  bool_value: bool = false,
-  char_value: char = 'T',
-  double_value: double = 4.2,
-  long_double_value: {= long_double =} = 4.2,
-  float_value: float = 10.5,
-  string_value: string = "This is a testvalue",
-  custom_class_value: {= CustomClass =}("Peter")
-) {
+    int_value: int = 10,
+    signed_value: signed = -10,
+    unsigned_value: unsigned = 11,
+    long_value: long = -100,
+    unsigned_long_value: {= unsigned_long =} = 42,
+    long_long_value: {= long_long =} = -42,
+    ull_value: {= uns_long_long =} = 42,
+    bool_value: bool = false,
+    char_value: char = 'T',
+    double_value: double = 4.2,
+    long_double_value: {= long_double =} = 4.2,
+    float_value: float = 10.5,
+    string_value: string = "This is a testvalue",
+    custom_class_value: {= CustomClass =}("Peter")) {
   reaction(startup) {= std::cout << "Hello World!\n"; =}
 }

--- a/test/Cpp/src/target/CombinedTypeNames.lf
+++ b/test/Cpp/src/target/CombinedTypeNames.lf
@@ -15,5 +15,5 @@ reactor Foo(bar: {= unsigned int =} = 0, baz: {= const unsigned int* =} = {= nul
 }
 
 main reactor(bar: {= unsigned int =} = 42) {
-  foo = new Foo(bar = bar, baz = {= &bar =})
+  foo = new Foo(bar=bar, baz = {= &bar =})
 }

--- a/test/Cpp/src/target/GenericParameterAndState.lf
+++ b/test/Cpp/src/target/GenericParameterAndState.lf
@@ -16,6 +16,6 @@ reactor Foo<T>(bar: T = 0, expected: T = 14542135) {
 }
 
 main reactor {
-  foo = new Foo<int>(bar = 42, expected = 42)
-  bar = new Foo<int>(expected = 0)  // default value is used
+  foo = new Foo<int>(bar=42, expected=42)
+  bar = new Foo<int>(expected=0)  // default value is used
 }

--- a/test/Cpp/src/target/InitializerSyntax.lf
+++ b/test/Cpp/src/target/InitializerSyntax.lf
@@ -31,20 +31,20 @@ public preamble {=
 =}
 
 reactor TestReactor(
-  /**
-   * FIXME: should work without an explicit initialization, see
-   * https://github.com/lf-lang/lingua-franca/issues/623
-   */
-  // p_default: TestType, constructor #1
-  p_default: TestType(),
-  p_empty: TestType(),  // constructor #1
-  p_value: TestType(24),  // constructor #2
-  p_init_empty: TestType{},  // constructor #1
-  p_init_empty2: TestType({}),  // constructor #1
-  p_init_some: TestType{2, 6, 6, 3, 1},  // constructor #1
-  p_assign_init_empty: TestType = {},  // constructor #1
-  p_assign_init_some: TestType = {4, 2, 1}  // constructor #3
-) {
+    /**
+     * FIXME: should work without an explicit initialization, see
+     * https://github.com/lf-lang/lingua-franca/issues/623
+     */
+    // p_default: TestType, constructor #1
+    p_default: TestType(),
+    p_empty: TestType(),  // constructor #1
+    p_value: TestType(24),  // constructor #2
+    p_init_empty: TestType{},  // constructor #1
+    p_init_empty2: TestType({}),  // constructor #1
+    p_init_some: TestType{2, 6, 6, 3, 1},  // constructor #1
+    p_assign_init_empty: TestType = {},  // constructor #1
+    // constructor #3
+    p_assign_init_some: TestType = {4, 2, 1}) {
   state s_default: TestType                 // constructor #1
   state s_empty: TestType()                 // constructor #1
   state s_value: TestType(24)               // constructor #2

--- a/test/Python/src/ArrayAsType.lf
+++ b/test/Python/src/ArrayAsType.lf
@@ -12,7 +12,7 @@ reactor Source {
 }
 
 # The scale parameter is just for testing.
-reactor Print(scale = 1) {
+reactor Print(scale=1) {
   input _in
 
   reaction(_in) {=

--- a/test/Python/src/ArrayFree.lf
+++ b/test/Python/src/ArrayFree.lf
@@ -7,7 +7,7 @@ target Python
 import Source, Print from "ArrayPrint.lf"
 import Scale from "ArrayScale.lf"
 
-reactor Free(scale = 2) {
+reactor Free(scale=2) {
   mutable input _in
 
   reaction(_in) {=
@@ -20,7 +20,7 @@ main reactor ArrayFree {
   s = new Source()
   c = new Free()
   c2 = new Scale()
-  p = new Print(scale = 2)
+  p = new Print(scale=2)
   s.out -> c._in
   s.out -> c2._in
   c2.out -> p._in

--- a/test/Python/src/ArrayParallel.lf
+++ b/test/Python/src/ArrayParallel.lf
@@ -9,9 +9,9 @@ import Source, Print from "ArrayPrint.lf"
 main reactor ArrayParallel {
   s = new Source()
   c1 = new Scale()
-  c2 = new Scale(scale = 3)
-  p1 = new Print(scale = 2)
-  p2 = new Print(scale = 3)
+  c2 = new Scale(scale=3)
+  p1 = new Print(scale=2)
+  p2 = new Print(scale=3)
   s.out -> c1._in
   s.out -> c2._in
   c1.out -> p1._in

--- a/test/Python/src/ArrayPrint.lf
+++ b/test/Python/src/ArrayPrint.lf
@@ -12,7 +12,7 @@ reactor Source {
 }
 
 # The scale parameter is just for testing.
-reactor Print(scale = 1) {
+reactor Print(scale=1) {
   input _in
 
   reaction(_in) {=

--- a/test/Python/src/ArrayScale.lf
+++ b/test/Python/src/ArrayScale.lf
@@ -5,7 +5,7 @@ target Python
 
 import Print, Source from "ArrayPrint.lf"
 
-reactor Scale(scale = 2) {
+reactor Scale(scale=2) {
   mutable input _in
   output out
 
@@ -19,7 +19,7 @@ reactor Scale(scale = 2) {
 main reactor ArrayScale {
   s = new Source()
   c = new Scale()
-  p = new Print(scale = 2)
+  p = new Print(scale=2)
   s.out -> c._in
   c.out -> p._in
 }

--- a/test/Python/src/DelayArray.lf
+++ b/test/Python/src/DelayArray.lf
@@ -25,7 +25,7 @@ reactor Source {
 }
 
 # The scale parameter is just for testing.
-reactor Print(scale = 1) {
+reactor Print(scale=1) {
   input _in
 
   reaction(_in) {=

--- a/test/Python/src/DelayArrayWithAfter.lf
+++ b/test/Python/src/DelayArrayWithAfter.lf
@@ -18,7 +18,7 @@ reactor Source {
 }
 
 # The scale parameter is just for testing.
-reactor Print(scale = 1) {
+reactor Print(scale=1) {
   input _in
   state iteration = 1
   state inputs_received = 0

--- a/test/Python/src/DelayStruct.lf
+++ b/test/Python/src/DelayStruct.lf
@@ -26,7 +26,7 @@ reactor Source {
 }
 
 # expected parameter is for testing.
-reactor Print(expected = 42) {
+reactor Print(expected=42) {
   input _in
 
   reaction(_in) {=

--- a/test/Python/src/DelayStructWithAfter.lf
+++ b/test/Python/src/DelayStructWithAfter.lf
@@ -12,7 +12,7 @@ reactor Source {
 }
 
 # expected parameter is for testing.
-reactor Print(expected = 42) {
+reactor Print(expected=42) {
   input _in
 
   reaction(_in) {=

--- a/test/Python/src/DoubleReaction.lf
+++ b/test/Python/src/DoubleReaction.lf
@@ -5,7 +5,7 @@ target Python {
   fast: true
 }
 
-reactor Clock(offset = 0, period = 1 sec) {
+reactor Clock(offset=0, period = 1 sec) {
   output y
   timer t(offset, period)
   state count = 0

--- a/test/Python/src/Gain.lf
+++ b/test/Python/src/Gain.lf
@@ -1,7 +1,7 @@
 # Example in the Wiki.
 target Python
 
-reactor Scale(scale = 2) {
+reactor Scale(scale=2) {
   input x
   output y
 

--- a/test/Python/src/Hello.lf
+++ b/test/Python/src/Hello.lf
@@ -38,7 +38,7 @@ reactor Reschedule(period = 2 sec, message = "Hello Python") {
 }
 
 reactor Inside(period = 1 sec, message = "Composite default message.") {
-  third_instance = new Reschedule(period = period, message = message)
+  third_instance = new Reschedule(period=period, message=message)
 }
 
 main reactor Hello {

--- a/test/Python/src/IdentifierLength.lf
+++ b/test/Python/src/IdentifierLength.lf
@@ -5,8 +5,7 @@ target Python {
 }
 
 reactor A_Really_Long_Name_For_A_Source_But_Not_Quite_255_Characters_Which_Is_The_Maximum_For_The_Python_Target(
-  period = 2 sec
-) {
+    period = 2 sec) {
   output y
   timer t(1 sec, period)
   state count = 0
@@ -31,9 +30,7 @@ reactor Another_Really_Long_Name_For_A_Test_Class {
 }
 
 main reactor IdentifierLength {
-  a_really_long_name_for_a_source_instance = new A_Really_Long_Name_For_A_Source_But_Not_Quite_255_Characters_Which_Is_The_Maximum_For_The_Python_Target(
-
-  )
+  a_really_long_name_for_a_source_instance = new A_Really_Long_Name_For_A_Source_But_Not_Quite_255_Characters_Which_Is_The_Maximum_For_The_Python_Target()
   another_really_long_name_for_a_test_instance = new Another_Really_Long_Name_For_A_Test_Class()
   a_really_long_name_for_a_source_instance.y -> another_really_long_name_for_a_test_instance.x
 }

--- a/test/Python/src/NativeListsAndTimes.lf
+++ b/test/Python/src/NativeListsAndTimes.lf
@@ -2,13 +2,13 @@ target Python
 
 # This test passes if it is successfully compiled into valid target code.
 main reactor(
-  x = 0,
-  y = 0,             # Units are missing but not required
-  z = 1 msec,        # Type is missing but not required
-  p(1, 2, 3, 4),     # List of integers
-  q(1 msec, 2 msec, 3 msec),  # list of time values
-  g(1 msec, 2 msec)  # List of time values
-) {
+    x=0,
+    y=0,               # Units are missing but not required
+    z = 1 msec,        # Type is missing but not required
+    p(1, 2, 3, 4),     # List of integers
+    q(1 msec, 2 msec, 3 msec),  # list of time values
+    # List of time values
+    g(1 msec, 2 msec)) {
   state s = y        # Reference to explicitly typed time parameter
   state t = z        # Reference to implicitly typed time parameter
   state v            # Uninitialized boolean state variable

--- a/test/Python/src/ParameterizedState.lf
+++ b/test/Python/src/ParameterizedState.lf
@@ -1,6 +1,6 @@
 target Python
 
-reactor Foo(bar = 42) {
+reactor Foo(bar=42) {
   state baz = bar
 
   reaction(startup) {= print("Baz: ", self.baz) =}

--- a/test/Python/src/PeriodicDesugared.lf
+++ b/test/Python/src/PeriodicDesugared.lf
@@ -3,7 +3,7 @@ target Python {
   timeout: 1 sec
 }
 
-main reactor(offset = 0, period = 500 msec) {
+main reactor(offset=0, period = 500 msec) {
   logical action init(offset)
   logical action recur(period)
 

--- a/test/Python/src/PingPong.lf
+++ b/test/Python/src/PingPong.lf
@@ -21,7 +21,7 @@ target Python {
   fast: true
 }
 
-reactor Ping(count = 10) {
+reactor Ping(count=10) {
   input receive
   output send
   state pingsLeft = count
@@ -40,7 +40,7 @@ reactor Ping(count = 10) {
   =}
 }
 
-reactor Pong(expected = 10) {
+reactor Pong(expected=10) {
   input receive
   output send
   state count = 0

--- a/test/Python/src/SetArray.lf
+++ b/test/Python/src/SetArray.lf
@@ -9,7 +9,7 @@ reactor Source {
 }
 
 # The scale parameter is just for testing.
-reactor Print(scale = 1) {
+reactor Print(scale=1) {
   input _in
 
   reaction(_in) {=

--- a/test/Python/src/Stride.lf
+++ b/test/Python/src/Stride.lf
@@ -5,7 +5,7 @@ target Python {
   fast: true
 }
 
-reactor Count(stride = 1) {
+reactor Count(stride=1) {
   state count = 1
   output y
   timer t(0, 100 msec)
@@ -29,7 +29,7 @@ reactor Display {
 }
 
 main reactor Stride {
-  c = new Count(stride = 2)
+  c = new Count(stride=2)
   d = new Display()
   c.y -> d.x
 }

--- a/test/Python/src/StructAsType.lf
+++ b/test/Python/src/StructAsType.lf
@@ -14,7 +14,7 @@ reactor Source {
 }
 
 # expected parameter is for testing.
-reactor Print(expected = 42) {
+reactor Print(expected=42) {
   input _in
 
   reaction(_in) {=

--- a/test/Python/src/StructAsTypeDirect.lf
+++ b/test/Python/src/StructAsTypeDirect.lf
@@ -17,7 +17,7 @@ reactor Source {
 }
 
 # expected parameter is for testing.
-reactor Print(expected = 42) {
+reactor Print(expected=42) {
   input _in
 
   reaction(_in) {=

--- a/test/Python/src/StructParallel.lf
+++ b/test/Python/src/StructParallel.lf
@@ -8,7 +8,7 @@ import Source from "StructScale.lf"
 
 preamble {= import hello =}
 
-reactor Check(expected = 42) {
+reactor Check(expected=42) {
   input _in
 
   reaction(_in) {=
@@ -19,7 +19,7 @@ reactor Check(expected = 42) {
   =}
 }
 
-reactor Print(scale = 2) {
+reactor Print(scale=2) {
   # Mutable keyword indicates that this reactor wants a writable copy of the input.
   mutable input _in
 
@@ -35,9 +35,9 @@ reactor Print(scale = 2) {
 main reactor StructParallel {
   s = new Source()
   c1 = new Print()
-  c2 = new Print(scale = 3)
-  p1 = new Check(expected = 84)
-  p2 = new Check(expected = 126)
+  c2 = new Print(scale=3)
+  p1 = new Check(expected=84)
+  p2 = new Check(expected=126)
   s.out -> c1._in
   s.out -> c2._in
   c1.out -> p1._in

--- a/test/Python/src/StructPrint.lf
+++ b/test/Python/src/StructPrint.lf
@@ -13,7 +13,7 @@ reactor Print {
 }
 
 # expected parameter is for testing.
-reactor Check(expected = 42) {
+reactor Check(expected=42) {
   input _in
 
   reaction(_in) {=

--- a/test/Python/src/StructScale.lf
+++ b/test/Python/src/StructScale.lf
@@ -13,7 +13,7 @@ reactor Source {
 }
 
 # expected parameter is for testing.
-reactor TestInput(expected = 42) {
+reactor TestInput(expected=42) {
   input _in
 
   reaction(_in) {=
@@ -24,7 +24,7 @@ reactor TestInput(expected = 42) {
   =}
 }
 
-reactor Print(scale = 2) {
+reactor Print(scale=2) {
   # Mutable keyword indicates that this reactor wants a writable copy of the input.
   mutable input _in
 
@@ -39,7 +39,7 @@ reactor Print(scale = 2) {
 main reactor StructScale {
   s = new Source()
   c = new Print()
-  p = new TestInput(expected = 84)
+  p = new TestInput(expected=84)
   s.out -> c._in
   c.out -> p._in
 }

--- a/test/Python/src/SubclassesAndStartup.lf
+++ b/test/Python/src/SubclassesAndStartup.lf
@@ -15,7 +15,7 @@ reactor Super {
   =}
 }
 
-reactor SubA(name = "SubA") extends Super {
+reactor SubA(name="SubA") extends Super {
   reaction(startup) {=
     print("{:s} started".format(self.name))
     if self.count == 0:
@@ -24,7 +24,7 @@ reactor SubA(name = "SubA") extends Super {
   =}
 }
 
-reactor SubB(name = "SubB") extends Super {
+reactor SubB(name="SubB") extends Super {
   reaction(startup) {=
     print("{:s} started".format(self.name))
     if self.count == 0:

--- a/test/Python/src/TimeLimit.lf
+++ b/test/Python/src/TimeLimit.lf
@@ -4,7 +4,7 @@ target Python {
   fast: true
 }
 
-reactor Clock(offset = 0, period = 1 sec) {
+reactor Clock(offset=0, period = 1 sec) {
   output y
   timer t(offset, period)
   state count = 0
@@ -38,7 +38,7 @@ reactor Destination {
 
 main reactor TimeLimit(period = 1 sec) {
   timer stop(10 sec)
-  c = new Clock(period = period)
+  c = new Clock(period=period)
   d = new Destination()
   c.y -> d.x
 

--- a/test/Python/src/TimeState.lf
+++ b/test/Python/src/TimeState.lf
@@ -1,6 +1,6 @@
 target Python
 
-reactor Foo(bar = 42) {
+reactor Foo(bar=42) {
   state baz = 500 msec
 
   reaction(startup) {= print("Baz: ", self.baz) =}

--- a/test/Python/src/federated/ChainWithDelay.lf
+++ b/test/Python/src/federated/ChainWithDelay.lf
@@ -14,7 +14,7 @@ import TestCount from "../lib/TestCount.lf"
 federated reactor {
   c = new Count(period = 1 msec)
   i = new InternalDelay(delay = 500 usec)
-  t = new TestCount(num_inputs = 3)
+  t = new TestCount(num_inputs=3)
   c.out -> i.in_
   i.out -> t.in_
 }

--- a/test/Python/src/federated/DecentralizedP2PComm.lf
+++ b/test/Python/src/federated/DecentralizedP2PComm.lf
@@ -5,7 +5,7 @@ target Python {
   coordination: decentralized
 }
 
-reactor Platform(start = 0, expected_start = 0, stp_offset_param = 0) {
+reactor Platform(start=0, expected_start=0, stp_offset_param=0) {
   preamble {= import sys =}
   input in_
   output out
@@ -40,8 +40,8 @@ reactor Platform(start = 0, expected_start = 0, stp_offset_param = 0) {
 }
 
 federated reactor DecentralizedP2PComm {
-  a = new Platform(expected_start = 100, stp_offset_param = 10 msec)
-  b = new Platform(start = 100, stp_offset_param = 10 msec)
+  a = new Platform(expected_start=100, stp_offset_param = 10 msec)
+  b = new Platform(start=100, stp_offset_param = 10 msec)
   a.out -> b.in_
   b.out -> a.in_
 }

--- a/test/Python/src/federated/DecentralizedP2PUnbalancedTimeout.lf
+++ b/test/Python/src/federated/DecentralizedP2PUnbalancedTimeout.lf
@@ -11,7 +11,7 @@ target Python {
 }
 
 # reason for failing: lf_tag() not supported by the python target
-reactor Clock(offset = 0, period = 1 sec) {
+reactor Clock(offset=0, period = 1 sec) {
   output y
   timer t(offset, period)
   state count = 0
@@ -50,7 +50,7 @@ reactor Destination {
 }
 
 federated reactor(period = 10 usec) {
-  c = new Clock(period = period)
+  c = new Clock(period=period)
   d = new Destination()
   c.y -> d.x
 }

--- a/test/Python/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
+++ b/test/Python/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
@@ -11,7 +11,7 @@ target Python {
   coordination: decentralized
 }
 
-reactor Clock(offset = 0, period = 1 sec) {
+reactor Clock(offset=0, period = 1 sec) {
   output y
   timer t(offset, period)
   state count = 0
@@ -43,7 +43,7 @@ reactor Destination {
 }
 
 federated reactor(period = 10 usec) {
-  c = new Clock(period = period)
+  c = new Clock(period=period)
   d = new Destination()
   c.y ~> d.x
 }

--- a/test/Python/src/federated/DistributedLoopedAction.lf
+++ b/test/Python/src/federated/DistributedLoopedAction.lf
@@ -9,7 +9,7 @@ target Python {
 
 import Sender from "../lib/LoopedActionSender.lf"
 
-reactor Receiver(take_a_break_after = 10, break_interval = 400 msec) {
+reactor Receiver(take_a_break_after=10, break_interval = 400 msec) {
   preamble {= import sys =}
   input in_
   state received_messages = 0

--- a/test/Python/src/federated/DistributedLoopedPhysicalAction.lf
+++ b/test/Python/src/federated/DistributedLoopedPhysicalAction.lf
@@ -13,7 +13,7 @@ target Python {
   keepalive: true
 }
 
-reactor Sender(take_a_break_after = 10, break_interval = 550 msec) {
+reactor Sender(take_a_break_after=10, break_interval = 550 msec) {
   output out
   physical action act
   state sent_messages = 0
@@ -31,7 +31,7 @@ reactor Sender(take_a_break_after = 10, break_interval = 550 msec) {
   =}
 }
 
-reactor Receiver(take_a_break_after = 10, break_interval = 550 msec) {
+reactor Receiver(take_a_break_after=10, break_interval = 550 msec) {
   preamble {= import sys =}
   input in_
   state received_messages = 0

--- a/test/Python/src/federated/DistributedStop.lf
+++ b/test/Python/src/federated/DistributedStop.lf
@@ -61,8 +61,8 @@ reactor Sender {
 }
 
 reactor Receiver(
-  stp_offset = 10 msec  # Used in the decentralized variant of the test
-) {
+    # Used in the decentralized variant of the test
+    stp_offset = 10 msec) {
   input in_
   state reaction_invoked_correctly = False
 

--- a/test/Python/src/federated/DistributedStructParallel.lf
+++ b/test/Python/src/federated/DistributedStructParallel.lf
@@ -13,9 +13,9 @@ preamble {= import hello =}
 federated reactor {
   s = new Source()
   c1 = new Print()
-  c2 = new Print(scale = 3)
-  p1 = new Check(expected = 84)
-  p2 = new Check(expected = 126)
+  c2 = new Print(scale=3)
+  p1 = new Check(expected=84)
+  p2 = new Check(expected=126)
   s.out -> c1._in
   s.out -> c2._in
   c1.out -> p1._in

--- a/test/Python/src/federated/DistributedStructScale.lf
+++ b/test/Python/src/federated/DistributedStructScale.lf
@@ -12,7 +12,7 @@ preamble {= import hello =}
 federated reactor {
   s = new Source()
   c = new Print()
-  p = new TestInput(expected = 84)
+  p = new TestInput(expected=84)
   s.out -> c._in
   c.out -> p._in
 }

--- a/test/Python/src/federated/LoopDistributedCentralizedPrecedenceHierarchy.lf
+++ b/test/Python/src/federated/LoopDistributedCentralizedPrecedenceHierarchy.lf
@@ -13,7 +13,7 @@ target Python {
   timeout: 5 sec
 }
 
-reactor Contained(incr = 1) {
+reactor Contained(incr=1) {
   timer t(0, 1 sec)
   input inp
   state count = 0
@@ -30,13 +30,13 @@ reactor Contained(incr = 1) {
   =}
 }
 
-reactor Looper(incr = 1, delay = 0 msec) {
+reactor Looper(incr=1, delay = 0 msec) {
   input inp
   output out
   state count = 0
   timer t(0, 1 sec)
 
-  c = new Contained(incr = incr)
+  c = new Contained(incr=incr)
   inp -> c.inp
 
   reaction(t) -> out {=
@@ -58,9 +58,9 @@ reactor Looper(incr = 1, delay = 0 msec) {
   =}
 }
 
-federated reactor(delay = 0) {
+federated reactor(delay=0) {
   left = new Looper()
-  right = new Looper(incr = -1)
+  right = new Looper(incr=-1)
   left.out -> right.inp
   right.out -> left.inp
 }

--- a/test/Python/src/federated/ParallelDestinations.lf
+++ b/test/Python/src/federated/ParallelDestinations.lf
@@ -16,8 +16,8 @@ reactor Source {
 
 federated reactor {
   s = new Source()
-  t1 = new TestCount(num_inputs = 3)
-  t2 = new TestCount(num_inputs = 3)
+  t1 = new TestCount(num_inputs=3)
+  t2 = new TestCount(num_inputs=3)
 
   s.out -> t1.in_, t2.in_
 }

--- a/test/Python/src/federated/ParallelSources.lf
+++ b/test/Python/src/federated/ParallelSources.lf
@@ -9,8 +9,8 @@ import TestCount from "../lib/TestCount.lf"
 reactor Destination {
   input[2] in_
 
-  t1 = new TestCount(num_inputs = 3)
-  t2 = new TestCount(num_inputs = 3)
+  t1 = new TestCount(num_inputs=3)
+  t2 = new TestCount(num_inputs=3)
 
   in_ -> t1.in_, t2.in_
 }

--- a/test/Python/src/federated/ParallelSourcesMultiport.lf
+++ b/test/Python/src/federated/ParallelSourcesMultiport.lf
@@ -17,9 +17,9 @@ reactor Source {
 reactor Destination1 {
   input[3] in_
 
-  t1 = new TestCount(num_inputs = 3)
-  t2 = new TestCount(num_inputs = 3)
-  t3 = new TestCount(num_inputs = 3)
+  t1 = new TestCount(num_inputs=3)
+  t2 = new TestCount(num_inputs=3)
+  t3 = new TestCount(num_inputs=3)
 
   in_ -> t1.in_, t2.in_, t3.in_
 }
@@ -28,7 +28,7 @@ federated reactor {
   s1 = new Source()
   s2 = new Source()
   d1 = new Destination1()
-  t4 = new TestCount(num_inputs = 3)
+  t4 = new TestCount(num_inputs=3)
 
   s1.out, s2.out -> d1.in_, t4.in_
 }

--- a/test/Python/src/federated/PhysicalSTP.lf
+++ b/test/Python/src/federated/PhysicalSTP.lf
@@ -6,7 +6,7 @@ target Python {
 
 import Count from "../lib/Count.lf"
 
-reactor Print(STP_offset = 0) {
+reactor Print(STP_offset=0) {
   preamble {= import sys =}
   input in_
   state c = 1

--- a/test/Python/src/federated/PingPongDistributed.lf
+++ b/test/Python/src/federated/PingPongDistributed.lf
@@ -19,7 +19,7 @@
  */
 target Python
 
-reactor Ping(count = 10) {
+reactor Ping(count=10) {
   input receive
   output send
   state pingsLeft = count
@@ -39,7 +39,7 @@ reactor Ping(count = 10) {
   =}
 }
 
-reactor Pong(expected = 10) {
+reactor Pong(expected=10) {
   preamble {= import sys =}
 
   input receive
@@ -62,9 +62,9 @@ reactor Pong(expected = 10) {
   =}
 }
 
-federated reactor(count = 10) {
-  ping = new Ping(count = count)
-  pong = new Pong(expected = count)
+federated reactor(count=10) {
+  ping = new Ping(count=count)
+  pong = new Pong(expected=count)
   ping.send ~> pong.receive
   pong.send ~> ping.receive
 }

--- a/test/Python/src/lib/Count.lf
+++ b/test/Python/src/lib/Count.lf
@@ -1,6 +1,6 @@
 target Python
 
-reactor Count(offset = 0, period = 1 sec) {
+reactor Count(offset=0, period = 1 sec) {
   state count = 1
   output out
   timer t(offset, period)

--- a/test/Python/src/lib/LoopedActionSender.lf
+++ b/test/Python/src/lib/LoopedActionSender.lf
@@ -10,7 +10,7 @@ target Python
  * @param break_interval: Determines how long the reactor should take a break after sending
  * take_a_break_after messages.
  */
-reactor Sender(take_a_break_after = 10, break_interval = 400 msec) {
+reactor Sender(take_a_break_after=10, break_interval = 400 msec) {
   output out
   logical action act
   state sent_messages = 0

--- a/test/Python/src/lib/TestCount.lf
+++ b/test/Python/src/lib/TestCount.lf
@@ -8,7 +8,7 @@
  */
 target Python
 
-reactor TestCount(start = 1, stride = 1, num_inputs = 1) {
+reactor TestCount(start=1, stride=1, num_inputs=1) {
   preamble {= import sys =}
   state count = start
   state inputs_received = 0

--- a/test/Python/src/lib/TestCountMultiport.lf
+++ b/test/Python/src/lib/TestCountMultiport.lf
@@ -10,7 +10,7 @@
  */
 target Python
 
-reactor TestCountMultiport(start = 1, stride = 1, num_inputs = 1, width = 2) {
+reactor TestCountMultiport(start=1, stride=1, num_inputs=1, width=2) {
   preamble {= import sys =}
   state count = start
   state inputs_received = 0

--- a/test/Python/src/modal_models/ConvertCaseTest.lf
+++ b/test/Python/src/modal_models/ConvertCaseTest.lf
@@ -67,7 +67,7 @@ reactor Converter {
   }
 }
 
-reactor InputFeeder(message = "") {
+reactor InputFeeder(message="") {
   output character
   state idx = 0
 

--- a/test/Python/src/modal_models/ModalAfter.lf
+++ b/test/Python/src/modal_models/ModalAfter.lf
@@ -19,8 +19,8 @@ reactor Modal {
   output consumed2
 
   initial mode One {
-    producer1 = new Producer(mode_id = 1)
-    consumer1 = new Consumer(mode_id = 1)
+    producer1 = new Producer(mode_id=1)
+    consumer1 = new Consumer(mode_id=1)
     producer1.product -> produced1
     producer1.product -> consumer1.product after 500 msec
     consumer1.report -> consumed1
@@ -32,8 +32,8 @@ reactor Modal {
   }
 
   mode Two {
-    producer2 = new Producer(mode_id = 2)
-    consumer2 = new Consumer(mode_id = 2)
+    producer2 = new Producer(mode_id=2)
+    consumer2 = new Consumer(mode_id=2)
     producer2.product -> produced2
     producer2.product -> consumer2.product after 500 msec
     consumer2.report -> consumed2
@@ -45,7 +45,7 @@ reactor Modal {
   }
 }
 
-reactor Producer(mode_id = 0) {
+reactor Producer(mode_id=0) {
   output product
 
   timer t(0, 750 msec)
@@ -56,7 +56,7 @@ reactor Producer(mode_id = 0) {
   =}
 }
 
-reactor Consumer(mode_id = 0) {
+reactor Consumer(mode_id=0) {
   input product
   output report
 

--- a/test/Python/src/modal_models/util/TraceTesting.lf
+++ b/test/Python/src/modal_models/util/TraceTesting.lf
@@ -1,7 +1,7 @@
 /** Utility reactor to record and test execution traces. */
 target Python
 
-reactor TraceTesting(events_size = 0, trace = {= [] =}, training = False) {
+reactor TraceTesting(events_size=0, trace = {= [] =}, training=False) {
   input[events_size] events
 
   state last_reaction_time = 0

--- a/test/Python/src/multiport/BankIndexInitializer.lf
+++ b/test/Python/src/multiport/BankIndexInitializer.lf
@@ -3,13 +3,13 @@ target Python
 
 preamble {= table = [4, 3, 2, 1] =}
 
-reactor Source(bank_index = 0, value = 0) {
+reactor Source(bank_index=0, value=0) {
   output out
 
   reaction(startup) -> out {= out.set(self.value) =}
 }
 
-reactor Sink(width = 4) {
+reactor Sink(width=4) {
   input[width] _in
   state received = False
 
@@ -30,8 +30,8 @@ reactor Sink(width = 4) {
   =}
 }
 
-main reactor(width = 4) {
+main reactor(width=4) {
   source = new[width] Source(value = {= table[bank_index] =})
-  sink = new Sink(width = width)
+  sink = new Sink(width=width)
   source.out -> sink._in
 }

--- a/test/Python/src/multiport/BankReactionsInContainer.lf
+++ b/test/Python/src/multiport/BankReactionsInContainer.lf
@@ -3,7 +3,7 @@ target Python {
   timeout: 1 sec
 }
 
-reactor R(bank_index = 0) {
+reactor R(bank_index=0) {
   output[2] out
   input[2] inp
   state received = False

--- a/test/Python/src/multiport/BankToBank.lf
+++ b/test/Python/src/multiport/BankToBank.lf
@@ -4,7 +4,7 @@ target Python {
   fast: true
 }
 
-reactor Source(bank_index = 0) {
+reactor Source(bank_index=0) {
   timer t(0, 200 msec)
   output out
   state s = 0
@@ -15,7 +15,7 @@ reactor Source(bank_index = 0) {
   =}
 }
 
-reactor Destination(bank_index = 0) {
+reactor Destination(bank_index=0) {
   state s = 0
   input _in
 
@@ -35,7 +35,7 @@ reactor Destination(bank_index = 0) {
   =}
 }
 
-main reactor BankToBank(width = 4) {
+main reactor BankToBank(width=4) {
   a = new[width] Source()
   b = new[width] Destination()
   a.out -> b._in

--- a/test/Python/src/multiport/BankToBankMultiport.lf
+++ b/test/Python/src/multiport/BankToBankMultiport.lf
@@ -4,7 +4,7 @@ target Python {
   fast: true
 }
 
-reactor Source(width = 1) {
+reactor Source(width=1) {
   timer t(0, 200 msec)
   output[width] out
   state s = 0
@@ -16,7 +16,7 @@ reactor Source(width = 1) {
   =}
 }
 
-reactor Destination(width = 1) {
+reactor Destination(width=1) {
   state s = 6
   input[width] _in
 
@@ -43,8 +43,8 @@ reactor Destination(width = 1) {
   =}
 }
 
-main reactor BankToBankMultiport(bank_width = 4) {
-  a = new[bank_width] Source(width = 4)
-  b = new[bank_width] Destination(width = 4)
+main reactor BankToBankMultiport(bank_width=4) {
+  a = new[bank_width] Source(width=4)
+  b = new[bank_width] Destination(width=4)
   a.out -> b._in
 }

--- a/test/Python/src/multiport/BankToBankMultiportAfter.lf
+++ b/test/Python/src/multiport/BankToBankMultiportAfter.lf
@@ -6,8 +6,8 @@ target Python {
 
 import Source, Destination from "BankToBankMultiport.lf"
 
-main reactor BankToBankMultiportAfter(bank_width = 4) {
-  a = new[bank_width] Source(width = 4)
-  b = new[bank_width] Destination(width = 4)
+main reactor BankToBankMultiportAfter(bank_width=4) {
+  a = new[bank_width] Source(width=4)
+  b = new[bank_width] Destination(width=4)
   a.out -> b._in after 200 msec
 }

--- a/test/Python/src/multiport/BankToMultiport.lf
+++ b/test/Python/src/multiport/BankToMultiport.lf
@@ -1,13 +1,13 @@
 # Test bank of reactors to multiport input with id parameter in the bank.
 target Python
 
-reactor Source(bank_index = 0) {
+reactor Source(bank_index=0) {
   output out
 
   reaction(startup) -> out {= out.set(self.bank_index) =}
 }
 
-reactor Sink(width = 4) {
+reactor Sink(width=4) {
   input[width] _in
   state received = False
 
@@ -28,8 +28,8 @@ reactor Sink(width = 4) {
   =}
 }
 
-main reactor BankToMultiport(width = 5) {
+main reactor BankToMultiport(width=5) {
   source = new[width] Source()
-  sink = new Sink(width = width)
+  sink = new Sink(width=width)
   source.out -> sink._in
 }

--- a/test/Python/src/multiport/Broadcast.lf
+++ b/test/Python/src/multiport/Broadcast.lf
@@ -3,13 +3,13 @@ target Python {
   fast: true
 }
 
-reactor Source(value = 42) {
+reactor Source(value=42) {
   output out
 
   reaction(startup) -> out {= out.set(self.value) =}
 }
 
-reactor Destination(bank_index = 0, delay = 0) {
+reactor Destination(bank_index=0, delay=0) {
   input _in
   state received = False
 

--- a/test/Python/src/multiport/BroadcastMultipleAfter.lf
+++ b/test/Python/src/multiport/BroadcastMultipleAfter.lf
@@ -5,7 +5,7 @@ target Python {
 
 import Source from "Broadcast.lf"
 
-reactor Destination(bank_index = 0, delay = 0) {
+reactor Destination(bank_index=0, delay=0) {
   input _in
   state received = False
 
@@ -31,9 +31,9 @@ reactor Destination(bank_index = 0, delay = 0) {
 }
 
 main reactor {
-  a1 = new Source(value = 1)
-  a2 = new Source(value = 2)
-  a3 = new Source(value = 3)
+  a1 = new Source(value=1)
+  a2 = new Source(value=2)
+  a3 = new Source(value=3)
   b = new[9] Destination(delay = 1 sec)
   (a1.out, a2.out, a3.out)+ -> b._in after 1 sec
 }

--- a/test/Python/src/multiport/MultiportFromBank.lf
+++ b/test/Python/src/multiport/MultiportFromBank.lf
@@ -5,7 +5,7 @@ target Python {
   fast: true
 }
 
-reactor Source(check_override = 0, bank_index = 0) {
+reactor Source(check_override=0, bank_index=0) {
   output out
 
   reaction(startup) -> out {= out.set(self.bank_index * self.check_override) =}
@@ -35,7 +35,7 @@ reactor Destination {
 }
 
 main reactor MultiportFromBank {
-  a = new[3] Source(check_override = 1)
+  a = new[3] Source(check_override=1)
   b = new Destination()
   a.out -> b._in
 }

--- a/test/Python/src/multiport/MultiportFromBankHierarchy.lf
+++ b/test/Python/src/multiport/MultiportFromBankHierarchy.lf
@@ -7,7 +7,7 @@ target Python {
 
 import Destination from "MultiportFromBank.lf"
 
-reactor Source(bank_index = 0) {
+reactor Source(bank_index=0) {
   output out
 
   reaction(startup) -> out {= out.set(self.bank_index) =}

--- a/test/Python/src/multiport/MultiportFromReaction.lf
+++ b/test/Python/src/multiport/MultiportFromReaction.lf
@@ -4,7 +4,7 @@ target Python {
   fast: true
 }
 
-reactor Destination(width = 1) {
+reactor Destination(width=1) {
   state s = 6
   input[width] _in
 
@@ -32,7 +32,7 @@ reactor Destination(width = 1) {
 main reactor MultiportFromReaction {
   timer t(0, 200 msec)
   state s = 0
-  b = new Destination(width = 4)
+  b = new Destination(width=4)
 
   reaction(t) -> b._in {=
     for (idx, port) in enumerate(b._in):

--- a/test/Python/src/multiport/MultiportInParameterized.lf
+++ b/test/Python/src/multiport/MultiportInParameterized.lf
@@ -23,7 +23,7 @@ reactor Computation {
   reaction(_in) -> out {= out.set(_in.value) =}
 }
 
-reactor Destination(width = 1) {
+reactor Destination(width=1) {
   state s = 0
   input[width] _in
 
@@ -52,7 +52,7 @@ main reactor MultiportInParameterized {
   t2 = new Computation()
   t3 = new Computation()
   t4 = new Computation()
-  b = new Destination(width = 4)
+  b = new Destination(width=4)
   a.out -> t1._in
   a.out -> t2._in
   a.out -> t3._in

--- a/test/Python/src/multiport/MultiportMutableInput.lf
+++ b/test/Python/src/multiport/MultiportMutableInput.lf
@@ -12,7 +12,7 @@ reactor Source {
 }
 
 # The scale parameter is just for testing.
-reactor Print(scale = 1) {
+reactor Print(scale=1) {
   input[2] _in
 
   reaction(_in) {=
@@ -26,7 +26,7 @@ reactor Print(scale = 1) {
   =}
 }
 
-reactor Scale(scale = 2) {
+reactor Scale(scale=2) {
   mutable input[2] _in
   output[2] out
 
@@ -41,7 +41,7 @@ reactor Scale(scale = 2) {
 main reactor MultiportMutableInput {
   s = new Source()
   c = new Scale()
-  p = new Print(scale = 2)
+  p = new Print(scale=2)
   s.out -> c._in
   c.out -> p._in
 }

--- a/test/Python/src/multiport/MultiportMutableInputArray.lf
+++ b/test/Python/src/multiport/MultiportMutableInputArray.lf
@@ -13,7 +13,7 @@ reactor Source {
 }
 
 # The scale parameter is just for testing.
-reactor Print(scale = 1) {
+reactor Print(scale=1) {
   input[2] _in
 
   reaction(_in) {=
@@ -25,7 +25,7 @@ reactor Print(scale = 1) {
   =}
 }
 
-reactor Scale(scale = 2) {
+reactor Scale(scale=2) {
   mutable input[2] _in
   output[2] out
 
@@ -40,7 +40,7 @@ reactor Scale(scale = 2) {
 main reactor MultiportMutableInputArray {
   s = new Source()
   c = new Scale()
-  p = new Print(scale = 2)
+  p = new Print(scale=2)
   s.out -> c._in
   c.out -> p._in
 }

--- a/test/Python/src/multiport/MultiportToBank.lf
+++ b/test/Python/src/multiport/MultiportToBank.lf
@@ -13,7 +13,7 @@ reactor Source {
   =}
 }
 
-reactor Destination(bank_index = 0) {
+reactor Destination(bank_index=0) {
   input _in
   state received = 0
 

--- a/test/Python/src/multiport/MultiportToBankAfter.lf
+++ b/test/Python/src/multiport/MultiportToBankAfter.lf
@@ -6,7 +6,7 @@ target Python {
 
 import Source from "MultiportToBank.lf"
 
-reactor Destination(bank_index = 0) {
+reactor Destination(bank_index=0) {
   input _in
   state received = False
 

--- a/test/Python/src/multiport/MultiportToBankHierarchy.lf
+++ b/test/Python/src/multiport/MultiportToBankHierarchy.lf
@@ -7,7 +7,7 @@ target Python {
 
 import Source from "MultiportToBank.lf"
 
-reactor Destination(bank_index = 0) {
+reactor Destination(bank_index=0) {
   input _in
   state received = False
 

--- a/test/Python/src/multiport/MultiportToHierarchy.lf
+++ b/test/Python/src/multiport/MultiportToHierarchy.lf
@@ -17,7 +17,7 @@ reactor Source {
   =}
 }
 
-reactor Destination(width = 4) {
+reactor Destination(width=4) {
   state s = 6
   input[width] _in
 
@@ -41,7 +41,7 @@ reactor Destination(width = 4) {
   =}
 }
 
-reactor Container(width = 4) {
+reactor Container(width=4) {
   input[width] _in
   dst = new Destination()
   _in -> dst._in

--- a/test/Python/src/multiport/MultiportToMultiport.lf
+++ b/test/Python/src/multiport/MultiportToMultiport.lf
@@ -6,7 +6,7 @@ target Python {
 
 import Destination from "MultiportToHierarchy.lf"
 
-reactor Source(width = 1) {
+reactor Source(width=1) {
   timer t(0, 200 msec)
   output[width] out
   state s = 0
@@ -22,7 +22,7 @@ reactor Source(width = 1) {
 }
 
 main reactor MultiportToMultiport {
-  a = new Source(width = 4)
-  b = new Destination(width = 4)
+  a = new Source(width=4)
+  b = new Destination(width=4)
   a.out -> b._in
 }

--- a/test/Python/src/multiport/MultiportToMultiport2.lf
+++ b/test/Python/src/multiport/MultiportToMultiport2.lf
@@ -1,7 +1,7 @@
 # Test multiport to multiport connections. See also MultiportToMultiport.
 target Python
 
-reactor Source(width = 2) {
+reactor Source(width=2) {
   output[width] out
 
   reaction(startup) -> out {=
@@ -10,7 +10,7 @@ reactor Source(width = 2) {
   =}
 }
 
-reactor Destination(width = 2) {
+reactor Destination(width=2) {
   input[width] _in
 
   reaction(_in) {=
@@ -26,8 +26,8 @@ reactor Destination(width = 2) {
 }
 
 main reactor MultiportToMultiport2 {
-  a1 = new Source(width = 3)
-  a2 = new Source(width = 2)
-  b = new Destination(width = 5)
+  a1 = new Source(width=3)
+  a2 = new Source(width=2)
+  b = new Destination(width=5)
   a1.out, a2.out -> b._in
 }

--- a/test/Python/src/multiport/MultiportToMultiport2After.lf
+++ b/test/Python/src/multiport/MultiportToMultiport2After.lf
@@ -3,7 +3,7 @@ target Python
 
 import Source from "MultiportToMultiport2.lf"
 
-reactor Destination(width = 2) {
+reactor Destination(width=2) {
   input[width] _in
 
   reaction(_in) {=
@@ -22,8 +22,8 @@ reactor Destination(width = 2) {
 }
 
 main reactor MultiportToMultiport2After {
-  a1 = new Source(width = 3)
-  a2 = new Source(width = 2)
-  b = new Destination(width = 5)
+  a1 = new Source(width=3)
+  a2 = new Source(width=2)
+  b = new Destination(width=5)
   a1.out, a2.out -> b._in after 1 sec
 }

--- a/test/Python/src/multiport/MultiportToMultiportParameter.lf
+++ b/test/Python/src/multiport/MultiportToMultiportParameter.lf
@@ -7,8 +7,8 @@ target Python {
 import Source from "MultiportToMultiport.lf"
 import Destination from "MultiportToHierarchy.lf"
 
-main reactor MultiportToMultiportParameter(width = 4) {
-  a = new Source(width = width)
-  b = new Destination(width = width)
+main reactor MultiportToMultiportParameter(width=4) {
+  a = new Source(width=width)
+  b = new Destination(width=width)
   a.out -> b._in
 }

--- a/test/Python/src/multiport/MultiportToPort.lf
+++ b/test/Python/src/multiport/MultiportToPort.lf
@@ -14,7 +14,7 @@ reactor Source {
   =}
 }
 
-reactor Destination(expected = 0) {
+reactor Destination(expected=0) {
   input _in
   state received = False
 
@@ -37,6 +37,6 @@ reactor Destination(expected = 0) {
 main reactor MultiportToPort {
   a = new Source()
   b1 = new Destination()
-  b2 = new Destination(expected = 1)
+  b2 = new Destination(expected=1)
   a.out -> b1._in, b2._in
 }

--- a/test/Python/src/multiport/MultiportToReaction.lf
+++ b/test/Python/src/multiport/MultiportToReaction.lf
@@ -4,7 +4,7 @@ target Python {
   fast: true
 }
 
-reactor Source(width = 1) {
+reactor Source(width=1) {
   timer t(0, 200 msec)
   state s = 0
   output[width] out
@@ -18,7 +18,7 @@ reactor Source(width = 1) {
 
 main reactor {
   state s = 6
-  b = new Source(width = 4)
+  b = new Source(width=4)
 
   reaction(b.out) {=
     sm = 0

--- a/test/Python/src/multiport/NestedBanks.lf
+++ b/test/Python/src/multiport/NestedBanks.lf
@@ -13,13 +13,13 @@ main reactor {
   (a.x)+ -> c.z, d.u, e.t
 }
 
-reactor A(bank_index = 0) {
+reactor A(bank_index=0) {
   output[4] x
-  b = new[2] B(a_bank_index = bank_index)
+  b = new[2] B(a_bank_index=bank_index)
   b.y -> x
 }
 
-reactor B(a_bank_index = 0, bank_index = 0) {
+reactor B(a_bank_index=0, bank_index=0) {
   output[2] y
 
   reaction(startup) -> y {=
@@ -29,10 +29,10 @@ reactor B(a_bank_index = 0, bank_index = 0) {
   =}
 }
 
-reactor C(bank_index = 0) {
+reactor C(bank_index=0) {
   input[2] z
-  f = new F(c_bank_index = bank_index)
-  g = new G(c_bank_index = bank_index)
+  f = new F(c_bank_index=bank_index)
+  g = new G(c_bank_index=bank_index)
   z -> f.w, g.s
 }
 
@@ -57,7 +57,7 @@ reactor E {
   =}
 }
 
-reactor F(c_bank_index = 0) {
+reactor F(c_bank_index=0) {
   input w
 
   reaction(w) {=
@@ -68,7 +68,7 @@ reactor F(c_bank_index = 0) {
   =}
 }
 
-reactor G(c_bank_index = 0) {
+reactor G(c_bank_index=0) {
   input s
 
   reaction(s) {=

--- a/test/Python/src/multiport/NestedInterleavedBanks.lf
+++ b/test/Python/src/multiport/NestedInterleavedBanks.lf
@@ -4,7 +4,7 @@
  */
 target Python
 
-reactor A(bank_index = 0, outer_bank_index = 0) {
+reactor A(bank_index=0, outer_bank_index=0) {
   output[2] p
 
   reaction(startup) -> p {=
@@ -14,9 +14,9 @@ reactor A(bank_index = 0, outer_bank_index = 0) {
   =}
 }
 
-reactor B(bank_index = 0) {
+reactor B(bank_index=0) {
   output[4] q
-  a = new[2] A(outer_bank_index = bank_index)
+  a = new[2] A(outer_bank_index=bank_index)
   interleaved(a.p) -> q
 }
 

--- a/test/Python/src/multiport/ReactionsToNested.lf
+++ b/test/Python/src/multiport/ReactionsToNested.lf
@@ -3,7 +3,7 @@ target Python {
   timeout: 1 sec
 }
 
-reactor T(expected = 0) {
+reactor T(expected=0) {
   input z
   state received = False
 
@@ -24,8 +24,8 @@ reactor T(expected = 0) {
 
 reactor D {
   input[2] y
-  t1 = new T(expected = 42)
-  t2 = new T(expected = 43)
+  t1 = new T(expected=42)
+  t2 = new T(expected=43)
   y -> t1.z, t2.z
 }
 

--- a/test/Rust/src/CtorParamMixed.lf
+++ b/test/Rust/src/CtorParamMixed.lf
@@ -14,5 +14,5 @@ reactor Print(value: i32 = 42, name: String = {= "xxx".into() =}, other: bool = 
 }
 
 main reactor CtorParamMixed {
-  p = new Print(other = true, name = {= "x2hr".into() =})
+  p = new Print(other=true, name = {= "x2hr".into() =})
 }

--- a/test/Rust/src/CtorParamSimple.lf
+++ b/test/Rust/src/CtorParamSimple.lf
@@ -10,5 +10,5 @@ reactor Print(value: i32 = 42) {
 }
 
 main reactor CtorParamSimple {
-  p = new Print(value = 23)
+  p = new Print(value=23)
 }

--- a/test/Rust/src/NativeListsAndTimes.lf
+++ b/test/Rust/src/NativeListsAndTimes.lf
@@ -2,16 +2,16 @@ target Rust
 
 // This test passes if it is successfully compiled into valid target code.
 reactor Foo(
-  x: i32 = 0,
-  y: time = 0,  // Units are missing but not required
-  z = 1 msec,  // Type is missing but not required
-  p: i32[](1, 2, 3, 4),  // List of integers
-  p2: i32[] = {= vec![1] =},  // List of integers with single element
-  // todo // p2: i32[](1), // List of integers with single element p3: i32[](), // Empty list of
-  // integers List of time values
-  q: Vec<Duration>(1 msec, 2 msec, 3 msec),
-  g: time[](1 msec, 2 msec)  // List of time values
-) {
+    x: i32 = 0,
+    y: time = 0,  // Units are missing but not required
+    z = 1 msec,  // Type is missing but not required
+    p: i32[](1, 2, 3, 4),  // List of integers
+    p2: i32[] = {= vec![1] =},  // List of integers with single element
+    // todo // p2: i32[](1), // List of integers with single element p3: i32[](), // Empty list of
+    // integers List of time values
+    q: Vec<Duration>(1 msec, 2 msec, 3 msec),
+    // List of time values
+    g: time[](1 msec, 2 msec)) {
   state s: time = y  // Reference to explicitly typed time parameter
   state t: time = z  // Reference to implicitly typed time parameter
   state v: bool  // Uninitialized boolean state variable

--- a/test/Rust/src/generics/CtorParamGeneric.lf
+++ b/test/Rust/src/generics/CtorParamGeneric.lf
@@ -2,8 +2,7 @@
 target Rust
 
 reactor Generic<{= T: Default + Eq + Sync + std::fmt::Debug =}>(
-  value: T = {= Default::default() =}
-) {
+    value: T = {= Default::default() =}) {
   input in: T
   state v: T = value
 
@@ -16,7 +15,7 @@ reactor Generic<{= T: Default + Eq + Sync + std::fmt::Debug =}>(
 }
 
 main reactor {
-  p = new Generic<u32>(value = 23)
+  p = new Generic<u32>(value=23)
 
   reaction(startup) -> p.in {= ctx.set(p__in, 23); =}
 }

--- a/test/Rust/src/generics/CtorParamGenericInst.lf
+++ b/test/Rust/src/generics/CtorParamGenericInst.lf
@@ -3,8 +3,7 @@
 target Rust
 
 reactor Generic2<{= T: Default + Eq + Sync + std::fmt::Debug + Send + 'static =}>(
-  value: T = {= Default::default() =}
-) {
+    value: T = {= Default::default() =}) {
   input in: T
   state v: T = value
 
@@ -17,17 +16,16 @@ reactor Generic2<{= T: Default + Eq + Sync + std::fmt::Debug + Send + 'static =}
 }
 
 reactor Generic<{= T: Default + Eq + Sync + std::fmt::Debug + Copy + Send + 'static =}>(
-  value: T = {= Default::default() =}
-) {
+    value: T = {= Default::default() =}) {
   input in: T
 
-  inner = new Generic2<T>(value = value)
+  inner = new Generic2<T>(value=value)
 
   in -> inner.in
 }
 
 main reactor {
-  p = new Generic<u32>(value = 23)
+  p = new Generic<u32>(value=23)
 
   reaction(startup) -> p.in {= ctx.set(p__in, 23); =}
 }

--- a/test/Rust/src/multiport/ConnectionToSelfBank.lf
+++ b/test/Rust/src/multiport/ConnectionToSelfBank.lf
@@ -16,6 +16,6 @@ reactor Node(bank_index: usize = 0, num_nodes: usize = 4) {
 }
 
 main reactor(num_nodes: usize = 4) {
-  nodes = new[num_nodes] Node(num_nodes = num_nodes)
+  nodes = new[num_nodes] Node(num_nodes=num_nodes)
   (nodes.out)+ -> nodes.in
 }

--- a/test/Rust/src/multiport/ConnectionToSelfMultiport.lf
+++ b/test/Rust/src/multiport/ConnectionToSelfMultiport.lf
@@ -20,6 +20,6 @@ reactor Node(num_nodes: usize = 4) {
 }
 
 main reactor(num_nodes: usize = 4) {
-  nodes = new Node(num_nodes = num_nodes)
+  nodes = new Node(num_nodes=num_nodes)
   nodes.out -> nodes.in  // todo: (nodes.out)+ -> nodes.in;
 }

--- a/test/Rust/src/multiport/FullyConnected.lf
+++ b/test/Rust/src/multiport/FullyConnected.lf
@@ -21,6 +21,6 @@ reactor Right(bank_index: usize = 0, num_nodes: usize = 4) {
 
 main reactor(num_nodes: usize = 4) {
   left = new[num_nodes] Left()
-  right = new[num_nodes] Right(num_nodes = num_nodes)
+  right = new[num_nodes] Right(num_nodes=num_nodes)
   (left.out)+ -> right.in
 }

--- a/test/Rust/src/multiport/FullyConnectedAddressable.lf
+++ b/test/Rust/src/multiport/FullyConnectedAddressable.lf
@@ -44,9 +44,9 @@ reactor Node(bank_index: usize = 0, num_nodes: usize = 4) {
 }
 
 main reactor(num_nodes: usize = 4) {
-  nodes1 = new[num_nodes] Node(num_nodes = num_nodes)
+  nodes1 = new[num_nodes] Node(num_nodes=num_nodes)
   nodes1.out -> interleaved(nodes1.inpt)
 
-  nodes2 = new[num_nodes] Node(num_nodes = num_nodes)
+  nodes2 = new[num_nodes] Node(num_nodes=num_nodes)
   interleaved(nodes2.out) -> nodes2.inpt
 }

--- a/test/Rust/src/multiport/MultiportFromBank.lf
+++ b/test/Rust/src/multiport/MultiportFromBank.lf
@@ -23,6 +23,6 @@ reactor Destination(port_width: usize = 2) {
 
 main reactor {
   a = new[4] Source()
-  b = new Destination(port_width = 4)
+  b = new Destination(port_width=4)
   a.out -> b.in
 }

--- a/test/Rust/src/multiport/MultiportToMultiport2.lf
+++ b/test/Rust/src/multiport/MultiportToMultiport2.lf
@@ -25,8 +25,8 @@ reactor Destination(width: usize = 2) {
 }
 
 main reactor MultiportToMultiport2 {
-  a1 = new Source(width = 3)
-  a2 = new Source(width = 2)
-  b = new Destination(width = 5)
+  a1 = new Source(width=3)
+  a2 = new Source(width=2)
+  b = new Destination(width=5)
   a1.out, a2.out -> b.in
 }

--- a/test/Rust/src/multiport/WidthWithParameter.lf
+++ b/test/Rust/src/multiport/WidthWithParameter.lf
@@ -11,7 +11,7 @@ reactor Some(value: usize = 30) {
 }
 
 main reactor {
-  some = new Some(value = 20)
+  some = new Some(value=20)
 
   reaction(some.finished) {= println!("success"); =}
 }

--- a/test/TypeScript/src/ArrayScale.lf
+++ b/test/TypeScript/src/ArrayScale.lf
@@ -21,7 +21,7 @@ reactor Scale(scale: number = 2) {
 main reactor ArrayScale {
   s = new Source()
   c = new Scale()
-  p = new Print(scale = 2)
+  p = new Print(scale=2)
   s.out -> c.x
   c.out -> p.x
 }

--- a/test/TypeScript/src/Hello.lf
+++ b/test/TypeScript/src/Hello.lf
@@ -37,7 +37,7 @@ reactor Reschedule(period: time = 2 sec, message: string = "Hello TypeScript") {
 }
 
 reactor Inside(period: time = 1 sec, message: string = "Composite default message.") {
-  third_instance = new Reschedule(period = period, message = message)
+  third_instance = new Reschedule(period=period, message=message)
 }
 
 main reactor Hello {

--- a/test/TypeScript/src/NativeListsAndTimes.lf
+++ b/test/TypeScript/src/NativeListsAndTimes.lf
@@ -2,13 +2,13 @@ target TypeScript
 
 // This test passes if it is successfully compiled into valid target code.
 main reactor(
-  x: number = 0,
-  y: time = 0,               // Units are missing but not required
-  z = 1 msec,                // Type is missing but not required
-  p: number[](1, 2, 3, 4),   // List of integers
-  q: TimeValue[](1 msec, 2 msec, 3 msec),  // list of time values
-  g: time[](1 msec, 2 msec)  // List of time values
-) {
+    x: number = 0,
+    y: time = 0,               // Units are missing but not required
+    z = 1 msec,                // Type is missing but not required
+    p: number[](1, 2, 3, 4),   // List of integers
+    q: TimeValue[](1 msec, 2 msec, 3 msec),  // list of time values
+    // List of time values
+    g: time[](1 msec, 2 msec)) {
   state s: time = y  // Reference to explicitly typed time parameter
   state t: time = z  // Reference to implicitly typed time parameter
   state v: boolean   // Uninitialized boolean state variable

--- a/test/TypeScript/src/Stride.lf
+++ b/test/TypeScript/src/Stride.lf
@@ -23,7 +23,7 @@ reactor Display {
 }
 
 main reactor Stride {
-  c = new Count(stride = 2)
+  c = new Count(stride=2)
   d = new Display()
   c.y -> d.x
 }

--- a/test/TypeScript/src/StructScale.lf
+++ b/test/TypeScript/src/StructScale.lf
@@ -20,7 +20,7 @@ reactor Scale(scale: number = 2) {
 main reactor StructScale {
   s = new Source()
   c = new Scale()
-  p = new Print(expected = 84)
+  p = new Print(expected=84)
   s.out -> c.x
   c.out -> p.x
 }

--- a/test/TypeScript/src/TimeLimit.lf
+++ b/test/TypeScript/src/TimeLimit.lf
@@ -33,7 +33,7 @@ reactor Destination {
 main reactor TimeLimit(period: time = 1 msec) {
   timer stop(10 sec)
 
-  c = new Clock(period = period)
+  c = new Clock(period=period)
   d = new Destination()
   c.y -> d.x
 

--- a/test/TypeScript/src/federated/ChainWithDelay.lf
+++ b/test/TypeScript/src/federated/ChainWithDelay.lf
@@ -15,7 +15,7 @@ import TestCount from "../lib/TestCount.lf"
 federated reactor {
   c = new Count(period = 1 msec)
   i = new InternalDelay(delay = 500 usec)
-  t = new TestCount(numInputs = 3)
+  t = new TestCount(numInputs=3)
   c.out -> i.inp
   i.out -> t.inp
 }

--- a/test/TypeScript/src/federated/DistributedStop.lf
+++ b/test/TypeScript/src/federated/DistributedStop.lf
@@ -57,8 +57,8 @@ reactor Sender {
 }
 
 reactor Receiver(
-  stp_offset: time = 10 msec  // Used in the decentralized variant of the test
-) {
+    // Used in the decentralized variant of the test
+    stp_offset: time = 10 msec) {
   input in1: number
   state reaction_invoked_correctly: boolean = false
 

--- a/test/TypeScript/src/multiport/BankMulticast.lf
+++ b/test/TypeScript/src/multiport/BankMulticast.lf
@@ -16,7 +16,7 @@ reactor Foo {
   c = new Count()
   c.out -> out
 
-  d = new TestCount(numInputs = 4)
+  d = new TestCount(numInputs=4)
   inp -> d.inp
 }
 
@@ -32,6 +32,6 @@ reactor Bar {
 main reactor {
   bar = new Bar()
 
-  d = new[4] TestCount(numInputs = 4)
+  d = new[4] TestCount(numInputs=4)
   bar.out -> d.inp
 }

--- a/test/TypeScript/src/multiport/BankToBankMultiport.lf
+++ b/test/TypeScript/src/multiport/BankToBankMultiport.lf
@@ -41,7 +41,7 @@ reactor Destination(width: number = 1) {
 }
 
 main reactor BankToBankMultiport(bankWidth: number = 4) {
-  a = new[bankWidth] Source(width = 4)
-  b = new[bankWidth] Destination(width = 4)
+  a = new[bankWidth] Source(width=4)
+  b = new[bankWidth] Destination(width=4)
   a.out -> b.inp
 }

--- a/test/TypeScript/src/multiport/BankToBankMultiportAfter.lf
+++ b/test/TypeScript/src/multiport/BankToBankMultiportAfter.lf
@@ -41,7 +41,7 @@ reactor Destination(width: number = 1) {
 }
 
 main reactor(bankWidth: number = 4) {
-  a = new[bankWidth] Source(width = 4)
-  b = new[bankWidth] Destination(width = 4)
+  a = new[bankWidth] Source(width=4)
+  b = new[bankWidth] Destination(width=4)
   a.out -> b.inp after 200 msec
 }

--- a/test/TypeScript/src/multiport/BroadcastMultipleAfter.lf
+++ b/test/TypeScript/src/multiport/BroadcastMultipleAfter.lf
@@ -34,9 +34,9 @@ reactor Destination {
 }
 
 main reactor {
-  a1 = new Source(value = 1)
-  a2 = new Source(value = 2)
-  a3 = new Source(value = 3)
+  a1 = new Source(value=1)
+  a2 = new Source(value=2)
+  a3 = new Source(value=3)
   b = new[9] Destination()
   (a1.out, a2.out, a3.out)+ -> b.inp after 1 sec
 }

--- a/test/TypeScript/src/multiport/FullyConnected.lf
+++ b/test/TypeScript/src/multiport/FullyConnected.lf
@@ -37,6 +37,6 @@ reactor Node(numNodes: number = 4) {
 }
 
 main reactor(numNodes: number = 4) {
-  nodes = new[numNodes] Node(numNodes = numNodes)
+  nodes = new[numNodes] Node(numNodes=numNodes)
   (nodes.out)+ -> nodes.inp
 }

--- a/test/TypeScript/src/multiport/MultiportFromBank.lf
+++ b/test/TypeScript/src/multiport/MultiportFromBank.lf
@@ -34,6 +34,6 @@ reactor Destination(portWidth: number = 3) {
 
 main reactor(width: number = 4) {
   a = new[width] Source()
-  b = new Destination(portWidth = width)
+  b = new Destination(portWidth=width)
   a.out -> b.inp
 }

--- a/test/TypeScript/src/multiport/MultiportFromBankHierarchyAfter.lf
+++ b/test/TypeScript/src/multiport/MultiportFromBankHierarchyAfter.lf
@@ -8,7 +8,7 @@ import Destination from "MultiportFromBank.lf"
 import Container from "MultiportFromBankHierarchy.lf"
 
 main reactor MultiportFromBankHierarchyAfter {
-  a = new Container(portWidth = 4)
-  b = new Destination(portWidth = 4)
+  a = new Container(portWidth=4)
+  b = new Destination(portWidth=4)
   a.out -> b.inp after 1 sec
 }

--- a/test/TypeScript/src/multiport/MultiportFromHierarchy.lf
+++ b/test/TypeScript/src/multiport/MultiportFromHierarchy.lf
@@ -42,18 +42,18 @@ reactor Destination(width: number = 3) {
 
 reactor Container(width: number = 3) {
   output[width] out: number
-  src = new InsideContainer(width = width)
+  src = new InsideContainer(width=width)
   src.out -> out
 }
 
 reactor InsideContainer(width: number = 3) {
   output[width] out: number
-  src = new Source(width = width)
+  src = new Source(width=width)
   src.out -> out
 }
 
 main reactor MultiportFromHierarchy(width: number = 4) {
-  a = new Container(width = width)
-  b = new Destination(width = width)
+  a = new Container(width=width)
+  b = new Destination(width=width)
   a.out -> b.inp
 }

--- a/test/TypeScript/src/multiport/MultiportFromReaction.lf
+++ b/test/TypeScript/src/multiport/MultiportFromReaction.lf
@@ -31,7 +31,7 @@ reactor Destination(width: number = 1) {
 main reactor MultiportFromReaction(width: number = 4) {
   timer t(0, 200 msec)
   state s: number = 0
-  b = new Destination(width = width)
+  b = new Destination(width=width)
 
   reaction(t) -> b.inp {=
     for (let i = 0; i < b.inp.length; i++) {

--- a/test/TypeScript/src/multiport/MultiportInParameterized.lf
+++ b/test/TypeScript/src/multiport/MultiportInParameterized.lf
@@ -55,7 +55,7 @@ main reactor {
   t2 = new Computation()
   t3 = new Computation()
   t4 = new Computation()
-  b = new Destination(width = 4)
+  b = new Destination(width=4)
   a.out -> t1.inp
   a.out -> t2.inp
   a.out -> t3.inp

--- a/test/TypeScript/src/multiport/MultiportMutableInput.lf
+++ b/test/TypeScript/src/multiport/MultiportMutableInput.lf
@@ -43,7 +43,7 @@ reactor Scale(scale: number = 2) {
 main reactor {
   s = new Source()
   c = new Scale()
-  p = new Print(scale = 2)
+  p = new Print(scale=2)
   s.out -> c.inp
   c.out -> p.inp
 }

--- a/test/TypeScript/src/multiport/MultiportMutableInputArray.lf
+++ b/test/TypeScript/src/multiport/MultiportMutableInputArray.lf
@@ -75,7 +75,7 @@ reactor Scale(scale: number = 2) {
 main reactor {
   s = new Source()
   c = new Scale()
-  p = new Print(scale = 2)
+  p = new Print(scale=2)
   s.out -> c.inp
   c.out -> p.inp
 }

--- a/test/TypeScript/src/multiport/MultiportToBankAfter.lf
+++ b/test/TypeScript/src/multiport/MultiportToBankAfter.lf
@@ -39,7 +39,7 @@ reactor Destination {
 }
 
 main reactor(width: number = 3) {
-  a = new Source(width = width)
+  a = new Source(width=width)
   b = new[width] Destination()
   a.out -> b.inp after 1 sec  // Width of the bank of delays will be inferred.
 }

--- a/test/TypeScript/src/multiport/MultiportToHierarchy.lf
+++ b/test/TypeScript/src/multiport/MultiportToHierarchy.lf
@@ -48,7 +48,7 @@ reactor Container(width: number = 4) {
 }
 
 main reactor MultiportToHierarchy(width: number = 4) {
-  a = new Source(width = width)
-  b = new Container(width = width)
+  a = new Source(width=width)
+  b = new Container(width=width)
   a.out -> b.inp
 }

--- a/test/TypeScript/src/multiport/MultiportToMultiport2.lf
+++ b/test/TypeScript/src/multiport/MultiportToMultiport2.lf
@@ -27,8 +27,8 @@ reactor Destination(width: number = 2) {
 }
 
 main reactor MultiportToMultiport2 {
-  a1 = new Source(width = 3)
-  a2 = new Source(width = 2)
-  b = new Destination(width = 5)
+  a1 = new Source(width=3)
+  a2 = new Source(width=2)
+  b = new Destination(width=5)
   a1.out, a2.out -> b.inp
 }

--- a/test/TypeScript/src/multiport/MultiportToMultiport2After.lf
+++ b/test/TypeScript/src/multiport/MultiportToMultiport2After.lf
@@ -34,8 +34,8 @@ reactor Destination(width: number = 2) {
 }
 
 main reactor {
-  a1 = new Source(width = 3)
-  a2 = new Source(width = 2)
-  b = new Destination(width = 5)
+  a1 = new Source(width=3)
+  a2 = new Source(width=2)
+  b = new Destination(width=5)
   a1.out, a2.out -> b.inp after 1 sec
 }

--- a/test/TypeScript/src/multiport/MultiportToMultiportParameter.lf
+++ b/test/TypeScript/src/multiport/MultiportToMultiportParameter.lf
@@ -40,7 +40,7 @@ reactor Destination(width: number = 1) {
 }
 
 main reactor(width: number = 4) {
-  a = new Source(width = width)
-  b = new Destination(width = width)
+  a = new Source(width=width)
+  b = new Destination(width=width)
   a.out -> b.inp
 }

--- a/test/TypeScript/src/multiport/MultiportToPort.lf
+++ b/test/TypeScript/src/multiport/MultiportToPort.lf
@@ -37,6 +37,6 @@ reactor Destination(expected: number = 0) {
 main reactor MultiportToPort {
   a = new Source()
   b1 = new Destination()
-  b2 = new Destination(expected = 1)
+  b2 = new Destination(expected=1)
   a.out -> b1.inp, b2.inp
 }

--- a/test/TypeScript/src/multiport/MultiportToReaction.lf
+++ b/test/TypeScript/src/multiport/MultiportToReaction.lf
@@ -18,7 +18,7 @@ reactor Source(width: number = 1) {
 
 main reactor MultiportToReaction {
   state s: number = 6
-  b = new Source(width = 4)
+  b = new Source(width=4)
 
   reaction(b.out) {=
     let sum = 0;

--- a/test/TypeScript/src/multiport/ReactionToContainedBank.lf
+++ b/test/TypeScript/src/multiport/ReactionToContainedBank.lf
@@ -9,7 +9,7 @@ main reactor ReactionToContainedBank(width: number = 2) {
   timer t(0, 100 msec)
   state count: number = 1
 
-  test = new[width] TestCount(numInputs = 11)
+  test = new[width] TestCount(numInputs=11)
 
   reaction(t) -> test.inp {=
     for (let i = 0; i < width; i++) {

--- a/test/TypeScript/src/multiport/ReactionsToNested.lf
+++ b/test/TypeScript/src/multiport/ReactionsToNested.lf
@@ -24,8 +24,8 @@ reactor T(expected: number = 0) {
 
 reactor D {
   input[2] y: number
-  t1 = new T(expected = 42)
-  t2 = new T(expected = 43)
+  t1 = new T(expected=42)
+  t2 = new T(expected=43)
   y -> t1.z, t2.z
 }
 


### PR DESCRIPTION
This addresses some issues raised in https://github.com/lf-lang/examples-lingua-franca/pull/48.

- [x] Usually put the ending delimiter of a list on the same line as the last element of the list
- [x] Do not always surround `=` signs with whitespace when they are in parameter lists
- [ ] Resolve the issues with bad formatting of comments