### PR TITLE
C math lib always linked for C target

### DIFF
--- a/core/src/main/java/org/lflang/TargetConfig.java
+++ b/core/src/main/java/org/lflang/TargetConfig.java
@@ -184,9 +184,6 @@ public class TargetConfig {
    */
   public Map<String, String> compileDefinitions = new HashMap<>();
 
-  /** Additional libraries to add to the compile command using the "-l" command-line option. */
-  public List<String> compileLibraries = new ArrayList<>();
-
   /** Flags to pass to the compiler, unless a build command has been specified. */
   public List<String> compilerFlags = new ArrayList<>();
 

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -29,7 +29,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Stream;
 import org.lflang.FileConfig;
 import org.lflang.MessageReporter;
@@ -302,29 +301,19 @@ public class CCmakeGenerator {
       cMakeCode.pr(
           "target_include_directories( ${LF_MAIN_TARGET} PUBLIC ${PROTOBUF_INCLUDE_DIR} )");
       cMakeCode.pr("target_link_libraries(${LF_MAIN_TARGET} PRIVATE ${PROTOBUF_LIBRARY})");
+      cMakeCode.newLine();
     }
 
     // Set the compiler flags
     // We can detect a few common libraries and use the proper target_link_libraries to find them
     for (String compilerFlag : targetConfig.compilerFlags) {
-      switch (compilerFlag.trim()) {
-        case "-O2":
-          if (Objects.equals(targetConfig.compiler, "gcc") || CppMode) {
-            // Workaround for the pre-added -O2 option in the CGenerator.
-            // This flag is specific to gcc/g++ and the clang compiler
-            cMakeCode.pr("add_compile_options(-O2)");
-            cMakeCode.pr("add_link_options(-O2)");
-            break;
-          }
-        default:
-          messageReporter
-              .nowhere()
-              .warning(
-                  "Using the flags target property with cmake is dangerous.\n"
-                      + " Use cmake-include instead.");
-          cMakeCode.pr("add_compile_options( " + compilerFlag + " )");
-          cMakeCode.pr("add_link_options( " + compilerFlag + ")");
-      }
+      messageReporter
+          .nowhere()
+          .warning(
+              "Using the flags target property with cmake is dangerous.\n"
+                  + " Use cmake-include instead.");
+      cMakeCode.pr("add_compile_options( " + compilerFlag + " )");
+      cMakeCode.pr("add_link_options( " + compilerFlag + ")");
     }
     cMakeCode.newLine();
 

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -287,25 +287,27 @@ public class CCmakeGenerator {
       cMakeCode.newLine();
     }
 
+    // link protobuf
+    if (!targetConfig.protoFiles.isEmpty()) {
+      cMakeCode.pr("include(FindPackageHandleStandardArgs)");
+      cMakeCode.pr("FIND_PATH( PROTOBUF_INCLUDE_DIR protobuf-c/protobuf-c.h)");
+      cMakeCode.pr(
+          """
+                         find_library(PROTOBUF_LIBRARY\s
+                         NAMES libprotobuf-c.a libprotobuf-c.so libprotobuf-c.dylib protobuf-c.lib protobuf-c.dll
+                         )""");
+      cMakeCode.pr(
+          "find_package_handle_standard_args(libprotobuf-c DEFAULT_MSG PROTOBUF_INCLUDE_DIR"
+              + " PROTOBUF_LIBRARY)");
+      cMakeCode.pr(
+          "target_include_directories( ${LF_MAIN_TARGET} PUBLIC ${PROTOBUF_INCLUDE_DIR} )");
+      cMakeCode.pr("target_link_libraries(${LF_MAIN_TARGET} PRIVATE ${PROTOBUF_LIBRARY})");
+    }
+
     // Set the compiler flags
     // We can detect a few common libraries and use the proper target_link_libraries to find them
     for (String compilerFlag : targetConfig.compilerFlags) {
       switch (compilerFlag.trim()) {
-        case "-lprotobuf-c":
-          cMakeCode.pr("include(FindPackageHandleStandardArgs)");
-          cMakeCode.pr("FIND_PATH( PROTOBUF_INCLUDE_DIR protobuf-c/protobuf-c.h)");
-          cMakeCode.pr(
-              """
-                         find_library(PROTOBUF_LIBRARY\s
-                         NAMES libprotobuf-c.a libprotobuf-c.so libprotobuf-c.dylib protobuf-c.lib protobuf-c.dll
-                         )""");
-          cMakeCode.pr(
-              "find_package_handle_standard_args(libprotobuf-c DEFAULT_MSG PROTOBUF_INCLUDE_DIR"
-                  + " PROTOBUF_LIBRARY)");
-          cMakeCode.pr(
-              "target_include_directories( ${LF_MAIN_TARGET} PUBLIC ${PROTOBUF_INCLUDE_DIR} )");
-          cMakeCode.pr("target_link_libraries(${LF_MAIN_TARGET} PRIVATE ${PROTOBUF_LIBRARY})");
-          break;
         case "-O2":
           if (Objects.equals(targetConfig.compiler, "gcc") || CppMode) {
             // Workaround for the pre-added -O2 option in the CGenerator.

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -215,6 +215,12 @@ public class CCmakeGenerator {
               Stream.concat(additionalSources.stream(), sources.stream())));
     }
 
+    // Ensure that the math library is linked
+    cMakeCode.pr("find_library(MATH_LIBRARY m)");
+    cMakeCode.pr("if(MATH_LIBRARY)");
+    cMakeCode.pr("  target_link_libraries(${LF_MAIN_TARGET} PUBLIC ${MATH_LIBRARY})");
+    cMakeCode.pr("endif()");
+
     cMakeCode.pr("target_link_libraries(${LF_MAIN_TARGET} PRIVATE core)");
 
     cMakeCode.pr("target_include_directories(${LF_MAIN_TARGET} PUBLIC .)");
@@ -285,9 +291,6 @@ public class CCmakeGenerator {
     // We can detect a few common libraries and use the proper target_link_libraries to find them
     for (String compilerFlag : targetConfig.compilerFlags) {
       switch (compilerFlag.trim()) {
-        case "-lm":
-          cMakeCode.pr("target_link_libraries(${LF_MAIN_TARGET} PRIVATE m)");
-          break;
         case "-lprotobuf-c":
           cMakeCode.pr("include(FindPackageHandleStandardArgs)");
           cMakeCode.pr("FIND_PATH( PROTOBUF_INCLUDE_DIR protobuf-c/protobuf-c.h)");

--- a/core/src/main/java/org/lflang/generator/c/CCompiler.java
+++ b/core/src/main/java/org/lflang/generator/c/CCompiler.java
@@ -402,7 +402,6 @@ public class CCompiler {
           fileConfig.getOutPath().relativize(fileConfig.getSrcGenPath().resolve(Paths.get(file)));
       compileArgs.add(FileUtil.toUnixString(relativePath));
     }
-    compileArgs.addAll(targetConfig.compileLibraries);
 
     // Add compile definitions
     targetConfig.compileDefinitions.forEach(

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1642,10 +1642,6 @@ public class CGenerator extends GeneratorBase {
       var nameSansProto = filename.substring(0, filename.length() - 6);
       targetConfig.compileAdditionalSources.add(
           fileConfig.getSrcGenPath().resolve(nameSansProto + ".pb-c.c").toString());
-
-      targetConfig.compileLibraries.add("-l");
-      targetConfig.compileLibraries.add("protobuf-c");
-      targetConfig.compilerFlags.add("-lprotobuf-c");
     } else {
       messageReporter.nowhere().error("protoc-c returns error code " + returnCode);
     }

--- a/test/C/src/target/Math.lf
+++ b/test/C/src/target/Math.lf
@@ -1,0 +1,10 @@
+/** Test that math functions are linked. */
+target C
+
+preamble {=
+  #include <math.h>
+=}
+
+main reactor {
+  reaction(startup) {= lf_print("Maximum of 42.0 and 75 is %.2f", fmax(4.20, 75)); =}
+}


### PR DESCRIPTION
This PR replaces https://github.com/lf-lang/lingua-franca/pull/1121. Instead of adding a new target property that is likely to cause various problems (as it is platform dependent) and that is difficult to maintain, this PR simply always links the math lib. To add other libraries, we can use the `cmake-include` property.

This PR also removes the magic matching of compiler flags in the C generator.

Replaces https://github.com/lf-lang/lingua-franca/pull/1121
Replaces https://github.com/lf-lang/benchmarks-lingua-franca/pull/11
Fixes https://github.com/lf-lang/lingua-franca/issues/1120