### PR TITLE
Zephyr: Move from newlibc to picolibc

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -317,9 +317,11 @@ public class CCmakeGenerator {
     }
     cMakeCode.newLine();
 
-    // Add the install option
-    cMakeCode.pr(installCode);
-    cMakeCode.newLine();
+    // Add the install option. Unless we are targeting Zephyr
+    if (targetConfig.platformOptions.platform != Platform.ZEPHYR) {
+      cMakeCode.pr(installCode);
+      cMakeCode.newLine();
+    }
 
     // Add the include file
     for (String includeFile : targetConfig.cmakeIncludes) {

--- a/core/src/main/resources/lib/platform/zephyr/prj_lf.conf
+++ b/core/src/main/resources/lib/platform/zephyr/prj_lf.conf
@@ -7,8 +7,12 @@
 
 # Enable printf
 CONFIG_PRINTK=y
-# Use the newlib C library
-CONFIG_NEWLIB_LIBC=y
-CONFIG_NEWLIB_LIBC_FLOAT_PRINTF=y
+# Use the picolib C library. This is used instead of newlib because it also
+# supports regexp used by federate.c
+CONFIG_PICOLIBC=y
+CONFIG_PICOLIBC_IO_FLOAT=y
+CONFIG_PICOLIBC_IO_C99_FORMATS=y
+CONFIG_PICOLIBC_IO_LONG_LONG=y
+
 # Enable the counter API used for hi-res clock
 CONFIG_COUNTER=y

--- a/core/src/main/resources/lib/platform/zephyr/prj_lf.conf
+++ b/core/src/main/resources/lib/platform/zephyr/prj_lf.conf
@@ -14,5 +14,8 @@ CONFIG_PICOLIBC_IO_FLOAT=y
 CONFIG_PICOLIBC_IO_C99_FORMATS=y
 CONFIG_PICOLIBC_IO_LONG_LONG=y
 
+# To get `read`, `write`, `lseek` and `close` used by tracing infrastructure.
+CONFIG_FILE_SYSTEM=y
+
 # Enable the counter API used for hi-res clock
 CONFIG_COUNTER=y

--- a/test/C/src/TestForPreviousOutput.lf
+++ b/test/C/src/TestForPreviousOutput.lf
@@ -17,7 +17,7 @@ reactor Source {
 
   reaction(startup) -> out {=
     // Set a seed for random number generation based on the current time.
-    srand(time(0));
+    srand(lf_time_physical());
     // Randomly produce an output or not.
     if (rand() % 2) {
       lf_set(out, 21);


### PR DESCRIPTION
We originally used newlib, but they provided no implementation of the regexp.h (which they should?). However, picolibc does and is also smaller. This PR has Zephyr use picolibc instead. It required changing a bit of the CMake infrastructure. In particular we had to remove the calls to install() in the generated CMakeLists.txt