### PR TITLE
Critical sections enabled outside of the context of a reactor

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -986,7 +986,6 @@ public class CGenerator extends GeneratorBase {
     }
     header.pr("#include \"include/core/reactor.h\"");
     src.pr("#include \"include/api/api.h\"");
-    src.pr("#include \"include/api/set.h\"");
     generateIncludes(tpr);
     if (CCppMode) {
       src.pr("}");

--- a/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
@@ -81,7 +81,6 @@ public class CReactorHeaderFileGenerator {
             extern "C" {
             #endif
             #include "../include/api/api.h"
-            #include "../include/api/set.h"
             #include "../include/core/reactor.h"
             #ifdef __cplusplus
             }


### PR DESCRIPTION
This PR makes it possible for users to enter and exit critical sections and access time both inside and outside of the context of a reactor. This enables resurrecting the MQTT examples in the example repo. 

This is a companion to the [enclave-fixes PR](https://github.com/lf-lang/reactor-c/pull/249) in reactor-c.