### PR TITLE
Fix bug when top-level multiport width in federation depends on parameter

### DIFF
--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -657,8 +657,15 @@ public class FedASTUtils {
     Input in = factory.createInput();
     in.setName("msg");
     in.setType(type);
-    in.setWidthSpec(
-        EcoreUtil.copy(connection.getSourcePortInstance().getDefinition().getWidthSpec()));
+    var width =
+        ASTUtils.width(
+            connection.getSourcePortInstance().getDefinition().getWidthSpec(),
+            List.of(connection.getSrcFederate().instantiation));
+    var widthSpec = factory.createWidthSpec();
+    var widthTerm = factory.createWidthTerm();
+    widthTerm.setWidth(width);
+    widthSpec.getTerms().add(widthTerm);
+    in.setWidthSpec(widthSpec);
     inRef.setVariable(in);
 
     destRef.setContainer(connection.getDestinationPortInstance().getParent().getDefinition());

--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -553,7 +553,11 @@ public class FedGenerator {
         FedASTUtils.addReactorDefinition(
             "_" + reactorInstance.getName() + input.getName(), resource);
     var output = LfFactory.eINSTANCE.createOutput();
-    output.setWidthSpec(EcoreUtil.copy(input.getDefinition().getWidthSpec()));
+    var widthSpec = LfFactory.eINSTANCE.createWidthSpec();
+    var widthTerm = LfFactory.eINSTANCE.createWidthTerm();
+    widthTerm.setWidth(input.getWidth());
+    widthSpec.getTerms().add(widthTerm);
+    output.setWidthSpec(widthSpec);
     output.setType(EcoreUtil.copy(input.getDefinition().getType()));
     output.setName("port");
     indexer.getOutputs().add(output);


### PR DESCRIPTION
This simply computes the concrete numeric value of the parameter at compile time.