### PR TITLE
Cleanup gradle config

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -57,7 +57,6 @@ tasks.register('generateXtextLanguage', JavaExec) {
     inputs.file "src/main/java/org/lflang/GenerateLinguaFranca.mwe2"
     inputs.file "src/main/java/org/lflang/LinguaFranca.xtext"
     outputs.dir "src-gen"
-    outputs.dir "test-gen"
     outputs.dir "model"
     outputs.file ".antlr-generator-3.2.0-patch.jar"
     args += "src/main/java/org/lflang/GenerateLinguaFranca.mwe2"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,23 +6,10 @@ plugins {
 sourceSets {
     main {
         java {
-            srcDirs = ['src/main/java', 'src-gen']
+            srcDirs += ['src-gen']
         }
         resources {
-            srcDirs = ['src/main/resources', 'src-gen']
-        }
-    }
-    test {
-        java {
-            srcDirs = ['src/test/java']
-        }
-        resources {
-            srcDirs = [ 'src/test/resources' ]
-        }
-    }
-    testFixtures {
-        java {
-            srcDirs = ['src/testFixtures/java']
+            srcDirs += ['src-gen']
         }
     }
 }
@@ -31,8 +18,6 @@ dependencies {
     api enforcedPlatform("org.eclipse.xtext:org.eclipse.xtext:$xtextVersion")
     api "org.eclipse.xtext:org.eclipse.xtext.xbase.lib:$xtextVersion"
     api "org.eclipse.xtext:org.eclipse.xtext.ide:$xtextVersion"
-
-    implementation "org.eclipse.emf:org.eclipse.emf.mwe2.launch:$mwe2LaunchVersion"
 
     implementation "com.fasterxml.jackson.core:jackson-core:$fasterxmlVersion"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$fasterxmlVersion"
@@ -57,15 +42,13 @@ dependencies {
 }
 
 configurations {
-    mwe2 {
-        extendsFrom implementation
-    }
+    mwe2
 }
 
 dependencies {
-    mwe2 'org.eclipse.emf:org.eclipse.emf.mwe2.launch'
-    mwe2 "org.eclipse.xtext:org.eclipse.xtext.common.types:${xtextVersion}"
-    mwe2 "org.eclipse.xtext:org.eclipse.xtext.xtext.generator:${xtextVersion}"
+    mwe2 "org.eclipse.emf:org.eclipse.emf.mwe2.launch:$mwe2LaunchVersion"
+    mwe2 "org.eclipse.xtext:org.eclipse.xtext.common.types:$xtextVersion"
+    mwe2 "org.eclipse.xtext:org.eclipse.xtext.xtext.generator:$xtextVersion"
 }
 
 tasks.register('generateXtextLanguage', JavaExec) {

--- a/core/src/main/java/org/lflang/GenerateLinguaFranca.mwe2
+++ b/core/src/main/java/org/lflang/GenerateLinguaFranca.mwe2
@@ -23,10 +23,7 @@ Workflow {
                     src = "src/main/java"
                 }
                 runtimeTest = {
-                    enabled = true
-                    name = coreProject // add into the core project
-                    src = "src/test/java"
-                    srcGen = "test-gen"
+                    enabled = false
                 }
                 // Only generate Eclipse infrastructure for the Epoch build (separate repository).
                 createEclipseMetaData = false


### PR DESCRIPTION
This is a small cleanup of the gradle configuration. 
- Remove the test source set configuration that became superfluous after https://github.com/lf-lang/lingua-franca/pull/1845.
- Backport clean-ups in the gradle configuration made in https://github.com/lf-lang/lingua-franca/pull/1271 so that we can merge them quicker.
- Disable test code generation from xtext as https://github.com/lf-lang/lingua-franca/pull/1845 made this superfluous.