### PR TITLE
Add smoke test for clock synchronization

### DIFF
--- a/test/C/src/federated/DistributedCountDecentralized.lf
+++ b/test/C/src/federated/DistributedCountDecentralized.lf
@@ -9,8 +9,8 @@ target C {
   coordination: decentralized,
   clock-sync: on,
   clock-sync-options: {
-    local-federates-on: true,
-  },
+    local-federates-on: true
+  }
 }
 
 import Count from "../lib/Count.lf"

--- a/test/C/src/federated/DistributedCountDecentralized.lf
+++ b/test/C/src/federated/DistributedCountDecentralized.lf
@@ -6,7 +6,11 @@
  */
 target C {
   timeout: 5 sec,
-  coordination: decentralized
+  coordination: decentralized,
+  clock-sync: on,
+  clock-sync-options: {
+    local-federates-on: true,
+  },
 }
 
 import Count from "../lib/Count.lf"


### PR DESCRIPTION
This makes `DistributedCountDecentralized` also serve as a smoke test for clock synchronization. The test still runs quickly and seemingly reliably on my machine, so this seems like a harmless change. This is a response to our recently discovering that programs with clock synchronization haven't been building on Ubuntu.