### PR TITLE
Fixed code coverage aggregation and reporting

### DIFF
--- a/.github/actions/report-code-coverage/action.yml
+++ b/.github/actions/report-code-coverage/action.yml
@@ -16,4 +16,4 @@ runs:
           files: ${{ inputs.files }}
           fail_ci_if_error: true
           verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: 18fd5ab8-d6ba-4f5d-b0f4-7c26340ab98c

--- a/.github/actions/report-code-coverage/action.yml
+++ b/.github/actions/report-code-coverage/action.yml
@@ -13,7 +13,7 @@ runs:
         attempt_delay: 20000
         action: codecov/codecov-action@v3.1.4
         with: |
-          files: ${{ files }}
+          files: ${{ inputs.files }}
           fail_ci_if_error: true
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/actions/report-code-coverage/action.yml
+++ b/.github/actions/report-code-coverage/action.yml
@@ -1,0 +1,19 @@
+name: Report code coverage to CodeCov
+inputs:
+  files:
+    description: 'list of coverage files to send to CodeCov'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Report code coverage to CodeCov
+      uses: Wandalen/wretry.action@v1.3.0
+      with:
+        attempt_limit: 5
+        attempt_delay: 20000
+        action: codecov/codecov-action@v3.1.4
+        with: |
+          files: ${{ files }}
+          fail_ci_if_error: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,14 +24,12 @@ jobs:
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
       - name: Build and package lf cli tools (regular build)
-        run: ./gradlew build
+        run: ./gradlew build testCodeCoverageReport
         shell: bash
-      - name: Collect code coverage
-        run: ./gradlew jacocoTestReport
-        if: ${{ runner.os == 'Linux' }}
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
           files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/base/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfc/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfd/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lff/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
+        if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 2000
-          action: uses: codecov/codecov-action@v3.1.4
+          action: codecov/codecov-action@v3.1.4
           with: |
             files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/base/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfc/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfd/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lff/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
             fail_ci_if_error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,13 +27,6 @@ jobs:
         run: ./gradlew build testCodeCoverageReport
         shell: bash
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: ./.github/actions/report-code-coverage
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: codecov/codecov-action@v3.1.4
-          with: |
-            files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/base/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfc/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfd/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lff/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
-            fail_ci_if_error: true
-            verbose: true
-        if: ${{ runner.os == 'Linux' }}
+          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/base/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfc/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfd/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lff/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/xml/jacoco,cli/lfc/build/reports/xml/jacoco,cli/lff/build/reports/xml/jacoco,cli/lfd/build/reports/xml/jacoco
+          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/base/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfc/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfd/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lff/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,13 @@ jobs:
         run: ./gradlew build testCodeCoverageReport
         shell: bash
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v3.1.1
+        uses: Wandalen/wretry.action@1.3.0
         with:
-          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/base/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfc/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfd/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lff/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
-          fail_ci_if_error: false
-          verbose: true
+          attempt_limit: 3
+          attempt_delay: 2000
+          action: uses: codecov/codecov-action@v3.1.4
+          with: |
+            files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/base/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfc/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lfd/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,cli/lff/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+            fail_ci_if_error: true
+            verbose: true
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         run: ./gradlew build testCodeCoverageReport
         shell: bash
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/c-arduino-tests.yml
+++ b/.github/workflows/c-arduino-tests.yml
@@ -64,12 +64,10 @@ jobs:
           arduino-cli core install arduino:mbed
       - name: Perform Arduino tests for C target with default scheduler
         run: ./gradlew targetTest -Ptarget=CArduino
-      - name: Collect code coverage
-        run: ./gradlew jacocoTestReport
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.runtime-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/c-arduino-tests.yml
+++ b/.github/workflows/c-arduino-tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Perform Arduino tests for C target with default scheduler
         run: ./gradlew targetTest -Ptarget=CArduino
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/c-arduino-tests.yml
+++ b/.github/workflows/c-arduino-tests.yml
@@ -65,9 +65,13 @@ jobs:
       - name: Perform Arduino tests for C target with default scheduler
         run: ./gradlew targetTest -Ptarget=CArduino
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v3.1.1
+        uses: Wandalen/wretry.action@1.3.0
         with:
-          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-          fail_ci_if_error: false
-          verbose: true
+          attempt_limit: 3
+          attempt_delay: 2000
+          action: uses: codecov/codecov-action@v3.1.4
+          with: |
+            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+            fail_ci_if_error: true
+            verbose: true
         if: ${{ !inputs.runtime-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/c-arduino-tests.yml
+++ b/.github/workflows/c-arduino-tests.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 2000
-          action: uses: codecov/codecov-action@v3.1.4
+          action: codecov/codecov-action@v3.1.4
           with: |
             files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
             fail_ci_if_error: true

--- a/.github/workflows/c-arduino-tests.yml
+++ b/.github/workflows/c-arduino-tests.yml
@@ -65,13 +65,7 @@ jobs:
       - name: Perform Arduino tests for C target with default scheduler
         run: ./gradlew targetTest -Ptarget=CArduino
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: ./.github/actions/report-code-coverage
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: codecov/codecov-action@v3.1.4
-          with: |
-            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-            fail_ci_if_error: true
-            verbose: true
-        if: ${{ !inputs.runtime-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/c-arduino-tests.yml
+++ b/.github/workflows/c-arduino-tests.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/xml/jacoco
+          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.runtime-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -65,13 +65,7 @@ jobs:
         run: ./gradlew targetTest -Ptarget=CCpp
         if: ${{ inputs.use-cpp && !inputs.scheduler }}
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: ./.github/actions/report-code-coverage
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: codecov/codecov-action@v3.1.4
-          with: |
-            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-            fail_ci_if_error: true
-            verbose: true
-        if: ${{ !inputs.compiler-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 2000
-          action: uses: codecov/codecov-action@v3.1.4
+          action: codecov/codecov-action@v3.1.4
           with: |
             files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
             fail_ci_if_error: true

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/xml/jacoco
+          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.compiler-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -65,7 +65,7 @@ jobs:
         run: ./gradlew targetTest -Ptarget=CCpp
         if: ${{ inputs.use-cpp && !inputs.scheduler }}
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -64,12 +64,10 @@ jobs:
       - name: Perform tests for CCpp target with default scheduler
         run: ./gradlew targetTest -Ptarget=CCpp
         if: ${{ inputs.use-cpp && !inputs.scheduler }}
-      - name: Collect code coverage
-        run: ./gradlew jacocoTestReport
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.compiler-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -65,9 +65,13 @@ jobs:
         run: ./gradlew targetTest -Ptarget=CCpp
         if: ${{ inputs.use-cpp && !inputs.scheduler }}
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v3.1.1
+        uses: Wandalen/wretry.action@1.3.0
         with:
-          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-          fail_ci_if_error: false
-          verbose: true
+          attempt_limit: 3
+          attempt_delay: 2000
+          action: uses: codecov/codecov-action@v3.1.4
+          with: |
+            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+            fail_ci_if_error: true
+            verbose: true
         if: ${{ !inputs.compiler-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -55,7 +55,7 @@ jobs:
           util/RunZephyrTests.sh test/C/src-gen
           rm -r test/C/src-gen
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -55,9 +55,13 @@ jobs:
           util/RunZephyrTests.sh test/C/src-gen
           rm -r test/C/src-gen
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v3.1.1
+        uses: Wandalen/wretry.action@1.3.0
         with:
-          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-          fail_ci_if_error: false
-          verbose: true
+          attempt_limit: 3
+          attempt_delay: 2000
+          action: uses: codecov/codecov-action@v3.1.4
+          with: |
+            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+            fail_ci_if_error: true
+            verbose: true
         if: ${{ !inputs.runtime-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -41,25 +41,23 @@ jobs:
         if: ${{ inputs.runtime-ref }}
       - name: Run Zephyr smoke tests
         run: |
-          ./gradlew core:integrationTest --tests org.lflang.tests.runtime.CZephyrTest.buildZephyr*
+          ./gradlew core:integrationTestCodeCoverageReport --tests org.lflang.tests.runtime.CZephyrTest.buildZephyr*
           util/RunZephyrTests.sh test/C/src-gen
           rm -r test/C/src-gen
       - name: Run basic tests
         run: |
-          ./gradlew core:integrationTest --tests org.lflang.tests.runtime.CZephyrTest.buildBasic*
+          ./gradlew core:integrationTestCodeCoverageReport --tests org.lflang.tests.runtime.CZephyrTest.buildBasic*
           util/RunZephyrTests.sh test/C/src-gen
           rm -r test/C/src-gen
       - name: Run concurrent tests
         run: |
-          ./gradlew core:integrationTest --tests org.lflang.tests.runtime.CZephyrTest.buildConcurrent*
+          ./gradlew core:integrationTestCodeCoverageReport --tests org.lflang.tests.runtime.CZephyrTest.buildConcurrent*
           util/RunZephyrTests.sh test/C/src-gen
           rm -r test/C/src-gen
-      - name: Collect code coverage
-        run: ./gradlew jacocoTestReport
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.runtime-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 2000
-          action: uses: codecov/codecov-action@v3.1.4
+          action: codecov/codecov-action@v3.1.4
           with: |
             files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
             fail_ci_if_error: true

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -41,17 +41,17 @@ jobs:
         if: ${{ inputs.runtime-ref }}
       - name: Run Zephyr smoke tests
         run: |
-          ./gradlew core:integrationTestCodeCoverageReport --tests org.lflang.tests.runtime.CZephyrTest.buildZephyr*
+          ./gradlew core:integrationTest --tests org.lflang.tests.runtime.CZephyrTest.buildZephyr* core:integrationTestCodeCoverageReport
           util/RunZephyrTests.sh test/C/src-gen
           rm -r test/C/src-gen
       - name: Run basic tests
         run: |
-          ./gradlew core:integrationTestCodeCoverageReport --tests org.lflang.tests.runtime.CZephyrTest.buildBasic*
+          ./gradlew core:integrationTest --tests org.lflang.tests.runtime.CZephyrTest.buildBasic* core:integrationTestCodeCoverageReport
           util/RunZephyrTests.sh test/C/src-gen
           rm -r test/C/src-gen
       - name: Run concurrent tests
         run: |
-          ./gradlew core:integrationTestCodeCoverageReport --tests org.lflang.tests.runtime.CZephyrTest.buildConcurrent*
+          ./gradlew core:integrationTest --tests org.lflang.tests.runtime.CZephyrTest.buildConcurrent* core:integrationTestCodeCoverageReport
           util/RunZephyrTests.sh test/C/src-gen
           rm -r test/C/src-gen
       - name: Report to CodeCov

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/xml/jacoco
+          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.runtime-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -55,13 +55,7 @@ jobs:
           util/RunZephyrTests.sh test/C/src-gen
           rm -r test/C/src-gen
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: ./.github/actions/report-code-coverage
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: codecov/codecov-action@v3.1.4
-          with: |
-            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-            fail_ci_if_error: true
-            verbose: true
-        if: ${{ !inputs.runtime-ref }}  # i.e., if this is part of the main repo's CI
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/cpp-ros2-tests.yml
+++ b/.github/workflows/cpp-ros2-tests.yml
@@ -37,9 +37,13 @@ jobs:
           source /opt/ros/*/setup.bash
           ./gradlew targetTest -Ptarget=CppRos2
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v3.1.1
+        uses: Wandalen/wretry.action@1.3.0
         with:
-          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-          fail_ci_if_error: false
-          verbose: true
+          attempt_limit: 3
+          attempt_delay: 2000
+          action: uses: codecov/codecov-action@v3.1.4
+          with: |
+            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+            fail_ci_if_error: true
+            verbose: true
         if: ${{ !inputs.runtime-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/cpp-ros2-tests.yml
+++ b/.github/workflows/cpp-ros2-tests.yml
@@ -36,12 +36,10 @@ jobs:
         run: |
           source /opt/ros/*/setup.bash
           ./gradlew targetTest -Ptarget=CppRos2
-      - name: Collect code coverage
-        run: ./gradlew jacocoTestReport
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.runtime-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/cpp-ros2-tests.yml
+++ b/.github/workflows/cpp-ros2-tests.yml
@@ -37,7 +37,7 @@ jobs:
           source /opt/ros/*/setup.bash
           ./gradlew targetTest -Ptarget=CppRos2
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/cpp-ros2-tests.yml
+++ b/.github/workflows/cpp-ros2-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/xml/jacoco
+          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.runtime-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/cpp-ros2-tests.yml
+++ b/.github/workflows/cpp-ros2-tests.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 2000
-          action: uses: codecov/codecov-action@v3.1.4
+          action: codecov/codecov-action@v3.1.4
           with: |
             files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
             fail_ci_if_error: true

--- a/.github/workflows/cpp-ros2-tests.yml
+++ b/.github/workflows/cpp-ros2-tests.yml
@@ -37,13 +37,7 @@ jobs:
           source /opt/ros/*/setup.bash
           ./gradlew targetTest -Ptarget=CppRos2
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: ./.github/actions/report-code-coverage
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: codecov/codecov-action@v3.1.4
-          with: |
-            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-            fail_ci_if_error: true
-            verbose: true
-        if: ${{ !inputs.runtime-ref }}  # i.e., if this is part of the main repo's CI
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -49,12 +49,10 @@ jobs:
       - name: Run C++ tests;
         run: |
           ./gradlew targetTest -Ptarget=Cpp
-      - name: Collect code coverage
-        run: ./gradlew jacocoTestReport
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.runtime-ref && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/xml/jacoco
+          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.runtime-ref && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -50,16 +50,10 @@ jobs:
         run: |
           ./gradlew targetTest -Ptarget=Cpp
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: ./.github/actions/report-code-coverage
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: codecov/codecov-action@v3.1.4
-          with: |
-            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-            fail_ci_if_error: true
-            verbose: true
-        if: ${{ !inputs.runtime-ref && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI
       - name: Collect reactor-cpp coverage data
         run: |
           lcov --capture --directory test/Cpp --output-file coverage.info
@@ -73,13 +67,7 @@ jobs:
           path: reactor-cpp.coverage
         if: matrix.platform == 'ubuntu-latest'
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: ./.github/actions/report-code-coverage
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: codecov/codecov-action@v3.1.4
-          with: |
-            file: reactor-cpp.info
-            fail_ci_if_error: true
-            verbose: true
-        if: ${{ runner.os == 'Linux' && inputs.all-platforms }}
+          files: reactor-cpp.info
+        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -50,11 +50,15 @@ jobs:
         run: |
           ./gradlew targetTest -Ptarget=Cpp
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v3.1.1
+        uses: Wandalen/wretry.action@1.3.0
         with:
-          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-          fail_ci_if_error: false
-          verbose: true
+          attempt_limit: 3
+          attempt_delay: 2000
+          action: uses: codecov/codecov-action@v3.1.4
+          with: |
+            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+            fail_ci_if_error: true
+            verbose: true
         if: ${{ !inputs.runtime-ref && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI
       - name: Collect reactor-cpp coverage data
         run: |
@@ -68,10 +72,14 @@ jobs:
           name: reactor-cpp.coverage
           path: reactor-cpp.coverage
         if: matrix.platform == 'ubuntu-latest'
-      - name: Report C++ coverage to CodeCov
-        uses: codecov/codecov-action@v3.1.1
+      - name: Report to CodeCov
+        uses: Wandalen/wretry.action@1.3.0
         with:
-          file: reactor-cpp.info
-          fail_ci_if_error: false
-          verbose: true
+          attempt_limit: 3
+          attempt_delay: 2000
+          action: uses: codecov/codecov-action@v3.1.4
+          with: |
+            file: reactor-cpp.info
+            fail_ci_if_error: true
+            verbose: true
         if: ${{ runner.os == 'Linux' && inputs.all-platforms }}

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           ./gradlew targetTest -Ptarget=Cpp
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           attempt_limit: 3
           attempt_delay: 2000
@@ -73,7 +73,7 @@ jobs:
           path: reactor-cpp.coverage
         if: matrix.platform == 'ubuntu-latest'
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -70,4 +70,4 @@ jobs:
         uses: ./.github/actions/report-code-coverage
         with:
           files: reactor-cpp.info
-        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI
+        if: ${{ !inputs.compiler-ref && matrix.platform == 'ubuntu-latest' }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 2000
-          action: uses: codecov/codecov-action@v3.1.4
+          action: codecov/codecov-action@v3.1.4
           with: |
             files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
             fail_ci_if_error: true
@@ -77,7 +77,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 2000
-          action: uses: codecov/codecov-action@v3.1.4
+          action: codecov/codecov-action@v3.1.4
           with: |
             file: reactor-cpp.info
             fail_ci_if_error: true

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/report-code-coverage
         with:
           files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI
+        if: ${{ runner.os == 'Linux' }}
       - name: Collect reactor-cpp coverage data
         run: |
           lcov --capture --directory test/Cpp --output-file coverage.info

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -79,13 +79,6 @@ jobs:
       - name: Run language server tests
         run: ./gradlew core:integrationTest --tests org.lflang.tests.lsp.LspTests.*ValidationTest core:integrationTestCodeCoverageReport
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: ./.github/actions/report-code-coverage
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: codecov/codecov-action@v3.1.4
-          with: |
-            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-            fail_ci_if_error: true
-            verbose: true
-        if: ${{ runner.os == 'Linux' && inputs.all-platforms }}
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Run language server Python tests without PyLint
-        run: ./gradlew core:testCodeCoverageReport --tests org.lflang.tests.lsp.LspTests.pythonValidationTestSyntaxOnly
+        run: ./gradlew core:test --tests org.lflang.tests.lsp.LspTests.pythonValidationTestSyntaxOnly core:testCodeCoverageReport
       - name: Install pylint
         run: python3 -m pip install pylint
         if: ${{ runner.os != 'macOS' }}
@@ -77,7 +77,7 @@ jobs:
         run: brew install pylint
         if: ${{ runner.os == 'macOS' }}
       - name: Run language server tests
-        run: ./gradlew core:testCodeCoverageReport --tests org.lflang.tests.lsp.LspTests.*ValidationTest
+        run: ./gradlew core:test --tests org.lflang.tests.lsp.LspTests.*ValidationTest core:testCodeCoverageReport
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -79,9 +79,13 @@ jobs:
       - name: Run language server tests
         run: ./gradlew core:integrationTest --tests org.lflang.tests.lsp.LspTests.*ValidationTest core:integrationTestCodeCoverageReport
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v3.1.1
+        uses: Wandalen/wretry.action@1.3.0
         with:
-          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-          fail_ci_if_error: false
-          verbose: true
+          attempt_limit: 3
+          attempt_delay: 2000
+          action: uses: codecov/codecov-action@v3.1.4
+          with: |
+            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+            fail_ci_if_error: true
+            verbose: true
         if: ${{ runner.os == 'Linux' && inputs.all-platforms }}

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/xml/jacoco
+          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ runner.os == 'Linux' && inputs.all-platforms }}

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Run language server Python tests without PyLint
-        run: ./gradlew core:test --tests org.lflang.tests.lsp.LspTests.pythonValidationTestSyntaxOnly core:testCodeCoverageReport
+        run: ./gradlew core:integrationTest --tests org.lflang.tests.lsp.LspTests.pythonValidationTestSyntaxOnly core:integrationTestCodeCoverageReport
       - name: Install pylint
         run: python3 -m pip install pylint
         if: ${{ runner.os != 'macOS' }}
@@ -77,11 +77,11 @@ jobs:
         run: brew install pylint
         if: ${{ runner.os == 'macOS' }}
       - name: Run language server tests
-        run: ./gradlew core:test --tests org.lflang.tests.lsp.LspTests.*ValidationTest core:testCodeCoverageReport
+        run: ./gradlew core:integrationTest --tests org.lflang.tests.lsp.LspTests.*ValidationTest core:integrationTestCodeCoverageReport
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ runner.os == 'Linux' && inputs.all-platforms }}

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 2000
-          action: uses: codecov/codecov-action@v3.1.4
+          action: codecov/codecov-action@v3.1.4
           with: |
             files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
             fail_ci_if_error: true

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Run language server Python tests without PyLint
-        run: ./gradlew core:integrationTest --tests org.lflang.tests.lsp.LspTests.pythonValidationTestSyntaxOnly
+        run: ./gradlew core:testCodeCoverageReport --tests org.lflang.tests.lsp.LspTests.pythonValidationTestSyntaxOnly
       - name: Install pylint
         run: python3 -m pip install pylint
         if: ${{ runner.os != 'macOS' }}
@@ -77,9 +77,7 @@ jobs:
         run: brew install pylint
         if: ${{ runner.os == 'macOS' }}
       - name: Run language server tests
-        run: ./gradlew core:integrationTest --tests org.lflang.tests.lsp.LspTests.*ValidationTest
-      - name: Collect code coverage
-        run: ./gradlew jacocoTestReport
+        run: ./gradlew core:testCodeCoverageReport --tests org.lflang.tests.lsp.LspTests.*ValidationTest
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run language server tests
         run: ./gradlew core:integrationTest --tests org.lflang.tests.lsp.LspTests.*ValidationTest core:integrationTestCodeCoverageReport
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -65,13 +65,7 @@ jobs:
       - name: Run Python tests
         run: ./gradlew targetTest -Ptarget=Python
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: ./.github/actions/report-code-coverage
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: codecov/codecov-action@v3.1.4
-          with: |
-            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-            fail_ci_if_error: true
-            verbose: true
-        if: ${{ !inputs.compiler-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 2000
-          action: uses: codecov/codecov-action@v3.1.4
+          action: codecov/codecov-action@v3.1.4
           with: |
             files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
             fail_ci_if_error: true

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/xml/jacoco
+          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.compiler-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -65,9 +65,13 @@ jobs:
       - name: Run Python tests
         run: ./gradlew targetTest -Ptarget=Python
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v3.1.1
+        uses: Wandalen/wretry.action@1.3.0
         with:
-          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-          fail_ci_if_error: false
-          verbose: true
+          attempt_limit: 3
+          attempt_delay: 2000
+          action: uses: codecov/codecov-action@v3.1.4
+          with: |
+            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+            fail_ci_if_error: true
+            verbose: true
         if: ${{ !inputs.compiler-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -64,12 +64,10 @@ jobs:
         if: ${{ inputs.reactor-c-py-ref }}
       - name: Run Python tests
         run: ./gradlew targetTest -Ptarget=Python
-      - name: Collect code coverage
-        run: ./gradlew jacocoTestReport
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.compiler-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Run Python tests
         run: ./gradlew targetTest -Ptarget=Python
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/rs-tests.yml
+++ b/.github/workflows/rs-tests.yml
@@ -66,13 +66,7 @@ jobs:
       - name: Run Rust tests
         run: ./gradlew targetTest -Ptarget=Rust
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: ./.github/actions/report-code-coverage
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: codecov/codecov-action@v3.1.4
-          with: |
-            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-            fail_ci_if_error: true
-            verbose: true
-        if: ${{ !inputs.compiler-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/rs-tests.yml
+++ b/.github/workflows/rs-tests.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/xml/jacoco
+          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.compiler-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/rs-tests.yml
+++ b/.github/workflows/rs-tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run Rust tests
         run: ./gradlew targetTest -Ptarget=Rust
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/rs-tests.yml
+++ b/.github/workflows/rs-tests.yml
@@ -65,12 +65,10 @@ jobs:
           components: clippy
       - name: Run Rust tests
         run: ./gradlew targetTest -Ptarget=Rust
-      - name: Collect code coverage
-        run: ./gradlew jacocoTestReport
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.compiler-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/rs-tests.yml
+++ b/.github/workflows/rs-tests.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 2000
-          action: uses: codecov/codecov-action@v3.1.4
+          action: codecov/codecov-action@v3.1.4
           with: |
             files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
             fail_ci_if_error: true

--- a/.github/workflows/rs-tests.yml
+++ b/.github/workflows/rs-tests.yml
@@ -66,9 +66,13 @@ jobs:
       - name: Run Rust tests
         run: ./gradlew targetTest -Ptarget=Rust
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v3.1.1
+        uses: Wandalen/wretry.action@1.3.0
         with:
-          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-          fail_ci_if_error: false
-          verbose: true
+          attempt_limit: 3
+          attempt_delay: 2000
+          action: uses: codecov/codecov-action@v3.1.4
+          with: |
+            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+            fail_ci_if_error: true
+            verbose: true
         if: ${{ !inputs.compiler-ref && runner.os == 'Linux' && inputs.all-platforms }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/serialization-tests.yml
+++ b/.github/workflows/serialization-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run serialization tests;
         run: |
           source /opt/ros/*/setup.bash
-          ./gradlew core:integrationTestCodeCoverageReport --tests org.lflang.tests.serialization.SerializationTest.*
+          ./gradlew core:integrationTest --tests org.lflang.tests.serialization.SerializationTest.* core:integrationTestCodeCoverageReport
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:

--- a/.github/workflows/serialization-tests.yml
+++ b/.github/workflows/serialization-tests.yml
@@ -36,9 +36,13 @@ jobs:
           source /opt/ros/*/setup.bash
           ./gradlew core:integrationTest --tests org.lflang.tests.serialization.SerializationTest.* core:integrationTestCodeCoverageReport
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v3.1.1
+        uses: Wandalen/wretry.action@1.3.0
         with:
-          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-          fail_ci_if_error: false
-          verbose: true
+          attempt_limit: 3
+          attempt_delay: 2000
+          action: uses: codecov/codecov-action@v3.1.4
+          with: |
+            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+            fail_ci_if_error: true
+            verbose: true
         if: ${{ !inputs.runtime-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/serialization-tests.yml
+++ b/.github/workflows/serialization-tests.yml
@@ -34,13 +34,11 @@ jobs:
       - name: Run serialization tests;
         run: |
           source /opt/ros/*/setup.bash
-          ./gradlew core:integrationTest --tests org.lflang.tests.serialization.SerializationTest.*
-      - name: Collect code coverage
-        run: ./gradlew jacocoTestReport
+          ./gradlew core:integrationTestCodeCoverageReport --tests org.lflang.tests.serialization.SerializationTest.*
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.runtime-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/serialization-tests.yml
+++ b/.github/workflows/serialization-tests.yml
@@ -36,13 +36,7 @@ jobs:
           source /opt/ros/*/setup.bash
           ./gradlew core:integrationTest --tests org.lflang.tests.serialization.SerializationTest.* core:integrationTestCodeCoverageReport
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: ./.github/actions/report-code-coverage
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: codecov/codecov-action@v3.1.4
-          with: |
-            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-            fail_ci_if_error: true
-            verbose: true
-        if: ${{ !inputs.runtime-ref }}  # i.e., if this is part of the main repo's CI
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/serialization-tests.yml
+++ b/.github/workflows/serialization-tests.yml
@@ -36,7 +36,7 @@ jobs:
           source /opt/ros/*/setup.bash
           ./gradlew core:integrationTest --tests org.lflang.tests.serialization.SerializationTest.* core:integrationTestCodeCoverageReport
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/serialization-tests.yml
+++ b/.github/workflows/serialization-tests.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 2000
-          action: uses: codecov/codecov-action@v3.1.4
+          action: codecov/codecov-action@v3.1.4
           with: |
             files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
             fail_ci_if_error: true

--- a/.github/workflows/serialization-tests.yml
+++ b/.github/workflows/serialization-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/xml/jacoco
+          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ !inputs.runtime-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           ./gradlew targetTest -Ptarget=TypeScript -Druntime="git://github.com/lf-lang/reactor-ts.git#master"
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 2000
-          action: uses: codecov/codecov-action@v3.1.4
+          action: codecov/codecov-action@v3.1.4
           with: |
             files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
             fail_ci_if_error: true

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -39,13 +39,7 @@ jobs:
         run: |
           ./gradlew targetTest -Ptarget=TypeScript -Druntime="git://github.com/lf-lang/reactor-ts.git#master"
       - name: Report to CodeCov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: ./.github/actions/report-code-coverage
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: codecov/codecov-action@v3.1.4
-          with: |
-            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-            fail_ci_if_error: true
-            verbose: true
-        if: ${{ runner.os == 'Linux' && inputs.all-platforms }}
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -38,12 +38,10 @@ jobs:
       - name: Perform TypeScript tests
         run: |
           ./gradlew targetTest -Ptarget=TypeScript -Druntime="git://github.com/lf-lang/reactor-ts.git#master"
-      - name: Collect code coverage
-        run: ./gradlew jacocoTestReport
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ runner.os == 'Linux' && inputs.all-platforms }}

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Report to CodeCov
         uses: codecov/codecov-action@v3.1.1
         with:
-          files: core/build/reports/xml/jacoco
+          files: core/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           fail_ci_if_error: false
           verbose: true
         if: ${{ runner.os == 'Linux' && inputs.all-platforms }}

--- a/.github/workflows/ts-tests.yml
+++ b/.github/workflows/ts-tests.yml
@@ -39,9 +39,13 @@ jobs:
         run: |
           ./gradlew targetTest -Ptarget=TypeScript -Druntime="git://github.com/lf-lang/reactor-ts.git#master"
       - name: Report to CodeCov
-        uses: codecov/codecov-action@v3.1.1
+        uses: Wandalen/wretry.action@1.3.0
         with:
-          files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-          fail_ci_if_error: false
-          verbose: true
+          attempt_limit: 3
+          attempt_delay: 2000
+          action: uses: codecov/codecov-action@v3.1.4
+          with: |
+            files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+            fail_ci_if_error: true
+            verbose: true
         if: ${{ runner.os == 'Linux' && inputs.all-platforms }}

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ tasks.register('targetTest') {
             throw new GradleException("Please set the \'target\' project property using -Ptarget=<...>. You may chose any of $targets")
         }
     }
-    finalizedBy('core:integrationTest')
+    finalizedBy('core:integrationTestCodeCoverageReport')
 }
 tasks.register('singleTest') {
     doLast {

--- a/buildSrc/src/main/groovy/org.lflang.test-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.lflang.test-conventions.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-test-fixtures'
     id 'jacoco'
+    id 'jacoco-report-aggregation'
 }
 
 jacoco {
@@ -79,28 +80,5 @@ test {
         failFast = true
         workingDir = rootProject.projectDir
         maxParallelForks = 1
-    }
-}
-
-jacocoTestReport {
-    getExecutionData().setFrom(fileTree(buildDir).include("/jacoco/*.exec"))
-
-    reports {
-        xml.required = true
-        csv.required = false
-        html.outputLocation = file("${buildDir}/reports/html/jacoco")
-        xml.outputLocation = file("${buildDir}/reports/xml/jacoco")
-    }
-
-    afterEvaluate {
-        classDirectories.setFrom(files(classDirectories.files.collect {
-            fileTree(dir: it,
-                    exclude: ['**/org/lflang/services/**',
-                              '**/org/lflang/lf/**',
-                              '**/org/lflang/serializer/**',
-                              '**/org/lflang/parser/antlr/**'
-                    ]
-            )
-        }))
     }
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,9 @@ coverage:
     # do not run coverage on patch nor changes
     patch: no
     changes: no
+
+ignore: ['**/org/lflang/services/**',
+         '**/org/lflang/lf/**',
+         '**/org/lflang/ide/**',
+         '**/org/lflang/serializer/**',
+         '**/org/lflang/parser/antlr/**']


### PR DESCRIPTION
There are some small problems in our current test coverage reporting. For instance, the diagram tests implemented in `cil/lfd` do not contribute to the coverage in `core` (where the diagram synthesis is implemented). This PR updates the gradle setup to use the jacoco aggregation plugin. While this plugin automates the test coverage aggregation across subprojects, it gives less control than the simple jacoco plugin. Therefore, we now filter packages out during the reporting to codecov.