### PR TITLE
Fix verifier error when there is no main reactor

### DIFF
--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -154,14 +155,13 @@ public class ASTUtils {
    * @param resource the resource to extract reactors from
    * @return An iterable over all reactors found in the resource
    */
-  public static Reactor getMainReactor(Resource resource) {
+  public static Optional<Reactor> getMainReactor(Resource resource) {
     return StreamSupport.stream(
             IteratorExtensions.toIterable(resource.getAllContents()).spliterator(), false)
         .filter(Reactor.class::isInstance)
         .map(Reactor.class::cast)
         .filter(it -> it.isMain())
-        .findFirst()
-        .get();
+        .findFirst();
   }
 
   /**

--- a/core/src/main/java/org/lflang/generator/LFGenerator.java
+++ b/core/src/main/java/org/lflang/generator/LFGenerator.java
@@ -8,6 +8,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.generator.AbstractGenerator;
@@ -158,7 +159,9 @@ public class LFGenerator extends AbstractGenerator {
    * connections, etc.).
    */
   private void runVerifierIfPropertiesDetected(Resource resource, LFGeneratorContext lfContext) {
-    Reactor main = ASTUtils.getMainReactor(resource);
+    Optional<Reactor> mainOpt = ASTUtils.getMainReactor(resource);
+    if (mainOpt.isEmpty()) return;
+    Reactor main = mainOpt.get();
     final MessageReporter messageReporter = lfContext.getErrorReporter();
     List<Attribute> properties =
         AttributeUtils.getAttributes(main).stream()


### PR DESCRIPTION
As the title suggests, the verifier no longer complains when the program has no main reactor.