### PR TITLE
Fixed path issue in generated `docker-compose.yml` for federations

### DIFF
--- a/core/src/main/java/org/lflang/generator/DockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/DockerGenerator.java
@@ -38,7 +38,7 @@ public abstract class DockerGenerator {
     var dockerFilePath = context.getFileConfig().getSrcGenPath().resolve("Dockerfile");
     var dockerFileContent = generateDockerFileContent();
 
-    return new DockerData(name.replace("_", ""), dockerFilePath, dockerFileContent, context);
+    return new DockerData(name, dockerFilePath, dockerFileContent, context);
   }
 
   public static DockerGenerator dockerGeneratorFactory(LFGeneratorContext context) {


### PR DESCRIPTION
This PR is meant to fix a problem identified by @rcakella where the produced `docker-compose.yml` used a incorrect context.