### PR TITLE
Fix for edge case in which comments are dropped

### DIFF
--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -125,9 +125,13 @@ public class ToLf extends LfSwitch<MalleableString> {
           .forEach(allComments::add);
     } else {
       Stream<String> precedingComments =
-          ASTUtils.getPrecedingComments(node, doesNotBelongToPrevious).map(String::strip);
+          ASTUtils.getPrecedingComments(node, doesNotBelongToPrevious.and(doesNotBelongToAncestor))
+              .map(String::strip);
       precedingComments.forEachOrdered(allComments::add);
-      getContainedCodeComments(node).stream().map(INode::getText).forEach(allComments::add);
+      getContainedCodeComments(node).stream()
+          .filter(doesNotBelongToAncestor)
+          .map(INode::getText)
+          .forEach(allComments::add);
     }
     allComments.addAll(followingComments);
     if (allComments.stream().anyMatch(s -> KEEP_FORMAT_COMMENT.matcher(s).matches())) {
@@ -146,6 +150,7 @@ public class ToLf extends LfSwitch<MalleableString> {
         ancestor = ancestor.getParent()) {
       ancestorComments.addAll(getContainedCodeComments(ancestor));
       ASTUtils.getPrecedingCommentNodes(ancestor, u -> true).forEachOrdered(ancestorComments::add);
+      ancestorComments.addAll(getContainedCodeComments(ancestor));
     }
     return ancestorComments;
   }

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -2,7 +2,6 @@ package org.lflang.ast;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -117,14 +116,19 @@ public class ToLf extends LfSwitch<MalleableString> {
     Predicate<INode> doesNotBelongToPrevious =
         doesNotBelongToAncestor.and(
             previous == null ? n -> true : ASTUtils.sameLine(previous).negate());
-    Stream<String> precedingComments =
-        ASTUtils.getPrecedingComments(node, doesNotBelongToPrevious).map(String::strip);
-    Collection<String> allComments = new ArrayList<>();
-    precedingComments.forEachOrdered(allComments::add);
-    getContainedComments(node).stream()
-        .filter(doesNotBelongToAncestor)
-        .map(INode::getText)
-        .forEachOrdered(allComments::add);
+    var allComments = new ArrayList<String>();
+    if (eObject.eContents().isEmpty() && !(eObject instanceof Code)) {
+      getContainedComments(node).stream()
+          .filter(doesNotBelongToAncestor)
+          .filter(doesNotBelongToPrevious)
+          .map(INode::getText)
+          .forEach(allComments::add);
+    } else {
+      Stream<String> precedingComments =
+          ASTUtils.getPrecedingComments(node, doesNotBelongToPrevious).map(String::strip);
+      precedingComments.forEachOrdered(allComments::add);
+      getContainedCodeComments(node).stream().map(INode::getText).forEach(allComments::add);
+    }
     allComments.addAll(followingComments);
     if (allComments.stream().anyMatch(s -> KEEP_FORMAT_COMMENT.matcher(s).matches())) {
       return MalleableString.anyOf(StringUtil.trimCodeBlock(node.getText(), 0))
@@ -140,7 +144,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     for (ICompositeNode ancestor = node.getParent();
         ancestor != null;
         ancestor = ancestor.getParent()) {
-      ancestorComments.addAll(getContainedComments(ancestor));
+      ancestorComments.addAll(getContainedCodeComments(ancestor));
       ASTUtils.getPrecedingCommentNodes(ancestor, u -> true).forEachOrdered(ancestorComments::add);
     }
     return ancestorComments;
@@ -192,7 +196,7 @@ public class ToLf extends LfSwitch<MalleableString> {
    * Return comments contained by {@code node} that logically belong to this node (and not to any of
    * its children).
    */
-  private static List<INode> getContainedComments(INode node) {
+  private static List<INode> getContainedCodeComments(INode node) {
     ArrayList<INode> ret = new ArrayList<>();
     boolean inSemanticallyInsignificantLeadingRubbish = true;
     for (INode child : node.getAsTreeIterable()) {
@@ -208,6 +212,18 @@ public class ToLf extends LfSwitch<MalleableString> {
       } else if (ASTUtils.isInCode(node) && !child.getText().isBlank()) {
         break;
       }
+    }
+    return ret;
+  }
+
+  /**
+   * Return all comments that are part of {@code node}, regardless of where they appear relative to
+   * the main content of the node.
+   */
+  private static List<INode> getContainedComments(INode node) {
+    var ret = new ArrayList<INode>();
+    for (INode child : node.getAsTreeIterable()) {
+      if (ASTUtils.isComment(child)) ret.add(child);
     }
     return ret;
   }


### PR DESCRIPTION
Fixes [vscode-lingua-franca/133](https://github.com/lf-lang/vscode-lingua-franca/issues/133#issuecomment-1654465957).

In the issue, the comment `// test` would be completely erased from the following program by the formatter:
```
target C

main reactor Minimal {
  // test
}
```

This fixes that issue such that the program is instead formatted like this:
```
target C

// test
main reactor Minimal {
}
```

I realize that some people might expect the comment to remain inside the reactor, but I think that that would be too much work to implement without much obvious benefit. With the current design, the comment must be associated with some AST node in order to not be dropped; in this case, it is associated with the whole reactor (no other alternatives are available), and as a result, it goes above the reactor.