### PR TITLE
TypeScript runtime bumped to `v0.5.0`

### DIFF
--- a/core/src/main/resources/lib/ts/package.json
+++ b/core/src/main/resources/lib/ts/package.json
@@ -2,7 +2,7 @@
     "name": "LinguaFrancaDefault",
     "type": "commonjs",
     "dependencies": {
-        "@lf-lang/reactor-ts": "git://github.com/lf-lang/reactor-ts.git#ts-level-assignment",
+        "@lf-lang/reactor-ts": "git://github.com/lf-lang/reactor-ts.git#master",
         "command-line-args": "^5.1.1",
         "command-line-usage": "^6.1.3"
     },

--- a/core/src/main/resources/lib/ts/package.json
+++ b/core/src/main/resources/lib/ts/package.json
@@ -2,7 +2,7 @@
     "name": "LinguaFrancaDefault",
     "type": "commonjs",
     "dependencies": {
-        "@lf-lang/reactor-ts": "git://github.com/lf-lang/reactor-ts.git#master",
+        "@lf-lang/reactor-ts": "^0.5.0",
         "command-line-args": "^5.1.1",
         "command-line-usage": "^6.1.3"
     },


### PR DESCRIPTION
This PR bumps the `reactor-ts` package to `0.5.0`.