### PR TITLE
More natural syntax for reaction declarations

### DIFF
--- a/cli/lfc/src/test/resources/org/lflang/cli/issue490.stderr
+++ b/cli/lfc/src/test/resources/org/lflang/cli/issue490.stderr
@@ -1,5 +1,5 @@
 lfc: error: Name of main reactor must match the file name (or be omitted).
---> cli/lfc/src/test/resources/org/lflang/cli/issue490.lf:4:14
+--> %%%PATH.lf%%%:4:14
   |
 3 | target Python;
 4 | main reactor R(p(3)) {
@@ -7,7 +7,7 @@ lfc: error: Name of main reactor must match the file name (or be omitted).
   |
 5 |   state liss(2, 3);
 lfc: error: The Python target does not support reaction declarations. Please specify a reaction body.
---> cli/lfc/src/test/resources/org/lflang/cli/issue490.lf:6:3
+--> %%%PATH.lf%%%:6:3
   |
 5 |   state liss(2, 3);
 6 |   reaction (startup) {
@@ -15,7 +15,7 @@ lfc: error: The Python target does not support reaction declarations. Please spe
   |
 7 |     print(self.liss)
 lfc: error: no viable alternative at input '{'
---> cli/lfc/src/test/resources/org/lflang/cli/issue490.lf:6:22
+--> %%%PATH.lf%%%:6:22
   |
 5 |   state liss(2, 3);
 6 |   reaction (startup) {
@@ -23,7 +23,7 @@ lfc: error: no viable alternative at input '{'
   |
 7 |     print(self.liss)
 lfc: error: no viable alternative at input '('
---> cli/lfc/src/test/resources/org/lflang/cli/issue490.lf:7:5
+--> %%%PATH.lf%%%:7:5
   |
 6 |   reaction (startup) {
 7 |     print(self.liss)

--- a/cli/lfc/src/test/resources/org/lflang/cli/issue490.stderr
+++ b/cli/lfc/src/test/resources/org/lflang/cli/issue490.stderr
@@ -1,13 +1,21 @@
 lfc: error: Name of main reactor must match the file name (or be omitted).
---> %%%PATH.lf%%%:4:14
+--> cli/lfc/src/test/resources/org/lflang/cli/issue490.lf:4:14
   |
 3 | target Python;
 4 | main reactor R(p(3)) {
   |              ^ Name of main reactor must match the file name (or be omitted).
   |
 5 |   state liss(2, 3);
+lfc: error: The Python target does not support reaction declarations. Please specify a reaction body.
+--> cli/lfc/src/test/resources/org/lflang/cli/issue490.lf:6:3
+  |
+5 |   state liss(2, 3);
+6 |   reaction (startup) {
+  |   ^^^^^^^^^^^^^^^^^^^^ The Python target does not support reaction declarations. Please specify a reaction body.
+  |
+7 |     print(self.liss)
 lfc: error: no viable alternative at input '{'
---> %%%PATH.lf%%%:6:22
+--> cli/lfc/src/test/resources/org/lflang/cli/issue490.lf:6:22
   |
 5 |   state liss(2, 3);
 6 |   reaction (startup) {
@@ -15,7 +23,7 @@ lfc: error: no viable alternative at input '{'
   |
 7 |     print(self.liss)
 lfc: error: no viable alternative at input '('
---> %%%PATH.lf%%%:7:5
+--> cli/lfc/src/test/resources/org/lflang/cli/issue490.lf:7:5
   |
 6 |   reaction (startup) {
 7 |     print(self.liss)

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -200,10 +200,13 @@ Action:
 Reaction:
     (attributes+=Attribute)*
     (('reaction') | mutation ?= 'mutation')
+    (name=ID)?
     ('(' (triggers+=TriggerRef (',' triggers+=TriggerRef)*)? ')')
     (sources+=VarRef (',' sources+=VarRef)*)?
     ('->' effects+=VarRefOrModeTransition (',' effects+=VarRefOrModeTransition)*)?
-    ((('named' name=ID)? code=Code) | 'named' name=ID)(stp=STP)?(deadline=Deadline)?
+    (((code=Code)(stp=STP)?(deadline=Deadline)? ';'?) |
+     ((stp=STP)?(deadline=Deadline)? ';')
+    )
     ;
 
 TriggerRef:
@@ -511,7 +514,7 @@ Token:
     'mutable' | 'input' | 'output' | 'timer' | 'action' | 'reaction' |
     'startup' | 'shutdown' | 'after' | 'deadline' | 'mutation' | 'preamble' |
     'new' | 'federated' | 'at' | 'as' | 'from' | 'widthof' | 'const' | 'method' |
-    'interleaved' | 'mode' | 'initial' | 'reset' | 'history' | 'watchdog' | 'named' |
+    'interleaved' | 'mode' | 'initial' | 'reset' | 'history' | 'watchdog' |
 
     // Other terminals
     NEGINT | TRUE | FALSE |

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -204,7 +204,7 @@ Reaction:
     ('(' (triggers+=TriggerRef (',' triggers+=TriggerRef)*)? ')')
     ( => sources+=VarRef (',' sources+=VarRef)*)?
     ('->' effects+=VarRefOrModeTransition (',' effects+=VarRefOrModeTransition)*)?
-    (code=Code)? (stp=STP)? (deadline=Deadline)? ';'?
+    (code=Code)? (stp=STP)? (deadline=Deadline)? (delimited?=';')?
     ;
 
 TriggerRef:

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -202,11 +202,9 @@ Reaction:
     (('reaction') | mutation ?= 'mutation')
     (name=ID)?
     ('(' (triggers+=TriggerRef (',' triggers+=TriggerRef)*)? ')')
-    (sources+=VarRef (',' sources+=VarRef)*)?
+    ( => sources+=VarRef (',' sources+=VarRef)*)?
     ('->' effects+=VarRefOrModeTransition (',' effects+=VarRefOrModeTransition)*)?
-    (((code=Code)(stp=STP)?(deadline=Deadline)? ';'?) |
-     ((stp=STP)?(deadline=Deadline)? ';')
-    )
+    (code=Code)? (stp=STP)? (deadline=Deadline)? ';'?
     ;
 
 TriggerRef:

--- a/core/src/main/java/org/lflang/Target.java
+++ b/core/src/main/java/org/lflang/Target.java
@@ -491,6 +491,15 @@ public enum Target {
   }
 
   /**
+   * Return true of reaction declarations (i.e., reactions without inlined code) are supported by
+   * this target.
+   */
+  public boolean supportsReactionDeclarations() {
+    if (this.equals(Target.C)) return true;
+    else return false;
+  }
+
+  /**
    * Return true if this code for this target should be built using Docker if Docker is used.
    *
    * @return

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -643,7 +643,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     if (object.getCode() != null) msb.append(" ").append(doSwitch(object.getCode()));
     if (object.getStp() != null) msb.append(" ").append(doSwitch(object.getStp()));
     if (object.getDeadline() != null) msb.append(" ").append(doSwitch(object.getDeadline()));
-    if (object.getName() != null) msb.append(";");
+    if (object.getCode() == null) msb.append(";");
     return msb.get();
   }
 

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -618,7 +618,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     } else {
       msb.append("reaction");
     }
-    if (object.getName() != null) msb.append(object.getName());
+    if (object.getName() != null) msb.append(" ").append(object.getName());
     msb.append(list(true, object.getTriggers()));
     msb.append(list(", ", " ", "", true, false, object.getSources()));
     if (!object.getEffects().isEmpty()) {

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -643,7 +643,6 @@ public class ToLf extends LfSwitch<MalleableString> {
     if (object.getCode() != null) msb.append(" ").append(doSwitch(object.getCode()));
     if (object.getStp() != null) msb.append(" ").append(doSwitch(object.getStp()));
     if (object.getDeadline() != null) msb.append(" ").append(doSwitch(object.getDeadline()));
-    if (object.isDelimited()) msb.append(";");
     return msb.get();
   }
 

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -618,6 +618,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     } else {
       msb.append("reaction");
     }
+    if (object.getName() != null) msb.append(object.getName());
     msb.append(list(true, object.getTriggers()));
     msb.append(list(", ", " ", "", true, false, object.getSources()));
     if (!object.getEffects().isEmpty()) {
@@ -639,10 +640,10 @@ public class ToLf extends LfSwitch<MalleableString> {
                               : doSwitch(varRef))
                   .collect(new Joiner(", ")));
     }
-    if (object.getName() != null) msb.append(" named ").append(object.getName());
     if (object.getCode() != null) msb.append(" ").append(doSwitch(object.getCode()));
     if (object.getStp() != null) msb.append(" ").append(doSwitch(object.getStp()));
     if (object.getDeadline() != null) msb.append(" ").append(doSwitch(object.getDeadline()));
+    if (object.getName() != null) msb.append(";");
     return msb.get();
   }
 

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -643,7 +643,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     if (object.getCode() != null) msb.append(" ").append(doSwitch(object.getCode()));
     if (object.getStp() != null) msb.append(" ").append(doSwitch(object.getStp()));
     if (object.getDeadline() != null) msb.append(" ").append(doSwitch(object.getDeadline()));
-    if (object.getCode() == null) msb.append(";");
+    if (object.isDelimited()) msb.append(";");
     return msb.get();
   }
 

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -712,7 +712,7 @@ public class LFValidator extends BaseLFValidator {
         && reaction.getDeadline() == null
         && reaction.getStp() == null
         && reaction.getSources() != null
-        && reaction.getSources().size() != 0) {
+        && !reaction.getSources().isEmpty()) {
       error("Missing semicolon at the end of reaction declaration.", Literals.REACTION__SOURCES);
     }
     HashSet<VarRef> triggers = new HashSet<>();

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -709,19 +709,28 @@ public class LFValidator extends BaseLFValidator {
       warning("Reaction has no trigger.", Literals.REACTION__TRIGGERS);
     }
 
-    if (reaction.getCode() == null && reaction.getDeadline() == null && reaction.getStp() == null) {
-      var text = NodeModelUtils.findActualNodeFor(reaction).getText();
-      var matcher = Pattern.compile("\\)\\s*[\\n\\r]+(.*[\\n\\r])*.*->").matcher(text);
-      if (matcher.find()) {
+    if (reaction.getCode() == null) {
+      if (!this.target.supportsReactionDeclarations()) {
         error(
-            "A connection statement may have been unintentionally parsed as the sources and effects"
-                + " of a reaction declaration. To correct this, add a semicolon at the end of the"
-                + " reaction declaration. To instead silence this warning, remove any newlines"
-                + " between the reaction triggers and sources.",
+            "The "
+                + this.target
+                + " target does not support reaction declarations. Please specify a reaction body.",
             Literals.REACTION__CODE);
+        return;
+      }
+      if (reaction.getDeadline() == null && reaction.getStp() == null) {
+        var text = NodeModelUtils.findActualNodeFor(reaction).getText();
+        var matcher = Pattern.compile("\\)\\s*[\\n\\r]+(.*[\\n\\r])*.*->").matcher(text);
+        if (matcher.find()) {
+          error(
+              "A connection statement may have been unintentionally parsed as the sources and"
+                  + " effects of a reaction declaration. To correct this, add a semicolon at the"
+                  + " end of the reaction declaration. To instead silence this warning, remove any"
+                  + " newlines between the reaction triggers and sources.",
+              Literals.REACTION__CODE);
+        }
       }
     }
-
     HashSet<VarRef> triggers = new HashSet<>();
     // Make sure input triggers have no container and output sources do.
     for (TriggerRef trigger : reaction.getTriggers()) {

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -708,8 +708,11 @@ public class LFValidator extends BaseLFValidator {
       warning("Reaction has no trigger.", Literals.REACTION__TRIGGERS);
     }
     if (!reaction.isDelimited()
-        && (reaction.getSources() != null && reaction.getSources().size() != 0)
-        && reaction.getCode() == null) {
+        && reaction.getCode() == null
+        && reaction.getDeadline() == null
+        && reaction.getStp() == null
+        && reaction.getSources() != null
+        && reaction.getSources().size() != 0) {
       error("Missing semicolon at the end of reaction declaration.", Literals.REACTION__SOURCES);
     }
     HashSet<VarRef> triggers = new HashSet<>();

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -708,7 +708,7 @@ public class LFValidator extends BaseLFValidator {
       warning("Reaction has no trigger.", Literals.REACTION__TRIGGERS);
     }
     if (!reaction.isDelimited()
-        && (reaction.getSources() != null || reaction.getSources().size() != 0)
+        && (reaction.getSources() != null && reaction.getSources().size() != 0)
         && reaction.getCode() == null) {
       error("Missing semicolon at the end of reaction declaration.", Literals.REACTION__SOURCES);
     }

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -725,7 +725,7 @@ public class LFValidator extends BaseLFValidator {
           error(
               "A connection statement may have been unintentionally parsed as the sources and"
                   + " effects of a reaction declaration. To correct this, add a semicolon at the"
-                  + " end of the reaction declaration. To instead silence this warning, remove any"
+                  + " end of the reaction declaration. To instead silence this message, remove any"
                   + " newlines between the reaction triggers and sources.",
               Literals.REACTION__CODE);
         }

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -172,6 +172,35 @@ public class LinguaFrancaValidationTest {
         "Reactor cannot be named 'Preamble'");
   }
 
+  @Test
+  public void requireSemicolonIfAmbiguous() throws Exception {
+    String testCase =
+        """
+            target C
+
+            reactor Foo {
+              output out: int
+              input inp: int
+              reaction(inp) -> out {==}
+            }
+
+            main reactor {
+              f1 = new Foo()
+              f2 = new Foo()
+              f3 = new Foo()
+
+              reaction increment(f1.out)
+              f2.out -> f3.inp
+            }
+
+            """;
+    validator.assertError(
+        parseWithoutError(testCase),
+        LfPackage.eINSTANCE.getReaction(),
+        null,
+        "Missing semicolon at the end of reaction declaration.");
+  }
+
   /** Ensure that "__" is not allowed at the start of an input name. */
   @Test
   public void disallowUnderscoreInputs() throws Exception {

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -198,7 +198,7 @@ public class LinguaFrancaValidationTest {
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getReaction(),
         null,
-        "Missing semicolon at the end of reaction declaration.");
+        "A connection statement may have been unintentionally parsed");
   }
 
   @Test

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -201,6 +201,23 @@ public class LinguaFrancaValidationTest {
         "Missing semicolon at the end of reaction declaration.");
   }
 
+  @Test
+  public void noSemicolonIfNotAmbiguous() throws Exception {
+    String testCase =
+        """
+            target C
+
+            main reactor {
+              timer t(0)
+
+              reaction increment(t)
+              reaction multiply(t)
+            }
+
+            """;
+    validator.assertNoErrors(parseWithoutError(testCase));
+  }
+
   /** Ensure that "__" is not allowed at the start of an input name. */
   @Test
   public void disallowUnderscoreInputs() throws Exception {

--- a/test/C/src/no_inlining/BankMultiportToReactionNoInlining.lf
+++ b/test/C/src/no_inlining/BankMultiportToReactionNoInlining.lf
@@ -20,7 +20,7 @@ main reactor {
 
   s = new[2] DoubleCount()
 
-  reaction check(s.out);
+  reaction check(s.out)
 
   reaction(shutdown) {=
     if (!self->received) {

--- a/test/C/src/no_inlining/BankMultiportToReactionNoInlining.lf
+++ b/test/C/src/no_inlining/BankMultiportToReactionNoInlining.lf
@@ -20,7 +20,7 @@ main reactor {
 
   s = new[2] DoubleCount()
 
-  reaction(s.out) named check
+  reaction check(s.out);
 
   reaction(shutdown) {=
     if (!self->received) {

--- a/test/C/src/no_inlining/BankToReactionNoInlining.lf
+++ b/test/C/src/no_inlining/BankToReactionNoInlining.lf
@@ -12,5 +12,5 @@ main reactor {
 
   s = new[2] Count()
 
-  reaction check(s.out);
+  reaction check(s.out)
 }

--- a/test/C/src/no_inlining/BankToReactionNoInlining.lf
+++ b/test/C/src/no_inlining/BankToReactionNoInlining.lf
@@ -12,5 +12,5 @@ main reactor {
 
   s = new[2] Count()
 
-  reaction(s.out) named check
+  reaction check(s.out);
 }

--- a/test/C/src/no_inlining/Count.lf
+++ b/test/C/src/no_inlining/Count.lf
@@ -8,9 +8,9 @@ main reactor Count {
 
   state count: int
 
-  reaction(t) named increment
+  reaction increment(t);
 
-  reaction(t) named check_done
+  reaction check_done(t);
 
   reaction(shutdown) {= printf("%s", "shutting down\n"); =}
 }

--- a/test/C/src/no_inlining/Count.lf
+++ b/test/C/src/no_inlining/Count.lf
@@ -8,9 +8,9 @@ main reactor Count {
 
   state count: int
 
-  reaction increment(t);
+  reaction increment(t)
 
-  reaction check_done(t);
+  reaction check_done(t)
 
   reaction(shutdown) {= printf("%s", "shutting down\n"); =}
 }

--- a/test/C/src/no_inlining/CountHierarchy.lf
+++ b/test/C/src/no_inlining/CountHierarchy.lf
@@ -15,9 +15,9 @@ main reactor {
 
   state count: int
 
-  reaction increment(t.out);
+  reaction increment(t.out)
 
-  reaction check_done(t.out);
+  reaction check_done(t.out)
 
   reaction(shutdown) {= printf("%s", "shutting down\n"); =}
 }

--- a/test/C/src/no_inlining/CountHierarchy.lf
+++ b/test/C/src/no_inlining/CountHierarchy.lf
@@ -15,9 +15,9 @@ main reactor {
 
   state count: int
 
-  reaction(t.out) named increment
+  reaction increment(t.out);
 
-  reaction(t.out) named check_done
+  reaction check_done(t.out);
 
   reaction(shutdown) {= printf("%s", "shutting down\n"); =}
 }

--- a/test/C/src/no_inlining/IntPrint.lf
+++ b/test/C/src/no_inlining/IntPrint.lf
@@ -6,14 +6,14 @@ target C {
 reactor Print {
   output out: int
 
-  reaction(startup) -> out named sender
+  reaction sender(startup) -> out;
 }
 
 // expected parameter is for testing.
 reactor Check(expected: int = 42) {
   input in: int
 
-  reaction(in) named receiver
+  reaction receiver(in);
 }
 
 main reactor {

--- a/test/C/src/no_inlining/IntPrint.lf
+++ b/test/C/src/no_inlining/IntPrint.lf
@@ -6,14 +6,14 @@ target C {
 reactor Print {
   output out: int
 
-  reaction sender(startup) -> out;
+  reaction sender(startup) -> out
 }
 
 // expected parameter is for testing.
 reactor Check(expected: int = 42) {
   input in: int
 
-  reaction receiver(in);
+  reaction receiver(in)
 }
 
 main reactor {

--- a/test/C/src/no_inlining/MultiportToReactionNoInlining.lf
+++ b/test/C/src/no_inlining/MultiportToReactionNoInlining.lf
@@ -23,7 +23,7 @@ main reactor {
   state s: int = 6
   b = new Source(width = 4)
 
-  reaction check(b.out);
+  reaction check(b.out)
 
   reaction(shutdown) {=
     if (self->s <= 6) {

--- a/test/C/src/no_inlining/MultiportToReactionNoInlining.lf
+++ b/test/C/src/no_inlining/MultiportToReactionNoInlining.lf
@@ -23,7 +23,7 @@ main reactor {
   state s: int = 6
   b = new Source(width = 4)
 
-  reaction(b.out) named check
+  reaction check(b.out);
 
   reaction(shutdown) {=
     if (self->s <= 6) {


### PR DESCRIPTION
This PR changes the syntax for reaction declarations (which no inline implementation) from `reaction(t) s -> e named foo` to `reaction foo(t) s -> e`. Moreover, these changes allow reactions definitions (which do have an inline implementation) to also specify a name. This can be useful for documentation purposes and for making the generated code more readable. Also see #1856.

~~Note the semicolon at the end, which is required to avoid ambiguity with connection statements. We can make the semicolon optional if we pay attention to newlines, which we currently simply filter out. There is no mandatory semicolon for concrete reactions (ones that feature a body).~~

A trailing semicolon is only required in situations where not having one leads to ambiguity. A validator check makes sure that we handle this situation.

- [x] Implement validator check
- [x] Make error message more specific
- [x] Ensure that formatter does not introduce newline between triggers and sources (@petervdonovan)
- [x] Add a validator check to avoid NPE in targets other than C
- [x] Add unit tests


Note: this PR also fixes a problem where duplicate sources were detected inaccurately (62113a4b0)