### PR TITLE
Action for setting up francabot

### DIFF
--- a/.github/actions/setup-francabot/action.yml
+++ b/.github/actions/setup-francabot/action.yml
@@ -1,0 +1,34 @@
+name: Load global configuration settings for francabot
+description: Set up author information and GPG signature
+author: Marten Lohstroh <marten@berkeley.edu>
+
+inputs:
+  gpg-key:
+    description: 'francabot GPG key'
+    required: true
+  gpg-passphrase:
+    description: 'francabot GPG passphrase'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set environment variables
+      run: |
+        echo "username=lingua-franca[bot]" >> "$GITHUB_ENV"
+        echo "email=97201490+francabot@users.noreply.github.com" >> "$GITHUB_ENV"
+        echo "user-and-email=lingua-franca[bot] <97201490+francabot@users.noreply.github.com>" >> "$GITHUB_ENV"
+      shell: bash
+    - name: Configure git username and email
+      run: |
+        git config --global user.name '${{ env.username }}'
+        git config --global user.email '${{ env.email }}'
+      shell: bash
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v5
+      with:
+        gpg_private_key: ${{ inputs.gpg-key }}
+        passphrase: ${{ inputs.gpg-passphrase }}
+        git_config_global: true
+        git_user_signingkey: true
+        git_commit_gpgsign: true


### PR DESCRIPTION
This action originally resided in `release-tools` repo but wasn't accessible by other repos (such as `epoch`) because `release-tools` is private.