### PR TITLE
Fix AST Transformation to Support Platform Target Property in Federates

### DIFF
--- a/core/src/main/java/org/lflang/TargetProperty.java
+++ b/core/src/main/java/org/lflang/TargetProperty.java
@@ -476,7 +476,7 @@ public enum TargetProperty {
             throw new AssertionError(s);
           }
           config.platformOptions.platform = p;
-          
+
         } else {
           config.platformOptions = new PlatformOptions();
           for (KeyValuePair entry : value.getKeyvalue().getPairs()) {

--- a/core/src/main/java/org/lflang/TargetProperty.java
+++ b/core/src/main/java/org/lflang/TargetProperty.java
@@ -434,27 +434,31 @@ public enum TargetProperty {
         for (PlatformOption opt : PlatformOption.values()) {
           KeyValuePair pair = LfFactory.eINSTANCE.createKeyValuePair();
           pair.setName(opt.toString());
+          Element temp = null;
           switch (opt) {
             case NAME:
-              pair.setValue(ASTUtils.toElement(config.platformOptions.platform.toString()));
+              temp = ASTUtils.toElement(config.platformOptions.platform.toString());
               break;
             case BAUDRATE:
-              pair.setValue(ASTUtils.toElement(config.platformOptions.baudRate));
+              temp = ASTUtils.toElement(config.platformOptions.baudRate);
               break;
             case BOARD:
-              pair.setValue(ASTUtils.toElement(config.platformOptions.board));
+              temp = ASTUtils.toElement(config.platformOptions.board);
               break;
             case FLASH:
-              pair.setValue(ASTUtils.toElement(config.platformOptions.flash));
+              temp = ASTUtils.toElement(config.platformOptions.flash);
               break;
             case PORT:
-              pair.setValue(ASTUtils.toElement(config.platformOptions.port));
+              temp = ASTUtils.toElement(config.platformOptions.port);
               break;
             case USER_THREADS:
-              pair.setValue(ASTUtils.toElement(config.platformOptions.userThreads));
+              temp = ASTUtils.toElement(config.platformOptions.userThreads);
               break;
           }
-          kvp.getPairs().add(pair);
+          if (temp != null) {
+            pair.setValue(temp);
+            kvp.getPairs().add(pair);
+          }
         }
         e.setKeyvalue(kvp);
         if (kvp.getPairs().isEmpty()) return null;

--- a/core/src/main/java/org/lflang/TargetProperty.java
+++ b/core/src/main/java/org/lflang/TargetProperty.java
@@ -467,8 +467,16 @@ public enum TargetProperty {
       (config, value, err) -> {
         if (value.getLiteral() != null) {
           config.platformOptions = new PlatformOptions();
-          config.platformOptions.platform =
+          Platform p =
               (Platform) UnionType.PLATFORM_UNION.forName(ASTUtils.elementToSingleString(value));
+          if (p == null) {
+            String s =
+                "Unidentified Platform Type, LF supports the following platform types: "
+                    + Arrays.asList(Platform.values()).toString();
+            throw new AssertionError(s);
+          }
+          config.platformOptions.platform = p;
+          
         } else {
           config.platformOptions = new PlatformOptions();
           for (KeyValuePair entry : value.getKeyvalue().getPairs()) {

--- a/test/C/src/federated/FederatedGenPlatform.lf
+++ b/test/C/src/federated/FederatedGenPlatform.lf
@@ -3,6 +3,7 @@
  * parameter (i.e. without key-value pairs)
  */
 target C {
+  timeout: 2 secs,
   platform: "Linux"
 }
 

--- a/test/C/src/federated/FederatedGenPlatform.lf
+++ b/test/C/src/federated/FederatedGenPlatform.lf
@@ -3,13 +3,13 @@
  * parameter (i.e. without key-value pairs)
  */
 target C {
-    platform: "Linux"
+  platform: "Linux"
 }
-  
+
 reactor R {
 }
-  
+
 federated reactor {
-    r1 = new R()
-    r2 = new R()
+  r1 = new R()
+  r2 = new R()
 }

--- a/test/C/src/federated/FederatedGenPlatform.lf
+++ b/test/C/src/federated/FederatedGenPlatform.lf
@@ -7,9 +7,13 @@ target C {
 }
 
 reactor R {
+  input in: int
+  output out: int
 }
 
 federated reactor {
   r1 = new R()
   r2 = new R()
+  r1.out -> r2.in
+  r2.out -> r1.in
 }

--- a/test/C/src/federated/FederatedGenPlatform.lf
+++ b/test/C/src/federated/FederatedGenPlatform.lf
@@ -1,0 +1,15 @@
+/**
+ * Tests if the federate emitter correctly handles an overloaded definition of the platform
+ * parameter (i.e. without key-value pairs)
+ */
+target C {
+    platform: "Linux"
+}
+  
+reactor R {
+}
+  
+federated reactor {
+    r1 = new R()
+    r2 = new R()
+}


### PR DESCRIPTION
Allows for Platform target property to not require every key-value pair to be defined as well as overloading the platform with a literal string.