### PR TITLE
Fix extra whitespace around info messages

### DIFF
--- a/cli/base/src/main/java/org/lflang/cli/CliBase.java
+++ b/cli/base/src/main/java/org/lflang/cli/CliBase.java
@@ -263,19 +263,19 @@ public abstract class CliBase implements Runnable {
         try {
           path = FileUtil.toPath(uri);
         } catch (IllegalArgumentException e) {
-          reporter.printError("Unable to convert '" + uri + "' to path." + e);
+          reporter.printError("Unable to convert '" + uri + "' to path. " + e);
         }
       }
       issueCollector.accept(
           new LfIssue(
               issue.getMessage(),
               issue.getSeverity(),
+              path,
               issue.getLineNumber(),
               issue.getColumn(),
               issue.getLineNumberEnd(),
               issue.getColumnEnd(),
-              issue.getLength(),
-              path));
+              issue.getLength()));
     }
   }
 

--- a/cli/base/src/main/java/org/lflang/cli/StandaloneIssueAcceptor.java
+++ b/cli/base/src/main/java/org/lflang/cli/StandaloneIssueAcceptor.java
@@ -13,13 +13,19 @@ import org.lflang.util.FileUtil;
 public class StandaloneIssueAcceptor implements ValidationMessageAcceptor {
 
   @Inject private IssueCollector collector;
+  @Inject private ReportingBackend backend;
 
   boolean getErrorsOccurred() {
     return collector.getErrorsOccurred();
   }
 
   void accept(LfIssue lfIssue) {
-    collector.accept(lfIssue);
+    if (lfIssue.getSeverity() == Severity.INFO) {
+      // print info statements instead of collecting them
+      backend.printIssue(lfIssue);
+    } else {
+      collector.accept(lfIssue);
+    }
   }
 
   void accept(
@@ -37,12 +43,12 @@ public class StandaloneIssueAcceptor implements ValidationMessageAcceptor {
         new LfIssue(
             message,
             severity,
+            getPath(diagnostic),
             diagnostic.getLine(),
             diagnostic.getColumn(),
             diagnostic.getLineEnd(),
             diagnostic.getColumnEnd(),
-            diagnostic.getLength(),
-            getPath(diagnostic));
+            diagnostic.getLength());
 
     accept(lfIssue);
   }

--- a/cli/base/src/main/kotlin/org/lflang/cli/ReportingUtil.kt
+++ b/cli/base/src/main/kotlin/org/lflang/cli/ReportingUtil.kt
@@ -128,12 +128,12 @@ class Io @JvmOverloads constructor(
 data class LfIssue(
     val message: String,
     val severity: Severity,
-    val line: Int?,
-    val column: Int?,
-    val endLine: Int?,
-    val endColumn: Int?,
-    val length: Int?,
-    val file: Path?
+    val file: Path? = null,
+    val line: Int? = null,
+    val column: Int? = null,
+    val endLine: Int? = null,
+    val endColumn: Int? = null,
+    val length: Int? = null,
 ) : Comparable<LfIssue> {
 
     constructor(
@@ -199,7 +199,7 @@ class IssueCollector {
  *
  * @author Clément Fournier
  */
-class ReportingBackend constructor(
+class ReportingBackend(
     /** Environment of the process, contains IO streams. */
     private val io: Io,
     /** Header for all messages. */
@@ -253,18 +253,18 @@ class ReportingBackend constructor(
 
     /** Print an error message to [Io.err]. */
     fun printError(message: String) {
-        io.err.println(header + colors.redAndBold("error: ") + message)
+        printIssue(LfIssue(message, Severity.ERROR))
         errorsOccurred = true
     }
 
     /** Print a warning message to [Io.err]. */
     fun printWarning(message: String) {
-        io.err.println(header + colors.yellowAndBold("warning: ") + message)
+        printIssue(LfIssue(message, Severity.WARNING))
     }
 
     /** Print an informational message to [Io.out]. */
     fun printInfo(message: String) {
-        io.out.println(header + colors.bold("info: ") + message)
+        printIssue(LfIssue(message, Severity.INFO))
     }
 
     /**
@@ -277,18 +277,17 @@ class ReportingBackend constructor(
 
         val header = severity.name.lowercase(Locale.ROOT)
 
-        var fullMessage: String = this.header + colors.severityColors(header, severity) + colors.bold(": " + issue.message) + System.lineSeparator()
+        var fullMessage: String = this.header + colors.severityColors(header, severity) + colors.bold(": " + issue.message)
         val snippet: String? = filePath?.let { formatIssue(issue, filePath) }
 
         if (snippet == null) {
             filePath?.let { io.wd.relativize(it) }?.let {
-                fullMessage += " --> " + it + ":" + issue.line + ":" + issue.column + " - "
+                fullMessage += "\n --> " + it + ":" + issue.line + ":" + issue.column + " - \n"
             }
         } else {
-            fullMessage += snippet
+            fullMessage += "\n" + snippet + "\n"
         }
         io.err.println(fullMessage)
-        io.err.println()
     }
 
     private fun formatIssue(issue: LfIssue, path: Path): String? {

--- a/cli/lfc/src/main/java/org/lflang/cli/Lfc.java
+++ b/cli/lfc/src/main/java/org/lflang/cli/Lfc.java
@@ -193,7 +193,7 @@ public class Lfc extends CliBase {
       // Print all other issues (not errors).
       issueCollector.getAllIssues().forEach(reporter::printIssue);
 
-      this.io.getOut().println("Code generation finished.");
+      messageReporter.nowhere().info("Code generation finished.");
     }
   }
 

--- a/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
+++ b/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
@@ -230,7 +230,7 @@ public class LffCliTest {
 
     result.checkOk();
 
-    result.checkStdOut(containsString("Formatted src" + File.separator + "File.lf"));
+    result.checkStdErr(containsString("Formatted src" + File.separator + "File.lf"));
     dirChecker(tempDir).checkContentsOf("src/File.lf", equalTo(FILE_AFTER_REFORMAT));
   }
 

--- a/core/src/main/java/org/lflang/generator/GeneratorBase.java
+++ b/core/src/main/java/org/lflang/generator/GeneratorBase.java
@@ -664,10 +664,10 @@ public abstract class GeneratorBase extends AbstractLFValidator {
     messageReporter
         .nowhere()
         .info("Generating code for: " + context.getFileConfig().resource.getURI().toString());
-    messageReporter.nowhere().info("******** mode: " + mode);
+    messageReporter.nowhere().info("Generation mode: " + mode);
     messageReporter
         .nowhere()
-        .info("******** generated sources: " + context.getFileConfig().getSrcGenPath());
+        .info("Generating sources into: " + context.getFileConfig().getSrcGenPath());
   }
 
   /** Get the buffer type used for network messages */


### PR DESCRIPTION
Fix #1867 

The end of the log of LFC looks like this now:
```
[100%] Linking C executable DoubleReaction
[100%] Built target DoubleReaction
Install the project...
-- Install configuration: "Release"
lfc: info: SUCCESS: Compiling generated code for DoubleReaction finished with no errors.
lfc: info: Compiled binary is in /home/clem/Documents/LF/lingua-franca/test/C/bin
lfc: info: Code generation finished.
```