### PR TITLE
Add delimeter to each argument, fixes 

### DIFF
--- a/util/scripts/launch.sh
+++ b/util/scripts/launch.sh
@@ -75,5 +75,9 @@ gradlew="${base}/gradlew"
 if [ $# -eq 0 ]; then
     "${gradlew}" -p "${base}" "cli:${tool}:run"
 else
-    "${gradlew}" -p "${base}" "cli:${tool}:run" --args="$*"
+    shopt -s extglob
+    # Split through IFS
+    arr=("$*")
+    # For magic in args, see https://stackoverflow.com/a/50932265/22274983
+    "${gradlew}" -p "${base}" "cli:${tool}:run" --args="'${arr//+([[:space:]])/"' '"}'"
 fi


### PR DESCRIPTION
**Might** be a fix for https://github.com/lf-lang/lingua-franca/issues/1909

This issue specifically is caused by gradle wrapper. Specifically, it uses `org.gradle.api.tasks.JavaExec.setArgsString`, but as the doc suggested, 

> Note: the parser does not support using backslash to escape quotes. If this is needed, use the other quote delimiter around it. For example, to pass the argument 'singly quoted', use "'singly quoted'". 

This is not a good solution imo, but I guess it could work as of now? This is not touching gradlew, so I guess it's not that bad.

There's a separate issue that our scripts are named `.sh` but it is not POSIX-shell compatible (it uses `[[`, `function`, and I added `extglob` and IFS in this commit). While we reasonably expect everyone to have bash, I'm unsure if that will be the case (e.g. openwrt only have `sh` and `busybox`, maybe some day openwrt will use LF??????)

Also refer https://github.com/gradle/gradle/issues/6056 .