### PR TITLE
Handling of caching across runs using `gradle-build-action`

### DIFF
--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -9,3 +9,5 @@ runs:
         java-version: 17
     - name: Gradle Build Action
       uses: gradle/gradle-build-action@v2.8.0
+      with:
+        - cache-read-only: false

--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -10,4 +10,4 @@ runs:
     - name: Gradle Build Action
       uses: gradle/gradle-build-action@v2.8.0
       with:
-        - cache-read-only: false
+        cache-read-only: false

--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -1,5 +1,5 @@
-name: Prepare build environment (Linux only)
-description: Set up Java, Maven, Gradle, etc.
+name: Set up build environment
+description: Set up Java and Gradle (including caching).
 runs:
   using: "composite"
   steps:
@@ -8,35 +8,7 @@ runs:
         echo "$JAVA_HOME_17_X64/bin" >> $GITHUB_PATH
         echo "org.gradle.java.home=${JAVA_HOME_17_X64//\\/\/}" >> gradle.properties
         echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
+        echo "$GRADLE_USER_HOME"
       shell: bash
-    - name: Check settings
-      run: |
-        echo $(which java)
-        cat gradle.properties
-        echo $JAVA_HOME
-      shell: bash
-    - name: Create hash of Gradle configuration (macOS only)
-      run: |
-        echo "gradle-hash"="$(find . -type f \( -name "gradle.properties" -o -name "gradle-wrapper.properties" \) -exec cat {} + | shasum -a 256 | cut -d ' ' -f 1)" >> $GITHUB_ENV
-      if: ${{ runner.os == 'macOS' }}
-      shell: bash
-    - name: Create hash of Gradle configuration (Linux and Windows only)
-      run: |
-        echo "gradle-hash"="$(find . -type f \( -name "gradle.properties" -o -name "gradle-wrapper.properties" \) -exec cat {} + | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
-      if: ${{ runner.os == 'Windows' || runner.os == 'Linux' }}
-      shell: bash
-    - name: Cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: gradle-${{ runner.os }}-${{ env.gradle-hash }}
-        # restore-keys: |
-        #   ${{ runner.os }}-gradle-
-    - name: Bring down Gradle daemon (Windows)
-      uses: webiny/action-post-run@3.0.0
-      id: post-run-command
-      with:
-        run: ./gradlew --stop
-      if: ${{ runner.os == 'Windows' }}
+    - name: Gradle Build Action
+      uses: gradle/gradle-build-action@v2.8.0

--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -3,12 +3,9 @@ description: Set up Java and Gradle (including caching).
 runs:
   using: "composite"
   steps:
-    - name: Set up Java 17
-      run: |
-        echo "$JAVA_HOME_17_X64/bin" >> $GITHUB_PATH
-        echo "org.gradle.java.home=${JAVA_HOME_17_X64//\\/\/}" >> gradle.properties
-        echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
-        echo "$GRADLE_USER_HOME"
-      shell: bash
+    - uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
     - name: Gradle Build Action
       uses: gradle/gradle-build-action@v2.8.0


### PR DESCRIPTION
Fixes #1898.

The default behavior of this action is to only write the cache on `main`/`master`, but this leads to cache misses and the associated network errors that occur when downloading stuff, so we allow writing to the cache in all branches currently. We should keep and eye on this and make adjustments down the road..