### PR TITLE
Let the reaction number begin at 0 instead of 1.

### DIFF
--- a/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
@@ -418,7 +418,7 @@ public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
     if (reactor.reactions.size() > 1) {
       KText textToAdd =
           _kContainerRenderingExtensions.addText(
-              contentContainer, Integer.toString(reactor.reactions.indexOf(reaction) + 1));
+              contentContainer, Integer.toString(reactor.reactions.indexOf(reaction)));
       _kRenderingExtensions.setFontBold(textToAdd, true);
       _linguaFrancaStyleExtensions.noSelectionStyle(textToAdd);
       DiagramSyntheses.suppressSelectability(textToAdd);


### PR DESCRIPTION
This corresponds to their internal names.

Fixes #1782