### PR TITLE
Small fixes to make CI more robust

### DIFF
--- a/.github/actions/report-code-coverage/action.yml
+++ b/.github/actions/report-code-coverage/action.yml
@@ -6,14 +6,39 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Report code coverage to CodeCov
-      uses: Wandalen/wretry.action@v1.3.0
+    - name: Report code coverage to CodeCov (1st try)
+      id: codecov1
+      uses: codecov/codecov-action@v3.1.4
       with:
-        attempt_limit: 5
-        attempt_delay: 20000
-        action: codecov/codecov-action@v3.1.4
-        with: |
-          files: ${{ inputs.files }}
-          fail_ci_if_error: true
-          verbose: true
-          token: 18fd5ab8-d6ba-4f5d-b0f4-7c26340ab98c
+        files: ${{ inputs.files }}
+        fail_ci_if_error: true
+        verbose: true
+        token: 18fd5ab8-d6ba-4f5d-b0f4-7c26340ab98c
+      continue-on-error: true
+    - name: Wait 20 seconds
+      run: sleep 20
+      shell: bash
+      if: steps.codecov1.outcome == 'failure'
+    - name: Report code coverage to CodeCov (2nd try)
+      id: codecov2
+      uses: codecov/codecov-action@v3.1.4
+      with:
+        files: ${{ inputs.files }}
+        fail_ci_if_error: true
+        verbose: true
+        token: 18fd5ab8-d6ba-4f5d-b0f4-7c26340ab98c
+      continue-on-error: true
+      if: steps.codecov1.outcome == 'failure'
+    - name: Wait 20 seconds
+      run: sleep 20
+      shell: bash
+      if: steps.codecov2.outcome == 'failure'
+    - name: Report code coverage to CodeCov (3rd try)
+      id: codecov3
+      uses: codecov/codecov-action@v3.1.4
+      with:
+        files: ${{ inputs.files }}
+        fail_ci_if_error: true
+        verbose: true
+        token: 18fd5ab8-d6ba-4f5d-b0f4-7c26340ab98c
+      if: steps.codecov2.outcome == 'failure'

--- a/.github/workflows/c-arduino-tests.yml
+++ b/.github/workflows/c-arduino-tests.yml
@@ -66,7 +66,6 @@ jobs:
         run: ./gradlew targetTest -Ptarget=CArduino
       - name: Report to CodeCov
         uses: ./.github/actions/report-code-coverage
-
         with:
           files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
         if: ${{ github.repository == 'lf-lang/lingua-franca' }}

--- a/.github/workflows/c-arduino-tests.yml
+++ b/.github/workflows/c-arduino-tests.yml
@@ -66,6 +66,7 @@ jobs:
         run: ./gradlew targetTest -Ptarget=CArduino
       - name: Report to CodeCov
         uses: ./.github/actions/report-code-coverage
+
         with:
           files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI
+        if: ${{ github.repository == 'lf-lang/lingua-franca' }}

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -68,4 +68,4 @@ jobs:
         uses: ./.github/actions/report-code-coverage
         with:
           files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI
+        if: ${{ github.repository == 'lf-lang/lingua-franca' }}

--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -58,4 +58,4 @@ jobs:
         uses: ./.github/actions/report-code-coverage
         with:
           files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI
+        if: ${{ github.repository == 'lf-lang/lingua-franca' }}

--- a/.github/workflows/cpp-ros2-tests.yml
+++ b/.github/workflows/cpp-ros2-tests.yml
@@ -40,4 +40,4 @@ jobs:
         uses: ./.github/actions/report-code-coverage
         with:
           files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI
+        if: ${{ github.repository == 'lf-lang/lingua-franca' }}

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -70,4 +70,4 @@ jobs:
         uses: ./.github/actions/report-code-coverage
         with:
           files: reactor-cpp.info
-        if: ${{ !inputs.compiler-ref && matrix.platform == 'ubuntu-latest' }}  # i.e., if this is part of the main repo's CI
+        if: ${{ github.repository == 'lf-lang/lingua-franca' && matrix.platform == 'ubuntu-latest' }}

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/report-code-coverage
         with:
           files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-        if: ${{ runner.os == 'Linux' }}
+        if: ${{ github.repository == 'lf-lang/lingua-franca' }}
       - name: Collect reactor-cpp coverage data
         run: |
           lcov --capture --directory test/Cpp --output-file coverage.info

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -82,3 +82,4 @@ jobs:
         uses: ./.github/actions/report-code-coverage
         with:
           files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
+        if: ${{ github.repository == 'lf-lang/lingua-franca' }}

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -68,4 +68,4 @@ jobs:
         uses: ./.github/actions/report-code-coverage
         with:
           files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI
+        if: ${{ github.repository == 'lf-lang/lingua-franca' }}

--- a/.github/workflows/rs-tests.yml
+++ b/.github/workflows/rs-tests.yml
@@ -69,4 +69,4 @@ jobs:
         uses: ./.github/actions/report-code-coverage
         with:
           files: core/build/reports/jacoco/integrationTestCodeCoverageReport/integrationTestCodeCoverageReport.xml
-        if: ${{ !inputs.compiler-ref }}  # i.e., if this is part of the main repo's CI
+        if: ${{ github.repository == 'lf-lang/lingua-franca' }}


### PR DESCRIPTION
- [x] Determine when to report coverage based on `github.repository`
- [x] Replace the wretry action (which appears to be unreliable), with a custom retry mechanism based on multiple steps.