### PR TITLE
Fix IllegalArgumentException in diagram synthesis

### DIFF
--- a/cli/lff/src/main/java/org/lflang/cli/Lff.java
+++ b/cli/lff/src/main/java/org/lflang/cli/Lff.java
@@ -12,6 +12,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.lflang.ast.FormattingUtil;
 import org.lflang.ast.IsEqual;
 import org.lflang.ast.LfParsingHelper;
+import org.lflang.lf.Model;
 import org.lflang.util.FileUtil;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -175,7 +176,7 @@ public class Lff extends CliBase {
     }
 
     final String formattedFileContents =
-        FormattingUtil.render(resource.getContents().get(0), lineLength);
+        FormattingUtil.render((Model) resource.getContents().get(0), lineLength);
     if (!new IsEqual(resource.getContents().get(0))
         .doSwitch(
             new LfParsingHelper()

--- a/core/src/main/java/org/lflang/ast/FormattingUtil.java
+++ b/core/src/main/java/org/lflang/ast/FormattingUtil.java
@@ -42,7 +42,7 @@ public class FormattingUtil {
   static final long BADNESS_PER_NEWLINE = 1;
 
   /** Return a String representation of {@code object}, with lines wrapped at {@code lineLength}. */
-  public static String render(EObject object, int lineLength) {
+  public static String render(Model object, int lineLength) {
     return render(object, lineLength, inferTarget(object), false);
   }
 
@@ -89,7 +89,7 @@ public class FormattingUtil {
   }
 
   /** Return a String representation of {@code object} using a reasonable default line length. */
-  public static String render(EObject object) {
+  public static String render(Model object) {
     return render(object, DEFAULT_LINE_LENGTH);
   }
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -98,7 +98,7 @@ import org.eclipse.xtext.xbase.lib.StringExtensions;
 import org.lflang.AttributeUtils;
 import org.lflang.InferredType;
 import org.lflang.ast.ASTUtils;
-import org.lflang.ast.FormattingUtil;
+import org.lflang.ast.ToLf;
 import org.lflang.diagram.synthesis.action.CollapseAllReactorsAction;
 import org.lflang.diagram.synthesis.action.ExpandAllReactorsAction;
 import org.lflang.diagram.synthesis.action.FilterCycleAction;
@@ -1481,7 +1481,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
     if (param.getOverride() != null) {
       b.append(" = ");
       var init = param.getActualValue();
-      b.append(FormattingUtil.render(init));
+      b.append(ToLf.instance.doSwitch(init));
     }
     return b.toString();
   }
@@ -1512,7 +1512,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
       b.append(":").append(t.toOriginalText());
     }
     if (variable.getInit() != null) {
-      b.append(FormattingUtil.render(variable.getInit()));
+      b.append(ToLf.instance.doSwitch(variable.getInit()));
     }
     return b.toString();
   }

--- a/core/src/main/java/org/lflang/formatting2/LFFormatter.java
+++ b/core/src/main/java/org/lflang/formatting2/LFFormatter.java
@@ -17,6 +17,7 @@ import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.IResourceValidator;
 import org.lflang.ast.FormattingUtil;
+import org.lflang.lf.Model;
 
 public class LFFormatter implements IFormatter2 {
 
@@ -40,6 +41,6 @@ public class LFFormatter implements IFormatter2 {
             request.getTextRegionAccess(),
             documentRegion.getOffset(),
             documentRegion.getLength(),
-            FormattingUtil.render(documentContents.get(0))));
+            FormattingUtil.render((Model) documentContents.get(0))));
   }
 }


### PR DESCRIPTION
This is a runtime type error -- this is my bad, as such things should not happen in well written Java code. This commit modifies `FormattingUtil.render` to make it slightly more type-safe. It also changes the diagram synthesis to bypass the regular formatting logic -- the formatting logic seems more heavyweight than necessary since in diagrams we should not usually have to worry about how to represent comments and where to break lines (comment representation is the reason why the target was needed by the FormattingUtil.render function).

Fixes #1930.