### PR TITLE
Keyword `extends` added to tokens allowed in reaction bodies

### DIFF
--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -513,6 +513,7 @@ Token:
     'startup' | 'shutdown' | 'after' | 'deadline' | 'mutation' | 'preamble' |
     'new' | 'federated' | 'at' | 'as' | 'from' | 'widthof' | 'const' | 'method' |
     'interleaved' | 'mode' | 'initial' | 'reset' | 'history' | 'watchdog' |
+    'extends' |
 
     // Other terminals
     NEGINT | TRUE | FALSE |


### PR DESCRIPTION
Fixes #1912.