### PR TITLE
Memory leak in Python target fixed

### DIFF
--- a/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
@@ -144,10 +144,7 @@ public class PythonExtension extends CExtension {
           value = action.getName();
           FedNativePythonSerialization pickler = new FedNativePythonSerialization();
           result.pr(pickler.generateNetworkDeserializerCode(value, null));
-          // changed
-          // result.pr("lf_set(" + receiveRef + ", "
-          //              + FedSerialization.deserializedVarName + ");\n");
-          // Use token to set ports
+          // Use token to set ports and destructor
           result.pr(
               "lf_token_t* token = lf_new_token((void*)"
                   + receiveRef
@@ -190,7 +187,7 @@ public class PythonExtension extends CExtension {
           result.pr(pickler.generateNetworkSerializerCode(variableToSerialize, null));
           result.pr("size_t message_length = " + lengthExpression + ";");
           result.pr(sendingFunction + "(" + commonArgs + ", " + pointerExpression + ");\n");
-          // FIXED: Decrease the reference count of serialized_pyobject
+          // Decrease the reference count for serialized_pyobject
           result.pr("Py_XDECREF(serialized_pyobject);\n");
           break;
         }

--- a/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
@@ -144,7 +144,18 @@ public class PythonExtension extends CExtension {
           value = action.getName();
           FedNativePythonSerialization pickler = new FedNativePythonSerialization();
           result.pr(pickler.generateNetworkDeserializerCode(value, null));
-          result.pr("lf_set(" + receiveRef + ", " + FedSerialization.deserializedVarName + ");\n");
+          // changed
+          // result.pr("lf_set(" + receiveRef + ", "
+          //              + FedSerialization.deserializedVarName + ");\n");
+          // Use token to set ports
+          result.pr(
+              "lf_token_t* token = lf_new_token((void*)"
+                  + receiveRef
+                  + ", "
+                  + FedSerialization.deserializedVarName
+                  + ", 1);\n");
+          result.pr("lf_set_destructor(" + receiveRef + ", python_count_decrement);\n");
+          result.pr("lf_set_token(" + receiveRef + ", token);\n");
           break;
         }
       case PROTO:
@@ -179,6 +190,8 @@ public class PythonExtension extends CExtension {
           result.pr(pickler.generateNetworkSerializerCode(variableToSerialize, null));
           result.pr("size_t message_length = " + lengthExpression + ";");
           result.pr(sendingFunction + "(" + commonArgs + ", " + pointerExpression + ");\n");
+          // FIXED: Decrease the reference count of serialized_pyobject
+          result.pr("Py_XDECREF(serialized_pyobject);\n");
           break;
         }
       case PROTO:

--- a/core/src/main/java/org/lflang/federated/serialization/FedNativePythonSerialization.java
+++ b/core/src/main/java/org/lflang/federated/serialization/FedNativePythonSerialization.java
@@ -105,8 +105,6 @@ public class FedNativePythonSerialization implements FedSerialization {
             + varName
             + "->token->length);\n");
     // Deserialize using Pickle
-    // FIXED: We should not manually increase the reference count for message_byte_array
-    // deserializerCode.append("Py_XINCREF(message_byte_array);\n");
     deserializerCode.append(
         "PyObject* "
             + deserializedVarName

--- a/core/src/main/java/org/lflang/federated/serialization/FedNativePythonSerialization.java
+++ b/core/src/main/java/org/lflang/federated/serialization/FedNativePythonSerialization.java
@@ -89,7 +89,6 @@ public class FedNativePythonSerialization implements FedSerialization {
     serializerCode.append(
         "    lf_print_error_and_exit(\"Could not serialize " + serializedVarName + ".\");\n");
     serializerCode.append("}\n");
-
     return serializerCode;
   }
 
@@ -106,7 +105,8 @@ public class FedNativePythonSerialization implements FedSerialization {
             + varName
             + "->token->length);\n");
     // Deserialize using Pickle
-    deserializerCode.append("Py_XINCREF(message_byte_array);\n");
+    // FIXED: We should not manually increase the reference count for message_byte_array
+    // deserializerCode.append("Py_XINCREF(message_byte_array);\n");
     deserializerCode.append(
         "PyObject* "
             + deserializedVarName

--- a/core/src/main/java/org/lflang/generator/python/PythonDelayBodyGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonDelayBodyGenerator.java
@@ -35,6 +35,7 @@ public class PythonDelayBodyGenerator extends CDelayBodyGenerator {
           "    lf_schedule_token(" + action.getName() + ", 0, " + ref + "->token);",
           "}");
     } else {
+      var value = "self->_lf_" + ref + "->value";
       return String.join(
           "\n",
           "// Create a token.",
@@ -44,9 +45,10 @@ public class PythonDelayBodyGenerator extends CDelayBodyGenerator {
           "#endif",
           "lf_token_t* t = _lf_new_token((token_type_t*)"
               + action.getName()
-              + ", self->_lf_"
-              + ref
-              + "->value, 1);",
+              + ", "
+              + value
+              + ", 1);",
+          "Py_INCREF(" + value + ");",
           "#if NUMBER_OF_WORKERS > 0",
           "lf_mutex_unlock(&mutex);",
           "#endif",

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -574,7 +574,7 @@ public class PythonGenerator extends CGenerator {
       boolean hasMain, String executableName, Stream<String> cSources) {
     return ("""
             set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-            add_compile_definitions(_LF_GARBAGE_COLLECTED)
+            add_compile_definitions(_PYTHON_TARGET_ENABLED)
             add_subdirectory(core)
             set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
             set(LF_MAIN_TARGET <pyModuleName>)


### PR DESCRIPTION
This pull request addresses a memory leak issue observed in the current implementation. As shown in the following screenshot, it is noticeable that with each iteration, the size of Python objects constructed using C extensions continues to grow.

![Untitled picture](https://github.com/lf-lang/lingua-franca/assets/77720778/9628bd54-6ed3-4022-b8f9-a9aaccb6685d)

This problem could be attributed to several key issues, which are as follows:

1. PyObject Reference Count: The reference counts for the majority of `PyObjects `are not being appropriately managed.

2. Port Assignment: Rather than using the `_LF_SET `macro to assign values to the generic_port_instance_struct in the current implementation, the more suitable method would be to use `lf_set_token `and define a destructor for the token to ensure proper garbage collection.

3. Function Definition: The existing `_lf_free_token_value ` function is incorrect and fails to invoke the destructor.

Notes:
- The function call `Py_XINCREF(message_byte_array)` has been removed. This is due to the fact that `PyBytes_FromStringAndSize` already performs the necessary operation to increment the reference count.
- The macro identifier `_LF_GARBAGE_COLLECTED` has been renamed to `_PYTHON_TARGET_ENABLED`. This modification gives the macro a more indicative name.

Other related changes have also been made in the reactor-c repository ([LINK](https://github.com/lf-lang/reactor-c/pull/246)).