### PR TITLE
Avoid squeezing reaction, method, or preamble bodies onto a single line

### DIFF
--- a/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
+++ b/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
@@ -83,7 +83,9 @@ public class LffCliTest {
 
                     /** moo */
                     // this is a humbug reaction
-                    reaction(a) -> humbug {= /* it reacts like this*/ react react =}
+                    reaction(a) -> humbug {=
+                      /* it reacts like this*/ react react
+                    =}
                   }
                   """),
           List.of(

--- a/core/src/main/java/org/lflang/ast/FormattingUtil.java
+++ b/core/src/main/java/org/lflang/ast/FormattingUtil.java
@@ -56,7 +56,7 @@ public class FormattingUtil {
    * with the assumption that the target language is {@code target}.
    */
   public static String render(EObject object, int lineLength, Target target, boolean codeMapTags) {
-    MalleableString ms = ToLf.instance.doSwitch(object);
+    MalleableString ms = new ToLf().doSwitch(object);
     String singleLineCommentPrefix = target.getSingleLineCommentPrefix();
     ms.findBestRepresentation(
         () -> ms.render(INDENTATION, singleLineCommentPrefix, codeMapTags, null),

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -89,19 +89,11 @@ public class ToLf extends LfSwitch<MalleableString> {
   private static final Pattern KEEP_FORMAT_COMMENT =
       Pattern.compile("\\s*(//|#)\\s*keep-format\\s*");
 
-  /// public instance initialized when loading the class
-  public static final ToLf instance = new ToLf();
-
   /**
    * The eObjects in the syntax tree on the path from the root up to and including the current
    * eObject.
    */
   private final ArrayDeque<EObject> callStack = new ArrayDeque<>();
-
-  // private constructor
-  private ToLf() {
-    super();
-  }
 
   @Override
   public MalleableString caseArraySpec(ArraySpec spec) {

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -263,7 +263,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     if (content.lines().count() > 1 || content.contains("#") || content.contains("//")) {
       return multilineRepresentation;
     }
-    if (callStack.stream().anyMatch(it -> it instanceof Code) && !content.isBlank()) {
+    if (callStack.stream().anyMatch(it -> it instanceof Reaction || it instanceof Preamble || it instanceof Method) && !content.isBlank()) {
       return MalleableString.anyOf(multilineRepresentation);
     }
     return MalleableString.anyOf(singleLineRepresentation, multilineRepresentation);

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -263,7 +263,10 @@ public class ToLf extends LfSwitch<MalleableString> {
     if (content.lines().count() > 1 || content.contains("#") || content.contains("//")) {
       return multilineRepresentation;
     }
-    if (callStack.stream().anyMatch(it -> it instanceof Reaction || it instanceof Preamble || it instanceof Method) && !content.isBlank()) {
+    if (callStack.stream()
+            .anyMatch(
+                it -> it instanceof Reaction || it instanceof Preamble || it instanceof Method)
+        && !content.isBlank()) {
       return MalleableString.anyOf(multilineRepresentation);
     }
     return MalleableString.anyOf(singleLineRepresentation, multilineRepresentation);

--- a/core/src/main/java/org/lflang/ast/ToText.java
+++ b/core/src/main/java/org/lflang/ast/ToText.java
@@ -34,7 +34,7 @@ public class ToText extends LfSwitch<String> {
 
   @Override
   public String caseArraySpec(ArraySpec spec) {
-    return ToLf.instance.doSwitch(spec).toString();
+    return new ToLf().doSwitch(spec).toString();
   }
 
   @Override
@@ -77,27 +77,27 @@ public class ToText extends LfSwitch<String> {
 
   @Override
   public String caseBracedListExpression(BracedListExpression object) {
-    return ToLf.instance.caseBracedListExpression(object).toString();
+    return new ToLf().caseBracedListExpression(object).toString();
   }
 
   @Override
   public String caseHost(Host host) {
-    return ToLf.instance.caseHost(host).toString();
+    return new ToLf().caseHost(host).toString();
   }
 
   @Override
   public String caseLiteral(Literal l) {
-    return ToLf.instance.caseLiteral(l).toString();
+    return new ToLf().caseLiteral(l).toString();
   }
 
   @Override
   public String caseParameterReference(ParameterReference p) {
-    return ToLf.instance.caseParameterReference(p).toString();
+    return new ToLf().caseParameterReference(p).toString();
   }
 
   @Override
   public String caseTime(Time t) {
-    return ToLf.instance.caseTime(t).toString();
+    return new ToLf().caseTime(t).toString();
   }
 
   @Override
@@ -105,13 +105,13 @@ public class ToText extends LfSwitch<String> {
     if (type.getCode() != null) {
       return caseCode(type.getCode());
     }
-    return ToLf.instance.caseType(type).toString();
+    return new ToLf().caseType(type).toString();
   }
 
   @Override
   public String caseTypeParm(TypeParm t) {
     if (t.getCode() != null) return doSwitch(t.getCode());
-    return ToLf.instance.caseTypeParm(t).toString();
+    return new ToLf().caseTypeParm(t).toString();
   }
 
   @Override

--- a/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -1492,7 +1492,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
     if (param.getOverride() != null) {
       b.append(" = ");
       var init = param.getActualValue();
-      b.append(ToLf.instance.doSwitch(init));
+      b.append(new ToLf().doSwitch(init));
     }
     return b.toString();
   }
@@ -1523,7 +1523,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
       b.append(":").append(t.toOriginalText());
     }
     if (variable.getInit() != null) {
-      b.append(ToLf.instance.doSwitch(variable.getInit()));
+      b.append(new ToLf().doSwitch(variable.getInit()));
     }
     return b.toString();
   }

--- a/test/C/src/ActionDelay.lf
+++ b/test/C/src/ActionDelay.lf
@@ -12,13 +12,17 @@ reactor GeneratedDelay {
     lf_schedule(act, MSEC(0));
   =}
 
-  reaction(act) -> y_out {= lf_set(y_out, self->y_state); =}
+  reaction(act) -> y_out {=
+    lf_set(y_out, self->y_state);
+  =}
 }
 
 reactor Source {
   output out: int
 
-  reaction(startup) -> out {= lf_set(out, 1); =}
+  reaction(startup) -> out {=
+    lf_set(out, 1);
+  =}
 }
 
 reactor Sink {

--- a/test/C/src/ActionWithNoReaction.lf
+++ b/test/C/src/ActionWithNoReaction.lf
@@ -33,5 +33,7 @@ main reactor ActionWithNoReaction {
   timer t(0, 1 sec)
   f.y -> p.x after 10 msec
 
-  reaction(t) -> f.x {= lf_set(f.x, 42); =}
+  reaction(t) -> f.x {=
+    lf_set(f.x, 42);
+  =}
 }

--- a/test/C/src/After.lf
+++ b/test/C/src/After.lf
@@ -8,7 +8,9 @@ reactor foo {
   input x: int
   output y: int
 
-  reaction(x) -> y {= lf_set(y, 2*x->value); =}
+  reaction(x) -> y {=
+    lf_set(y, 2*x->value);
+  =}
 }
 
 reactor print {
@@ -47,5 +49,7 @@ main reactor After {
   timer t(0, 1 sec)
   f.y -> p.x after 10 msec
 
-  reaction(t) -> f.x {= lf_set(f.x, 42); =}
+  reaction(t) -> f.x {=
+    lf_set(f.x, 42);
+  =}
 }

--- a/test/C/src/AfterCycles.lf
+++ b/test/C/src/AfterCycles.lf
@@ -5,14 +5,18 @@ target C
 reactor Source {
   output out: unsigned
 
-  reaction(startup) -> out {= lf_set(out, 1); =}
+  reaction(startup) -> out {=
+    lf_set(out, 1);
+  =}
 }
 
 reactor Work {
   input in: unsigned
   output out: unsigned
 
-  reaction(in) -> out {= lf_set(out, in->value); =}
+  reaction(in) -> out {=
+    lf_set(out, in->value);
+  =}
 }
 
 main reactor AfterCycles {

--- a/test/C/src/AfterZero.lf
+++ b/test/C/src/AfterZero.lf
@@ -8,7 +8,9 @@ reactor foo {
   input x: int
   output y: int
 
-  reaction(x) -> y {= SET(y, 2*x->value); =}
+  reaction(x) -> y {=
+    SET(y, 2*x->value);
+  =}
 }
 
 reactor print {
@@ -52,5 +54,7 @@ main reactor {
   timer t(0, 1 sec)
   f.y -> p.x after 0
 
-  reaction(t) -> f.x {= SET(f.x, 42); =}
+  reaction(t) -> f.x {=
+    SET(f.x, 42);
+  =}
 }

--- a/test/C/src/Alignment.lf
+++ b/test/C/src/Alignment.lf
@@ -9,7 +9,9 @@ reactor Source {
   state count: int = 1
   timer t(0, 100 msec)
 
-  reaction(t) -> out {= lf_set(out, self->count++); =}
+  reaction(t) -> out {=
+    lf_set(out, self->count++);
+  =}
 }
 
 reactor Sieve {

--- a/test/C/src/CompositionGain.lf
+++ b/test/C/src/CompositionGain.lf
@@ -22,7 +22,9 @@ reactor Wrapper {
 main reactor CompositionGain {
   wrapper = new Wrapper()
 
-  reaction(startup) -> wrapper.x {= lf_set(wrapper.x, 42); =}
+  reaction(startup) -> wrapper.x {=
+    lf_set(wrapper.x, 42);
+  =}
 
   reaction(wrapper.y) {=
     printf("Received %d\n", wrapper.y->value);

--- a/test/C/src/DanglingOutput.lf
+++ b/test/C/src/DanglingOutput.lf
@@ -6,7 +6,9 @@ reactor Source {
   output out: int
   timer t
 
-  reaction(t) -> out {= lf_set(out, 1); =}
+  reaction(t) -> out {=
+    lf_set(out, 1);
+  =}
 }
 
 reactor Gain {

--- a/test/C/src/DeadlineAnytime.lf
+++ b/test/C/src/DeadlineAnytime.lf
@@ -8,9 +8,13 @@ reactor A {
   reaction(startup) -> a {=
     self->i = 0;
     while (!lf_check_deadline(self, true));
-  =} deadline(10 msec) {= lf_schedule(a, 0); =}
+  =} deadline(10 msec) {=
+    lf_schedule(a, 0);
+  =}
 
-  reaction(a) {= self->i = 42; =}
+  reaction(a) {=
+    self->i = 42;
+  =}
 
   reaction(shutdown) {=
     if (self->i == 42) {

--- a/test/C/src/DeadlineInherited.lf
+++ b/test/C/src/DeadlineInherited.lf
@@ -4,13 +4,19 @@ target C {
   threading: false
 }
 
-preamble {= extern int global_cnt; =}
+preamble {=
+  extern int global_cnt;
+=}
 
 reactor NoDeadline {
-  preamble {= int global_cnt = 0; =}
+  preamble {=
+    int global_cnt = 0;
+  =}
   timer t(0 msec, 100 msec)
 
-  reaction(t) {= global_cnt++; =}
+  reaction(t) {=
+    global_cnt++;
+  =}
 }
 
 reactor WithDeadline {

--- a/test/C/src/DeadlinePriority.lf
+++ b/test/C/src/DeadlinePriority.lf
@@ -4,13 +4,19 @@ target C {
   threading: false
 }
 
-preamble {= extern int global_cnt; =}
+preamble {=
+  extern int global_cnt;
+=}
 
 reactor NoDeadline {
-  preamble {= int global_cnt = 0; =}
+  preamble {=
+    int global_cnt = 0;
+  =}
   timer t(0 msec, 100 msec)
 
-  reaction(t) {= global_cnt++; =}
+  reaction(t) {=
+    global_cnt++;
+  =}
 }
 
 reactor WithDeadline {

--- a/test/C/src/DeadlineWithAfterDelay.lf
+++ b/test/C/src/DeadlineWithAfterDelay.lf
@@ -4,10 +4,14 @@ target C {
   threading: false
 }
 
-preamble {= extern int global_cnt; =}
+preamble {=
+  extern int global_cnt;
+=}
 
 reactor Source {
-  preamble {= int global_cnt = 0; =}
+  preamble {=
+    int global_cnt = 0;
+  =}
 
   output out: int
   timer t(0 msec, 100 msec)

--- a/test/C/src/DeadlineWithBanks.lf
+++ b/test/C/src/DeadlineWithBanks.lf
@@ -8,10 +8,14 @@ target C {
   build-type: Debug
 }
 
-preamble {= extern volatile int global_cnt; =}
+preamble {=
+  extern volatile int global_cnt;
+=}
 
 reactor Bank(bank_index: int = 0) {
-  preamble {= volatile int global_cnt = 0; =}
+  preamble {=
+    volatile int global_cnt = 0;
+  =}
 
   timer t(0, 100 msec)
   output out: int

--- a/test/C/src/DeadlineZero.lf
+++ b/test/C/src/DeadlineZero.lf
@@ -10,14 +10,18 @@ reactor Detector {
   reaction(trigger) {=
     printf("ERROR: failed to detect zero-duration deadline at iteration %d.\n", self->cnt);
     exit(1);
-  =} deadline(0 msec) {= self->cnt++; =}
+  =} deadline(0 msec) {=
+    self->cnt++;
+  =}
 }
 
 reactor Generator {
   output pulse: int
   timer t(0, 100 msec)
 
-  reaction(t) -> pulse {= lf_set(pulse, 0); =}
+  reaction(t) -> pulse {=
+    lf_set(pulse, 0);
+  =}
 }
 
 main reactor {

--- a/test/C/src/DelayArray.lf
+++ b/test/C/src/DelayArray.lf
@@ -8,9 +8,13 @@ reactor DelayPointer(delay: time = 100 msec) {
   output out: int[]
   logical action a: int[]
 
-  reaction(in) -> a {= lf_schedule_token(a, self->delay, in->token); =}
+  reaction(in) -> a {=
+    lf_schedule_token(a, self->delay, in->token);
+  =}
 
-  reaction(a) -> out {= lf_set_token(out, a->token); =}
+  reaction(a) -> out {=
+    lf_set_token(out, a->token);
+  =}
 }
 
 reactor Source {

--- a/test/C/src/DelayInt.lf
+++ b/test/C/src/DelayInt.lf
@@ -6,7 +6,9 @@ reactor Delay(delay: time = 100 msec) {
   output out: int
   logical action a: int
 
-  reaction(a) -> out {= if (a->has_value && a->is_present) lf_set(out, a->value); =}
+  reaction(a) -> out {=
+    if (a->has_value && a->is_present) lf_set(out, a->value);
+  =}
 
   reaction(in) -> a {=
     // Use specialized form of schedule for integer payloads.
@@ -55,5 +57,7 @@ main reactor DelayInt {
   t = new Test()
   d.out -> t.in
 
-  reaction(startup) -> d.in {= lf_set(d.in, 42); =}
+  reaction(startup) -> d.in {=
+    lf_set(d.in, 42);
+  =}
 }

--- a/test/C/src/DelayString.lf
+++ b/test/C/src/DelayString.lf
@@ -16,7 +16,9 @@ reactor DelayString2(delay: time = 100 msec) {
   output out: string
   logical action a: string
 
-  reaction(a) -> out {= lf_set(out, a->value); =}
+  reaction(a) -> out {=
+    lf_set(out, a->value);
+  =}
 
   reaction(in) -> a {=
     // The following copies the char*, not the string.
@@ -48,5 +50,7 @@ main reactor {
   t = new Test()
   d.out -> t.in
 
-  reaction(startup) -> d.in {= lf_set(d.in, "Hello"); =}
+  reaction(startup) -> d.in {=
+    lf_set(d.in, "Hello");
+  =}
 }

--- a/test/C/src/DelayedAction.lf
+++ b/test/C/src/DelayedAction.lf
@@ -8,7 +8,9 @@ main reactor DelayedAction {
   logical action a
   state count: int = 0
 
-  reaction(t) -> a {= lf_schedule(a, MSEC(100)); =}
+  reaction(t) -> a {=
+    lf_schedule(a, MSEC(100));
+  =}
 
   reaction(a) {=
     interval_t elapsed = lf_time_logical_elapsed();

--- a/test/C/src/DelayedReaction.lf
+++ b/test/C/src/DelayedReaction.lf
@@ -5,7 +5,9 @@ reactor Source {
   output out: int
   timer t
 
-  reaction(t) -> out {= lf_set(out, 1); =}
+  reaction(t) -> out {=
+    lf_set(out, 1);
+  =}
 }
 
 reactor Sink {

--- a/test/C/src/Determinism.lf
+++ b/test/C/src/Determinism.lf
@@ -4,7 +4,9 @@ reactor Source {
   output y: int
   timer t
 
-  reaction(t) -> y {= lf_set(y, 1); =}
+  reaction(t) -> y {=
+    lf_set(y, 1);
+  =}
 }
 
 reactor Destination {
@@ -31,7 +33,9 @@ reactor Pass {
   input x: int
   output y: int
 
-  reaction(x) -> y {= lf_set(y, x->value); =}
+  reaction(x) -> y {=
+    lf_set(y, x->value);
+  =}
 }
 
 main reactor Determinism {

--- a/test/C/src/DoublePort.lf
+++ b/test/C/src/DoublePort.lf
@@ -17,9 +17,13 @@ reactor CountMicrostep {
   logical action act: int
   timer t(0, 1 sec)
 
-  reaction(t) -> act {= lf_schedule_int(act, 0, self->count++); =}
+  reaction(t) -> act {=
+    lf_schedule_int(act, 0, self->count++);
+  =}
 
-  reaction(act) -> out {= lf_set(out, act->value); =}
+  reaction(act) -> out {=
+    lf_set(out, act->value);
+  =}
 }
 
 reactor Print {
@@ -35,7 +39,9 @@ reactor Print {
     }
   =}
 
-  reaction(shutdown) {= printf("SUCCESS: messages were at least one microstep apart.\n"); =}
+  reaction(shutdown) {=
+    printf("SUCCESS: messages were at least one microstep apart.\n");
+  =}
 }
 
 main reactor DoublePort {

--- a/test/C/src/Gain.lf
+++ b/test/C/src/Gain.lf
@@ -5,7 +5,9 @@ reactor Scale(scale: int = 2) {
   input x: int
   output y: int
 
-  reaction(x) -> y {= lf_set(y, x->value * self->scale); =}
+  reaction(x) -> y {=
+    lf_set(y, x->value * self->scale);
+  =}
 }
 
 reactor Test {
@@ -35,5 +37,7 @@ main reactor Gain {
   d = new Test()
   g.y -> d.x
 
-  reaction(startup) -> g.x {= lf_set(g.x, 1); =}
+  reaction(startup) -> g.x {=
+    lf_set(g.x, 1);
+  =}
 }

--- a/test/C/src/GetMicroStep.lf
+++ b/test/C/src/GetMicroStep.lf
@@ -6,7 +6,9 @@ main reactor GetMicroStep {
 
   logical action l
 
-  reaction(startup) -> l {= lf_schedule(l, 0); =}
+  reaction(startup) -> l {=
+    lf_schedule(l, 0);
+  =}
 
   reaction(l) -> l {=
     microstep_t microstep = lf_tag().microstep;

--- a/test/C/src/Hierarchy.lf
+++ b/test/C/src/Hierarchy.lf
@@ -5,7 +5,9 @@ reactor Source {
   output out: int
   timer t
 
-  reaction(t) -> out {= lf_set(out, 1); =}
+  reaction(t) -> out {=
+    lf_set(out, 1);
+  =}
 }
 
 reactor Gain {

--- a/test/C/src/Hierarchy2.lf
+++ b/test/C/src/Hierarchy2.lf
@@ -8,7 +8,9 @@ reactor Source {
   output out: int
   timer t(0, 1 sec)
 
-  reaction(t) -> out {= lf_set(out, 1); =}
+  reaction(t) -> out {=
+    lf_set(out, 1);
+  =}
 }
 
 reactor Count {

--- a/test/C/src/Import.lf
+++ b/test/C/src/Import.lf
@@ -7,5 +7,7 @@ main reactor Import {
   timer t
   a = new Imported()
 
-  reaction(t) -> a.x {= lf_set(a.x, 42); =}
+  reaction(t) -> a.x {=
+    lf_set(a.x, 42);
+  =}
 }

--- a/test/C/src/ImportComposition.lf
+++ b/test/C/src/ImportComposition.lf
@@ -7,7 +7,9 @@ main reactor ImportComposition {
   a = new ImportedComposition()
   state received: bool = false
 
-  reaction(startup) -> a.x {= lf_set(a.x, 42); =}
+  reaction(startup) -> a.x {=
+    lf_set(a.x, 42);
+  =}
 
   reaction(a.y) {=
     interval_t receive_time = lf_time_logical_elapsed();

--- a/test/C/src/ImportRenamed.lf
+++ b/test/C/src/ImportRenamed.lf
@@ -11,5 +11,7 @@ main reactor {
   b = new Y()
   c = new Z()
 
-  reaction(t) -> a.x {= lf_set(a.x, 42); =}
+  reaction(t) -> a.x {=
+    lf_set(a.x, 42);
+  =}
 }

--- a/test/C/src/InheritanceAction.lf
+++ b/test/C/src/InheritanceAction.lf
@@ -7,11 +7,15 @@ reactor Source {
   logical action foo: int
   output y: int
 
-  reaction(foo) -> y {= lf_set(y, foo->value); =}
+  reaction(foo) -> y {=
+    lf_set(y, foo->value);
+  =}
 }
 
 reactor SourceExtended extends Source {
-  reaction(startup) -> foo {= lf_schedule_int(foo, 0, 42); =}
+  reaction(startup) -> foo {=
+    lf_schedule_int(foo, 0, 42);
+  =}
 }
 
 reactor Test {

--- a/test/C/src/ManualDelayedReaction.lf
+++ b/test/C/src/ManualDelayedReaction.lf
@@ -18,14 +18,19 @@ reactor GeneratedDelay {
     lf_schedule(act, MSEC(100));
   =}
 
-  reaction(act) -> y_out {= lf_set(y_out, self->y_state); =}
+  reaction(act) -> y_out {=
+    lf_set(y_out, self->y_state);
+  =}
 }
 
 reactor Source {
   output out: int
   timer t
 
-  reaction(t) -> out {= lf_set(out, 1); =}  // reaction(t) -> out after 100 msec
+  // reaction(t) -> out after 100 msec
+  reaction(t) -> out {=
+    lf_set(out, 1);
+  =}
 }
 
 reactor Sink {

--- a/test/C/src/Methods.lf
+++ b/test/C/src/Methods.lf
@@ -3,9 +3,13 @@ target C
 main reactor {
   state foo: int = 2
 
-  method getFoo(): int {= return self->foo; =}
+  method getFoo(): int {=
+    return self->foo;
+  =}
 
-  method add(x: int) {= self->foo += x; =}
+  method add(x: int) {=
+    self->foo += x;
+  =}
 
   reaction(startup) {=
     lf_print("Foo is initialized to %d", getFoo());

--- a/test/C/src/MethodsRecursive.lf
+++ b/test/C/src/MethodsRecursive.lf
@@ -10,7 +10,9 @@ main reactor {
     return add(fib(n-1), fib(n-2));
   =}
 
-  method add(x: int, y: int): int {= return x + y; =}
+  method add(x: int, y: int): int {=
+    return x + y;
+  =}
 
   reaction(startup) {=
     for (int n = 1; n < 10; n++) {

--- a/test/C/src/MethodsSameName.lf
+++ b/test/C/src/MethodsSameName.lf
@@ -4,7 +4,9 @@ target C
 reactor Foo {
   state foo: int = 2
 
-  method add(x: int) {= self->foo += x; =}
+  method add(x: int) {=
+    self->foo += x;
+  =}
 
   reaction(startup) {=
     add(40);
@@ -20,7 +22,9 @@ main reactor {
 
   a = new Foo()
 
-  method add(x: int) {= self->foo += x; =}
+  method add(x: int) {=
+    self->foo += x;
+  =}
 
   reaction(startup) {=
     add(40);

--- a/test/C/src/Microsteps.lf
+++ b/test/C/src/Microsteps.lf
@@ -37,5 +37,7 @@ main reactor Microsteps {
     lf_schedule(repeat, 0);
   =}
 
-  reaction(repeat) -> d.y {= lf_set(d.y, 1); =}
+  reaction(repeat) -> d.y {=
+    lf_set(d.y, 1);
+  =}
 }

--- a/test/C/src/Minimal.lf
+++ b/test/C/src/Minimal.lf
@@ -2,5 +2,7 @@
 target C
 
 main reactor Minimal {
-  reaction(startup) {= printf("Hello World.\n"); =}
+  reaction(startup) {=
+    printf("Hello World.\n");
+  =}
 }

--- a/test/C/src/MultipleContained.lf
+++ b/test/C/src/MultipleContained.lf
@@ -7,7 +7,9 @@ reactor Contained {
   input in2: int
   state count: int = 0
 
-  reaction(startup) -> trigger {= lf_set(trigger, 42); =}
+  reaction(startup) -> trigger {=
+    lf_set(trigger, 42);
+  =}
 
   reaction(in1) {=
     printf("in1 received %d.\n", in1->value);

--- a/test/C/src/NestedTriggeredReactions.lf
+++ b/test/C/src/NestedTriggeredReactions.lf
@@ -9,7 +9,9 @@ reactor Container {
 
   in -> contained.in
 
-  reaction(in) {= self->triggered = true; =}
+  reaction(in) {=
+    self->triggered = true;
+  =}
 
   reaction(shutdown) {=
     if (!self->triggered) {
@@ -23,7 +25,9 @@ reactor Contained {
 
   state triggered: bool = false
 
-  reaction(in) {= self->triggered = true; =}
+  reaction(in) {=
+    self->triggered = true;
+  =}
 
   reaction(shutdown) {=
     if (!self->triggered) {
@@ -35,5 +39,7 @@ reactor Contained {
 main reactor {
   container = new Container()
 
-  reaction(startup) -> container.in {= lf_set(container.in, true); =}
+  reaction(startup) -> container.in {=
+    lf_set(container.in, true);
+  =}
 }

--- a/test/C/src/ParameterizedState.lf
+++ b/test/C/src/ParameterizedState.lf
@@ -3,7 +3,9 @@ target C
 reactor Foo(bar: int = 42) {
   state baz = bar
 
-  reaction(startup) {= printf("Baz: %d\n", self->baz); =}
+  reaction(startup) {=
+    printf("Baz: %d\n", self->baz);
+  =}
 }
 
 main reactor {

--- a/test/C/src/PersistentInputs.lf
+++ b/test/C/src/PersistentInputs.lf
@@ -8,7 +8,9 @@ reactor Source {
   timer t(100 ms, 200 ms)
   state count: int = 1
 
-  reaction(t) -> out {= lf_set(out, self->count++); =}
+  reaction(t) -> out {=
+    lf_set(out, self->count++);
+  =}
 }
 
 reactor Sink {
@@ -17,7 +19,9 @@ reactor Sink {
   state count: int = 0  // For testing, emulate the count variable of Source.
   timer t2(100 ms, 200 ms)
 
-  reaction(t2) {= self->count++; =}
+  reaction(t2) {=
+    self->count++;
+  =}
 
   reaction(t) in {=
     printf("Value of the input is %d at time %lld\n", in->value, lf_time_logical_elapsed());

--- a/test/C/src/PhysicalConnection.lf
+++ b/test/C/src/PhysicalConnection.lf
@@ -4,7 +4,9 @@ target C
 reactor Source {
   output out: int
 
-  reaction(startup) -> out {= lf_set(out, 42); =}
+  reaction(startup) -> out {=
+    lf_set(out, 42);
+  =}
 }
 
 reactor Destination {

--- a/test/C/src/PingPong.lf
+++ b/test/C/src/PingPong.lf
@@ -28,7 +28,9 @@ reactor Ping(count: int = 10) {
   state pingsLeft: int = count
   logical action serve
 
-  reaction(startup, serve) -> send {= lf_set(send, self->pingsLeft--); =}
+  reaction(startup, serve) -> send {=
+    lf_set(send, self->pingsLeft--);
+  =}
 
   reaction(receive) -> serve {=
     if (self->pingsLeft > 0) {

--- a/test/C/src/PreambleInherited.lf
+++ b/test/C/src/PreambleInherited.lf
@@ -6,7 +6,9 @@ reactor A {
     #define FOO 2
   =}
 
-  reaction(startup) {= printf("FOO: %d\n", FOO); =}
+  reaction(startup) {=
+    printf("FOO: %d\n", FOO);
+  =}
 }
 
 reactor B extends A {

--- a/test/C/src/ReadOutputOfContainedReactor.lf
+++ b/test/C/src/ReadOutputOfContainedReactor.lf
@@ -4,7 +4,9 @@ target C
 reactor Contained {
   output out: int
 
-  reaction(startup) -> out {= lf_set(out, 42); =}
+  reaction(startup) -> out {=
+    lf_set(out, 42);
+  =}
 }
 
 main reactor ReadOutputOfContainedReactor {

--- a/test/C/src/RepeatedInheritance.lf
+++ b/test/C/src/RepeatedInheritance.lf
@@ -27,7 +27,9 @@ reactor A extends B, C {
   input a: int
   output out: int
 
-  reaction(a, b, c, d) -> out {= lf_set(out, a->value + b->value + c->value + d->value); =}
+  reaction(a, b, c, d) -> out {=
+    lf_set(out, a->value + b->value + c->value + d->value);
+  =}
 }
 
 main reactor {

--- a/test/C/src/Schedule.lf
+++ b/test/C/src/Schedule.lf
@@ -5,7 +5,9 @@ reactor Schedule2 {
   input x: int
   logical action a
 
-  reaction(x) -> a {= lf_schedule(a, MSEC(200)); =}
+  reaction(x) -> a {=
+    lf_schedule(a, MSEC(200));
+  =}
 
   reaction(a) {=
     interval_t elapsed_time = lf_time_logical_elapsed();
@@ -21,5 +23,7 @@ main reactor {
   a = new Schedule2()
   timer t
 
-  reaction(t) -> a.x {= lf_set(a.x, 1); =}
+  reaction(t) -> a.x {=
+    lf_set(a.x, 1);
+  =}
 }

--- a/test/C/src/ScheduleLogicalAction.lf
+++ b/test/C/src/ScheduleLogicalAction.lf
@@ -16,7 +16,9 @@ reactor foo {
     lf_schedule(a, MSEC(500));
   =}
 
-  reaction(a) -> y {= lf_set(y, -42); =}
+  reaction(a) -> y {=
+    lf_set(y, -42);
+  =}
 }
 
 reactor print {
@@ -42,5 +44,7 @@ main reactor {
   timer t(0, 1 sec)
   f.y -> p.x
 
-  reaction(t) -> f.x {= lf_set(f.x, 42); =}
+  reaction(t) -> f.x {=
+    lf_set(f.x, 42);
+  =}
 }

--- a/test/C/src/SelfLoop.lf
+++ b/test/C/src/SelfLoop.lf
@@ -24,7 +24,9 @@ reactor Self {
     lf_schedule_int(a, MSEC(100), x->value);
   =}
 
-  reaction(startup) -> a {= lf_schedule_int(a, 0, 42); =}
+  reaction(startup) -> a {=
+    lf_schedule_int(a, 0, 42);
+  =}
 
   reaction(shutdown) {=
     if (self->expected <= 43) {

--- a/test/C/src/SendingInside2.lf
+++ b/test/C/src/SendingInside2.lf
@@ -16,5 +16,7 @@ main reactor SendingInside2 {
   timer t
   p = new Printer()
 
-  reaction(t) -> p.x {= lf_set(p.x, 1); =}
+  reaction(t) -> p.x {=
+    lf_set(p.x, 1);
+  =}
 }

--- a/test/C/src/SendsPointerTest.lf
+++ b/test/C/src/SendsPointerTest.lf
@@ -2,7 +2,9 @@
 // ensures that the struct is freed.
 target C
 
-preamble {= typedef int* int_pointer; =}
+preamble {=
+  typedef int* int_pointer;
+=}
 
 reactor SendsPointer {
   output out: int_pointer

--- a/test/C/src/SetToken.lf
+++ b/test/C/src/SetToken.lf
@@ -5,9 +5,13 @@ reactor Source {
   output out: int*
   logical action a: int
 
-  reaction(startup) -> a {= lf_schedule_int(a, MSEC(200), 42); =}
+  reaction(startup) -> a {=
+    lf_schedule_int(a, MSEC(200), 42);
+  =}
 
-  reaction(a) -> out {= lf_set_token(out, a->token); =}
+  reaction(a) -> out {=
+    lf_set_token(out, a->token);
+  =}
 }
 
 // expected parameter is for testing.

--- a/test/C/src/SlowingClock.lf
+++ b/test/C/src/SlowingClock.lf
@@ -13,7 +13,9 @@ main reactor SlowingClock {
   state interval: time = 100 msec
   state expected_time: time = 100 msec
 
-  reaction(startup) -> a {= lf_schedule(a, 0); =}
+  reaction(startup) -> a {=
+    lf_schedule(a, 0);
+  =}
 
   reaction(a) -> a {=
     instant_t elapsed_logical_time = lf_time_logical_elapsed();

--- a/test/C/src/StartupOutFromInside.lf
+++ b/test/C/src/StartupOutFromInside.lf
@@ -3,7 +3,9 @@ target C
 reactor Bar {
   output out: int
 
-  reaction(startup) -> out {= lf_set(out, 42); =}
+  reaction(startup) -> out {=
+    lf_set(out, 42);
+  =}
 }
 
 main reactor StartupOutFromInside {

--- a/test/C/src/TimeLimit.lf
+++ b/test/C/src/TimeLimit.lf
@@ -44,5 +44,7 @@ main reactor TimeLimit(period: time = 1 sec) {
   d = new Destination()
   c.y -> d.x
 
-  reaction(stop) {= lf_request_stop(); =}
+  reaction(stop) {=
+    lf_request_stop();
+  =}
 }

--- a/test/C/src/TimeState.lf
+++ b/test/C/src/TimeState.lf
@@ -3,7 +3,9 @@ target C
 reactor Foo(bar: int = 42) {
   state baz: time = 500 msec
 
-  reaction(startup) {= printf("Baz: %lld\n", self->baz); =}
+  reaction(startup) {=
+    printf("Baz: %lld\n", self->baz);
+  =}
 }
 
 main reactor {

--- a/test/C/src/UnconnectedInput.lf
+++ b/test/C/src/UnconnectedInput.lf
@@ -9,7 +9,9 @@ reactor Source {
   timer t(0, 1 sec)
   state s: int = 1
 
-  reaction(t) -> out {= lf_set(out, self->s++); =}
+  reaction(t) -> out {=
+    lf_set(out, self->s++);
+  =}
 }
 
 reactor Add {

--- a/test/C/src/Wcet.lf
+++ b/test/C/src/Wcet.lf
@@ -31,7 +31,9 @@ reactor Work {
 reactor Print {
   input in: int
 
-  reaction(in) {= printf("Received: %d\n", in->value); =}
+  reaction(in) {=
+    printf("Received: %d\n", in->value);
+  =}
 }
 
 main reactor Wcet {

--- a/test/C/src/arduino/Blink.lf
+++ b/test/C/src/arduino/Blink.lf
@@ -13,9 +13,15 @@ main reactor Blink {
   timer t1(0, 1 sec)
   timer t2(500 msec, 1 sec)
 
-  reaction(startup) {= pinMode(LED_BUILTIN, OUTPUT); =}
+  reaction(startup) {=
+    pinMode(LED_BUILTIN, OUTPUT);
+  =}
 
-  reaction(t1) {= digitalWrite(LED_BUILTIN, HIGH); =}
+  reaction(t1) {=
+    digitalWrite(LED_BUILTIN, HIGH);
+  =}
 
-  reaction(t2) {= digitalWrite(LED_BUILTIN, LOW); =}
+  reaction(t2) {=
+    digitalWrite(LED_BUILTIN, LOW);
+  =}
 }

--- a/test/C/src/arduino/BlinkAttemptThreading.lf
+++ b/test/C/src/arduino/BlinkAttemptThreading.lf
@@ -15,9 +15,15 @@ main reactor BlinkAttemptThreading {
   timer t1(0, 1 sec)
   timer t2(500 msec, 1 sec)
 
-  reaction(startup) {= pinMode(LED_BUILTIN, OUTPUT); =}
+  reaction(startup) {=
+    pinMode(LED_BUILTIN, OUTPUT);
+  =}
 
-  reaction(t1) {= digitalWrite(LED_BUILTIN, HIGH); =}
+  reaction(t1) {=
+    digitalWrite(LED_BUILTIN, HIGH);
+  =}
 
-  reaction(t2) {= digitalWrite(LED_BUILTIN, LOW); =}
+  reaction(t2) {=
+    digitalWrite(LED_BUILTIN, LOW);
+  =}
 }

--- a/test/C/src/arduino/BlinkMBED.lf
+++ b/test/C/src/arduino/BlinkMBED.lf
@@ -13,9 +13,15 @@ main reactor BlinkMBED {
   timer t1(0, 1 sec)
   timer t2(500 msec, 1 sec)
 
-  reaction(startup) {= pinMode(LED_BUILTIN, OUTPUT); =}
+  reaction(startup) {=
+    pinMode(LED_BUILTIN, OUTPUT);
+  =}
 
-  reaction(t1) {= digitalWrite(LED_BUILTIN, HIGH); =}
+  reaction(t1) {=
+    digitalWrite(LED_BUILTIN, HIGH);
+  =}
 
-  reaction(t2) {= digitalWrite(LED_BUILTIN, LOW); =}
+  reaction(t2) {=
+    digitalWrite(LED_BUILTIN, LOW);
+  =}
 }

--- a/test/C/src/arduino/DigitalReadSerial.lf
+++ b/test/C/src/arduino/DigitalReadSerial.lf
@@ -10,7 +10,9 @@ main reactor DigitalReadSerial {
   timer t1(0, 1 msec)
   state pushButton: int = 2
 
-  reaction(startup) {= pinMode(self->pushButton, INPUT); =}
+  reaction(startup) {=
+    pinMode(self->pushButton, INPUT);
+  =}
 
   reaction(t1) {=
     int buttonState = digitalRead(self->pushButton);

--- a/test/C/src/arduino/Fade.lf
+++ b/test/C/src/arduino/Fade.lf
@@ -17,7 +17,9 @@ main reactor Fade {
   state brightness: int = 9
   state fadeAmount: int = 5
 
-  reaction(startup) {= pinMode(self->led, OUTPUT); =}
+  reaction(startup) {=
+    pinMode(self->led, OUTPUT);
+  =}
 
   reaction(t1) {=
     analogWrite(self->led, self->brightness);

--- a/test/C/src/arduino/ReadAnalogVoltage.lf
+++ b/test/C/src/arduino/ReadAnalogVoltage.lf
@@ -14,7 +14,9 @@ target C {
 main reactor ReadAnalogVoltage {
   logical action a
 
-  reaction(startup) -> a {= lf_schedule(a, 0); =}
+  reaction(startup) -> a {=
+    lf_schedule(a, 0);
+  =}
 
   reaction(a) -> a {=
     int sensorValue = analogRead(A0);

--- a/test/C/src/concurrent/DelayIntThreaded.lf
+++ b/test/C/src/concurrent/DelayIntThreaded.lf
@@ -6,7 +6,9 @@ reactor Delay(delay: time = 100 msec) {
   output out: int
   logical action a: int
 
-  reaction(a) -> out {= lf_set(out, a->value); =}
+  reaction(a) -> out {=
+    lf_set(out, a->value);
+  =}
 
   reaction(in) -> a {=
     // Use specialized form of schedule for integer payloads.
@@ -55,5 +57,7 @@ main reactor {
   t = new Test()
   d.out -> t.in
 
-  reaction(startup) -> d.in {= lf_set(d.in, 42); =}
+  reaction(startup) -> d.in {=
+    lf_set(d.in, 42);
+  =}
 }

--- a/test/C/src/concurrent/DeterminismThreaded.lf
+++ b/test/C/src/concurrent/DeterminismThreaded.lf
@@ -4,7 +4,9 @@ reactor Source {
   output y: int
   timer t
 
-  reaction(t) -> y {= lf_set(y, 1); =}
+  reaction(t) -> y {=
+    lf_set(y, 1);
+  =}
 }
 
 reactor Destination {
@@ -31,7 +33,9 @@ reactor Pass {
   input x: int
   output y: int
 
-  reaction(x) -> y {= lf_set(y, x->value); =}
+  reaction(x) -> y {=
+    lf_set(y, x->value);
+  =}
 }
 
 main reactor {

--- a/test/C/src/concurrent/GainThreaded.lf
+++ b/test/C/src/concurrent/GainThreaded.lf
@@ -5,7 +5,9 @@ reactor Scale(scale: int = 2) {
   input x: int
   output y: int
 
-  reaction(x) -> y {= lf_set(y, x->value * self->scale); =}
+  reaction(x) -> y {=
+    lf_set(y, x->value * self->scale);
+  =}
 }
 
 reactor Test {
@@ -35,5 +37,7 @@ main reactor {
   d = new Test()
   g.y -> d.x
 
-  reaction(startup) -> g.x {= lf_set(g.x, 1); =}
+  reaction(startup) -> g.x {=
+    lf_set(g.x, 1);
+  =}
 }

--- a/test/C/src/concurrent/ImportThreaded.lf
+++ b/test/C/src/concurrent/ImportThreaded.lf
@@ -7,5 +7,7 @@ main reactor ImportThreaded {
   timer t
   a = new Imported()
 
-  reaction(t) -> a.x {= lf_set(a.x, 42); =}
+  reaction(t) -> a.x {=
+    lf_set(a.x, 42);
+  =}
 }

--- a/test/C/src/concurrent/MinimalThreaded.lf
+++ b/test/C/src/concurrent/MinimalThreaded.lf
@@ -4,5 +4,7 @@ target C
 main reactor MinimalThreaded {
   timer t
 
-  reaction(t) {= printf("Hello World.\n"); =}
+  reaction(t) {=
+    printf("Hello World.\n");
+  =}
 }

--- a/test/C/src/concurrent/PingPongThreaded.lf
+++ b/test/C/src/concurrent/PingPongThreaded.lf
@@ -27,7 +27,9 @@ reactor Ping(count: int = 10) {
   state pingsLeft: int = count
   logical action serve
 
-  reaction(startup, serve) -> send {= lf_set(send, self->pingsLeft--); =}
+  reaction(startup, serve) -> send {=
+    lf_set(send, self->pingsLeft--);
+  =}
 
   reaction(receive) -> serve {=
     if (self->pingsLeft > 0) {

--- a/test/C/src/concurrent/TimeLimitThreaded.lf
+++ b/test/C/src/concurrent/TimeLimitThreaded.lf
@@ -44,5 +44,7 @@ main reactor(period: time = 1 sec) {
   d = new Destination()
   c.y -> d.x
 
-  reaction(stop) {= lf_request_stop(); =}
+  reaction(stop) {=
+    lf_request_stop();
+  =}
 }

--- a/test/C/src/enclave/EnclaveRequestStop.lf
+++ b/test/C/src/enclave/EnclaveRequestStop.lf
@@ -9,7 +9,9 @@ reactor Stop(stop_time: time = 5 s) {
   =}
   timer t(stop_time)
 
-  reaction(t) {= lf_request_stop(); =}
+  reaction(t) {=
+    lf_request_stop();
+  =}
 
   reaction(shutdown) {=
     lf_print("Stopped at tag (" PRINTF_TIME ", %d)", lf_time_logical_elapsed(), lf_tag().microstep);

--- a/test/C/src/federated/BroadcastFeedback.lf
+++ b/test/C/src/federated/BroadcastFeedback.lf
@@ -9,7 +9,9 @@ reactor SenderAndReceiver {
   input[2] in: int
   state received: bool = false
 
-  reaction(startup) -> out {= lf_set(out, 42); =}
+  reaction(startup) -> out {=
+    lf_set(out, 42);
+  =}
 
   reaction(in) {=
     if (in[0]->is_present && in[1]->is_present && in[0]->value == 42 && in[1]->value == 42) {

--- a/test/C/src/federated/BroadcastFeedbackWithHierarchy.lf
+++ b/test/C/src/federated/BroadcastFeedbackWithHierarchy.lf
@@ -11,7 +11,9 @@ reactor SenderAndReceiver {
   r = new Receiver()
   in -> r.in
 
-  reaction(startup) -> out {= lf_set(out, 42); =}
+  reaction(startup) -> out {=
+    lf_set(out, 42);
+  =}
 }
 
 reactor Receiver {

--- a/test/C/src/federated/CycleDetection.lf
+++ b/test/C/src/federated/CycleDetection.lf
@@ -23,14 +23,18 @@ reactor CAReplica {
     }
   =}
 
-  reaction(query) -> response {= lf_set(response, self->balance); =}
+  reaction(query) -> response {=
+    lf_set(response, self->balance);
+  =}
 }
 
 reactor UserInput {
   input balance: int
   output deposit: int
 
-  reaction(startup) -> deposit {= lf_set(deposit, 100); =}
+  reaction(startup) -> deposit {=
+    lf_set(deposit, 100);
+  =}
 
   reaction(balance) {=
     if (balance->value != 200) {
@@ -45,7 +49,9 @@ reactor UserInput {
     lf_request_stop();
   =}
 
-  reaction(shutdown) {= lf_print("Shutdown reaction invoked."); =}
+  reaction(shutdown) {=
+    lf_print("Shutdown reaction invoked.");
+  =}
 }
 
 federated reactor {

--- a/test/C/src/federated/DecentralizedP2PComm.lf
+++ b/test/C/src/federated/DecentralizedP2PComm.lf
@@ -12,7 +12,9 @@ reactor Platform(start: int = 0, expected_start: int = 0, stp_offset_param: time
   state count: int = start
   state expected: int = expected_start
 
-  reaction(t) -> out {= lf_set(out, self->count++); =}
+  reaction(t) -> out {=
+    lf_set(out, self->count++);
+  =}
 
   reaction(in) {=
     lf_print("Received %d.", in->value);

--- a/test/C/src/federated/DecentralizedP2PUnbalancedTimeout.lf
+++ b/test/C/src/federated/DecentralizedP2PUnbalancedTimeout.lf
@@ -21,7 +21,9 @@ reactor Clock(offset: time = 0, period: time = 1 sec) {
     lf_set(y, self->count);
   =}
 
-  reaction(shutdown) {= lf_print("SUCCESS: the source exited successfully."); =}
+  reaction(shutdown) {=
+    lf_print("SUCCESS: the source exited successfully.");
+  =}
 }
 
 reactor Destination {

--- a/test/C/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
+++ b/test/C/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
@@ -22,7 +22,9 @@ reactor Clock(offset: time = 0, period: time = 1 sec) {
     lf_set(y, self->count);
   =}
 
-  reaction(shutdown) {= lf_print("SUCCESS: the source exited successfully."); =}
+  reaction(shutdown) {=
+    lf_print("SUCCESS: the source exited successfully.");
+  =}
 }
 
 reactor Destination {

--- a/test/C/src/federated/DistributedBank.lf
+++ b/test/C/src/federated/DistributedBank.lf
@@ -8,7 +8,9 @@ reactor Node(bank_index: int = 0) {
   timer t(0, 100 msec)
   state count: int = 0
 
-  reaction(t) {= lf_print("Hello world %d.", self->count++); =}
+  reaction(t) {=
+    lf_print("Hello world %d.", self->count++);
+  =}
 
   reaction(shutdown) {=
     if (self->bank_index) {

--- a/test/C/src/federated/DistributedDoublePort.lf
+++ b/test/C/src/federated/DistributedDoublePort.lf
@@ -18,9 +18,13 @@ reactor CountMicrostep {
   logical action act: int
   timer t(0, 1 sec)
 
-  reaction(t) -> act {= lf_schedule_int(act, 0, self->count++); =}
+  reaction(t) -> act {=
+    lf_schedule_int(act, 0, self->count++);
+  =}
 
-  reaction(act) -> out {= lf_set(out, act->value); =}
+  reaction(act) -> out {=
+    lf_set(out, act->value);
+  =}
 }
 
 reactor Print {
@@ -35,7 +39,9 @@ reactor Print {
     }
   =}
 
-  reaction(shutdown) {= lf_print("SUCCESS: messages were at least one microstep apart."); =}
+  reaction(shutdown) {=
+    lf_print("SUCCESS: messages were at least one microstep apart.");
+  =}
 }
 
 federated reactor DistributedDoublePort {

--- a/test/C/src/federated/DistributedPhysicalActionUpstream.lf
+++ b/test/C/src/federated/DistributedPhysicalActionUpstream.lf
@@ -44,7 +44,9 @@ reactor WithPhysicalAction {
     lf_thread_create(&self->thread_id, &take_time, act);
   =}
 
-  reaction(act) -> out {= lf_set(out, act->value); =}
+  reaction(act) -> out {=
+    lf_set(out, act->value);
+  =}
 }
 
 federated reactor {

--- a/test/C/src/federated/DistributedPhysicalActionUpstreamLong.lf
+++ b/test/C/src/federated/DistributedPhysicalActionUpstreamLong.lf
@@ -43,7 +43,9 @@ reactor WithPhysicalAction {
     lf_thread_create(&self->thread_id, &take_time, act);
   =}
 
-  reaction(act) -> out {= lf_set(out, act->value); =}
+  reaction(act) -> out {=
+    lf_set(out, act->value);
+  =}
 }
 
 federated reactor {

--- a/test/C/src/federated/EnclaveFederatedRequestStop.lf
+++ b/test/C/src/federated/EnclaveFederatedRequestStop.lf
@@ -12,7 +12,9 @@ reactor Stop(stop_time: time = 5 s) {
   =}
   timer t(stop_time)
 
-  reaction(t) {= lf_request_stop(); =}
+  reaction(t) {=
+    lf_request_stop();
+  =}
 
   reaction(shutdown) {=
     lf_print("Stopped at tag (" PRINTF_TIME ", %d)", lf_time_logical_elapsed(), lf_tag().microstep);

--- a/test/C/src/federated/FeedbackDelay.lf
+++ b/test/C/src/federated/FeedbackDelay.lf
@@ -20,7 +20,9 @@ reactor PhysicalPlant {
     instant_t control_time = lf_time_physical();
     lf_print("Latency %lld.", control_time - self->previous_sensor_time);
     lf_print("Logical time: %lld.", lf_time_logical_elapsed());
-  =} STP(33 msec) {= lf_print_warning("STP violation."); =}
+  =} STP(33 msec) {=
+    lf_print_warning("STP violation.");
+  =}
 }
 
 reactor Controller {
@@ -33,7 +35,9 @@ reactor Controller {
   output request_for_planning: double
   input planning: double
 
-  reaction(planning) {= self->latest_control = planning->value; =}
+  reaction(planning) {=
+    self->latest_control = planning->value;
+  =}
 
   reaction(sensor) -> control, request_for_planning {=
     if (!self->first) {

--- a/test/C/src/federated/FeedbackDelaySimple.lf
+++ b/test/C/src/federated/FeedbackDelaySimple.lf
@@ -20,7 +20,9 @@ reactor Loop {
     self->count++;
   =}
 
-  reaction(t) -> out {= lf_set(out, self->count); =}
+  reaction(t) -> out {=
+    lf_set(out, self->count);
+  =}
 
   reaction(shutdown) {=
     if (self->count != 11) {

--- a/test/C/src/federated/HelloDistributed.lf
+++ b/test/C/src/federated/HelloDistributed.lf
@@ -24,7 +24,9 @@ reactor Destination {
   input in: string
   state received: bool = false
 
-  reaction(startup) {= lf_print("Destination started."); =}
+  reaction(startup) {=
+    lf_print("Destination started.");
+  =}
 
   reaction(in) {=
     lf_print("At logical time %lld, destination received: %s", lf_time_logical_elapsed(), in->value);
@@ -48,5 +50,7 @@ federated reactor HelloDistributed at localhost {
   d = new Destination()  // Reactor d is in federate Destination
   s.out -> d.in          // This version preserves the timestamp.
 
-  reaction(startup) {= lf_print("Printing something in top-level federated reactor."); =}
+  reaction(startup) {=
+    lf_print("Printing something in top-level federated reactor.");
+  =}
 }

--- a/test/C/src/federated/InheritanceFederated.lf
+++ b/test/C/src/federated/InheritanceFederated.lf
@@ -6,7 +6,9 @@ target C {
 }
 
 reactor A {
-  reaction(startup) {= printf("Hello\n"); =}
+  reaction(startup) {=
+    printf("Hello\n");
+  =}
 }
 
 reactor B {

--- a/test/C/src/federated/InheritanceFederatedImport.lf
+++ b/test/C/src/federated/InheritanceFederatedImport.lf
@@ -7,7 +7,9 @@ target C {
 import HelloWorld2 from "../HelloWorld.lf"
 
 reactor Print extends HelloWorld2 {
-  reaction(startup) {= printf("Foo\n"); =}
+  reaction(startup) {=
+    printf("Foo\n");
+  =}
 }
 
 federated reactor {

--- a/test/C/src/federated/LevelPattern.lf
+++ b/test/C/src/federated/LevelPattern.lf
@@ -15,7 +15,9 @@ reactor Through {
   input in: int
   output out: int
 
-  reaction(in) -> out {= lf_set(out, in->value); =}
+  reaction(in) -> out {=
+    lf_set(out, in->value);
+  =}
 }
 
 reactor A {
@@ -30,9 +32,13 @@ reactor A {
   i2 = new Through()
   i2.out -> out2
 
-  reaction(in1) -> i1.in {= lf_set(i1.in, in1->value); =}
+  reaction(in1) -> i1.in {=
+    lf_set(i1.in, in1->value);
+  =}
 
-  reaction(in2) -> i2.in {= lf_set(i2.in, in2->value); =}
+  reaction(in2) -> i2.in {=
+    lf_set(i2.in, in2->value);
+  =}
 }
 
 federated reactor {

--- a/test/C/src/federated/LoopDistributedCentralizedPrecedenceHierarchy.lf
+++ b/test/C/src/federated/LoopDistributedCentralizedPrecedenceHierarchy.lf
@@ -20,9 +20,13 @@ reactor Contained(incr: int = 1) {
   state count: int = 0
   state received_count: int = 0
 
-  reaction(t) {= self->count += self->incr; =}
+  reaction(t) {=
+    self->count += self->incr;
+  =}
 
-  reaction(in) {= self->received_count = self->count; =}
+  reaction(in) {=
+    self->received_count = self->count;
+  =}
 
   reaction(t) {=
     if (self->received_count != self->count) {

--- a/test/C/src/federated/SpuriousDependency.lf
+++ b/test/C/src/federated/SpuriousDependency.lf
@@ -35,7 +35,9 @@ reactor Check {
 
   state count: int = 0
 
-  reaction(in) {= lf_print("count is now %d", ++self->count); =}
+  reaction(in) {=
+    lf_print("count is now %d", ++self->count);
+  =}
 
   reaction(shutdown) {=
     lf_print("******* Shutdown invoked.");
@@ -55,5 +57,7 @@ federated reactor {
 
   t1.out0 -> check.in
 
-  reaction(startup) -> t0.in1 {= lf_set(t0.in1, 0); =}
+  reaction(startup) -> t0.in1 {=
+    lf_set(t0.in1, 0);
+  =}
 }

--- a/test/C/src/federated/StopAtShutdown.lf
+++ b/test/C/src/federated/StopAtShutdown.lf
@@ -12,20 +12,30 @@ target C {
 reactor A {
   input in: int
 
-  reaction(startup) {= lf_print("Hello World!"); =}
+  reaction(startup) {=
+    lf_print("Hello World!");
+  =}
 
-  reaction(in) {= lf_print("Got it"); =}
+  reaction(in) {=
+    lf_print("Got it");
+  =}
 
-  reaction(shutdown) {= lf_request_stop(); =}
+  reaction(shutdown) {=
+    lf_request_stop();
+  =}
 }
 
 reactor B {
   output out: int
   timer t(1 sec)
 
-  reaction(t) -> out {= lf_set(out, 1); =}
+  reaction(t) -> out {=
+    lf_set(out, 1);
+  =}
 
-  reaction(shutdown) {= lf_request_stop(); =}
+  reaction(shutdown) {=
+    lf_request_stop();
+  =}
 }
 
 federated reactor {

--- a/test/C/src/federated/TopLevelArtifacts.lf
+++ b/test/C/src/federated/TopLevelArtifacts.lf
@@ -22,14 +22,18 @@ federated reactor {
   tc = new TestCount()
   c.out -> tc.in
 
-  reaction(startup) {= self->successes++; =}
+  reaction(startup) {=
+    self->successes++;
+  =}
 
   reaction(t) -> act {=
     self->successes++;
     lf_schedule(act, 0);
   =}
 
-  reaction(act) {= self->successes++; =}
+  reaction(act) {=
+    self->successes++;
+  =}
 
   reaction(shutdown) {=
     if (self->successes != 3) {

--- a/test/C/src/generics/ParameterAsArgument.lf
+++ b/test/C/src/generics/ParameterAsArgument.lf
@@ -23,5 +23,7 @@ reactor Super<T1, T2, T3, In, Out> {
 main reactor {
   cc = new Super<long, double, char, int, float>()
 
-  reaction(startup) -> cc.in {= lf_set(cc.in, 42); =}
+  reaction(startup) -> cc.in {=
+    lf_set(cc.in, 42);
+  =}
 }

--- a/test/C/src/generics/TypeCheck.lf
+++ b/test/C/src/generics/TypeCheck.lf
@@ -9,7 +9,9 @@ reactor Count(offset: time = 0, period: time = 1 sec) {
   output out: int
   timer t(offset, period)
 
-  reaction(t) -> out {= lf_set(out, self->count++); =}
+  reaction(t) -> out {=
+    lf_set(out, self->count++);
+  =}
 }
 
 reactor TestCount<T>(start: int = 1, num_inputs: int = 1) {

--- a/test/C/src/lib/Count.lf
+++ b/test/C/src/lib/Count.lf
@@ -5,5 +5,7 @@ reactor Count(offset: time = 0, period: time = 1 sec) {
   output out: int
   timer t(offset, period)
 
-  reaction(t) -> out {= lf_set(out, self->count++); =}
+  reaction(t) -> out {=
+    lf_set(out, self->count++);
+  =}
 }

--- a/test/C/src/lib/FileLevelPreamble.lf
+++ b/test/C/src/lib/FileLevelPreamble.lf
@@ -6,5 +6,7 @@ preamble {=
 =}
 
 reactor FileLevelPreamble {
-  reaction(startup) {= printf("FOO: %d\n", FOO); =}
+  reaction(startup) {=
+    printf("FOO: %d\n", FOO);
+  =}
 }

--- a/test/C/src/lib/GenDelay.lf
+++ b/test/C/src/lib/GenDelay.lf
@@ -1,15 +1,21 @@
 target C
 
-preamble {= typedef int message_t; =}
+preamble {=
+  typedef int message_t;
+=}
 
 reactor Source {
   output out: message_t
 
-  reaction(startup) -> out {= lf_set(out, 42); =}
+  reaction(startup) -> out {=
+    lf_set(out, 42);
+  =}
 }
 
 reactor Sink {
   input in: message_t
 
-  reaction(in) {= lf_print("Received %d at time %lld", in->value, lf_time_logical_elapsed()); =}
+  reaction(in) {=
+    lf_print("Received %d at time %lld", in->value, lf_time_logical_elapsed());
+  =}
 }

--- a/test/C/src/lib/Imported.lf
+++ b/test/C/src/lib/Imported.lf
@@ -8,5 +8,7 @@ reactor Imported {
   input x: int
   a = new ImportedAgain()
 
-  reaction(x) -> a.x {= lf_set(a.x, x->value); =}
+  reaction(x) -> a.x {=
+    lf_set(a.x, x->value);
+  =}
 }

--- a/test/C/src/lib/ImportedComposition.lf
+++ b/test/C/src/lib/ImportedComposition.lf
@@ -6,7 +6,9 @@ reactor Gain {
   input x: int
   output y: int
 
-  reaction(x) -> y {= lf_set(y, x->value * 2); =}
+  reaction(x) -> y {=
+    lf_set(y, x->value * 2);
+  =}
 }
 
 reactor ImportedComposition {

--- a/test/C/src/lib/InternalDelay.lf
+++ b/test/C/src/lib/InternalDelay.lf
@@ -5,7 +5,11 @@ reactor InternalDelay(delay: time = 10 msec) {
   output out: int
   logical action d: int
 
-  reaction(in) -> d {= lf_schedule_int(d, self->delay, in->value); =}
+  reaction(in) -> d {=
+    lf_schedule_int(d, self->delay, in->value);
+  =}
 
-  reaction(d) -> out {= lf_set(out, d->value); =}
+  reaction(d) -> out {=
+    lf_set(out, d->value);
+  =}
 }

--- a/test/C/src/lib/PassThrough.lf
+++ b/test/C/src/lib/PassThrough.lf
@@ -5,5 +5,7 @@ reactor PassThrough {
   input in: int
   output out: int
 
-  reaction(in) -> out {= lf_set(out, in->value); =}
+  reaction(in) -> out {=
+    lf_set(out, in->value);
+  =}
 }

--- a/test/C/src/modal_models/BanksCount3ModesComplex.lf
+++ b/test/C/src/modal_models/BanksCount3ModesComplex.lf
@@ -25,7 +25,9 @@ reactor MetaCounter {
     mode1_counters.count -> mode1
 
     timer t1(500 msec, 250 msec)
-    reaction(t1) -> reset(Two) {= lf_set_mode(Two); =}
+    reaction(t1) -> reset(Two) {=
+      lf_set_mode(Two);
+    =}
   }
 
   mode Two {
@@ -35,7 +37,9 @@ reactor MetaCounter {
     mode2_counters.count -> mode2
 
     timer t2(500 msec, 250 msec)
-    reaction(t2) -> history(One) {= lf_set_mode(One); =}
+    reaction(t2) -> history(One) {=
+      lf_set_mode(One);
+    =}
   }
 
   mode Three {

--- a/test/C/src/modal_models/ConvertCaseTest.lf
+++ b/test/C/src/modal_models/ConvertCaseTest.lf
@@ -15,13 +15,19 @@ reactor ResetProcessor {
     converter = new Converter()
     character -> converter.raw
     converter.converted -> converted
-    reaction(discard) -> reset(Discarding) {= lf_set_mode(Discarding); =}
+    reaction(discard) -> reset(Discarding) {=
+      lf_set_mode(Discarding);
+    =}
   }
 
   mode Discarding {
-    reaction(character) -> converted {= lf_set(converted, '_'); =}
+    reaction(character) -> converted {=
+      lf_set(converted, '_');
+    =}
 
-    reaction(character) -> reset(Converting) {= lf_set_mode(Converting); =}
+    reaction(character) -> reset(Converting) {=
+      lf_set_mode(Converting);
+    =}
   }
 }
 
@@ -34,13 +40,19 @@ reactor HistoryProcessor {
     converter = new Converter()
     character -> converter.raw
     converter.converted -> converted
-    reaction(discard) -> reset(Discarding) {= lf_set_mode(Discarding); =}
+    reaction(discard) -> reset(Discarding) {=
+      lf_set_mode(Discarding);
+    =}
   }
 
   mode Discarding {
-    reaction(character) -> converted {= lf_set(converted, '_'); =}
+    reaction(character) -> converted {=
+      lf_set(converted, '_');
+    =}
 
-    reaction(character) -> history(Converting) {= lf_set_mode(Converting); =}
+    reaction(character) -> history(Converting) {=
+      lf_set_mode(Converting);
+    =}
   }
 }
 
@@ -128,7 +140,9 @@ main reactor {
     lf_set(history_processor.discard, true);
   =}
 
-  reaction(reset_processor.converted) {= printf("Reset: %c\n", reset_processor.converted->value); =}
+  reaction(reset_processor.converted) {=
+    printf("Reset: %c\n", reset_processor.converted->value);
+  =}
 
   reaction(history_processor.converted) {=
     printf("History: %c\n", history_processor.converted->value);

--- a/test/C/src/modal_models/Count3Modes.lf
+++ b/test/C/src/modal_models/Count3Modes.lf
@@ -36,7 +36,10 @@ main reactor {
 
   state expected_value: int = 1
 
-  reaction(stepper) -> counter.next {= lf_set(counter.next, true); =}  // Trigger
+  // Trigger
+  reaction(stepper) -> counter.next {=
+    lf_set(counter.next, true);
+  =}
 
   // Check
   reaction(stepper) counter.count {=

--- a/test/C/src/modal_models/MixedReactions.lf
+++ b/test/C/src/modal_models/MixedReactions.lf
@@ -13,9 +13,13 @@ main reactor {
 
   timer t(0, 100 msec)
 
-  reaction(t) {= self->x = self->x * 10 + 1; =}
+  reaction(t) {=
+    self->x = self->x * 10 + 1;
+  =}
 
-  reaction(t) {= self->x = self->x * 10 + 2; =}
+  reaction(t) {=
+    self->x = self->x * 10 + 2;
+  =}
 
   initial mode A {
     reaction(t) -> reset(B) {=
@@ -24,10 +28,14 @@ main reactor {
     =}
   }
 
-  reaction(t) {= self->x = self->x * 10 + 4; =}
+  reaction(t) {=
+    self->x = self->x * 10 + 4;
+  =}
 
   mode B {
-    reaction(t) {= self->x = self->x * 10 + 5; =}
+    reaction(t) {=
+      self->x = self->x * 10 + 5;
+    =}
   }
 
   reaction(t) {=

--- a/test/C/src/modal_models/ModalActions.lf
+++ b/test/C/src/modal_models/ModalActions.lf
@@ -89,5 +89,8 @@ main reactor {
   modal.action2_sched,
   modal.action2_exec -> test.events
 
-  reaction(stepper) -> modal.next {= lf_set(modal.next, true); =}  // Trigger mode change
+  // Trigger mode change
+  reaction(stepper) -> modal.next {=
+    lf_set(modal.next, true);
+  =}
 }

--- a/test/C/src/modal_models/ModalAfter.lf
+++ b/test/C/src/modal_models/ModalAfter.lf
@@ -91,5 +91,8 @@ main reactor {
   modal.mode_switch, modal.produced1, modal.consumed1, modal.produced2, modal.consumed2
     -> test.events
 
-  reaction(stepper) -> modal.next {= lf_set(modal.next, true); =}  // Trigger mode change
+  // Trigger mode change
+  reaction(stepper) -> modal.next {=
+    lf_set(modal.next, true);
+  =}
 }

--- a/test/C/src/modal_models/ModalCycleBreaker.lf
+++ b/test/C/src/modal_models/ModalCycleBreaker.lf
@@ -30,7 +30,9 @@ reactor Modal {
   }
 
   initial mode One {
-    reaction(in1) -> out {= lf_set(out, in1->value); =}
+    reaction(in1) -> out {=
+      lf_set(out, in1->value);
+    =}
 
     reaction(in1) -> reset(Two) {=
       if (in1->value % 5 == 4) {
@@ -47,7 +49,9 @@ reactor Counter(period: time = 1 sec) {
   timer t(0, period)
   state curval: int = 0
 
-  reaction(t) -> value {= lf_set(value, self->curval++); =}
+  reaction(t) -> value {=
+    lf_set(value, self->curval++);
+  =}
 }
 
 main reactor {
@@ -70,5 +74,8 @@ main reactor {
 
   modal.out -> test.events
 
-  reaction(modal.out) {= printf("%d\n", modal.out->value); =}  // Print
+  // Print
+  reaction(modal.out) {=
+    printf("%d\n", modal.out->value);
+  =}
 }

--- a/test/C/src/modal_models/ModalNestedReactions.lf
+++ b/test/C/src/modal_models/ModalNestedReactions.lf
@@ -29,7 +29,9 @@ reactor CounterCycle {
   }
 
   mode Three {
-    reaction(next) -> never {= lf_set(never, true); =}
+    reaction(next) -> never {=
+      lf_set(never, true);
+    =}
   }
 }
 
@@ -37,14 +39,19 @@ reactor Forward {
   input in: bool
   output out: bool
 
-  reaction(in) -> out {= lf_set(out, in->value); =}
+  reaction(in) -> out {=
+    lf_set(out, in->value);
+  =}
 }
 
 main reactor {
   timer stepper(0, 250 msec)
   counter = new CounterCycle()
 
-  reaction(stepper) -> counter.next {= lf_set(counter.next, true); =}  // Trigger
+  // Trigger
+  reaction(stepper) -> counter.next {=
+    lf_set(counter.next, true);
+  =}
 
   // Check
   reaction(stepper) counter.count, counter.only_in_two {=

--- a/test/C/src/modal_models/ModalStartupShutdown.lf
+++ b/test/C/src/modal_models/ModalStartupShutdown.lf
@@ -137,5 +137,8 @@ main reactor {
   modal.reset5,
   modal.shutdown5 -> test.events
 
-  reaction(stepper) -> modal.next {= lf_set(modal.next, true); =}  // Trigger mode change
+  // Trigger mode change
+  reaction(stepper) -> modal.next {=
+    lf_set(modal.next, true);
+  =}
 }

--- a/test/C/src/modal_models/ModalStateReset.lf
+++ b/test/C/src/modal_models/ModalStateReset.lf
@@ -24,7 +24,9 @@ reactor Modal {
   initial mode One {
     state counter1: int = 0
     timer T1(0 msec, 250 msec)
-    reaction(reset) {= self->counter1 = 0; =}
+    reaction(reset) {=
+      self->counter1 = 0;
+    =}
 
     reaction(T1) -> count1 {=
       printf("Counter1: %d\n", self->counter1);
@@ -41,7 +43,9 @@ reactor Modal {
   mode Two {
     state counter2: int = -2
     timer T2(0 msec, 250 msec)
-    reaction(reset) {= self->counter2 = -2; =}
+    reaction(reset) {=
+      self->counter2 = -2;
+    =}
 
     reaction(T2) -> count2 {=
       printf("Counter2: %d\n", self->counter2);
@@ -84,5 +88,8 @@ main reactor {
 
   modal.mode_switch, modal.count0, modal.count1, modal.count2 -> test.events
 
-  reaction(stepper) -> modal.next {= lf_set(modal.next, true); =}  // Trigger mode change
+  // Trigger mode change
+  reaction(stepper) -> modal.next {=
+    lf_set(modal.next, true);
+  =}
 }

--- a/test/C/src/modal_models/ModalStateResetAuto.lf
+++ b/test/C/src/modal_models/ModalStateResetAuto.lf
@@ -80,5 +80,8 @@ main reactor {
 
   modal.mode_switch, modal.count0, modal.count1, modal.count2 -> test.events
 
-  reaction(stepper) -> modal.next {= lf_set(modal.next, true); =}  // Trigger mode change
+  // Trigger mode change
+  reaction(stepper) -> modal.next {=
+    lf_set(modal.next, true);
+  =}
 }

--- a/test/C/src/modal_models/ModalTimers.lf
+++ b/test/C/src/modal_models/ModalTimers.lf
@@ -62,5 +62,8 @@ main reactor {
 
   modal.mode_switch, modal.timer1, modal.timer2 -> test.events
 
-  reaction(stepper) -> modal.next {= lf_set(modal.next, true); =}  // Trigger mode change
+  // Trigger mode change
+  reaction(stepper) -> modal.next {=
+    lf_set(modal.next, true);
+  =}
 }

--- a/test/C/src/modal_models/MultipleOutputFeeder_2Connections.lf
+++ b/test/C/src/modal_models/MultipleOutputFeeder_2Connections.lf
@@ -18,13 +18,17 @@ reactor Modal {
   initial mode One {
     counter1 = new Counter(period = 250 msec)
     counter1.value -> count
-    reaction(next) -> reset(Two) {= lf_set_mode(Two); =}
+    reaction(next) -> reset(Two) {=
+      lf_set_mode(Two);
+    =}
   }
 
   mode Two {
     counter2 = new Counter(period = 100 msec)
     counter2.value -> count
-    reaction(next) -> history(One) {= lf_set_mode(One); =}
+    reaction(next) -> history(One) {=
+      lf_set_mode(One);
+    =}
   }
 }
 
@@ -34,7 +38,9 @@ reactor Counter(period: time = 1 sec) {
   timer t(0, period)
   reset state curval: int = 0
 
-  reaction(t) -> value {= lf_set(value, self->curval++); =}
+  reaction(t) -> value {=
+    lf_set(value, self->curval++);
+  =}
 }
 
 main reactor {
@@ -63,7 +69,13 @@ main reactor {
 
   modal.count -> test.events
 
-  reaction(stepper) -> modal.next {= lf_set(modal.next, true); =}  // Trigger mode change
+  // Trigger mode change
+  reaction(stepper) -> modal.next {=
+    lf_set(modal.next, true);
+  =}
 
-  reaction(modal.count) {= printf("%d\n", modal.count->value); =}  // Print
+  // Print
+  reaction(modal.count) {=
+    printf("%d\n", modal.count->value);
+  =}
 }

--- a/test/C/src/modal_models/MultipleOutputFeeder_ReactionConnections.lf
+++ b/test/C/src/modal_models/MultipleOutputFeeder_ReactionConnections.lf
@@ -18,14 +18,20 @@ reactor Modal {
   initial mode One {
     counter1 = new Counter(period = 250 msec)
     counter1.value -> count
-    reaction(next) -> reset(Two) {= lf_set_mode(Two); =}
+    reaction(next) -> reset(Two) {=
+      lf_set_mode(Two);
+    =}
   }
 
   mode Two {
     counter2 = new Counter(period = 100 msec)
-    reaction(counter2.value) -> count {= lf_set(count, counter2.value->value * 10); =}
+    reaction(counter2.value) -> count {=
+      lf_set(count, counter2.value->value * 10);
+    =}
 
-    reaction(next) -> history(One) {= lf_set_mode(One); =}
+    reaction(next) -> history(One) {=
+      lf_set_mode(One);
+    =}
   }
 }
 
@@ -35,7 +41,9 @@ reactor Counter(period: time = 1 sec) {
   timer t(0, period)
   reset state curval: int = 0
 
-  reaction(t) -> value {= lf_set(value, self->curval++); =}
+  reaction(t) -> value {=
+    lf_set(value, self->curval++);
+  =}
 }
 
 main reactor {
@@ -64,7 +72,13 @@ main reactor {
 
   modal.count -> test.events
 
-  reaction(stepper) -> modal.next {= lf_set(modal.next, true); =}  // Trigger mode change
+  // Trigger mode change
+  reaction(stepper) -> modal.next {=
+    lf_set(modal.next, true);
+  =}
 
-  reaction(modal.count) {= printf("%d\n", modal.count->value); =}  // Print
+  // Print
+  reaction(modal.count) {=
+    printf("%d\n", modal.count->value);
+  =}
 }

--- a/test/C/src/modal_models/util/TraceTesting.lf
+++ b/test/C/src/modal_models/util/TraceTesting.lf
@@ -13,7 +13,9 @@ reactor TraceTesting(
   state recorded_events: int* = 0
   state recorded_events_next: int = 0
 
-  reaction(startup) {= self->last_reaction_time = lf_time_logical(); =}
+  reaction(startup) {=
+    self->last_reaction_time = lf_time_logical();
+  =}
 
   reaction(events) {=
     // Time passed since last reaction

--- a/test/C/src/multiport/BankGangedConnections.lf
+++ b/test/C/src/multiport/BankGangedConnections.lf
@@ -9,7 +9,9 @@ reactor Through {
   input in: int
   output out: int
 
-  reaction(in) -> out {= lf_set(out, in->value); =}
+  reaction(in) -> out {=
+    lf_set(out, in->value);
+  =}
 }
 
 reactor Bank {

--- a/test/C/src/multiport/BankIndexInitializer.lf
+++ b/test/C/src/multiport/BankIndexInitializer.lf
@@ -1,14 +1,20 @@
 // Test bank of reactors to multiport input with id parameter in the bank.
 target C
 
-preamble {= extern int table[4]; =}
+preamble {=
+  extern int table[4];
+=}
 
 reactor Source(bank_index: int = 0, value: int = 0) {
-  preamble {= int table[] = {4, 3, 2, 1}; =}
+  preamble {=
+    int table[] = {4, 3, 2, 1};
+  =}
 
   output out: int
 
-  reaction(startup) -> out {= lf_set(out, self->value); =}
+  reaction(startup) -> out {=
+    lf_set(out, self->value);
+  =}
 }
 
 reactor Sink(width: int = 4) {

--- a/test/C/src/multiport/BankSelfBroadcast.lf
+++ b/test/C/src/multiport/BankSelfBroadcast.lf
@@ -12,7 +12,9 @@ reactor A(bank_index: int = 0) {
   output out: int
   state received: bool = false
 
-  reaction(startup) -> out {= lf_set(out, self->bank_index); =}
+  reaction(startup) -> out {=
+    lf_set(out, self->bank_index);
+  =}
 
   reaction(in) {=
     for (int i = 0; i < in_width; i++) {

--- a/test/C/src/multiport/BankToMultiport.lf
+++ b/test/C/src/multiport/BankToMultiport.lf
@@ -4,7 +4,9 @@ target C
 reactor Source(bank_index: int = 0) {
   output out: int
 
-  reaction(startup) -> out {= lf_set(out, self->bank_index); =}
+  reaction(startup) -> out {=
+    lf_set(out, self->bank_index);
+  =}
 }
 
 reactor Sink(width: int = 4) {

--- a/test/C/src/multiport/Broadcast.lf
+++ b/test/C/src/multiport/Broadcast.lf
@@ -6,7 +6,9 @@ target C {
 reactor Source {
   output out: int
 
-  reaction(startup) -> out {= lf_set(out, 42); =}
+  reaction(startup) -> out {=
+    lf_set(out, 42);
+  =}
 }
 
 reactor Destination(bank_index: int = 0) {

--- a/test/C/src/multiport/BroadcastAfter.lf
+++ b/test/C/src/multiport/BroadcastAfter.lf
@@ -6,7 +6,9 @@ target C {
 reactor Source {
   output out: int
 
-  reaction(startup) -> out {= lf_set(out, 42); =}
+  reaction(startup) -> out {=
+    lf_set(out, 42);
+  =}
 }
 
 reactor Destination(bank_index: int = 0) {

--- a/test/C/src/multiport/BroadcastMultipleAfter.lf
+++ b/test/C/src/multiport/BroadcastMultipleAfter.lf
@@ -6,7 +6,9 @@ target C {
 reactor Source(value: int = 42) {
   output out: int
 
-  reaction(startup) -> out {= lf_set(out, self->value); =}
+  reaction(startup) -> out {=
+    lf_set(out, self->value);
+  =}
 }
 
 reactor Destination(bank_index: int = 0) {

--- a/test/C/src/multiport/MultiportFromBank.lf
+++ b/test/C/src/multiport/MultiportFromBank.lf
@@ -8,7 +8,9 @@ target C {
 reactor Source(check_override: int = 0, bank_index: int = 0) {
   output out: int
 
-  reaction(startup) -> out {= lf_set(out, self->bank_index * self->check_override); =}
+  reaction(startup) -> out {=
+    lf_set(out, self->bank_index * self->check_override);
+  =}
 }
 
 reactor Destination(port_width: int = 3) {

--- a/test/C/src/multiport/MultiportIn.lf
+++ b/test/C/src/multiport/MultiportIn.lf
@@ -20,7 +20,9 @@ reactor Computation {
   input in: int
   output out: int
 
-  reaction(in) -> out {= lf_set(out, in->value); =}
+  reaction(in) -> out {=
+    lf_set(out, in->value);
+  =}
 }
 
 reactor Destination {

--- a/test/C/src/multiport/MultiportInParameterized.lf
+++ b/test/C/src/multiport/MultiportInParameterized.lf
@@ -20,7 +20,9 @@ reactor Computation {
   input in: int
   output out: int
 
-  reaction(in) -> out {= lf_set(out, in->value); =}
+  reaction(in) -> out {=
+    lf_set(out, in->value);
+  =}
 }
 
 reactor Destination(width: int = 1) {

--- a/test/C/src/multiport/PipelineAfter.lf
+++ b/test/C/src/multiport/PipelineAfter.lf
@@ -3,14 +3,18 @@ target C
 reactor Source {
   output out: unsigned
 
-  reaction(startup) -> out {= lf_set(out, 40); =}
+  reaction(startup) -> out {=
+    lf_set(out, 40);
+  =}
 }
 
 reactor Compute {
   input in: unsigned
   output out: unsigned
 
-  reaction(in) -> out {= lf_set(out, in->value + 2); =}
+  reaction(in) -> out {=
+    lf_set(out, in->value + 2);
+  =}
 }
 
 reactor Sink {

--- a/test/C/src/multiport/ReactionsToNested.lf
+++ b/test/C/src/multiport/ReactionsToNested.lf
@@ -32,7 +32,11 @@ reactor D {
 main reactor {
   d = new D()
 
-  reaction(startup) -> d.y {= lf_set(d.y[0], 42); =}
+  reaction(startup) -> d.y {=
+    lf_set(d.y[0], 42);
+  =}
 
-  reaction(startup) -> d.y {= lf_set(d.y[1], 43); =}
+  reaction(startup) -> d.y {=
+    lf_set(d.y[1], 43);
+  =}
 }

--- a/test/C/src/no_inlining/Count.lf
+++ b/test/C/src/no_inlining/Count.lf
@@ -12,5 +12,7 @@ main reactor Count {
 
   reaction check_done(t)
 
-  reaction(shutdown) {= printf("%s", "shutting down\n"); =}
+  reaction(shutdown) {=
+    printf("%s", "shutting down\n");
+  =}
 }

--- a/test/C/src/no_inlining/CountHierarchy.lf
+++ b/test/C/src/no_inlining/CountHierarchy.lf
@@ -7,7 +7,9 @@ reactor Timer(m: time = 0, n: time = 0) {
   output out: int
   timer t(m, n)
 
-  reaction(t) -> out {= lf_set(out, 0); =}
+  reaction(t) -> out {=
+    lf_set(out, 0);
+  =}
 }
 
 main reactor {
@@ -19,5 +21,7 @@ main reactor {
 
   reaction check_done(t.out)
 
-  reaction(shutdown) {= printf("%s", "shutting down\n"); =}
+  reaction(shutdown) {=
+    printf("%s", "shutting down\n");
+  =}
 }

--- a/test/C/src/target/FederatedFiles.lf
+++ b/test/C/src/target/FederatedFiles.lf
@@ -6,7 +6,9 @@ target C {
 }
 
 reactor Foo {
-  reaction(startup) {= lf_print("Hello World"); =}
+  reaction(startup) {=
+    lf_print("Hello World");
+  =}
 }
 
 federated reactor {

--- a/test/C/src/target/Math.lf
+++ b/test/C/src/target/Math.lf
@@ -6,5 +6,7 @@ preamble {=
 =}
 
 main reactor {
-  reaction(startup) {= lf_print("Maximum of 42.0 and 75 is %.2f", fmax(4.20, 75)); =}
+  reaction(startup) {=
+    lf_print("Maximum of 42.0 and 75 is %.2f", fmax(4.20, 75));
+  =}
 }

--- a/test/C/src/target/Platform.lf
+++ b/test/C/src/target/Platform.lf
@@ -4,5 +4,7 @@ target C {
 }
 
 main reactor {
-  reaction(startup) {= lf_print("Hello, Mac!"); =}
+  reaction(startup) {=
+    lf_print("Hello, Mac!");
+  =}
 }

--- a/test/C/src/token/lib/Token.lf
+++ b/test/C/src/token/lib/Token.lf
@@ -95,7 +95,11 @@ reactor TokenDelay {
   output out: int_array_t*
   logical action a: int_array_t*
 
-  reaction(a) -> out {= lf_set_token(out, a->token); =}
+  reaction(a) -> out {=
+    lf_set_token(out, a->token);
+  =}
 
-  reaction(in) -> a {= lf_schedule_token(a, MSEC(1), in->token); =}
+  reaction(in) -> a {=
+    lf_schedule_token(a, MSEC(1), in->token);
+  =}
 }

--- a/test/C/src/verifier/ADASModel.lf
+++ b/test/C/src/verifier/ADASModel.lf
@@ -6,12 +6,8 @@ preamble {=
 =}
 
 reactor Camera {
-  output out: {=
-    c_frame_t
-  =}
-  state frame: {=
-    c_frame_t
-  =}
+  output out: {= c_frame_t =}
+  state frame: {= c_frame_t =}
   timer t(0, 17 msec)  // 60 fps
 
   reaction(t) -> out {=
@@ -22,12 +18,8 @@ reactor Camera {
 }
 
 reactor LiDAR {
-  output out: {=
-    l_frame_t
-  =}
-  state frame: {=
-    l_frame_t
-  =}
+  output out: {= l_frame_t =}
+  state frame: {= l_frame_t =}
   timer t(0, 34 msec)  // 30 fps
 
   reaction(t) -> out {=
@@ -58,12 +50,8 @@ reactor Brakes {
 }
 
 reactor ADASProcessor {
-  input in1: {=
-    l_frame_t
-  =}
-  input in2: {=
-    c_frame_t
-  =}
+  input in1: {= l_frame_t =}
+  input in2: {= c_frame_t =}
   output out1: int
   output out2: int
   logical action a(50 msec)

--- a/test/C/src/verifier/ADASModel.lf
+++ b/test/C/src/verifier/ADASModel.lf
@@ -6,8 +6,12 @@ preamble {=
 =}
 
 reactor Camera {
-  output out: {= c_frame_t =}
-  state frame: {= c_frame_t =}
+  output out: {=
+    c_frame_t
+  =}
+  state frame: {=
+    c_frame_t
+  =}
   timer t(0, 17 msec)  // 60 fps
 
   reaction(t) -> out {=
@@ -18,8 +22,12 @@ reactor Camera {
 }
 
 reactor LiDAR {
-  output out: {= l_frame_t =}
-  state frame: {= l_frame_t =}
+  output out: {=
+    l_frame_t
+  =}
+  state frame: {=
+    l_frame_t
+  =}
   timer t(0, 34 msec)  // 30 fps
 
   reaction(t) -> out {=
@@ -33,7 +41,9 @@ reactor Pedal {
   output out: int
   physical action a
 
-  reaction(a) -> out {= lf_set(out, 1); =}
+  reaction(a) -> out {=
+    lf_set(out, 1);
+  =}
 }
 
 reactor Brakes {
@@ -48,8 +58,12 @@ reactor Brakes {
 }
 
 reactor ADASProcessor {
-  input in1: {= l_frame_t =}
-  input in2: {= c_frame_t =}
+  input in1: {=
+    l_frame_t
+  =}
+  input in2: {=
+    c_frame_t
+  =}
   output out1: int
   output out2: int
   logical action a(50 msec)
@@ -72,7 +86,9 @@ reactor Dashboard {
   input in: int
   state received: int
 
-  reaction(in) {= self->received = 1; =}
+  reaction(in) {=
+    self->received = 1;
+  =}
 }
 
 @property(

--- a/test/C/src/verifier/AircraftDoor.lf
+++ b/test/C/src/verifier/AircraftDoor.lf
@@ -3,7 +3,9 @@ target C
 reactor Controller {
   output out: int
 
-  reaction(startup) -> out {= lf_set(out, 1); =}
+  reaction(startup) -> out {=
+    lf_set(out, 1);
+  =}
 }
 
 reactor Vision {

--- a/test/C/src/verifier/CoopSchedule.lf
+++ b/test/C/src/verifier/CoopSchedule.lf
@@ -4,7 +4,9 @@ reactor Trigger {
   output out: int
   timer t(0, 1 usec)
 
-  reaction(t) -> out {= lf_set(out, 1); =}
+  reaction(t) -> out {=
+    lf_set(out, 1);
+  =}
 }
 
 reactor Task {

--- a/test/C/src/verifier/ProcessMsg.lf
+++ b/test/C/src/verifier/ProcessMsg.lf
@@ -12,9 +12,13 @@ reactor Task {
 
   logical action updateMessage
 
-  reaction(startup) {= self->messageSent = 0; =}
+  reaction(startup) {=
+    self->messageSent = 0;
+  =}
 
-  reaction(t) -> out {= lf_set(out, self->messageSent); =}
+  reaction(t) -> out {=
+    lf_set(out, self->messageSent);
+  =}
 
   reaction(in) -> updateMessage {=
     /* Check for invalid message.  */

--- a/test/C/src/verifier/Ring.lf
+++ b/test/C/src/verifier/Ring.lf
@@ -12,7 +12,9 @@ reactor Source {
     lf_schedule(start, 0);
   =}
 
-  reaction(start) -> out {= lf_set(out, self->received); =}
+  reaction(start) -> out {=
+    lf_set(out, self->received);
+  =}
 
   /** Uncomment the following to debug feedback loops. */
   // reaction(in) -> start {=
@@ -26,7 +28,9 @@ reactor Node {
   input in: int
   output out: int
 
-  reaction(in) -> out {= lf_set(out, in->value + 1); =}
+  reaction(in) -> out {=
+    lf_set(out, in->value + 1);
+  =}
 }
 
 @property(

--- a/test/C/src/verifier/SafeSend.lf
+++ b/test/C/src/verifier/SafeSend.lf
@@ -41,7 +41,10 @@ reactor Server {
     }
   =}
 
-  reaction(err) {= self->error = 1; =}  // Error handling logic.
+  // Error handling logic.
+  reaction(err) {=
+    self->error = 1;
+  =}
 }
 
 @property(

--- a/test/C/src/verifier/Thermostat.lf
+++ b/test/C/src/verifier/Thermostat.lf
@@ -8,7 +8,9 @@ reactor Environment {
   state _heatOn: int
   state _temperature: int
 
-  reaction(startup) {= self->_temperature = 19; =}
+  reaction(startup) {=
+    self->_temperature = 19;
+  =}
 
   reaction(t) -> temperature {=
     if (self->_heatOn == 0) {
@@ -20,7 +22,9 @@ reactor Environment {
     lf_set(temperature, self->_temperature);
   =}
 
-  reaction(heatOn) {= self->_heatOn = heatOn->value; =}
+  reaction(heatOn) {=
+    self->_heatOn = heatOn->value;
+  =}
 }
 
 reactor _Thermostat {
@@ -29,7 +33,9 @@ reactor _Thermostat {
   state _mode: int    // 0 = COOLING, 1 = HEATING
   logical action changeMode
 
-  reaction(startup) {= self->_mode = 0; =}
+  reaction(startup) {=
+    self->_mode = 0;
+  =}
 
   reaction(temperature) -> heatOn, changeMode {=
     if (self->_mode == 0) {

--- a/test/C/src/verifier/TrainDoor.lf
+++ b/test/C/src/verifier/TrainDoor.lf
@@ -14,14 +14,18 @@ reactor Train {
   input in: int
   state received: int
 
-  reaction(in) {= self->received = in->value; =}
+  reaction(in) {=
+    self->received = in->value;
+  =}
 }
 
 reactor Door {
   input in: int
   state received: int
 
-  reaction(in) {= self->received = in->value; =}
+  reaction(in) {=
+    self->received = in->value;
+  =}
 }
 
 @property(

--- a/test/C/src/verifier/UnsafeSend.lf
+++ b/test/C/src/verifier/UnsafeSend.lf
@@ -41,7 +41,10 @@ reactor Server {
     }
   =}
 
-  reaction(err) {= self->error = 1; =}  // Error handling logic.
+  // Error handling logic.
+  reaction(err) {=
+    self->error = 1;
+  =}
 }
 
 @property(

--- a/test/C/src/zephyr/unthreaded/HelloZephyr.lf
+++ b/test/C/src/zephyr/unthreaded/HelloZephyr.lf
@@ -3,5 +3,7 @@ target C {
 }
 
 main reactor {
-  reaction(startup) {= printf("Hello World!\n"); =}
+  reaction(startup) {=
+    printf("Hello World!\n");
+  =}
 }

--- a/test/C/src/zephyr/unthreaded/Timer.lf
+++ b/test/C/src/zephyr/unthreaded/Timer.lf
@@ -7,5 +7,7 @@ target C {
 main reactor {
   timer t(0, 1 sec)
 
-  reaction(t) {= printf("Hello\n"); =}
+  reaction(t) {=
+    printf("Hello\n");
+  =}
 }

--- a/test/Cpp/src/ActionDelay.lf
+++ b/test/Cpp/src/ActionDelay.lf
@@ -12,13 +12,17 @@ reactor GeneratedDelay {
     act.schedule();
   =}
 
-  reaction(act) -> y_out {= y_out.set(y_state); =}
+  reaction(act) -> y_out {=
+    y_out.set(y_state);
+  =}
 }
 
 reactor Source {
   output out: int
 
-  reaction(startup) -> out {= out.set(1); =}
+  reaction(startup) -> out {=
+    out.set(1);
+  =}
 }
 
 reactor Sink {

--- a/test/Cpp/src/ActionWithNoReaction.lf
+++ b/test/Cpp/src/ActionWithNoReaction.lf
@@ -32,5 +32,7 @@ main reactor {
   timer t(0, 1 sec)
   f.y -> p.x
 
-  reaction(t) -> f.x {= f.x.set(42); =}
+  reaction(t) -> f.x {=
+    f.x.set(42);
+  =}
 }

--- a/test/Cpp/src/After.lf
+++ b/test/Cpp/src/After.lf
@@ -8,7 +8,9 @@ reactor foo {
   input x: int
   output y: int
 
-  reaction(x) -> y {= y.set(2*(*x.get())); =}
+  reaction(x) -> y {=
+    y.set(2*(*x.get()));
+  =}
 }
 
 reactor print {

--- a/test/Cpp/src/AfterZero.lf
+++ b/test/Cpp/src/AfterZero.lf
@@ -8,7 +8,9 @@ reactor foo {
   input x: int
   output y: int
 
-  reaction(x) -> y {= y.set(2*(*x.get())); =}
+  reaction(x) -> y {=
+    y.set(2*(*x.get()));
+  =}
 }
 
 reactor print {

--- a/test/Cpp/src/Alignment.lf
+++ b/test/Cpp/src/Alignment.lf
@@ -78,9 +78,7 @@ reactor Sieve {
 reactor Destination {
   input ok: bool
   input in: int
-  state last_invoked: {=
-    reactor::TimePoint
-  =}
+  state last_invoked: {= reactor::TimePoint =}
 
   reaction(ok, in) {=
     if (ok.is_present() && in.is_present()) {

--- a/test/Cpp/src/Alignment.lf
+++ b/test/Cpp/src/Alignment.lf
@@ -78,7 +78,9 @@ reactor Sieve {
 reactor Destination {
   input ok: bool
   input in: int
-  state last_invoked: {= reactor::TimePoint =}
+  state last_invoked: {=
+    reactor::TimePoint
+  =}
 
   reaction(ok, in) {=
     if (ok.is_present() && in.is_present()) {

--- a/test/Cpp/src/CompositionGain.lf
+++ b/test/Cpp/src/CompositionGain.lf
@@ -22,7 +22,9 @@ reactor Wrapper {
 main reactor CompositionGain {
   wrapper = new Wrapper()
 
-  reaction(startup) -> wrapper.x {= wrapper.x.set(42); =}
+  reaction(startup) -> wrapper.x {=
+    wrapper.x.set(42);
+  =}
 
   reaction(wrapper.y) {=
     reactor::log::Info() << "Received " << *wrapper.y.get();

--- a/test/Cpp/src/DanglingOutput.lf
+++ b/test/Cpp/src/DanglingOutput.lf
@@ -6,7 +6,9 @@ reactor Source {
   output out: int
   timer t
 
-  reaction(t) -> out {= out.set(1); =}
+  reaction(t) -> out {=
+    out.set(1);
+  =}
 }
 
 reactor Gain {

--- a/test/Cpp/src/DelayInt.lf
+++ b/test/Cpp/src/DelayInt.lf
@@ -19,9 +19,7 @@ reactor Delay(delay: time = 100 msec) {
 
 reactor Test {
   input in: int
-  state start_time: {=
-    reactor::TimePoint
-  =}
+  state start_time: {= reactor::TimePoint =}
   timer start
 
   reaction(start) {=

--- a/test/Cpp/src/DelayInt.lf
+++ b/test/Cpp/src/DelayInt.lf
@@ -6,7 +6,9 @@ reactor Delay(delay: time = 100 msec) {
   output out: int
   logical action d: int
 
-  reaction(in) -> d {= d.schedule(in.get(), delay); =}
+  reaction(in) -> d {=
+    d.schedule(in.get(), delay);
+  =}
 
   reaction(d) -> out {=
     if (d.is_present()) {
@@ -17,7 +19,9 @@ reactor Delay(delay: time = 100 msec) {
 
 reactor Test {
   input in: int
-  state start_time: {= reactor::TimePoint =}
+  state start_time: {=
+    reactor::TimePoint
+  =}
   timer start
 
   reaction(start) {=
@@ -50,5 +54,7 @@ main reactor DelayInt {
   test = new Test()
   d.out -> test.in
 
-  reaction(t) -> d.in {= d.in.set(42); =}
+  reaction(t) -> d.in {=
+    d.in.set(42);
+  =}
 }

--- a/test/Cpp/src/DelayedAction.lf
+++ b/test/Cpp/src/DelayedAction.lf
@@ -8,7 +8,9 @@ main reactor DelayedAction {
   logical action a: void
   state count: int = 0
 
-  reaction(t) -> a {= a.schedule(100ms); =}
+  reaction(t) -> a {=
+    a.schedule(100ms);
+  =}
 
   reaction(a) {=
     auto elapsed = get_elapsed_logical_time();

--- a/test/Cpp/src/DelayedReaction.lf
+++ b/test/Cpp/src/DelayedReaction.lf
@@ -4,7 +4,9 @@ target Cpp
 reactor Source {
   output out: void
 
-  reaction(startup) -> out {= out.set(); =}
+  reaction(startup) -> out {=
+    out.set();
+  =}
 }
 
 reactor Sink {

--- a/test/Cpp/src/Determinism.lf
+++ b/test/Cpp/src/Determinism.lf
@@ -4,7 +4,9 @@ reactor Source {
   output y: int
   timer t
 
-  reaction(t) -> y {= y.set(1); =}
+  reaction(t) -> y {=
+    y.set(1);
+  =}
 }
 
 reactor Destination {
@@ -31,7 +33,9 @@ reactor Pass {
   input x: int
   output y: int
 
-  reaction(x) -> y {= y.set(x.get()); =}
+  reaction(x) -> y {=
+    y.set(x.get());
+  =}
 }
 
 main reactor Determinism {

--- a/test/Cpp/src/DoublePort.lf
+++ b/test/Cpp/src/DoublePort.lf
@@ -22,7 +22,9 @@ reactor CountMicrostep {
     count++;
   =}
 
-  reaction(act) -> out {= out.set(act.get()); =}
+  reaction(act) -> out {=
+    out.set(act.get());
+  =}
 }
 
 reactor Print {

--- a/test/Cpp/src/Gain.lf
+++ b/test/Cpp/src/Gain.lf
@@ -5,7 +5,9 @@ reactor Scale(scale: int = 2) {
   input x: int
   output y: int
 
-  reaction(x) -> y {= y.set(*x.get() * scale); =}
+  reaction(x) -> y {=
+    y.set(*x.get() * scale);
+  =}
 }
 
 reactor Test {
@@ -27,5 +29,7 @@ main reactor Gain {
   g.y -> t.x
   timer tim
 
-  reaction(tim) -> g.x {= g.x.set(1); =}
+  reaction(tim) -> g.x {=
+    g.x.set(1);
+  =}
 }

--- a/test/Cpp/src/GetMicroStep.lf
+++ b/test/Cpp/src/GetMicroStep.lf
@@ -2,11 +2,15 @@
 target Cpp
 
 main reactor GetMicroStep {
-  state s: {= reactor::mstep_t =} = 1
+  state s: {=
+    reactor::mstep_t
+  =} = 1
 
   logical action l
 
-  reaction(startup) -> l {= l.schedule(reactor::Duration::zero()); =}
+  reaction(startup) -> l {=
+    l.schedule(reactor::Duration::zero());
+  =}
 
   reaction(l) -> l {=
     auto microstep = get_microstep();

--- a/test/Cpp/src/GetMicroStep.lf
+++ b/test/Cpp/src/GetMicroStep.lf
@@ -2,9 +2,7 @@
 target Cpp
 
 main reactor GetMicroStep {
-  state s: {=
-    reactor::mstep_t
-  =} = 1
+  state s: {= reactor::mstep_t =} = 1
 
   logical action l
 

--- a/test/Cpp/src/Hello.lf
+++ b/test/Cpp/src/Hello.lf
@@ -7,9 +7,13 @@ target Cpp {
   fast: true
 }
 
-reactor HelloCpp(period: time = 2 sec, message: {= std::string =} = "Hello C++") {
+reactor HelloCpp(period: time = 2 sec, message: {=
+  std::string
+=} = "Hello C++") {
   state count: int = 0
-  state previous_time: {= reactor::TimePoint =}
+  state previous_time: {=
+    reactor::TimePoint
+  =}
   timer t(1 sec, period)
   logical action a: void
 

--- a/test/Cpp/src/Hello.lf
+++ b/test/Cpp/src/Hello.lf
@@ -7,13 +7,9 @@ target Cpp {
   fast: true
 }
 
-reactor HelloCpp(period: time = 2 sec, message: {=
-  std::string
-=} = "Hello C++") {
+reactor HelloCpp(period: time = 2 sec, message: {= std::string =} = "Hello C++") {
   state count: int = 0
-  state previous_time: {=
-    reactor::TimePoint
-  =}
+  state previous_time: {= reactor::TimePoint =}
   timer t(1 sec, period)
   logical action a: void
 

--- a/test/Cpp/src/HelloWorld.lf
+++ b/test/Cpp/src/HelloWorld.lf
@@ -3,7 +3,9 @@ target Cpp
 reactor HelloWorld2 {
   timer t
 
-  reaction(t) {= std::cout << "Hello World." << std::endl; =}
+  reaction(t) {=
+    std::cout << "Hello World." << std::endl;
+  =}
 }
 
 main reactor {

--- a/test/Cpp/src/Hierarchy.lf
+++ b/test/Cpp/src/Hierarchy.lf
@@ -5,14 +5,18 @@ reactor Source {
   output out: int
   timer t
 
-  reaction(t) -> out {= out.set(1); =}
+  reaction(t) -> out {=
+    out.set(1);
+  =}
 }
 
 reactor Gain {
   input in: int
   output out: int
 
-  reaction(in) -> out {= out.set((*in.get()) * 2); =}
+  reaction(in) -> out {=
+    out.set((*in.get()) * 2);
+  =}
 }
 
 reactor Print {

--- a/test/Cpp/src/Hierarchy2.lf
+++ b/test/Cpp/src/Hierarchy2.lf
@@ -8,7 +8,9 @@ reactor Source {
   output out: int
   timer t(0, 1 sec)
 
-  reaction(t) -> out {= out.set(1); =}
+  reaction(t) -> out {=
+    out.set(1);
+  =}
 }
 
 reactor Count {

--- a/test/Cpp/src/Import.lf
+++ b/test/Cpp/src/Import.lf
@@ -7,5 +7,7 @@ main reactor Import {
   timer t
   a = new Imported()
 
-  reaction(t) -> a.x {= a.x.set(42); =}
+  reaction(t) -> a.x {=
+    a.x.set(42);
+  =}
 }

--- a/test/Cpp/src/ImportComposition.lf
+++ b/test/Cpp/src/ImportComposition.lf
@@ -17,7 +17,9 @@ main reactor ImportComposition {
   imp_comp = new ImportedComposition()
   state received: bool = false
 
-  reaction(startup) -> imp_comp.x {= imp_comp.x.set(42); =}
+  reaction(startup) -> imp_comp.x {=
+    imp_comp.x.set(42);
+  =}
 
   reaction(imp_comp.y) {=
     auto receive_time = get_elapsed_logical_time();

--- a/test/Cpp/src/ImportRenamed.lf
+++ b/test/Cpp/src/ImportRenamed.lf
@@ -17,5 +17,7 @@ main reactor {
   b = new Y()
   c = new Z()
 
-  reaction(t) -> a.x {= a.x.set(42); =}
+  reaction(t) -> a.x {=
+    a.x.set(42);
+  =}
 }

--- a/test/Cpp/src/ManualDelayedReaction.lf
+++ b/test/Cpp/src/ManualDelayedReaction.lf
@@ -8,16 +8,23 @@ reactor GeneratedDelay {
 
   logical action act(100 msec): int
 
-  reaction(y_in) -> act {= act.schedule(y_in.get()); =}
+  reaction(y_in) -> act {=
+    act.schedule(y_in.get());
+  =}
 
-  reaction(act) -> y_out {= y_out.set(act.get()); =}
+  reaction(act) -> y_out {=
+    y_out.set(act.get());
+  =}
 }
 
 reactor Source {
   output out: int
   timer t
 
-  reaction(t) -> out {= out.set(1); =}  // reaction(t) -> out after 100 msec {=
+  // reaction(t) -> out after 100 msec {=
+  reaction(t) -> out {=
+    out.set(1);
+  =}
 }
 
 reactor Sink {

--- a/test/Cpp/src/Methods.lf
+++ b/test/Cpp/src/Methods.lf
@@ -3,9 +3,13 @@ target Cpp
 main reactor {
   state foo: int = 2
 
-  const method getFoo(): int {= return foo; =}
+  const method getFoo(): int {=
+    return foo;
+  =}
 
-  method add(x: int) {= foo += x; =}
+  method add(x: int) {=
+    foo += x;
+  =}
 
   reaction(startup) {=
     std::cout << "Foo is initialized to " << getFoo() << '\n';

--- a/test/Cpp/src/Microsteps.lf
+++ b/test/Cpp/src/Microsteps.lf
@@ -39,5 +39,7 @@ main reactor Microsteps {
     repeat.schedule();
   =}
 
-  reaction(repeat) -> d.y {= d.y.set(1); =}
+  reaction(repeat) -> d.y {=
+    d.y.set(1);
+  =}
 }

--- a/test/Cpp/src/Minimal.lf
+++ b/test/Cpp/src/Minimal.lf
@@ -2,5 +2,7 @@
 target Cpp
 
 main reactor Minimal {
-  reaction(startup) {= std::cout << "Hello World!\n"; =}
+  reaction(startup) {=
+    std::cout << "Hello World!\n";
+  =}
 }

--- a/test/Cpp/src/MultipleContained.lf
+++ b/test/Cpp/src/MultipleContained.lf
@@ -6,7 +6,9 @@ reactor Contained {
   input in1: int
   input in2: int
 
-  reaction(startup) -> trigger {= trigger.set(42); =}
+  reaction(startup) -> trigger {=
+    trigger.set(42);
+  =}
 
   reaction(in1) {=
     std::cout << "in1 received " << *in1.get() << '\n';

--- a/test/Cpp/src/NativeListsAndTimes.lf
+++ b/test/Cpp/src/NativeListsAndTimes.lf
@@ -6,7 +6,9 @@ reactor Foo(
     y: time = 0,                // Units are missing but not required
     z = 1 msec,                 // Type is missing but not required
     p: int[]{1, 2, 3, 4},       // List of integers
-    q: {= std::vector<reactor::Duration> =}{1 msec, 2 msec, 3 msec},
+    q: {=
+      std::vector<reactor::Duration>
+    =}{1 msec, 2 msec, 3 msec},
     g: time[]{1 msec, 2 msec},  // List of time values
     g2: int[] = {}) {
   state s: time = y  // Reference to explicitly typed time parameter
@@ -18,7 +20,10 @@ reactor Foo(
   timer toe(z)       // Implicit type time
   state baz = p      // Implicit type int[]
   state period = z   // Implicit type time
-  state times: std::vector<std::vector<{= reactor::Duration =}>>{q, g}  // a list of lists
+  // a list of lists
+  state times: std::vector<std::vector<{=
+    reactor::Duration
+  =}>>{q, g}
   state empty_list: int[] = {}
 
   reaction(tick) {=

--- a/test/Cpp/src/NativeListsAndTimes.lf
+++ b/test/Cpp/src/NativeListsAndTimes.lf
@@ -6,9 +6,7 @@ reactor Foo(
     y: time = 0,                // Units are missing but not required
     z = 1 msec,                 // Type is missing but not required
     p: int[]{1, 2, 3, 4},       // List of integers
-    q: {=
-      std::vector<reactor::Duration>
-    =}{1 msec, 2 msec, 3 msec},
+    q: {= std::vector<reactor::Duration> =}{1 msec, 2 msec, 3 msec},
     g: time[]{1 msec, 2 msec},  // List of time values
     g2: int[] = {}) {
   state s: time = y  // Reference to explicitly typed time parameter
@@ -20,10 +18,7 @@ reactor Foo(
   timer toe(z)       // Implicit type time
   state baz = p      // Implicit type int[]
   state period = z   // Implicit type time
-  // a list of lists
-  state times: std::vector<std::vector<{=
-    reactor::Duration
-  =}>>{q, g}
+  state times: std::vector<std::vector<{= reactor::Duration =}>>{q, g}  // a list of lists
   state empty_list: int[] = {}
 
   reaction(tick) {=

--- a/test/Cpp/src/NestedTriggeredReactions.lf
+++ b/test/Cpp/src/NestedTriggeredReactions.lf
@@ -9,7 +9,9 @@ reactor Container {
 
   in -> contained.in
 
-  reaction(in) {= triggered = true; =}
+  reaction(in) {=
+    triggered = true;
+  =}
 
   reaction(shutdown) {=
     if (!triggered) {
@@ -24,7 +26,9 @@ reactor Contained {
 
   state triggered: bool = false
 
-  reaction(in) {= triggered = true; =}
+  reaction(in) {=
+    triggered = true;
+  =}
 
   reaction(shutdown) {=
     if (!triggered) {
@@ -37,5 +41,7 @@ reactor Contained {
 main reactor {
   container = new Container()
 
-  reaction(startup) -> container.in {= container.in.set(); =}
+  reaction(startup) -> container.in {=
+    container.in.set();
+  =}
 }

--- a/test/Cpp/src/PeriodicDesugared.lf
+++ b/test/Cpp/src/PeriodicDesugared.lf
@@ -13,7 +13,9 @@ main reactor(offset: time = 50 msec, period: time = 500 msec) {
     init.schedule();
   =}
 
-  reaction(init) -> recur {= recur.schedule(); =}
+  reaction(init) -> recur {=
+    recur.schedule();
+  =}
 
   reaction(init, recur) -> recur {=
     std::cout << "Periodic trigger!\n";

--- a/test/Cpp/src/PhysicalConnection.lf
+++ b/test/Cpp/src/PhysicalConnection.lf
@@ -4,7 +4,9 @@ target Cpp
 reactor Source {
   output out: int
 
-  reaction(startup) -> out {= out.set(42); =}
+  reaction(startup) -> out {=
+    out.set(42);
+  =}
 }
 
 reactor Destination {

--- a/test/Cpp/src/Pipeline.lf
+++ b/test/Cpp/src/Pipeline.lf
@@ -40,5 +40,7 @@ main reactor Pipeline {
   c3.out -> c4.in after 200 msec
   c4.out -> p.in
 
-  reaction(t) -> c1.in {= c1.in.set(count++); =}
+  reaction(t) -> c1.in {=
+    c1.in.set(count++);
+  =}
 }

--- a/test/Cpp/src/PreambleTest.lf
+++ b/test/Cpp/src/PreambleTest.lf
@@ -20,7 +20,9 @@ main reactor {
   =}
   logical action a: MyStruct
 
-  reaction(startup) -> a {= a.schedule({add_42(42), "baz"}); =}
+  reaction(startup) -> a {=
+    a.schedule({add_42(42), "baz"});
+  =}
 
   reaction(a) {=
     auto& value = *a.get();

--- a/test/Cpp/src/ReadOutputOfContainedReactor.lf
+++ b/test/Cpp/src/ReadOutputOfContainedReactor.lf
@@ -4,7 +4,9 @@ target Cpp
 reactor Contained {
   output out: int
 
-  reaction(startup) -> out {= out.set(42); =}
+  reaction(startup) -> out {=
+    out.set(42);
+  =}
 }
 
 main reactor ReadOutputOfContainedReactor {

--- a/test/Cpp/src/Schedule.lf
+++ b/test/Cpp/src/Schedule.lf
@@ -5,7 +5,9 @@ reactor ScheduleTest {
   input x: int
   logical action a: void
 
-  reaction(x) -> a {= a.schedule(200ms); =}
+  reaction(x) -> a {=
+    a.schedule(200ms);
+  =}
 
   reaction(a) {=
     auto elapsed_time = get_elapsed_logical_time();
@@ -23,5 +25,7 @@ main reactor Schedule {
   a = new ScheduleTest()
   timer t
 
-  reaction(t) -> a.x {= a.x.set(1); =}
+  reaction(t) -> a.x {=
+    a.x.set(1);
+  =}
 }

--- a/test/Cpp/src/ScheduleLogicalAction.lf
+++ b/test/Cpp/src/ScheduleLogicalAction.lf
@@ -22,7 +22,9 @@ reactor foo {
     a.schedule(500ms);
   =}
 
-  reaction(a) -> y {= y.set(-42); =}
+  reaction(a) -> y {=
+    y.set(-42);
+  =}
 }
 
 reactor print {
@@ -48,5 +50,7 @@ main reactor {
   timer t(0, 1 sec)
   f.y -> p.x
 
-  reaction(t) -> f.x {= f.x.set(42); =}
+  reaction(t) -> f.x {=
+    f.x.set(42);
+  =}
 }

--- a/test/Cpp/src/SelfLoop.lf
+++ b/test/Cpp/src/SelfLoop.lf
@@ -29,7 +29,9 @@ reactor Self {
     a.schedule(x.get(), 100ms);
   =}
 
-  reaction(startup) -> a {= a.schedule(42, 0ns); =}
+  reaction(startup) -> a {=
+    a.schedule(42, 0ns);
+  =}
 
   reaction(shutdown) {=
     if(expected <= 43) {

--- a/test/Cpp/src/SendingInside2.lf
+++ b/test/Cpp/src/SendingInside2.lf
@@ -16,5 +16,7 @@ main reactor SendingInside2 {
   timer t
   p = new Printer()
 
-  reaction(t) -> p.x {= p.x.set(1); =}
+  reaction(t) -> p.x {=
+    p.x.set(1);
+  =}
 }

--- a/test/Cpp/src/SlowingClock.lf
+++ b/test/Cpp/src/SlowingClock.lf
@@ -17,7 +17,9 @@ main reactor SlowingClock {
   state interval: time = 100 msec
   state expected_time: time = 100 msec
 
-  reaction(startup) -> a {= a.schedule(0ns); =}
+  reaction(startup) -> a {=
+    a.schedule(0ns);
+  =}
 
   reaction(a) -> a {=
     auto elapsed_logical_time = get_elapsed_logical_time();

--- a/test/Cpp/src/StartupOutFromInside.lf
+++ b/test/Cpp/src/StartupOutFromInside.lf
@@ -8,7 +8,9 @@ target Cpp
 reactor Bar {
   output out: int
 
-  reaction(startup) -> out {= out.set(42); =}
+  reaction(startup) -> out {=
+    out.set(42);
+  =}
 }
 
 main reactor StartupOutFromInside {

--- a/test/Cpp/src/Stride.lf
+++ b/test/Cpp/src/Stride.lf
@@ -19,7 +19,9 @@ reactor Count(stride: int = 1) {
 reactor Display {
   input x: int
 
-  reaction(x) {= std::cout << "Received " << *x.get() << std::endl; =}
+  reaction(x) {=
+    std::cout << "Received " << *x.get() << std::endl;
+  =}
 }
 
 main reactor Stride {

--- a/test/Cpp/src/StructPrint.lf
+++ b/test/Cpp/src/StructPrint.lf
@@ -18,9 +18,7 @@ reactor Source {
   =}
 }
 
-reactor Print(expected_value: int = 42, expected_name: {=
-  std::string
-=} = "Earth") {
+reactor Print(expected_value: int = 42, expected_name: {= std::string =} = "Earth") {
   input in: Hello
 
   reaction(in) {=

--- a/test/Cpp/src/StructPrint.lf
+++ b/test/Cpp/src/StructPrint.lf
@@ -18,7 +18,9 @@ reactor Source {
   =}
 }
 
-reactor Print(expected_value: int = 42, expected_name: {= std::string =} = "Earth") {
+reactor Print(expected_value: int = 42, expected_name: {=
+  std::string
+=} = "Earth") {
   input in: Hello
 
   reaction(in) {=

--- a/test/Cpp/src/TimeLimit.lf
+++ b/test/Cpp/src/TimeLimit.lf
@@ -44,5 +44,7 @@ main reactor TimeLimit(period: time = 1 sec) {
   d = new Destination()
   c.y -> d.x
 
-  reaction(stop) {= environment()->sync_shutdown(); =}
+  reaction(stop) {=
+    environment()->sync_shutdown();
+  =}
 }

--- a/test/Cpp/src/TimeState.lf
+++ b/test/Cpp/src/TimeState.lf
@@ -3,7 +3,9 @@ target Cpp
 reactor Foo(bar: time = 42 msec) {
   state baz = bar
 
-  reaction(startup) {= std::cout << "Baz: " << baz << std::endl; =}
+  reaction(startup) {=
+    std::cout << "Baz: " << baz << std::endl;
+  =}
 }
 
 main reactor {

--- a/test/Cpp/src/concurrent/AsyncCallback.lf
+++ b/test/Cpp/src/concurrent/AsyncCallback.lf
@@ -10,9 +10,7 @@ main reactor AsyncCallback {
   =}
 
   timer t(0, 200 msec)
-  state thread: {=
-    std::thread
-  =}
+  state thread: {= std::thread =}
   state expected_time: time = 100 msec
   state toggle: bool = false
 

--- a/test/Cpp/src/concurrent/AsyncCallback.lf
+++ b/test/Cpp/src/concurrent/AsyncCallback.lf
@@ -10,7 +10,9 @@ main reactor AsyncCallback {
   =}
 
   timer t(0, 200 msec)
-  state thread: {= std::thread =}
+  state thread: {=
+    std::thread
+  =}
   state expected_time: time = 100 msec
   state toggle: bool = false
 

--- a/test/Cpp/src/concurrent/DelayIntThreaded.lf
+++ b/test/Cpp/src/concurrent/DelayIntThreaded.lf
@@ -19,9 +19,7 @@ reactor Delay(delay: time = 100 msec) {
 
 reactor Test {
   input in: int
-  state start_time: {=
-    reactor::TimePoint
-  =}
+  state start_time: {= reactor::TimePoint =}
   timer start
 
   reaction(start) {=

--- a/test/Cpp/src/concurrent/DelayIntThreaded.lf
+++ b/test/Cpp/src/concurrent/DelayIntThreaded.lf
@@ -6,7 +6,9 @@ reactor Delay(delay: time = 100 msec) {
   output out: int
   logical action d: int
 
-  reaction(in) -> d {= d.schedule(in.get(), delay); =}
+  reaction(in) -> d {=
+    d.schedule(in.get(), delay);
+  =}
 
   reaction(d) -> out {=
     if (d.is_present()) {
@@ -17,7 +19,9 @@ reactor Delay(delay: time = 100 msec) {
 
 reactor Test {
   input in: int
-  state start_time: {= reactor::TimePoint =}
+  state start_time: {=
+    reactor::TimePoint
+  =}
   timer start
 
   reaction(start) {=
@@ -50,5 +54,7 @@ main reactor {
   test = new Test()
   d.out -> test.in
 
-  reaction(t) -> d.in {= d.in.set(42); =}
+  reaction(t) -> d.in {=
+    d.in.set(42);
+  =}
 }

--- a/test/Cpp/src/concurrent/DeterminismThreaded.lf
+++ b/test/Cpp/src/concurrent/DeterminismThreaded.lf
@@ -4,7 +4,9 @@ reactor Source {
   output y: int
   timer t
 
-  reaction(t) -> y {= y.set(1); =}
+  reaction(t) -> y {=
+    y.set(1);
+  =}
 }
 
 reactor Destination {
@@ -31,7 +33,9 @@ reactor Pass {
   input x: int
   output y: int
 
-  reaction(x) -> y {= y.set(x.get()); =}
+  reaction(x) -> y {=
+    y.set(x.get());
+  =}
 }
 
 main reactor {

--- a/test/Cpp/src/concurrent/GainThreaded.lf
+++ b/test/Cpp/src/concurrent/GainThreaded.lf
@@ -5,7 +5,9 @@ reactor Scale(scale: int = 2) {
   input x: int
   output y: int
 
-  reaction(x) -> y {= y.set(*x.get() * scale); =}
+  reaction(x) -> y {=
+    y.set(*x.get() * scale);
+  =}
 }
 
 reactor Test {
@@ -27,5 +29,7 @@ main reactor {
   g.y -> t.x
   timer tim
 
-  reaction(tim) -> g.x {= g.x.set(1); =}
+  reaction(tim) -> g.x {=
+    g.x.set(1);
+  =}
 }

--- a/test/Cpp/src/concurrent/HelloThreaded.lf
+++ b/test/Cpp/src/concurrent/HelloThreaded.lf
@@ -7,13 +7,9 @@ target Cpp {
   fast: true
 }
 
-reactor HelloCpp(period: time = 2 sec, message: {=
-  std::string
-=} = "Hello C++") {
+reactor HelloCpp(period: time = 2 sec, message: {= std::string =} = "Hello C++") {
   state count: int = 0
-  state previous_time: {=
-    reactor::TimePoint
-  =}
+  state previous_time: {= reactor::TimePoint =}
   timer t(1 sec, period)
   logical action a: void
 
@@ -39,9 +35,7 @@ reactor HelloCpp(period: time = 2 sec, message: {=
   =}
 }
 
-reactor Inside(period: time = 1 sec, message: {=
-  std::string
-=} = "Composite default message.") {
+reactor Inside(period: time = 1 sec, message: {= std::string =} = "Composite default message.") {
   third_instance = new HelloCpp(period=period, message=message)
 }
 

--- a/test/Cpp/src/concurrent/HelloThreaded.lf
+++ b/test/Cpp/src/concurrent/HelloThreaded.lf
@@ -7,9 +7,13 @@ target Cpp {
   fast: true
 }
 
-reactor HelloCpp(period: time = 2 sec, message: {= std::string =} = "Hello C++") {
+reactor HelloCpp(period: time = 2 sec, message: {=
+  std::string
+=} = "Hello C++") {
   state count: int = 0
-  state previous_time: {= reactor::TimePoint =}
+  state previous_time: {=
+    reactor::TimePoint
+  =}
   timer t(1 sec, period)
   logical action a: void
 
@@ -35,7 +39,9 @@ reactor HelloCpp(period: time = 2 sec, message: {= std::string =} = "Hello C++")
   =}
 }
 
-reactor Inside(period: time = 1 sec, message: {= std::string =} = "Composite default message.") {
+reactor Inside(period: time = 1 sec, message: {=
+  std::string
+=} = "Composite default message.") {
   third_instance = new HelloCpp(period=period, message=message)
 }
 

--- a/test/Cpp/src/concurrent/ImportThreaded.lf
+++ b/test/Cpp/src/concurrent/ImportThreaded.lf
@@ -7,5 +7,7 @@ main reactor {
   timer t
   a = new Imported()
 
-  reaction(t) -> a.x {= a.x.set(42); =}
+  reaction(t) -> a.x {=
+    a.x.set(42);
+  =}
 }

--- a/test/Cpp/src/concurrent/MinimalThreaded.lf
+++ b/test/Cpp/src/concurrent/MinimalThreaded.lf
@@ -2,5 +2,7 @@
 target Cpp
 
 main reactor {
-  reaction(startup) {= std::cout << "Hello World!\n"; =}
+  reaction(startup) {=
+    std::cout << "Hello World!\n";
+  =}
 }

--- a/test/Cpp/src/concurrent/TimeLimitThreaded.lf
+++ b/test/Cpp/src/concurrent/TimeLimitThreaded.lf
@@ -45,5 +45,7 @@ main reactor(period: time = 1 sec) {
   d = new Destination()
   c.y -> d.x
 
-  reaction(stop) {= environment()->sync_shutdown(); =}
+  reaction(stop) {=
+    environment()->sync_shutdown();
+  =}
 }

--- a/test/Cpp/src/enclave/EnclaveBankEach.lf
+++ b/test/Cpp/src/enclave/EnclaveBankEach.lf
@@ -6,12 +6,8 @@ target Cpp {
 reactor Node(
     bank_index: size_t = 0,
     id: std::string = {= "node" + std::to_string(bank_index) =},
-    period: {=
-      reactor::Duration
-    =} = {= 100ms * (bank_index+1) =},
-    duration: {=
-      reactor::Duration
-    =} = {= 50ms + 100ms * bank_index =}) {
+    period: {= reactor::Duration =} = {= 100ms * (bank_index+1) =},
+    duration: {= reactor::Duration =} = {= 50ms + 100ms * bank_index =}) {
   logical action a: void
 
   reaction(startup, a) -> a {=

--- a/test/Cpp/src/enclave/EnclaveBankEach.lf
+++ b/test/Cpp/src/enclave/EnclaveBankEach.lf
@@ -6,8 +6,12 @@ target Cpp {
 reactor Node(
     bank_index: size_t = 0,
     id: std::string = {= "node" + std::to_string(bank_index) =},
-    period: {= reactor::Duration =} = {= 100ms * (bank_index+1) =},
-    duration: {= reactor::Duration =} = {= 50ms + 100ms * bank_index =}) {
+    period: {=
+      reactor::Duration
+    =} = {= 100ms * (bank_index+1) =},
+    duration: {=
+      reactor::Duration
+    =} = {= 50ms + 100ms * bank_index =}) {
   logical action a: void
 
   reaction(startup, a) -> a {=

--- a/test/Cpp/src/enclave/EnclaveBroadcast.lf
+++ b/test/Cpp/src/enclave/EnclaveBroadcast.lf
@@ -5,7 +5,9 @@ target Cpp {
 reactor Source {
   output out: unsigned
 
-  reaction(startup) -> out {= out.set(42); =}
+  reaction(startup) -> out {=
+    out.set(42);
+  =}
 }
 
 reactor Sink(bank_index: size_t = 0) {

--- a/test/Cpp/src/enclave/EnclaveCommunication.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunication.lf
@@ -8,7 +8,9 @@ reactor Src {
   output out: int
   state counter: int = 0
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 }
 
 reactor Sink {

--- a/test/Cpp/src/enclave/EnclaveCommunication2.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunication2.lf
@@ -8,7 +8,9 @@ reactor Src {
   output out: int
   state counter: int = 0
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 }
 
 reactor Sink {

--- a/test/Cpp/src/enclave/EnclaveCommunicationDelayed.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationDelayed.lf
@@ -8,7 +8,9 @@ reactor Src {
   output out: int
   state counter: int = 0
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 }
 
 reactor Sink {

--- a/test/Cpp/src/enclave/EnclaveCommunicationDelayed2.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationDelayed2.lf
@@ -8,7 +8,9 @@ reactor Src {
   output out: int
   state counter: int = 0
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 }
 
 reactor Sink {

--- a/test/Cpp/src/enclave/EnclaveCommunicationDelayedLocalEvents.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationDelayedLocalEvents.lf
@@ -8,7 +8,9 @@ reactor Src {
   output out: int
   state counter: int = 0
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 }
 
 reactor Sink {
@@ -34,7 +36,9 @@ reactor Sink {
     }
   =}
 
-  reaction(t) {= reactor::log::Info() << "Tick"; =}
+  reaction(t) {=
+    reactor::log::Info() << "Tick";
+  =}
 }
 
 main reactor {

--- a/test/Cpp/src/enclave/EnclaveCommunicationLocalEvents.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationLocalEvents.lf
@@ -8,7 +8,9 @@ reactor Src {
   output out: int
   state counter: int = 0
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 }
 
 reactor Sink {
@@ -34,7 +36,9 @@ reactor Sink {
     }
   =}
 
-  reaction(t) {= reactor::log::Info() << "Tick"; =}
+  reaction(t) {=
+    reactor::log::Info() << "Tick";
+  =}
 }
 
 main reactor {

--- a/test/Cpp/src/enclave/EnclaveCommunicationMultiportToBank.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationMultiportToBank.lf
@@ -44,7 +44,9 @@ reactor Sink(bank_index: std::size_t = 0) {
     }
   =}
 
-  reaction(t) {= reactor::log::Info() << "Tick"; =}
+  reaction(t) {=
+    reactor::log::Info() << "Tick";
+  =}
 }
 
 main reactor {

--- a/test/Cpp/src/enclave/EnclaveCommunicationMultiportToBankDelayed.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationMultiportToBankDelayed.lf
@@ -44,7 +44,9 @@ reactor Sink(bank_index: std::size_t = 0) {
     }
   =}
 
-  reaction(t) {= reactor::log::Info() << "Tick"; =}
+  reaction(t) {=
+    reactor::log::Info() << "Tick";
+  =}
 }
 
 main reactor {

--- a/test/Cpp/src/enclave/EnclaveCommunicationMultiportToBankEach.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationMultiportToBankEach.lf
@@ -44,7 +44,9 @@ reactor Sink(bank_index: std::size_t = 0) {
     }
   =}
 
-  reaction(t) {= reactor::log::Info() << "Tick"; =}
+  reaction(t) {=
+    reactor::log::Info() << "Tick";
+  =}
 }
 
 main reactor {

--- a/test/Cpp/src/enclave/EnclaveCommunicationMultiportToBankEachDelayed.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationMultiportToBankEachDelayed.lf
@@ -44,7 +44,9 @@ reactor Sink(bank_index: std::size_t = 0) {
     }
   =}
 
-  reaction(t) {= reactor::log::Info() << "Tick"; =}
+  reaction(t) {=
+    reactor::log::Info() << "Tick";
+  =}
 }
 
 main reactor {

--- a/test/Cpp/src/enclave/EnclaveCommunicationMultiportToBankEachPhysical.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationMultiportToBankEachPhysical.lf
@@ -44,7 +44,9 @@ reactor Sink(bank_index: std::size_t = 0) {
     }
   =}
 
-  reaction(t) {= reactor::log::Info() << "Tick"; =}
+  reaction(t) {=
+    reactor::log::Info() << "Tick";
+  =}
 }
 
 main reactor {

--- a/test/Cpp/src/enclave/EnclaveCommunicationMultiportToBankPhysical.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationMultiportToBankPhysical.lf
@@ -44,7 +44,9 @@ reactor Sink(bank_index: std::size_t = 0) {
     }
   =}
 
-  reaction(t) {= reactor::log::Info() << "Tick"; =}
+  reaction(t) {=
+    reactor::log::Info() << "Tick";
+  =}
 }
 
 main reactor {

--- a/test/Cpp/src/enclave/EnclaveCommunicationPhysical.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationPhysical.lf
@@ -8,7 +8,9 @@ reactor Src {
   output out: int
   state counter: int = 0
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 }
 
 reactor Sink {

--- a/test/Cpp/src/enclave/EnclaveCommunicationPhysicalLocalEvents.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationPhysicalLocalEvents.lf
@@ -8,7 +8,9 @@ reactor Src {
   output out: int
   state counter: int = 0
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 }
 
 reactor Sink {
@@ -34,7 +36,9 @@ reactor Sink {
     }
   =}
 
-  reaction(t) {= reactor::log::Info() << "Tick"; =}
+  reaction(t) {=
+    reactor::log::Info() << "Tick";
+  =}
 }
 
 main reactor {

--- a/test/Cpp/src/enclave/EnclaveCycle.lf
+++ b/test/Cpp/src/enclave/EnclaveCycle.lf
@@ -10,7 +10,9 @@ reactor Ping {
   state counter: int = 0
   state received: bool = false
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 
   reaction(in) {=
     received = true;

--- a/test/Cpp/src/enclave/EnclaveCycleTwoTimers.lf
+++ b/test/Cpp/src/enclave/EnclaveCycleTwoTimers.lf
@@ -10,7 +10,9 @@ reactor Ping {
   state counter: int = 0
   state received: bool = false
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 
   reaction(in) {=
     received = true;
@@ -38,7 +40,9 @@ reactor Pong {
   state counter: int = 0
   state received: bool = false
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 
   reaction(in) {=
     received = true;

--- a/test/Cpp/src/enclave/EnclaveHelloWorld.lf
+++ b/test/Cpp/src/enclave/EnclaveHelloWorld.lf
@@ -1,7 +1,9 @@
 target Cpp
 
 reactor Hello(msg: std::string = "World") {
-  reaction(startup) {= reactor::log::Info() << "Hello " << msg << '!'; =}
+  reaction(startup) {=
+    reactor::log::Info() << "Hello " << msg << '!';
+  =}
 }
 
 main reactor(msg1: std::string = "World", msg2: std::string = "Enclave") {

--- a/test/Cpp/src/enclave/EnclaveShutdown.lf
+++ b/test/Cpp/src/enclave/EnclaveShutdown.lf
@@ -4,9 +4,13 @@ reactor Node(message: std::string = "Hello", period: time = 1 sec, stop: time = 
   timer t(0, period)
   timer s(stop)
 
-  reaction(t) {= reactor::log::Info() << message; =}
+  reaction(t) {=
+    reactor::log::Info() << message;
+  =}
 
-  reaction(s) {= request_stop(); =}
+  reaction(s) {=
+    request_stop();
+  =}
 
   reaction(shutdown) {=
     reactor::log::Info() << "Goodbye!";

--- a/test/Cpp/src/enclave/EnclaveSparseUpstreamEvents.lf
+++ b/test/Cpp/src/enclave/EnclaveSparseUpstreamEvents.lf
@@ -10,7 +10,9 @@ reactor Src {
   output out: int
   state counter: int = 0
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 }
 
 reactor Sink {
@@ -36,7 +38,9 @@ reactor Sink {
     }
   =}
 
-  reaction(t) {= reactor::log::Info() << "Tick"; =} deadline(2 s) {=
+  reaction(t) {=
+    reactor::log::Info() << "Tick";
+  =} deadline(2 s) {=
     reactor::log::Error() << "Deadline violated.";
     exit(2);
   =}

--- a/test/Cpp/src/enclave/EnclaveSparseUpstreamEventsDelayed.lf
+++ b/test/Cpp/src/enclave/EnclaveSparseUpstreamEventsDelayed.lf
@@ -10,7 +10,9 @@ reactor Src {
   output out: int
   state counter: int = 0
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 }
 
 reactor Sink {
@@ -36,7 +38,9 @@ reactor Sink {
     }
   =}
 
-  reaction(t) {= reactor::log::Info() << "Tick"; =} deadline(2 s) {=
+  reaction(t) {=
+    reactor::log::Info() << "Tick";
+  =} deadline(2 s) {=
     reactor::log::Error() << "Deadline violated.";
     exit(2);
   =}

--- a/test/Cpp/src/enclave/EnclaveSparseUpstreamEventsPhysical.lf
+++ b/test/Cpp/src/enclave/EnclaveSparseUpstreamEventsPhysical.lf
@@ -10,7 +10,9 @@ reactor Src {
   output out: int
   state counter: int = 0
 
-  reaction(t) -> out {= out.set(counter++); =}
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
 }
 
 reactor Sink {
@@ -36,7 +38,9 @@ reactor Sink {
     }
   =}
 
-  reaction(t) {= reactor::log::Info() << "Tick"; =} deadline(2 s) {=
+  reaction(t) {=
+    reactor::log::Info() << "Tick";
+  =} deadline(2 s) {=
     reactor::log::Error() << "Deadline violated.";
     exit(2);
   =}

--- a/test/Cpp/src/enclave/EnclaveTimeout.lf
+++ b/test/Cpp/src/enclave/EnclaveTimeout.lf
@@ -5,7 +5,9 @@ target Cpp {
 reactor Node(message: std::string = "Hello", period: time = 1 sec) {
   timer t(0, period)
 
-  reaction(t) {= reactor::log::Info() << message; =}
+  reaction(t) {=
+    reactor::log::Info() << message;
+  =}
 
   reaction(shutdown) {=
     reactor::log::Info() << "Goodbye!";

--- a/test/Cpp/src/enclave/EnclaveUpstreamPhysicalAction.lf
+++ b/test/Cpp/src/enclave/EnclaveUpstreamPhysicalAction.lf
@@ -25,7 +25,9 @@ reactor Src {
     });
   =}
 
-  reaction(a) -> out {= out.set(a.get()); =}
+  reaction(a) -> out {=
+    out.set(a.get());
+  =}
 
   reaction(shutdown) {=
     // make sure to join the thread before shutting down

--- a/test/Cpp/src/enclave/EnclaveUpstreamPhysicalActionDelayed.lf
+++ b/test/Cpp/src/enclave/EnclaveUpstreamPhysicalActionDelayed.lf
@@ -25,7 +25,9 @@ reactor Src {
     });
   =}
 
-  reaction(a) -> out {= out.set(a.get()); =}
+  reaction(a) -> out {=
+    out.set(a.get());
+  =}
 
   reaction(shutdown) {=
     // make sure to join the thread before shutting down

--- a/test/Cpp/src/enclave/FastAndSlow.lf
+++ b/test/Cpp/src/enclave/FastAndSlow.lf
@@ -20,7 +20,9 @@ reactor Slow {
 reactor Fast {
   timer t(0 msec, 100 msec)
 
-  reaction(t) {= reactor::log::Info() << "Fast reaction executes"; =} deadline(200 msec) {=
+  reaction(t) {=
+    reactor::log::Info() << "Fast reaction executes";
+  =} deadline(200 msec) {=
     reactor::log::Error() << "Fast deadline was violated!";
     exit(2);
   =}

--- a/test/Cpp/src/lib/Imported.lf
+++ b/test/Cpp/src/lib/Imported.lf
@@ -8,5 +8,7 @@ reactor Imported {
   input x: int
   a = new ImportedAgain()
 
-  reaction(x) -> a.x {= a.x.set(x.get()); =}
+  reaction(x) -> a.x {=
+    a.x.set(x.get());
+  =}
 }

--- a/test/Cpp/src/lib/ImportedComposition.lf
+++ b/test/Cpp/src/lib/ImportedComposition.lf
@@ -12,7 +12,9 @@ reactor Gain {
   input x: int
   output y: int
 
-  reaction(x) -> y {= y.set(*x.get() * 2); =}
+  reaction(x) -> y {=
+    y.set(*x.get() * 2);
+  =}
 }
 
 reactor ImportedComposition {

--- a/test/Cpp/src/multiport/BankSelfBroadcast.lf
+++ b/test/Cpp/src/multiport/BankSelfBroadcast.lf
@@ -13,7 +13,9 @@ reactor A(bank_index: size_t = 0) {
   output out: size_t
   state received: bool = false
 
-  reaction(startup) -> out {= out.set(bank_index); =}
+  reaction(startup) -> out {=
+    out.set(bank_index);
+  =}
 
   reaction(in) {=
     for (size_t i = 0; i < in.size(); i++) {

--- a/test/Cpp/src/multiport/BankToMultiport.lf
+++ b/test/Cpp/src/multiport/BankToMultiport.lf
@@ -4,7 +4,9 @@ target Cpp
 reactor Source(bank_index: size_t = 0) {
   output out: unsigned
 
-  reaction(startup) -> out {= out.set(bank_index); =}
+  reaction(startup) -> out {=
+    out.set(bank_index);
+  =}
 }
 
 reactor Sink {

--- a/test/Cpp/src/multiport/Broadcast.lf
+++ b/test/Cpp/src/multiport/Broadcast.lf
@@ -3,7 +3,9 @@ target Cpp
 reactor Source {
   output out: unsigned
 
-  reaction(startup) -> out {= out.set(42); =}
+  reaction(startup) -> out {=
+    out.set(42);
+  =}
 }
 
 reactor Sink(bank_index: size_t = 0) {

--- a/test/Cpp/src/multiport/BroadcastAfter.lf
+++ b/test/Cpp/src/multiport/BroadcastAfter.lf
@@ -5,7 +5,9 @@ target Cpp {
 reactor Source {
   output out: unsigned
 
-  reaction(startup) -> out {= out.set(42); =}
+  reaction(startup) -> out {=
+    out.set(42);
+  =}
 }
 
 reactor Sink(bank_index: size_t = 0) {

--- a/test/Cpp/src/multiport/BroadcastMultipleAfter.lf
+++ b/test/Cpp/src/multiport/BroadcastMultipleAfter.lf
@@ -5,7 +5,9 @@ target Cpp {
 reactor Source(value: unsigned = 42) {
   output out: unsigned
 
-  reaction(startup) -> out {= out.set(value); =}
+  reaction(startup) -> out {=
+    out.set(value);
+  =}
 }
 
 reactor Sink(bank_index: size_t = 0) {

--- a/test/Cpp/src/multiport/IndexIntoMultiportInput.lf
+++ b/test/Cpp/src/multiport/IndexIntoMultiportInput.lf
@@ -45,9 +45,15 @@ main reactor IndexIntoMultiportInput {
 
   splitter.out -> receiver.in
 
-  reaction(startup) -> splitter.in0 {= splitter.in0.set(0); =}
+  reaction(startup) -> splitter.in0 {=
+    splitter.in0.set(0);
+  =}
 
-  reaction(startup) -> splitter.in1 {= splitter.in1.set(1); =}
+  reaction(startup) -> splitter.in1 {=
+    splitter.in1.set(1);
+  =}
 
-  reaction(startup) -> splitter.in2 {= splitter.in2.set(2); =}
+  reaction(startup) -> splitter.in2 {=
+    splitter.in2.set(2);
+  =}
 }

--- a/test/Cpp/src/multiport/MultiportFromBank.lf
+++ b/test/Cpp/src/multiport/MultiportFromBank.lf
@@ -8,7 +8,9 @@ target Cpp {
 reactor Source(bank_index: size_t = 0) {
   output out: unsigned
 
-  reaction(startup) -> out {= out.set(bank_index); =}
+  reaction(startup) -> out {=
+    out.set(bank_index);
+  =}
 }
 
 reactor Destination(port_width: size_t = 2) {

--- a/test/Cpp/src/multiport/MultiportFromBankHierarchy.lf
+++ b/test/Cpp/src/multiport/MultiportFromBankHierarchy.lf
@@ -8,7 +8,9 @@ target Cpp {
 reactor Source(bank_index: size_t = 0) {
   output out: unsigned
 
-  reaction(startup) -> out {= out.set(bank_index); =}
+  reaction(startup) -> out {=
+    out.set(bank_index);
+  =}
 }
 
 reactor Container {

--- a/test/Cpp/src/multiport/MultiportFromBankHierarchyAfter.lf
+++ b/test/Cpp/src/multiport/MultiportFromBankHierarchyAfter.lf
@@ -8,7 +8,9 @@ target Cpp {
 reactor Source(bank_index: size_t = 0) {
   output out: int
 
-  reaction(startup) -> out {= out.set(bank_index); =}
+  reaction(startup) -> out {=
+    out.set(bank_index);
+  =}
 }
 
 reactor Container {

--- a/test/Cpp/src/multiport/MultiportIn.lf
+++ b/test/Cpp/src/multiport/MultiportIn.lf
@@ -10,14 +10,18 @@ reactor Source {
   output out: int
   state s: int = 0
 
-  reaction(t) -> out {= out.set(s++); =}
+  reaction(t) -> out {=
+    out.set(s++);
+  =}
 }
 
 reactor Computation {
   input in: int
   output out: int
 
-  reaction(in) -> out {= out.set(*in.get()); =}
+  reaction(in) -> out {=
+    out.set(*in.get());
+  =}
 }
 
 reactor Destination {

--- a/test/Cpp/src/multiport/PipelineAfter.lf
+++ b/test/Cpp/src/multiport/PipelineAfter.lf
@@ -3,14 +3,18 @@ target Cpp
 reactor Source {
   output out: unsigned
 
-  reaction(startup) -> out {= out.set(40); =}
+  reaction(startup) -> out {=
+    out.set(40);
+  =}
 }
 
 reactor Compute {
   input in: unsigned
   output out: unsigned
 
-  reaction(in) -> out {= out.set(*in.get() + 2); =}
+  reaction(in) -> out {=
+    out.set(*in.get() + 2);
+  =}
 }
 
 reactor Sink {

--- a/test/Cpp/src/multiport/ReadOutputOfContainedBank.lf
+++ b/test/Cpp/src/multiport/ReadOutputOfContainedBank.lf
@@ -4,7 +4,9 @@ target Cpp
 reactor Contained(bank_index: size_t = 0) {
   output out: unsigned
 
-  reaction(startup) -> out {= out.set(42 * bank_index); =}
+  reaction(startup) -> out {=
+    out.set(42 * bank_index);
+  =}
 }
 
 main reactor {

--- a/test/Cpp/src/multiport/WidthGivenByCode.lf
+++ b/test/Cpp/src/multiport/WidthGivenByCode.lf
@@ -1,8 +1,12 @@
 target Cpp
 
 reactor Foo(a: size_t = 8, b: size_t = 2) {
-  input[{= a*b =}] in: size_t
-  output[{= a/b =}] out: size_t
+  input[{=
+    a*b
+  =}] in: size_t
+  output[{=
+    a/b
+  =}] out: size_t
 
   reaction(startup) in -> out {=
     if (in.size() != a*b) {
@@ -20,7 +24,9 @@ main reactor {
   foo1 = new Foo()
   foo2 = new Foo(a=10, b=3)
   foo3 = new Foo(a=9, b=9)
-  foo_bank = new[{= 42 =}] Foo()
+  foo_bank = new[{=
+    42
+  =}] Foo()
 
   reaction(startup) foo_bank.out {=
     if (foo_bank.size() != 42) {

--- a/test/Cpp/src/multiport/WidthGivenByCode.lf
+++ b/test/Cpp/src/multiport/WidthGivenByCode.lf
@@ -1,12 +1,8 @@
 target Cpp
 
 reactor Foo(a: size_t = 8, b: size_t = 2) {
-  input[{=
-    a*b
-  =}] in: size_t
-  output[{=
-    a/b
-  =}] out: size_t
+  input[{= a*b =}] in: size_t
+  output[{= a/b =}] out: size_t
 
   reaction(startup) in -> out {=
     if (in.size() != a*b) {
@@ -24,9 +20,7 @@ main reactor {
   foo1 = new Foo()
   foo2 = new Foo(a=10, b=3)
   foo3 = new Foo(a=9, b=9)
-  foo_bank = new[{=
-    42
-  =}] Foo()
+  foo_bank = new[{= 42 =}] Foo()
 
   reaction(startup) foo_bank.out {=
     if (foo_bank.size() != 42) {

--- a/test/Cpp/src/properties/Fast.lf
+++ b/test/Cpp/src/properties/Fast.lf
@@ -7,7 +7,9 @@ main reactor {
 
   state triggered: bool = false
 
-  reaction(startup) -> a {= a.schedule(2s); =}
+  reaction(startup) -> a {=
+    a.schedule(2s);
+  =}
 
   reaction(a) {=
     triggered = true;

--- a/test/Cpp/src/target/AfterVoid.lf
+++ b/test/Cpp/src/target/AfterVoid.lf
@@ -8,7 +8,9 @@ reactor foo {
   timer t(0, 1 sec)
   output y: void
 
-  reaction(t) -> y {= y.set(); =}
+  reaction(t) -> y {=
+    y.set();
+  =}
 }
 
 reactor print {

--- a/test/Cpp/src/target/CliParserGenericArguments.lf
+++ b/test/Cpp/src/target/CliParserGenericArguments.lf
@@ -47,15 +47,27 @@ main reactor CliParserGenericArguments(
     signed_value: signed = -10,
     unsigned_value: unsigned = 11,
     long_value: long = -100,
-    unsigned_long_value: {= unsigned_long =} = 42,
-    long_long_value: {= long_long =} = -42,
-    ull_value: {= uns_long_long =} = 42,
+    unsigned_long_value: {=
+      unsigned_long
+    =} = 42,
+    long_long_value: {=
+      long_long
+    =} = -42,
+    ull_value: {=
+      uns_long_long
+    =} = 42,
     bool_value: bool = false,
     char_value: char = 'T',
     double_value: double = 4.2,
-    long_double_value: {= long_double =} = 4.2,
+    long_double_value: {=
+      long_double
+    =} = 4.2,
     float_value: float = 10.5,
     string_value: string = "This is a testvalue",
-    custom_class_value: {= CustomClass =}("Peter")) {
-  reaction(startup) {= std::cout << "Hello World!\n"; =}
+    custom_class_value: {=
+      CustomClass
+    =}("Peter")) {
+  reaction(startup) {=
+    std::cout << "Hello World!\n";
+  =}
 }

--- a/test/Cpp/src/target/CliParserGenericArguments.lf
+++ b/test/Cpp/src/target/CliParserGenericArguments.lf
@@ -47,26 +47,16 @@ main reactor CliParserGenericArguments(
     signed_value: signed = -10,
     unsigned_value: unsigned = 11,
     long_value: long = -100,
-    unsigned_long_value: {=
-      unsigned_long
-    =} = 42,
-    long_long_value: {=
-      long_long
-    =} = -42,
-    ull_value: {=
-      uns_long_long
-    =} = 42,
+    unsigned_long_value: {= unsigned_long =} = 42,
+    long_long_value: {= long_long =} = -42,
+    ull_value: {= uns_long_long =} = 42,
     bool_value: bool = false,
     char_value: char = 'T',
     double_value: double = 4.2,
-    long_double_value: {=
-      long_double
-    =} = 4.2,
+    long_double_value: {= long_double =} = 4.2,
     float_value: float = 10.5,
     string_value: string = "This is a testvalue",
-    custom_class_value: {=
-      CustomClass
-    =}("Peter")) {
+    custom_class_value: {= CustomClass =}("Peter")) {
   reaction(startup) {=
     std::cout << "Hello World!\n";
   =}

--- a/test/Cpp/src/target/CombinedTypeNames.lf
+++ b/test/Cpp/src/target/CombinedTypeNames.lf
@@ -2,17 +2,9 @@
 // int`) can be used correctly in LF code.
 target Cpp
 
-reactor Foo(bar: {=
-  unsigned int
-=} = 0, baz: {=
-  const unsigned int*
-=} = {= nullptr =}) {
-  state s_bar: {=
-    unsigned int
-  =} = bar
-  state s_baz: {=
-    const unsigned int*
-  =} = baz
+reactor Foo(bar: {= unsigned int =} = 0, baz: {= const unsigned int* =} = {= nullptr =}) {
+  state s_bar: {= unsigned int =} = bar
+  state s_baz: {= const unsigned int* =} = baz
 
   reaction(startup) {=
     if (bar != 42 || s_bar != 42 || *baz != 42 || *s_baz != 42) {
@@ -22,8 +14,6 @@ reactor Foo(bar: {=
   =}
 }
 
-main reactor(bar: {=
-  unsigned int
-=} = 42) {
+main reactor(bar: {= unsigned int =} = 42) {
   foo = new Foo(bar=bar, baz = {= &bar =})
 }

--- a/test/Cpp/src/target/CombinedTypeNames.lf
+++ b/test/Cpp/src/target/CombinedTypeNames.lf
@@ -2,9 +2,17 @@
 // int`) can be used correctly in LF code.
 target Cpp
 
-reactor Foo(bar: {= unsigned int =} = 0, baz: {= const unsigned int* =} = {= nullptr =}) {
-  state s_bar: {= unsigned int =} = bar
-  state s_baz: {= const unsigned int* =} = baz
+reactor Foo(bar: {=
+  unsigned int
+=} = 0, baz: {=
+  const unsigned int*
+=} = {= nullptr =}) {
+  state s_bar: {=
+    unsigned int
+  =} = bar
+  state s_baz: {=
+    const unsigned int*
+  =} = baz
 
   reaction(startup) {=
     if (bar != 42 || s_bar != 42 || *baz != 42 || *s_baz != 42) {
@@ -14,6 +22,8 @@ reactor Foo(bar: {= unsigned int =} = 0, baz: {= const unsigned int* =} = {= nul
   =}
 }
 
-main reactor(bar: {= unsigned int =} = 42) {
+main reactor(bar: {=
+  unsigned int
+=} = 42) {
   foo = new Foo(bar=bar, baz = {= &bar =})
 }

--- a/test/Cpp/src/target/GenericAfter.lf
+++ b/test/Cpp/src/target/GenericAfter.lf
@@ -7,9 +7,13 @@ reactor Delay<T>(delay: time(0)) {
   input in: T
   logical action a(delay): T
 
-  reaction(a) -> out {= out.set(a.get()); =}
+  reaction(a) -> out {=
+    out.set(a.get());
+  =}
 
-  reaction(in) -> a {= a.schedule(in.get()); =}
+  reaction(in) -> a {=
+    a.schedule(in.get());
+  =}
 }
 
 main reactor {
@@ -17,5 +21,7 @@ main reactor {
   test = new Test()
   d.out -> test.in after 50 msec
 
-  reaction(startup) -> d.in {= d.in.set(42); =}
+  reaction(startup) -> d.in {=
+    d.in.set(42);
+  =}
 }

--- a/test/Cpp/src/target/GenericDelay.lf
+++ b/test/Cpp/src/target/GenericDelay.lf
@@ -7,9 +7,13 @@ reactor Delay<T>(delay: time = 0) {
   input in: T
   logical action a(delay): T
 
-  reaction(a) -> out {= out.set(a.get()); =}
+  reaction(a) -> out {=
+    out.set(a.get());
+  =}
 
-  reaction(in) -> a {= a.schedule(in.get()); =}
+  reaction(in) -> a {=
+    a.schedule(in.get());
+  =}
 }
 
 main reactor {
@@ -17,5 +21,7 @@ main reactor {
   test = new Test()
   d.out -> test.in
 
-  reaction(startup) -> d.in {= d.in.set(42); =}
+  reaction(startup) -> d.in {=
+    d.in.set(42);
+  =}
 }

--- a/test/Cpp/src/target/MultipleContainedGeneric.lf
+++ b/test/Cpp/src/target/MultipleContainedGeneric.lf
@@ -6,7 +6,9 @@ reactor Contained<T> {
   input in1: T
   input in2: T
 
-  reaction(startup) -> trigger {= trigger.set(42); =}
+  reaction(startup) -> trigger {=
+    trigger.set(42);
+  =}
 
   reaction(in1) {=
     std::cout << "in1 received " << *in1.get() << '\n';

--- a/test/Cpp/src/target/PointerParameters.lf
+++ b/test/Cpp/src/target/PointerParameters.lf
@@ -12,7 +12,9 @@ reactor Foo(ptr: int* = {= nullptr =}) {
 }
 
 main reactor {
-  private preamble {= int a{42}; =}
+  private preamble {=
+    int a{42};
+  =}
 
   foo = new Foo(ptr = {= &a =})
 }

--- a/test/Python/src/ActionDelay.lf
+++ b/test/Python/src/ActionDelay.lf
@@ -12,13 +12,17 @@ reactor GeneratedDelay {
     act.schedule(MSEC(0))
   =}
 
-  reaction(act) -> y_out {= y_out.set(self.y_state) =}
+  reaction(act) -> y_out {=
+    y_out.set(self.y_state)
+  =}
 }
 
 reactor Source {
   output out
 
-  reaction(startup) -> out {= out.set(1) =}
+  reaction(startup) -> out {=
+    out.set(1)
+  =}
 }
 
 reactor Sink {

--- a/test/Python/src/ActionWithNoReaction.lf
+++ b/test/Python/src/ActionWithNoReaction.lf
@@ -33,5 +33,7 @@ main reactor {
   timer t(0, 1 sec)
   f.y -> p.x after 10 msec
 
-  reaction(t) -> f.x {= f.x.set(42) =}
+  reaction(t) -> f.x {=
+    f.x.set(42)
+  =}
 }

--- a/test/Python/src/After.lf
+++ b/test/Python/src/After.lf
@@ -8,7 +8,9 @@ reactor foo {
   input x
   output y
 
-  reaction(x) -> y {= y.set(2*x.value) =}
+  reaction(x) -> y {=
+    y.set(2*x.value)
+  =}
 }
 
 reactor print {
@@ -45,5 +47,7 @@ main reactor {
   timer t(0, 1 sec)
   f.y -> p.x after 10 msec
 
-  reaction(t) -> f.x {= f.x.set(42) =}
+  reaction(t) -> f.x {=
+    f.x.set(42)
+  =}
 }

--- a/test/Python/src/AfterCycles.lf
+++ b/test/Python/src/AfterCycles.lf
@@ -5,14 +5,18 @@ target Python
 reactor Source {
   output out
 
-  reaction(startup) -> out {= out.set(1) =}
+  reaction(startup) -> out {=
+    out.set(1)
+  =}
 }
 
 reactor Work {
   input _in
   output out
 
-  reaction(_in) -> out {= out.set(_in.value) =}
+  reaction(_in) -> out {=
+    out.set(_in.value)
+  =}
 }
 
 main reactor AfterCycles {

--- a/test/Python/src/CompareTags.lf
+++ b/test/Python/src/CompareTags.lf
@@ -5,7 +5,9 @@ target Python {
 }
 
 main reactor CompareTags {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   timer t(0, 1 msec)
   logical action l
 

--- a/test/Python/src/CompositionGain.lf
+++ b/test/Python/src/CompositionGain.lf
@@ -22,7 +22,9 @@ reactor Wrapper {
 main reactor {
   wrapper = new Wrapper()
 
-  reaction(startup) -> wrapper.x {= wrapper_x.set(42) =}
+  reaction(startup) -> wrapper.x {=
+    wrapper_x.set(42)
+  =}
 
   reaction(wrapper.y) {=
     print("Received " + str(wrapper_y.value))

--- a/test/Python/src/DanglingOutput.lf
+++ b/test/Python/src/DanglingOutput.lf
@@ -6,7 +6,9 @@ reactor Source {
   output out
   timer t
 
-  reaction(t) -> out {= out.set(1); =}
+  reaction(t) -> out {=
+    out.set(1);
+  =}
 }
 
 reactor Gain {

--- a/test/Python/src/Deadline.lf
+++ b/test/Python/src/Deadline.lf
@@ -4,7 +4,9 @@ target Python {
   timeout: 6 sec
 }
 
-preamble {= import time =}
+preamble {=
+  import time
+=}
 
 reactor Source(period = 3 sec) {
   output y

--- a/test/Python/src/DeadlineHandledAbove.lf
+++ b/test/Python/src/DeadlineHandledAbove.lf
@@ -2,7 +2,9 @@
 # output.
 target Python
 
-preamble {= import time =}
+preamble {=
+  import time
+=}
 
 reactor Deadline(threshold = 100 msec) {
   input x

--- a/test/Python/src/DelayArray.lf
+++ b/test/Python/src/DelayArray.lf
@@ -12,7 +12,9 @@ reactor DelayPointer(delay = 100 msec) {
     a.schedule(self.delay, _in.value);
   =}
 
-  reaction(a) -> out {= out.set(a.value); =}
+  reaction(a) -> out {=
+    out.set(a.value);
+  =}
 }
 
 reactor Source {

--- a/test/Python/src/DelayInt.lf
+++ b/test/Python/src/DelayInt.lf
@@ -11,7 +11,9 @@ reactor Delay(delay = 100 msec) {
       out.set(a.value)
   =}
 
-  reaction(_in) -> a {= a.schedule(self.delay, _in.value) =}
+  reaction(_in) -> a {=
+    a.schedule(self.delay, _in.value)
+  =}
 }
 
 reactor Test {
@@ -52,5 +54,7 @@ main reactor DelayInt {
   t = new Test()
   d.out -> t._in
 
-  reaction(startup) -> d._in {= d._in.set(42) =}
+  reaction(startup) -> d._in {=
+    d._in.set(42)
+  =}
 }

--- a/test/Python/src/DelayString.lf
+++ b/test/Python/src/DelayString.lf
@@ -6,9 +6,13 @@ reactor DelayString2(delay = 100 msec) {
   output out
   logical action a
 
-  reaction(a) -> out {= out.set(a.value) =}
+  reaction(a) -> out {=
+    out.set(a.value)
+  =}
 
-  reaction(_in) -> a {= a.schedule(self.delay, _in.value) =}
+  reaction(_in) -> a {=
+    a.schedule(self.delay, _in.value)
+  =}
 }
 
 reactor Test {
@@ -34,5 +38,7 @@ main reactor {
   t = new Test()
   d.out -> t._in
 
-  reaction(startup) -> d._in {= d._in.set("Hello") =}
+  reaction(startup) -> d._in {=
+    d._in.set("Hello")
+  =}
 }

--- a/test/Python/src/DelayStruct.lf
+++ b/test/Python/src/DelayStruct.lf
@@ -3,14 +3,18 @@ target Python {
   files: ["include/hello.py"]
 }
 
-preamble {= import hello =}
+preamble {=
+  import hello
+=}
 
 reactor DelayPointer(delay = 100 msec) {
   input _in
   output out
   logical action a
 
-  reaction(a) -> out {= out.set(a.value); =}
+  reaction(a) -> out {=
+    out.set(a.value);
+  =}
 
   reaction(_in) -> a {=
     # Schedule the actual token from the input rather than
@@ -22,7 +26,9 @@ reactor DelayPointer(delay = 100 msec) {
 reactor Source {
   output out
 
-  reaction(startup) -> out {= out.set(hello.hello("Earth", 42)) =}
+  reaction(startup) -> out {=
+    out.set(hello.hello("Earth", 42))
+  =}
 }
 
 # expected parameter is for testing.

--- a/test/Python/src/DelayStructWithAfter.lf
+++ b/test/Python/src/DelayStructWithAfter.lf
@@ -3,12 +3,16 @@ target Python {
   files: include/hello.py
 }
 
-preamble {= import hello =}
+preamble {=
+  import hello
+=}
 
 reactor Source {
   output out
 
-  reaction(startup) -> out {= out.set(hello.hello("Earth", 42)) =}
+  reaction(startup) -> out {=
+    out.set(hello.hello("Earth", 42))
+  =}
 }
 
 # expected parameter is for testing.

--- a/test/Python/src/DelayStructWithAfterOverlapped.lf
+++ b/test/Python/src/DelayStructWithAfterOverlapped.lf
@@ -5,7 +5,9 @@ target Python {
   files: ["include/hello.py"]
 }
 
-preamble {= import hello =}
+preamble {=
+  import hello
+=}
 
 reactor Source {
   output out

--- a/test/Python/src/DelayedAction.lf
+++ b/test/Python/src/DelayedAction.lf
@@ -8,7 +8,9 @@ main reactor DelayedAction {
   logical action a
   state count = 0
 
-  reaction(t) -> a {= a.schedule(MSEC(100)) =}
+  reaction(t) -> a {=
+    a.schedule(MSEC(100))
+  =}
 
   reaction(a) {=
     elapsed = lf.time.logical_elapsed()

--- a/test/Python/src/DelayedReaction.lf
+++ b/test/Python/src/DelayedReaction.lf
@@ -5,7 +5,9 @@ reactor Source {
   output out
   timer t
 
-  reaction(t) -> out {= out.set(1) =}
+  reaction(t) -> out {=
+    out.set(1)
+  =}
 }
 
 reactor Sink {

--- a/test/Python/src/Determinism.lf
+++ b/test/Python/src/Determinism.lf
@@ -4,7 +4,9 @@ reactor Source {
   output y
   timer t
 
-  reaction(t) -> y {= y.set(1) =}
+  reaction(t) -> y {=
+    y.set(1)
+  =}
 }
 
 reactor Destination {
@@ -28,7 +30,9 @@ reactor Pass {
   input x
   output y
 
-  reaction(x) -> y {= y.set(x.value) =}
+  reaction(x) -> y {=
+    y.set(x.value)
+  =}
 }
 
 main reactor Determinism {

--- a/test/Python/src/Gain.lf
+++ b/test/Python/src/Gain.lf
@@ -5,7 +5,9 @@ reactor Scale(scale=2) {
   input x
   output y
 
-  reaction(x) -> y {= y.set(x.value * self.scale) =}
+  reaction(x) -> y {=
+    y.set(x.value * self.scale)
+  =}
 }
 
 reactor Test {
@@ -33,5 +35,7 @@ main reactor Gain {
   d = new Test()
   g.y -> d.x
 
-  reaction(startup) -> g.x {= g.x.set(1) =}
+  reaction(startup) -> g.x {=
+    g.x.set(1)
+  =}
 }

--- a/test/Python/src/GetMicroStep.lf
+++ b/test/Python/src/GetMicroStep.lf
@@ -4,12 +4,16 @@ target Python {
 }
 
 main reactor GetMicroStep {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   state s = 1
 
   logical action l  # timer t(0, 1 msec);
 
-  reaction(startup) -> l {= l.schedule(0); =}
+  reaction(startup) -> l {=
+    l.schedule(0);
+  =}
 
   reaction(l) -> l {=
     microstep = lf.tag().microstep

--- a/test/Python/src/Hierarchy.lf
+++ b/test/Python/src/Hierarchy.lf
@@ -5,7 +5,9 @@ reactor Source {
   output out
   timer t
 
-  reaction(t) -> out {= out.set(1) =}
+  reaction(t) -> out {=
+    out.set(1)
+  =}
 }
 
 reactor Gain {

--- a/test/Python/src/Hierarchy2.lf
+++ b/test/Python/src/Hierarchy2.lf
@@ -8,7 +8,9 @@ reactor Source {
   output out
   timer t(0, 1 sec)
 
-  reaction(t) -> out {= out.set(1) =}
+  reaction(t) -> out {=
+    out.set(1)
+  =}
 }
 
 reactor Count {

--- a/test/Python/src/Import.lf
+++ b/test/Python/src/Import.lf
@@ -7,5 +7,7 @@ main reactor Import {
   timer t
   a = new Imported()
 
-  reaction(t) -> a.x {= a.x.set(42) =}
+  reaction(t) -> a.x {=
+    a.x.set(42)
+  =}
 }

--- a/test/Python/src/ImportComposition.lf
+++ b/test/Python/src/ImportComposition.lf
@@ -7,7 +7,9 @@ main reactor ImportComposition {
   a = new ImportedComposition()
   state received = False
 
-  reaction(startup) -> a.x {= a.x.set(42) =}
+  reaction(startup) -> a.x {=
+    a.x.set(42)
+  =}
 
   reaction(a.y) {=
     receive_time = lf.time.logical_elapsed()

--- a/test/Python/src/ImportRenamed.lf
+++ b/test/Python/src/ImportRenamed.lf
@@ -11,5 +11,7 @@ main reactor {
   b = new Y()
   c = new Z()
 
-  reaction(t) -> a.x {= a.x.set(42) =}
+  reaction(t) -> a.x {=
+    a.x.set(42)
+  =}
 }

--- a/test/Python/src/ManualDelayedReaction.lf
+++ b/test/Python/src/ManualDelayedReaction.lf
@@ -18,14 +18,19 @@ reactor GeneratedDelay {
     act.schedule(MSEC(100))
   =}
 
-  reaction(act) -> y_out {= y_out.set(self.y_state) =}
+  reaction(act) -> y_out {=
+    y_out.set(self.y_state)
+  =}
 }
 
 reactor Source {
   output out
   timer t
 
-  reaction(t) -> out {= out.set(1) =}  # reaction(t) -> out after 100 msec
+  # reaction(t) -> out after 100 msec
+  reaction(t) -> out {=
+    out.set(1)
+  =}
 }
 
 reactor Sink {

--- a/test/Python/src/Methods.lf
+++ b/test/Python/src/Methods.lf
@@ -4,9 +4,13 @@ target Python
 main reactor {
   state foo = 2
 
-  method getFoo() {= return self.foo =}
+  method getFoo() {=
+    return self.foo
+  =}
 
-  method add(x) {= self.foo += x =}
+  method add(x) {=
+    self.foo += x
+  =}
 
   reaction(startup) {=
     print(f"Foo is initialized to {self.getFoo()}")

--- a/test/Python/src/MethodsRecursive.lf
+++ b/test/Python/src/MethodsRecursive.lf
@@ -11,7 +11,9 @@ main reactor {
     return self.add(self.fib(n-1), self.fib(n-2))
   =}
 
-  method add(x, y) {= return x + y =}
+  method add(x, y) {=
+    return x + y
+  =}
 
   reaction(startup) {=
     for n in range(1, 10):

--- a/test/Python/src/MethodsSameName.lf
+++ b/test/Python/src/MethodsSameName.lf
@@ -4,7 +4,9 @@ target Python
 reactor Foo {
   state foo = 2
 
-  method add(x) {= self.foo += x =}
+  method add(x) {=
+    self.foo += x
+  =}
 
   reaction(startup) {=
     self.add(40)
@@ -20,7 +22,9 @@ main reactor {
 
   a = new Foo()
 
-  method add(x) {= self.foo += x =}
+  method add(x) {=
+    self.foo += x
+  =}
 
   reaction(startup) {=
     self.add(40)

--- a/test/Python/src/Microsteps.lf
+++ b/test/Python/src/Microsteps.lf
@@ -33,5 +33,7 @@ main reactor Microsteps {
     repeat.schedule(0)
   =}
 
-  reaction(repeat) -> d.y {= d.y.set(1) =}
+  reaction(repeat) -> d.y {=
+    d.y.set(1)
+  =}
 }

--- a/test/Python/src/Minimal.lf
+++ b/test/Python/src/Minimal.lf
@@ -2,5 +2,7 @@
 target Python
 
 main reactor Minimal {
-  reaction(startup) {= print("Hello World.") =}
+  reaction(startup) {=
+    print("Hello World.")
+  =}
 }

--- a/test/Python/src/MultipleContained.lf
+++ b/test/Python/src/MultipleContained.lf
@@ -7,7 +7,9 @@ reactor Contained {
   input in1
   input in2
 
-  reaction(startup) -> trigger {= trigger.set(42) =}
+  reaction(startup) -> trigger {=
+    trigger.set(42)
+  =}
 
   reaction(in1) {=
     print("in1 received ", in1.value);

--- a/test/Python/src/ParameterizedState.lf
+++ b/test/Python/src/ParameterizedState.lf
@@ -3,7 +3,9 @@ target Python
 reactor Foo(bar=42) {
   state baz = bar
 
-  reaction(startup) {= print("Baz: ", self.baz) =}
+  reaction(startup) {=
+    print("Baz: ", self.baz)
+  =}
 }
 
 main reactor {

--- a/test/Python/src/ReadOutputOfContainedReactor.lf
+++ b/test/Python/src/ReadOutputOfContainedReactor.lf
@@ -4,7 +4,9 @@ target Python
 reactor Contained {
   output out
 
-  reaction(startup) -> out {= out.set(42) =}
+  reaction(startup) -> out {=
+    out.set(42)
+  =}
 }
 
 main reactor ReadOutputOfContainedReactor {

--- a/test/Python/src/Schedule.lf
+++ b/test/Python/src/Schedule.lf
@@ -5,7 +5,9 @@ reactor Schedule2 {
   input x
   logical action a
 
-  reaction(x) -> a {= a.schedule(MSEC(200)) =}
+  reaction(x) -> a {=
+    a.schedule(MSEC(200))
+  =}
 
   reaction(a) {=
     elapsed_time = lf.time.logical_elapsed()
@@ -20,5 +22,7 @@ main reactor {
   a = new Schedule2()
   timer t
 
-  reaction(t) -> a.x {= a.x.set(1) =}
+  reaction(t) -> a.x {=
+    a.x.set(1)
+  =}
 }

--- a/test/Python/src/ScheduleLogicalAction.lf
+++ b/test/Python/src/ScheduleLogicalAction.lf
@@ -16,7 +16,9 @@ reactor foo {
     a.schedule(MSEC(500))
   =}
 
-  reaction(a) -> y {= y.set(-42) =}
+  reaction(a) -> y {=
+    y.set(-42)
+  =}
 }
 
 reactor print {
@@ -41,5 +43,7 @@ main reactor {
   timer t(0, 1 sec)
   f.y -> p.x
 
-  reaction(t) -> f.x {= f.x.set(42) =}
+  reaction(t) -> f.x {=
+    f.x.set(42)
+  =}
 }

--- a/test/Python/src/SelfLoop.lf
+++ b/test/Python/src/SelfLoop.lf
@@ -23,7 +23,9 @@ reactor Self {
     a.schedule(MSEC(100), x.value)
   =}
 
-  reaction(startup) -> a {= a.schedule(0, 42) =}
+  reaction(startup) -> a {=
+    a.schedule(0, 42)
+  =}
 
   reaction(shutdown) {=
     if self.expected <= 43:

--- a/test/Python/src/SendingInside2.lf
+++ b/test/Python/src/SendingInside2.lf
@@ -15,5 +15,7 @@ main reactor SendingInside2 {
   timer t
   p = new Printer()
 
-  reaction(t) -> p.x {= p.x.set(1) =}
+  reaction(t) -> p.x {=
+    p.x.set(1)
+  =}
 }

--- a/test/Python/src/SetArray.lf
+++ b/test/Python/src/SetArray.lf
@@ -5,7 +5,9 @@ target Python
 reactor Source {
   output out
 
-  reaction(startup) -> out {= out.set([0,1,2]) =}
+  reaction(startup) -> out {=
+    out.set([0,1,2])
+  =}
 }
 
 # The scale parameter is just for testing.

--- a/test/Python/src/SimpleDeadline.lf
+++ b/test/Python/src/SimpleDeadline.lf
@@ -29,7 +29,9 @@ main reactor SimpleDeadline {
   d = new Deadline(threshold = 10 msec)
   p = new Print()
   d.deadlineViolation -> p._in
-  preamble {= import time =}
+  preamble {=
+    import time
+  =}
 
   reaction(start) -> d.x {=
     self.time.sleep(0.02)

--- a/test/Python/src/SlowingClock.lf
+++ b/test/Python/src/SlowingClock.lf
@@ -13,7 +13,9 @@ main reactor SlowingClock {
   state interval = 100 msec
   state expected_time = 100 msec
 
-  reaction(startup) -> a {= a.schedule(0) =}
+  reaction(startup) -> a {=
+    a.schedule(0)
+  =}
 
   reaction(a) -> a {=
     elapsed_logical_time = lf.time.logical_elapsed()

--- a/test/Python/src/StartupOutFromInside.lf
+++ b/test/Python/src/StartupOutFromInside.lf
@@ -3,7 +3,9 @@ target Python
 reactor Bar {
   output out
 
-  reaction(startup) -> out {= out.set(42) =}
+  reaction(startup) -> out {=
+    out.set(42)
+  =}
 }
 
 main reactor StartupOutFromInside {

--- a/test/Python/src/StructAsType.lf
+++ b/test/Python/src/StructAsType.lf
@@ -2,7 +2,9 @@ target Python {
   files: include/hello.py
 }
 
-preamble {= import hello =}
+preamble {=
+  import hello
+=}
 
 reactor Source {
   output out

--- a/test/Python/src/StructAsTypeDirect.lf
+++ b/test/Python/src/StructAsTypeDirect.lf
@@ -2,7 +2,9 @@ target Python {
   files: include/hello.py
 }
 
-preamble {= import hello =}
+preamble {=
+  import hello
+=}
 
 reactor Source {
   output out

--- a/test/Python/src/StructParallel.lf
+++ b/test/Python/src/StructParallel.lf
@@ -6,7 +6,9 @@ target Python {
 
 import Source from "StructScale.lf"
 
-preamble {= import hello =}
+preamble {=
+  import hello
+=}
 
 reactor Check(expected=42) {
   input _in

--- a/test/Python/src/StructPrint.lf
+++ b/test/Python/src/StructPrint.lf
@@ -4,12 +4,16 @@ target Python {
   files: ["include/hello.py"]
 }
 
-preamble {= import hello =}
+preamble {=
+  import hello
+=}
 
 reactor Print {
   output out
 
-  reaction(startup) -> out {= out.set(hello.hello("Earth", 42)) =}
+  reaction(startup) -> out {=
+    out.set(hello.hello("Earth", 42))
+  =}
 }
 
 # expected parameter is for testing.

--- a/test/Python/src/StructScale.lf
+++ b/test/Python/src/StructScale.lf
@@ -4,12 +4,16 @@ target Python {
   files: ["include/hello.py"]
 }
 
-preamble {= import hello =}
+preamble {=
+  import hello
+=}
 
 reactor Source {
   output out
 
-  reaction(startup) -> out {= out.set(hello.hello("Earth", 42)) =}
+  reaction(startup) -> out {=
+    out.set(hello.hello("Earth", 42))
+  =}
 }
 
 # expected parameter is for testing.

--- a/test/Python/src/TestForPreviousOutput.lf
+++ b/test/Python/src/TestForPreviousOutput.lf
@@ -4,7 +4,9 @@ target Python
 
 reactor Source {
   output out
-  preamble {= import random =}
+  preamble {=
+    import random
+  =}
 
   reaction(startup) -> out {=
     # Set a seed for random number generation based on the current time.

--- a/test/Python/src/TimeLimit.lf
+++ b/test/Python/src/TimeLimit.lf
@@ -42,5 +42,7 @@ main reactor TimeLimit(period = 1 sec) {
   d = new Destination()
   c.y -> d.x
 
-  reaction(stop) {= request_stop() =}
+  reaction(stop) {=
+    request_stop()
+  =}
 }

--- a/test/Python/src/TimeState.lf
+++ b/test/Python/src/TimeState.lf
@@ -3,7 +3,9 @@ target Python
 reactor Foo(bar=42) {
   state baz = 500 msec
 
-  reaction(startup) {= print("Baz: ", self.baz) =}
+  reaction(startup) {=
+    print("Baz: ", self.baz)
+  =}
 }
 
 main reactor {

--- a/test/Python/src/Timers.lf
+++ b/test/Python/src/Timers.lf
@@ -8,9 +8,13 @@ main reactor {
   timer t2(0, 2 sec)
   state counter = 0
 
-  reaction(t2) {= self.counter += 2 =}
+  reaction(t2) {=
+    self.counter += 2
+  =}
 
-  reaction(t) {= self.counter -= 1 =}
+  reaction(t) {=
+    self.counter -= 1
+  =}
 
   reaction(shutdown) {=
     if self.counter != 1:

--- a/test/Python/src/TriggerDownstreamOnlyIfPresent2.lf
+++ b/test/Python/src/TriggerDownstreamOnlyIfPresent2.lf
@@ -27,7 +27,9 @@ reactor Destination {
       exit(1)
   =}
 
-  reaction(shutdown) {= print("SUCCESS.") =}
+  reaction(shutdown) {=
+    print("SUCCESS.")
+  =}
 }
 
 main reactor TriggerDownstreamOnlyIfPresent2 {

--- a/test/Python/src/Wcet.lf
+++ b/test/Python/src/Wcet.lf
@@ -30,7 +30,9 @@ reactor Work {
 reactor Print {
   input p_in
 
-  reaction(p_in) {= print("Received: ", p_in.value) =}
+  reaction(p_in) {=
+    print("Received: ", p_in.value)
+  =}
 }
 
 main reactor Wcet {

--- a/test/Python/src/docker/FilesPropertyContainerized.lf
+++ b/test/Python/src/docker/FilesPropertyContainerized.lf
@@ -20,7 +20,9 @@ main reactor {
   state passed = False
   timer t(1 msec)
 
-  reaction(t) {= self.passed = True =}
+  reaction(t) {=
+    self.passed = True
+  =}
 
   reaction(shutdown) {=
     if not self.passed:

--- a/test/Python/src/federated/BroadcastFeedback.lf
+++ b/test/Python/src/federated/BroadcastFeedback.lf
@@ -8,7 +8,9 @@ reactor SenderAndReceiver {
   input[2] inp
   state received = False
 
-  reaction(startup) -> out {= out.set(42) =}
+  reaction(startup) -> out {=
+    out.set(42)
+  =}
 
   reaction(inp) {=
     if inp[0].is_present and inp[1].is_present and inp[0].value == 42 and inp[1].value == 42:

--- a/test/Python/src/federated/BroadcastFeedbackWithHierarchy.lf
+++ b/test/Python/src/federated/BroadcastFeedbackWithHierarchy.lf
@@ -11,11 +11,15 @@ reactor SenderAndReceiver {
   r = new Receiver()
   in_ -> r.in_
 
-  reaction(startup) -> out {= out.set(42) =}
+  reaction(startup) -> out {=
+    out.set(42)
+  =}
 }
 
 reactor Receiver {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input[2] in_
   state received = False
 

--- a/test/Python/src/federated/CycleDetection.lf
+++ b/test/Python/src/federated/CycleDetection.lf
@@ -21,15 +21,21 @@ reactor CAReplica {
       self.balance += remote_update.value
   =}
 
-  reaction(query) -> response {= response.set(self.balance) =}
+  reaction(query) -> response {=
+    response.set(self.balance)
+  =}
 }
 
 reactor UserInput {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input balance
   output deposit
 
-  reaction(startup) -> deposit {= deposit.set(100) =}
+  reaction(startup) -> deposit {=
+    deposit.set(100)
+  =}
 
   reaction(balance) {=
     if balance.value != 200:
@@ -39,7 +45,9 @@ reactor UserInput {
     request_stop()
   =}
 
-  reaction(shutdown) {= print("Test passed!") =}
+  reaction(shutdown) {=
+    print("Test passed!")
+  =}
 }
 
 federated reactor {

--- a/test/Python/src/federated/DecentralizedP2PComm.lf
+++ b/test/Python/src/federated/DecentralizedP2PComm.lf
@@ -6,7 +6,9 @@ target Python {
 }
 
 reactor Platform(start=0, expected_start=0, stp_offset_param=0) {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input in_
   output out
   timer t(0, 100 msec)

--- a/test/Python/src/federated/DecentralizedP2PUnbalancedTimeout.lf
+++ b/test/Python/src/federated/DecentralizedP2PUnbalancedTimeout.lf
@@ -22,16 +22,22 @@ reactor Clock(offset=0, period = 1 sec) {
     y.set(self.count)
   =}
 
-  reaction(shutdown) {= print("SUCCESS: the source exited successfully.") =}
+  reaction(shutdown) {=
+    print("SUCCESS: the source exited successfully.")
+  =}
 }
 
 reactor Destination {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input x
   state s = 1
   state startup_logical_time
 
-  reaction(startup) {= self.startup_logical_time = lf.time.logical() =}
+  reaction(startup) {=
+    self.startup_logical_time = lf.time.logical()
+  =}
 
   reaction(x) {=
     print("Received {}".format(x.value))

--- a/test/Python/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
+++ b/test/Python/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
@@ -21,11 +21,15 @@ reactor Clock(offset=0, period = 1 sec) {
     y.set(self.count)
   =}
 
-  reaction(shutdown) {= print("SUCCESS: the source exited successfully.") =}
+  reaction(shutdown) {=
+    print("SUCCESS: the source exited successfully.")
+  =}
 }
 
 reactor Destination {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input x
   state s = 1
 

--- a/test/Python/src/federated/DistributedBank.lf
+++ b/test/Python/src/federated/DistributedBank.lf
@@ -5,7 +5,9 @@ target Python {
 }
 
 reactor Node {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   timer t(0, 100 msec)
   state count = 0
 

--- a/test/Python/src/federated/DistributedBankToMultiport.lf
+++ b/test/Python/src/federated/DistributedBankToMultiport.lf
@@ -6,7 +6,9 @@ target Python {
 import Count from "../lib/Count.lf"
 
 reactor Destination {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input[2] in_
   state count = 1
 

--- a/test/Python/src/federated/DistributedCount.lf
+++ b/test/Python/src/federated/DistributedCount.lf
@@ -12,7 +12,9 @@ target Python {
 import Count from "../lib/Count.lf"
 
 reactor Print {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input in_
   state c = 1
 

--- a/test/Python/src/federated/DistributedCountDecentralized.lf
+++ b/test/Python/src/federated/DistributedCountDecentralized.lf
@@ -13,7 +13,9 @@ target Python {
 import Count from "../lib/Count.lf"
 
 reactor Print {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input in_
   state c = 1
 

--- a/test/Python/src/federated/DistributedCountDecentralizedLate.lf
+++ b/test/Python/src/federated/DistributedCountDecentralizedLate.lf
@@ -13,7 +13,9 @@ target Python {
 import Count from "../lib/Count.lf"
 
 reactor Print {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input in_             # STP ()
   state success = 0     # STP(in, 30 msec);
   state success_stp_violation = 0

--- a/test/Python/src/federated/DistributedCountPhysical.lf
+++ b/test/Python/src/federated/DistributedCountPhysical.lf
@@ -23,7 +23,9 @@ reactor Count {
 }
 
 reactor Print {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input in_
   state c = 0
 

--- a/test/Python/src/federated/DistributedCountPhysicalAfterDelay.lf
+++ b/test/Python/src/federated/DistributedCountPhysicalAfterDelay.lf
@@ -23,7 +23,9 @@ reactor Count {
 }
 
 reactor Print {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input in_
   state c = 0
 

--- a/test/Python/src/federated/DistributedCountPhysicalDecentralized.lf
+++ b/test/Python/src/federated/DistributedCountPhysicalDecentralized.lf
@@ -24,7 +24,9 @@ reactor Count {
 }
 
 reactor Print {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input in_
   state c = 0
 

--- a/test/Python/src/federated/DistributedDoublePort.lf
+++ b/test/Python/src/federated/DistributedDoublePort.lf
@@ -23,11 +23,15 @@ reactor CountMicrostep {
     self.count += 1
   =}
 
-  reaction(act) -> out {= out.set(act.value) =}
+  reaction(act) -> out {=
+    out.set(act.value)
+  =}
 }
 
 reactor Print {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input in_
   input in2
 
@@ -39,7 +43,9 @@ reactor Print {
       self.sys.exit(1)
   =}
 
-  reaction(shutdown) {= print("SUCCESS: messages were at least one microstep apart.") =}
+  reaction(shutdown) {=
+    print("SUCCESS: messages were at least one microstep apart.")
+  =}
 }
 
 federated reactor DistributedDoublePort {

--- a/test/Python/src/federated/DistributedLoopedAction.lf
+++ b/test/Python/src/federated/DistributedLoopedAction.lf
@@ -10,7 +10,9 @@ target Python {
 import Sender from "../lib/LoopedActionSender.lf"
 
 reactor Receiver(take_a_break_after=10, break_interval = 400 msec) {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input in_
   state received_messages = 0
   state total_received_messages = 0

--- a/test/Python/src/federated/DistributedLoopedPhysicalAction.lf
+++ b/test/Python/src/federated/DistributedLoopedPhysicalAction.lf
@@ -32,7 +32,9 @@ reactor Sender(take_a_break_after=10, break_interval = 550 msec) {
 }
 
 reactor Receiver(take_a_break_after=10, break_interval = 550 msec) {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input in_
   state received_messages = 0
   state total_received_messages = 0
@@ -42,7 +44,9 @@ reactor Receiver(take_a_break_after=10, break_interval = 550 msec) {
   # but forces the logical time to advance Comment this line for a more sensible log output.
   state base_logical_time
 
-  reaction(startup) {= self.base_logical_time = lf.time.logical() =}
+  reaction(startup) {=
+    self.base_logical_time = lf.time.logical()
+  =}
 
   reaction(in_) {=
     current_tag = lf.tag()

--- a/test/Python/src/federated/DistributedMultiport.lf
+++ b/test/Python/src/federated/DistributedMultiport.lf
@@ -17,7 +17,9 @@ reactor Source {
 }
 
 reactor Destination {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input[4] in_
   state count = 0
 

--- a/test/Python/src/federated/DistributedMultiportToBank.lf
+++ b/test/Python/src/federated/DistributedMultiportToBank.lf
@@ -16,7 +16,9 @@ reactor Source {
 }
 
 reactor Destination {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input in_
   state count = 0
 

--- a/test/Python/src/federated/DistributedNoReact.lf
+++ b/test/Python/src/federated/DistributedNoReact.lf
@@ -15,7 +15,9 @@ reactor A {
 reactor B {
   output o
 
-  reaction(startup) -> o {= o.set(C()) =}
+  reaction(startup) -> o {=
+    o.set(C())
+  =}
 }
 
 federated reactor {

--- a/test/Python/src/federated/DistributedSendClass.lf
+++ b/test/Python/src/federated/DistributedSendClass.lf
@@ -9,13 +9,17 @@ preamble {=
 reactor A {
   input o
 
-  reaction(o) {= request_stop() =}
+  reaction(o) {=
+    request_stop()
+  =}
 }
 
 reactor B {
   output o
 
-  reaction(startup) -> o {= o.set(C()) =}
+  reaction(startup) -> o {=
+    o.set(C())
+  =}
 }
 
 federated reactor {

--- a/test/Python/src/federated/DistributedStop.lf
+++ b/test/Python/src/federated/DistributedStop.lf
@@ -5,7 +5,9 @@
  */
 target Python
 
-preamble {= import sys =}
+preamble {=
+  import sys
+=}
 
 reactor Sender {
   output out

--- a/test/Python/src/federated/DistributedStopZero.lf
+++ b/test/Python/src/federated/DistributedStopZero.lf
@@ -6,14 +6,18 @@
 # reason for failing: lf_tag().microstep and lf.tag_compare() are not not supported in python target
 target Python
 
-preamble {= import sys =}
+preamble {=
+  import sys
+=}
 
 reactor Sender {
   output out
   timer t(0, 1 usec)
   state startup_logical_time
 
-  reaction(startup) {= self.startup_logical_time = lf.time.logical() =}
+  reaction(startup) {=
+    self.startup_logical_time = lf.time.logical()
+  =}
 
   reaction(t) -> out {=
     tag = lf.tag()
@@ -47,7 +51,9 @@ reactor Receiver {
   input in_
   state startup_logical_time
 
-  reaction(startup) {= self.startup_logical_time = lf.time.logical() =}
+  reaction(startup) {=
+    self.startup_logical_time = lf.time.logical()
+  =}
 
   reaction(in_) {=
     tag = lf.tag()

--- a/test/Python/src/federated/DistributedStructAsType.lf
+++ b/test/Python/src/federated/DistributedStructAsType.lf
@@ -5,7 +5,9 @@ target Python {
 
 import Source, Print from "../StructAsType.lf"
 
-preamble {= import hello =}
+preamble {=
+  import hello
+=}
 
 federated reactor {
   s = new Source()

--- a/test/Python/src/federated/DistributedStructAsType.lf
+++ b/test/Python/src/federated/DistributedStructAsType.lf
@@ -5,10 +5,6 @@ target Python {
 
 import Source, Print from "../StructAsType.lf"
 
-preamble {=
-  import hello
-=}
-
 federated reactor {
   s = new Source()
   p = new Print()

--- a/test/Python/src/federated/DistributedStructAsTypeDirect.lf
+++ b/test/Python/src/federated/DistributedStructAsTypeDirect.lf
@@ -5,10 +5,6 @@ target Python {
 
 import Source, Print from "../StructAsTypeDirect.lf"
 
-preamble {=
-  import hello
-=}
-
 federated reactor {
   s = new Source()
   p = new Print()

--- a/test/Python/src/federated/DistributedStructAsTypeDirect.lf
+++ b/test/Python/src/federated/DistributedStructAsTypeDirect.lf
@@ -5,7 +5,9 @@ target Python {
 
 import Source, Print from "../StructAsTypeDirect.lf"
 
-preamble {= import hello =}
+preamble {=
+  import hello
+=}
 
 federated reactor {
   s = new Source()

--- a/test/Python/src/federated/DistributedStructParallel.lf
+++ b/test/Python/src/federated/DistributedStructParallel.lf
@@ -8,10 +8,6 @@ target Python {
 import Source from "../StructScale.lf"
 import Check, Print from "../StructParallel.lf"
 
-preamble {=
-  import hello
-=}
-
 federated reactor {
   s = new Source()
   c1 = new Print()

--- a/test/Python/src/federated/DistributedStructParallel.lf
+++ b/test/Python/src/federated/DistributedStructParallel.lf
@@ -8,7 +8,9 @@ target Python {
 import Source from "../StructScale.lf"
 import Check, Print from "../StructParallel.lf"
 
-preamble {= import hello =}
+preamble {=
+  import hello
+=}
 
 federated reactor {
   s = new Source()

--- a/test/Python/src/federated/DistributedStructPrint.lf
+++ b/test/Python/src/federated/DistributedStructPrint.lf
@@ -7,10 +7,6 @@ target Python {
 
 import Print, Check from "../StructPrint.lf"
 
-preamble {=
-  import hello
-=}
-
 federated reactor {
   s = new Print()
   p = new Check()

--- a/test/Python/src/federated/DistributedStructPrint.lf
+++ b/test/Python/src/federated/DistributedStructPrint.lf
@@ -7,7 +7,9 @@ target Python {
 
 import Print, Check from "../StructPrint.lf"
 
-preamble {= import hello =}
+preamble {=
+  import hello
+=}
 
 federated reactor {
   s = new Print()

--- a/test/Python/src/federated/DistributedStructScale.lf
+++ b/test/Python/src/federated/DistributedStructScale.lf
@@ -7,10 +7,6 @@ target Python {
 
 import Source, TestInput, Print from "../StructScale.lf"
 
-preamble {=
-  import hello
-=}
-
 federated reactor {
   s = new Source()
   c = new Print()

--- a/test/Python/src/federated/DistributedStructScale.lf
+++ b/test/Python/src/federated/DistributedStructScale.lf
@@ -7,7 +7,9 @@ target Python {
 
 import Source, TestInput, Print from "../StructScale.lf"
 
-preamble {= import hello =}
+preamble {=
+  import hello
+=}
 
 federated reactor {
   s = new Source()

--- a/test/Python/src/federated/HelloDistributed.lf
+++ b/test/Python/src/federated/HelloDistributed.lf
@@ -20,7 +20,9 @@ reactor Destination {
   input _in
   state received = False
 
-  reaction(startup) {= print("Destination started.") =}
+  reaction(startup) {=
+    print("Destination started.")
+  =}
 
   reaction(_in) {=
     print(f"At logical time {lf.time.logical_elapsed()}, destination received {_in.value}")

--- a/test/Python/src/federated/LoopDistributedCentralizedPrecedenceHierarchy.lf
+++ b/test/Python/src/federated/LoopDistributedCentralizedPrecedenceHierarchy.lf
@@ -19,9 +19,13 @@ reactor Contained(incr=1) {
   state count = 0
   state received_count = 0
 
-  reaction(t) {= self.count += self.incr =}
+  reaction(t) {=
+    self.count += self.incr
+  =}
 
-  reaction(inp) {= self.received_count = self.count =}
+  reaction(inp) {=
+    self.received_count = self.count
+  =}
 
   reaction(t) {=
     if self.received_count != self.count:

--- a/test/Python/src/federated/PhysicalSTP.lf
+++ b/test/Python/src/federated/PhysicalSTP.lf
@@ -7,7 +7,9 @@ target Python {
 import Count from "../lib/Count.lf"
 
 reactor Print(STP_offset=0) {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   input in_
   state c = 1
 

--- a/test/Python/src/federated/PingPongDistributed.lf
+++ b/test/Python/src/federated/PingPongDistributed.lf
@@ -40,7 +40,9 @@ reactor Ping(count=10) {
 }
 
 reactor Pong(expected=10) {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
 
   input receive
   output send

--- a/test/Python/src/federated/StopAtShutdown.lf
+++ b/test/Python/src/federated/StopAtShutdown.lf
@@ -12,20 +12,30 @@ target Python {
 reactor A {
   input in_
 
-  reaction(startup) {= print("Hello World!") =}
+  reaction(startup) {=
+    print("Hello World!")
+  =}
 
-  reaction(in_) {= print("Got it") =}
+  reaction(in_) {=
+    print("Got it")
+  =}
 
-  reaction(shutdown) {= request_stop() =}
+  reaction(shutdown) {=
+    request_stop()
+  =}
 }
 
 reactor B {
   output out
   timer t(1 sec)
 
-  reaction(t) -> out {= out.set(1) =}
+  reaction(t) -> out {=
+    out.set(1)
+  =}
 
-  reaction(shutdown) {= request_stop() =}
+  reaction(shutdown) {=
+    request_stop()
+  =}
 }
 
 federated reactor {

--- a/test/Python/src/lib/Imported.lf
+++ b/test/Python/src/lib/Imported.lf
@@ -8,5 +8,7 @@ reactor Imported {
   input x
   a = new ImportedAgain()
 
-  reaction(x) -> a.x {= a.x.set(x.value) =}
+  reaction(x) -> a.x {=
+    a.x.set(x.value)
+  =}
 }

--- a/test/Python/src/lib/ImportedComposition.lf
+++ b/test/Python/src/lib/ImportedComposition.lf
@@ -6,7 +6,9 @@ reactor Gain {
   input x
   output y
 
-  reaction(x) -> y {= y.set(x.value * 2) =}
+  reaction(x) -> y {=
+    y.set(x.value * 2)
+  =}
 }
 
 reactor ImportedComposition {

--- a/test/Python/src/lib/InternalDelay.lf
+++ b/test/Python/src/lib/InternalDelay.lf
@@ -5,7 +5,11 @@ reactor InternalDelay(delay = 10 msec) {
   output out
   logical action d
 
-  reaction(in_) -> d {= d.schedule(self.delay, in_.value) =}
+  reaction(in_) -> d {=
+    d.schedule(self.delay, in_.value)
+  =}
 
-  reaction(d) -> out {= out.set(d.value) =}
+  reaction(d) -> out {=
+    out.set(d.value)
+  =}
 }

--- a/test/Python/src/lib/TestCount.lf
+++ b/test/Python/src/lib/TestCount.lf
@@ -9,7 +9,9 @@
 target Python
 
 reactor TestCount(start=1, stride=1, num_inputs=1) {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   state count = start
   state inputs_received = 0
   input in_

--- a/test/Python/src/lib/TestCountMultiport.lf
+++ b/test/Python/src/lib/TestCountMultiport.lf
@@ -11,7 +11,9 @@
 target Python
 
 reactor TestCountMultiport(start=1, stride=1, num_inputs=1, width=2) {
-  preamble {= import sys =}
+  preamble {=
+    import sys
+  =}
   state count = start
   state inputs_received = 0
   input[width] inp

--- a/test/Python/src/modal_models/BanksCount3ModesComplex.lf
+++ b/test/Python/src/modal_models/BanksCount3ModesComplex.lf
@@ -25,7 +25,9 @@ reactor MetaCounter {
     mode1_counters.count -> mode1
 
     timer t1(500 msec, 250 msec)
-    reaction(t1) -> reset(Two) {= Two.set() =}
+    reaction(t1) -> reset(Two) {=
+      Two.set()
+    =}
   }
 
   mode Two {
@@ -35,7 +37,9 @@ reactor MetaCounter {
     mode2_counters.count -> mode2
 
     timer t2(500 msec, 250 msec)
-    reaction(t2) -> history(One) {= One.set() =}
+    reaction(t2) -> history(One) {=
+      One.set()
+    =}
   }
 
   mode Three {

--- a/test/Python/src/modal_models/ConvertCaseTest.lf
+++ b/test/Python/src/modal_models/ConvertCaseTest.lf
@@ -15,13 +15,19 @@ reactor ResetProcessor {
     converter = new Converter()
     character -> converter.raw
     converter.converted -> converted
-    reaction(discard) -> reset(Discarding) {= Discarding.set() =}
+    reaction(discard) -> reset(Discarding) {=
+      Discarding.set()
+    =}
   }
 
   mode Discarding {
-    reaction(character) -> converted {= converted.set('_') =}
+    reaction(character) -> converted {=
+      converted.set('_')
+    =}
 
-    reaction(character) -> reset(Converting) {= Converting.set() =}
+    reaction(character) -> reset(Converting) {=
+      Converting.set()
+    =}
   }
 }
 
@@ -34,13 +40,19 @@ reactor HistoryProcessor {
     converter = new Converter()
     character -> converter.raw
     converter.converted -> converted
-    reaction(discard) -> reset(Discarding) {= Discarding.set() =}
+    reaction(discard) -> reset(Discarding) {=
+      Discarding.set()
+    =}
   }
 
   mode Discarding {
-    reaction(character) -> converted {= converted.set('_') =}
+    reaction(character) -> converted {=
+      converted.set('_')
+    =}
 
-    reaction(character) -> history(Converting) {= Converting.set() =}
+    reaction(character) -> history(Converting) {=
+      Converting.set()
+    =}
   }
 }
 
@@ -113,7 +125,11 @@ main reactor {
     history_processor.discard.set(True)
   =}
 
-  reaction(reset_processor.converted) {= print(f"Reset: {reset_processor.converted.value}") =}
+  reaction(reset_processor.converted) {=
+    print(f"Reset: {reset_processor.converted.value}")
+  =}
 
-  reaction(history_processor.converted) {= print(f"History: {history_processor.converted.value}") =}
+  reaction(history_processor.converted) {=
+    print(f"History: {history_processor.converted.value}")
+  =}
 }

--- a/test/Python/src/modal_models/Count3Modes.lf
+++ b/test/Python/src/modal_models/Count3Modes.lf
@@ -36,7 +36,10 @@ main reactor {
 
   state expected_value = 1
 
-  reaction(stepper) -> counter.next {= counter.next.set(True) =}  # Trigger
+  # Trigger
+  reaction(stepper) -> counter.next {=
+    counter.next.set(True)
+  =}
 
   # Check
   reaction(stepper) counter.count {=

--- a/test/Python/src/modal_models/ModalActions.lf
+++ b/test/Python/src/modal_models/ModalActions.lf
@@ -89,5 +89,8 @@ main reactor {
   modal.action2_sched,
   modal.action2_exec -> test.events
 
-  reaction(stepper) -> modal.next {= modal.next.set(True) =}  # Trigger mode change
+  # Trigger mode change
+  reaction(stepper) -> modal.next {=
+    modal.next.set(True)
+  =}
 }

--- a/test/Python/src/modal_models/ModalAfter.lf
+++ b/test/Python/src/modal_models/ModalAfter.lf
@@ -91,5 +91,8 @@ main reactor {
   modal.mode_switch, modal.produced1, modal.consumed1, modal.produced2, modal.consumed2
     -> test.events
 
-  reaction(stepper) -> modal.next {= modal.next.set(True) =}  # Trigger mode change
+  # Trigger mode change
+  reaction(stepper) -> modal.next {=
+    modal.next.set(True)
+  =}
 }

--- a/test/Python/src/modal_models/ModalCycleBreaker.lf
+++ b/test/Python/src/modal_models/ModalCycleBreaker.lf
@@ -28,7 +28,9 @@ reactor Modal {
   }
 
   initial mode One {
-    reaction(in1) -> out {= out.set(in1.value) =}
+    reaction(in1) -> out {=
+      out.set(in1.value)
+    =}
 
     reaction(in1) -> reset(Two) {=
       if in1.value % 5 == 4:
@@ -70,5 +72,8 @@ main reactor {
 
   modal.out -> test.events
 
-  reaction(modal.out) {= print(modal.out.value) =}  # Print
+  # Print
+  reaction(modal.out) {=
+    print(modal.out.value)
+  =}
 }

--- a/test/Python/src/modal_models/ModalNestedReactions.lf
+++ b/test/Python/src/modal_models/ModalNestedReactions.lf
@@ -29,7 +29,9 @@ reactor CounterCycle {
   }
 
   mode Three {
-    reaction(next) -> never {= never.set(True) =}
+    reaction(next) -> never {=
+      never.set(True)
+    =}
   }
 }
 
@@ -37,14 +39,19 @@ reactor Forward {
   input inp
   output out
 
-  reaction(inp) -> out {= out.set(inp.value) =}
+  reaction(inp) -> out {=
+    out.set(inp.value)
+  =}
 }
 
 main reactor {
   timer stepper(0, 250 msec)
   counter = new CounterCycle()
 
-  reaction(stepper) -> counter.next {= counter.next.set(True) =}  # Trigger
+  # Trigger
+  reaction(stepper) -> counter.next {=
+    counter.next.set(True)
+  =}
 
   # Check
   reaction(stepper) counter.count, counter.only_in_two {=

--- a/test/Python/src/modal_models/ModalStartupShutdown.lf
+++ b/test/Python/src/modal_models/ModalStartupShutdown.lf
@@ -137,5 +137,8 @@ main reactor {
   modal.reset5,
   modal.shutdown5 -> test.events
 
-  reaction(stepper) -> modal.next {= modal.next.set(True) =}  # Trigger mode change
+  # Trigger mode change
+  reaction(stepper) -> modal.next {=
+    modal.next.set(True)
+  =}
 }

--- a/test/Python/src/modal_models/ModalStateReset.lf
+++ b/test/Python/src/modal_models/ModalStateReset.lf
@@ -25,7 +25,9 @@ reactor Modal {
   initial mode One {
     state counter1 = 0
     timer T1(0 msec, 250 msec)
-    reaction(reset) {= self.counter1 = 0 =}
+    reaction(reset) {=
+      self.counter1 = 0
+    =}
 
     reaction(T1) -> count1 {=
       print(f"Counter1: {self.counter1}")
@@ -43,7 +45,9 @@ reactor Modal {
   mode Two {
     state counter2 = -2
     timer T2(0 msec, 250 msec)
-    reaction(reset) {= self.counter2 = -2 =}
+    reaction(reset) {=
+      self.counter2 = -2
+    =}
 
     reaction(T2) -> count2 {=
       print(f"Counter2: {self.counter2}")
@@ -87,5 +91,8 @@ main reactor {
 
   modal.mode_switch, modal.count0, modal.count1, modal.count2 -> test.events
 
-  reaction(stepper) -> modal.next {= modal.next.set(True) =}  # Trigger mode change
+  # Trigger mode change
+  reaction(stepper) -> modal.next {=
+    modal.next.set(True)
+  =}
 }

--- a/test/Python/src/modal_models/ModalStateResetAuto.lf
+++ b/test/Python/src/modal_models/ModalStateResetAuto.lf
@@ -83,5 +83,8 @@ main reactor {
 
   modal.mode_switch, modal.count0, modal.count1, modal.count2 -> test.events
 
-  reaction(stepper) -> modal.next {= modal.next.set(True) =}  # Trigger mode change
+  # Trigger mode change
+  reaction(stepper) -> modal.next {=
+    modal.next.set(True)
+  =}
 }

--- a/test/Python/src/modal_models/ModalTimers.lf
+++ b/test/Python/src/modal_models/ModalTimers.lf
@@ -62,5 +62,8 @@ main reactor {
 
   modal.mode_switch, modal.timer1, modal.timer2 -> test.events
 
-  reaction(stepper) -> modal.next {= modal.next.set(True) =}  # Trigger mode change
+  # Trigger mode change
+  reaction(stepper) -> modal.next {=
+    modal.next.set(True)
+  =}
 }

--- a/test/Python/src/modal_models/MultipleOutputFeeder_2Connections.lf
+++ b/test/Python/src/modal_models/MultipleOutputFeeder_2Connections.lf
@@ -18,13 +18,17 @@ reactor Modal {
   initial mode One {
     counter1 = new Counter(period = 250 msec)
     counter1.value -> count
-    reaction(next) -> reset(Two) {= Two.set() =}
+    reaction(next) -> reset(Two) {=
+      Two.set()
+    =}
   }
 
   mode Two {
     counter2 = new Counter(period = 100 msec)
     counter2.value -> count
-    reaction(next) -> history(One) {= One.set() =}
+    reaction(next) -> history(One) {=
+      One.set()
+    =}
   }
 }
 
@@ -66,7 +70,13 @@ main reactor {
 
   modal.count -> test.events
 
-  reaction(stepper) -> modal.next {= modal.next.set(True) =}  # Trigger mode change
+  # Trigger mode change
+  reaction(stepper) -> modal.next {=
+    modal.next.set(True)
+  =}
 
-  reaction(modal.count) {= print(modal.count.value) =}        # Print
+  # Print
+  reaction(modal.count) {=
+    print(modal.count.value)
+  =}
 }

--- a/test/Python/src/modal_models/MultipleOutputFeeder_ReactionConnections.lf
+++ b/test/Python/src/modal_models/MultipleOutputFeeder_ReactionConnections.lf
@@ -18,14 +18,20 @@ reactor Modal {
   initial mode One {
     counter1 = new Counter(period = 250 msec)
     counter1.value -> count
-    reaction(next) -> reset(Two) {= Two.set() =}
+    reaction(next) -> reset(Two) {=
+      Two.set()
+    =}
   }
 
   mode Two {
     counter2 = new Counter(period = 100 msec)
-    reaction(counter2.value) -> count {= count.set(counter2.value.value * 10) =}
+    reaction(counter2.value) -> count {=
+      count.set(counter2.value.value * 10)
+    =}
 
-    reaction(next) -> history(One) {= One.set() =}
+    reaction(next) -> history(One) {=
+      One.set()
+    =}
   }
 }
 
@@ -67,7 +73,13 @@ main reactor {
 
   modal.count -> test.events
 
-  reaction(stepper) -> modal.next {= modal.next.set(True) =}  # Trigger mode change
+  # Trigger mode change
+  reaction(stepper) -> modal.next {=
+    modal.next.set(True)
+  =}
 
-  reaction(modal.count) {= print(modal.count.value) =}        # Print
+  # Print
+  reaction(modal.count) {=
+    print(modal.count.value)
+  =}
 }

--- a/test/Python/src/modal_models/util/TraceTesting.lf
+++ b/test/Python/src/modal_models/util/TraceTesting.lf
@@ -9,7 +9,9 @@ reactor TraceTesting(events_size=0, trace = {= [] =}, training=False) {
   state recorded_events = {= [] =}
   state recorded_events_next = 0
 
-  reaction(startup) {= self.last_reaction_time = lf.time.logical() =}
+  reaction(startup) {=
+    self.last_reaction_time = lf.time.logical()
+  =}
 
   reaction(events) {=
     # Time passed since last reaction

--- a/test/Python/src/multiport/BankIndexInitializer.lf
+++ b/test/Python/src/multiport/BankIndexInitializer.lf
@@ -1,12 +1,16 @@
 # Test bank of reactors to multiport input with id parameter in the bank.
 target Python
 
-preamble {= table = [4, 3, 2, 1] =}
+preamble {=
+  table = [4, 3, 2, 1]
+=}
 
 reactor Source(bank_index=0, value=0) {
   output out
 
-  reaction(startup) -> out {= out.set(self.value) =}
+  reaction(startup) -> out {=
+    out.set(self.value)
+  =}
 }
 
 reactor Sink(width=4) {

--- a/test/Python/src/multiport/BankToMultiport.lf
+++ b/test/Python/src/multiport/BankToMultiport.lf
@@ -4,7 +4,9 @@ target Python
 reactor Source(bank_index=0) {
   output out
 
-  reaction(startup) -> out {= out.set(self.bank_index) =}
+  reaction(startup) -> out {=
+    out.set(self.bank_index)
+  =}
 }
 
 reactor Sink(width=4) {

--- a/test/Python/src/multiport/Broadcast.lf
+++ b/test/Python/src/multiport/Broadcast.lf
@@ -6,7 +6,9 @@ target Python {
 reactor Source(value=42) {
   output out
 
-  reaction(startup) -> out {= out.set(self.value) =}
+  reaction(startup) -> out {=
+    out.set(self.value)
+  =}
 }
 
 reactor Destination(bank_index=0, delay=0) {

--- a/test/Python/src/multiport/MultiportFromBank.lf
+++ b/test/Python/src/multiport/MultiportFromBank.lf
@@ -8,7 +8,9 @@ target Python {
 reactor Source(check_override=0, bank_index=0) {
   output out
 
-  reaction(startup) -> out {= out.set(self.bank_index * self.check_override) =}
+  reaction(startup) -> out {=
+    out.set(self.bank_index * self.check_override)
+  =}
 }
 
 reactor Destination {

--- a/test/Python/src/multiport/MultiportFromBankHierarchy.lf
+++ b/test/Python/src/multiport/MultiportFromBankHierarchy.lf
@@ -10,7 +10,9 @@ import Destination from "MultiportFromBank.lf"
 reactor Source(bank_index=0) {
   output out
 
-  reaction(startup) -> out {= out.set(self.bank_index) =}
+  reaction(startup) -> out {=
+    out.set(self.bank_index)
+  =}
 }
 
 reactor Container {

--- a/test/Python/src/multiport/MultiportIn.lf
+++ b/test/Python/src/multiport/MultiportIn.lf
@@ -20,7 +20,9 @@ reactor Computation {
   input _in
   output out
 
-  reaction(_in) -> out {= out.set(_in.value) =}
+  reaction(_in) -> out {=
+    out.set(_in.value)
+  =}
 }
 
 reactor Destination {

--- a/test/Python/src/multiport/MultiportInParameterized.lf
+++ b/test/Python/src/multiport/MultiportInParameterized.lf
@@ -20,7 +20,9 @@ reactor Computation {
   input _in
   output out
 
-  reaction(_in) -> out {= out.set(_in.value) =}
+  reaction(_in) -> out {=
+    out.set(_in.value)
+  =}
 }
 
 reactor Destination(width=1) {

--- a/test/Python/src/multiport/MultiportOut.lf
+++ b/test/Python/src/multiport/MultiportOut.lf
@@ -21,7 +21,9 @@ reactor Computation {
   input _in
   output out
 
-  reaction(_in) -> out {= out.set(_in.value) =}
+  reaction(_in) -> out {=
+    out.set(_in.value)
+  =}
 }
 
 reactor Destination {

--- a/test/Python/src/multiport/PipelineAfter.lf
+++ b/test/Python/src/multiport/PipelineAfter.lf
@@ -3,14 +3,18 @@ target Python
 reactor Source {
   output out
 
-  reaction(startup) -> out {= out.set(40) =}
+  reaction(startup) -> out {=
+    out.set(40)
+  =}
 }
 
 reactor Compute {
   input inp
   output out
 
-  reaction(inp) -> out {= out.set(inp.value + 2) =}
+  reaction(inp) -> out {=
+    out.set(inp.value + 2)
+  =}
 }
 
 reactor Sink {

--- a/test/Python/src/multiport/ReactionsToNested.lf
+++ b/test/Python/src/multiport/ReactionsToNested.lf
@@ -32,7 +32,11 @@ reactor D {
 main reactor {
   d = new D()
 
-  reaction(startup) -> d.y {= d.y[0].set(42) =}
+  reaction(startup) -> d.y {=
+    d.y[0].set(42)
+  =}
 
-  reaction(startup) -> d.y {= d.y[1].set(43) =}
+  reaction(startup) -> d.y {=
+    d.y[1].set(43)
+  =}
 }

--- a/test/Python/src/target/AfterNoTypes.lf
+++ b/test/Python/src/target/AfterNoTypes.lf
@@ -9,7 +9,9 @@ reactor Foo {
   input x
   output y
 
-  reaction(x) -> y {= y.set(2*x.value); =}
+  reaction(x) -> y {=
+    y.set(2*x.value);
+  =}
 }
 
 reactor Print {
@@ -46,5 +48,7 @@ main reactor {
   timer t(0, 1 sec)
   f.y -> p.x after 10 msec
 
-  reaction(t) -> f.x {= f.x.set(42) =}
+  reaction(t) -> f.x {=
+    f.x.set(42)
+  =}
 }

--- a/test/Rust/src/ActionImplicitDelay.lf
+++ b/test/Rust/src/ActionImplicitDelay.lf
@@ -5,7 +5,9 @@ main reactor ActionImplicitDelay {
   logical action act(40 msec)
   state count: u64 = 1
 
-  reaction(startup) -> act {= ctx.schedule(act, Asap); =}
+  reaction(startup) -> act {=
+    ctx.schedule(act, Asap);
+  =}
 
   reaction(act) -> act {=
     assert_tag_is!(ctx, T0 + (40 * self.count) ms);

--- a/test/Rust/src/ActionValuesCleanup.lf
+++ b/test/Rust/src/ActionValuesCleanup.lf
@@ -22,7 +22,9 @@ main reactor ActionValuesCleanup {
   logical action act: FooDrop
   state count: u32 = 0
 
-  reaction(startup) -> act {= ctx.schedule_with_v(act, Some(FooDrop { }), Asap) =}
+  reaction(startup) -> act {=
+    ctx.schedule_with_v(act, Some(FooDrop { }), Asap)
+  =}
 
   reaction(act) -> act {=
     ctx.use_ref(act, |v| println!("{:?}", v));

--- a/test/Rust/src/CompositionInitializationOrder.lf
+++ b/test/Rust/src/CompositionInitializationOrder.lf
@@ -5,13 +5,19 @@ main reactor CompositionInitializationOrder {
   c1 = new Component1()
   c2 = new Component2()
 
-  reaction(startup) {= println!("parent woke up"); =}
+  reaction(startup) {=
+    println!("parent woke up");
+  =}
 }
 
 reactor Component2 {
-  reaction(startup) {= println!("c2 woke up"); =}
+  reaction(startup) {=
+    println!("c2 woke up");
+  =}
 }
 
 reactor Component1 {
-  reaction(startup) {= println!("c1 woke up"); =}
+  reaction(startup) {=
+    println!("c1 woke up");
+  =}
 }

--- a/test/Rust/src/CompositionWithPorts.lf
+++ b/test/Rust/src/CompositionWithPorts.lf
@@ -3,7 +3,9 @@ target Rust
 reactor Source {
   output out: i32
 
-  reaction(startup) -> out {= ctx.set(out, 76600) =}
+  reaction(startup) -> out {=
+    ctx.set(out, 76600)
+  =}
 }
 
 reactor Sink {

--- a/test/Rust/src/DependencyOnChildPort.lf
+++ b/test/Rust/src/DependencyOnChildPort.lf
@@ -16,9 +16,13 @@ main reactor {
 
   box0.out -> box1.inp
 
-  reaction(startup) -> box0.inp {= ctx.set(box0__inp, 444); =}
+  reaction(startup) -> box0.inp {=
+    ctx.set(box0__inp, 444);
+  =}
 
-  reaction(box1.out) {= assert!(ctx.get_elapsed_logical_time().is_zero()); self.done = true; =}
+  reaction(box1.out) {=
+    assert!(ctx.get_elapsed_logical_time().is_zero()); self.done = true;
+  =}
 
   reaction(shutdown) {=
     assert!(self.done, "reaction was not executed");

--- a/test/Rust/src/DependencyThroughChildPort.lf
+++ b/test/Rust/src/DependencyThroughChildPort.lf
@@ -40,5 +40,7 @@ main reactor {
     ctx.schedule(repeat, Asap);
   =}
 
-  reaction(repeat) -> d.y {= ctx.set(d__y, 1); =}
+  reaction(repeat) -> d.y {=
+    ctx.set(d__y, 1);
+  =}
 }

--- a/test/Rust/src/DependencyUseAccessible.lf
+++ b/test/Rust/src/DependencyUseAccessible.lf
@@ -8,11 +8,18 @@ reactor Source {
   timer t1(35 msec)
   timer t2(70 msec)
 
-  reaction(startup) -> clock {= ctx.set(clock, 0); =}
+  reaction(startup) -> clock {=
+    ctx.set(clock, 0);
+  =}
 
-  reaction(t1) -> clock, o1 {= ctx.set(clock, 1); ctx.set(o1, 10) =}
+  reaction(t1) -> clock, o1 {=
+    ctx.set(clock, 1); ctx.set(o1, 10)
+  =}
 
-  reaction(t2) -> clock, o2 {= ctx.set(clock, 2); =}  // has a dependency but doesn't use it
+  // has a dependency but doesn't use it
+  reaction(t2) -> clock, o2 {=
+    ctx.set(clock, 2);
+  =}
 }
 
 reactor Sink {

--- a/test/Rust/src/DependencyUseNonTrigger.lf
+++ b/test/Rust/src/DependencyUseNonTrigger.lf
@@ -4,16 +4,22 @@ target Rust
 reactor Source {
   output clock: u32
 
-  reaction(startup) -> clock {= ctx.set(clock, 0); =}
+  reaction(startup) -> clock {=
+    ctx.set(clock, 0);
+  =}
 }
 
 reactor Sink {
   input clock: u32
   input bogus: u32
 
-  reaction(bogus) clock {= panic!("Should not be executed") =}
+  reaction(bogus) clock {=
+    panic!("Should not be executed")
+  =}
 
-  reaction(shutdown) {= println!("Success") =}
+  reaction(shutdown) {=
+    println!("Success")
+  =}
 }
 
 main reactor {

--- a/test/Rust/src/Import.lf
+++ b/test/Rust/src/Import.lf
@@ -7,5 +7,7 @@ main reactor Import {
   timer t
   a = new Imported()
 
-  reaction(t) -> a.x {= ctx.set(a__x, 42); =}
+  reaction(t) -> a.x {=
+    ctx.set(a__x, 42);
+  =}
 }

--- a/test/Rust/src/ImportPreambleItem.lf
+++ b/test/Rust/src/ImportPreambleItem.lf
@@ -6,5 +6,7 @@ import SomethingWithAPreamble from "lib/SomethingWithAPreamble.lf"
 main reactor {
   r = new SomethingWithAPreamble()
 
-  reaction(startup) -> r.a {= ctx.set(r__a, super::something_with_a_preamble::some_fun()); =}
+  reaction(startup) -> r.a {=
+    ctx.set(r__a, super::something_with_a_preamble::some_fun());
+  =}
 }

--- a/test/Rust/src/MainReactorParam.lf
+++ b/test/Rust/src/MainReactorParam.lf
@@ -4,5 +4,7 @@ main reactor(one: u64 = 1152921504606846976, two: u64 = {= 1 << 60 =}) {
   state one = one
   state two = two
 
-  reaction(startup) {= assert_eq!(self.one, self.two); =}
+  reaction(startup) {=
+    assert_eq!(self.one, self.two);
+  =}
 }

--- a/test/Rust/src/Minimal.lf
+++ b/test/Rust/src/Minimal.lf
@@ -2,5 +2,7 @@
 target Rust
 
 main reactor Minimal {
-  reaction(startup) {= println!("Hello World."); =}
+  reaction(startup) {=
+    println!("Hello World.");
+  =}
 }

--- a/test/Rust/src/MovingAverage.lf
+++ b/test/Rust/src/MovingAverage.lf
@@ -17,7 +17,9 @@ reactor Source {
 }
 
 reactor MovingAverageImpl {
-  state delay_line: {= [f64 ; 4] =} = {= [ 0.0 ; 4 ] =}
+  state delay_line: {=
+    [f64 ; 4]
+  =} = {= [ 0.0 ; 4 ] =}
   state index: usize = 0
   input in_: f64
   output out: f64
@@ -40,7 +42,9 @@ reactor Print {
   input in_: f64
   state count: usize = 0
 
-  preamble {= const EXPECTED: [ f64 ; 6 ] = [0.0, 0.25, 0.75, 1.5, 2.5, 3.5]; =}
+  preamble {=
+    const EXPECTED: [ f64 ; 6 ] = [0.0, 0.25, 0.75, 1.5, 2.5, 3.5];
+  =}
 
   reaction(in_) {=
     let in_ = ctx.get(in_).unwrap();

--- a/test/Rust/src/MovingAverage.lf
+++ b/test/Rust/src/MovingAverage.lf
@@ -17,9 +17,7 @@ reactor Source {
 }
 
 reactor MovingAverageImpl {
-  state delay_line: {=
-    [f64 ; 4]
-  =} = {= [ 0.0 ; 4 ] =}
+  state delay_line: {= [f64 ; 4] =} = {= [ 0.0 ; 4 ] =}
   state index: usize = 0
   input in_: f64
   output out: f64

--- a/test/Rust/src/NativeListsAndTimes.lf
+++ b/test/Rust/src/NativeListsAndTimes.lf
@@ -30,7 +30,10 @@ reactor Foo(
   // state baz(p); // Implicit type i32[] fixme this interplays badly with syntax for array init
   // Implicit type time
   state period = z
-  state times: Vec<Vec<{= Duration =}>>(q, g)  // a list of lists
+  // a list of lists
+  state times: Vec<Vec<{=
+    Duration
+  =}>>(q, g)
 
   /**
    * reactor Foo (p: i32[](1, 2)) { state baz(p); // Implicit type i32[] state baz({=p=}); //

--- a/test/Rust/src/NativeListsAndTimes.lf
+++ b/test/Rust/src/NativeListsAndTimes.lf
@@ -30,10 +30,7 @@ reactor Foo(
   // state baz(p); // Implicit type i32[] fixme this interplays badly with syntax for array init
   // Implicit type time
   state period = z
-  // a list of lists
-  state times: Vec<Vec<{=
-    Duration
-  =}>>(q, g)
+  state times: Vec<Vec<{= Duration =}>>(q, g)  // a list of lists
 
   /**
    * reactor Foo (p: i32[](1, 2)) { state baz(p); // Implicit type i32[] state baz({=p=}); //

--- a/test/Rust/src/PortConnectionInSelfOutSelf.lf
+++ b/test/Rust/src/PortConnectionInSelfOutSelf.lf
@@ -26,7 +26,9 @@ reactor Sink {
     self.done = true;
   =}
 
-  reaction(shutdown) {= assert!(self.done, "reaction was not executed") =}
+  reaction(shutdown) {=
+    assert!(self.done, "reaction was not executed")
+  =}
 }
 
 main reactor {

--- a/test/Rust/src/PortConnectionOutChildOutSelf.lf
+++ b/test/Rust/src/PortConnectionOutChildOutSelf.lf
@@ -27,7 +27,9 @@ reactor Sink {
     self.done = true;
   =}
 
-  reaction(shutdown) {= assert!(self.done, "reaction was not executed") =}
+  reaction(shutdown) {=
+    assert!(self.done, "reaction was not executed")
+  =}
 }
 
 main reactor {
@@ -41,5 +43,7 @@ main reactor {
     self.done = true;
   =}
 
-  reaction(shutdown) {= assert!(self.done, "reaction was not executed") =}
+  reaction(shutdown) {=
+    assert!(self.done, "reaction was not executed")
+  =}
 }

--- a/test/Rust/src/PortValueCleanup.lf
+++ b/test/Rust/src/PortValueCleanup.lf
@@ -4,7 +4,9 @@ target Rust
 reactor Source {
   output out: u32
 
-  reaction(startup) -> out {= ctx.set(out, 150); =}
+  reaction(startup) -> out {=
+    ctx.set(out, 150);
+  =}
 }
 
 reactor Sink {

--- a/test/Rust/src/Preamble.lf
+++ b/test/Rust/src/Preamble.lf
@@ -7,5 +7,7 @@ main reactor Preamble {
     }
   =}
 
-  reaction(startup) {= println!("42 plus 42 is {}.\n", add_42(42)); =}
+  reaction(startup) {=
+    println!("42 plus 42 is {}.\n", add_42(42));
+  =}
 }

--- a/test/Rust/src/ReactionLabels.lf
+++ b/test/Rust/src/ReactionLabels.lf
@@ -5,5 +5,8 @@ target Rust
 main reactor {
   timer t(0)
 
-  reaction(t) {= println!("success"); =}  // @label foo
+  // @label foo
+  reaction(t) {=
+    println!("success");
+  =}
 }

--- a/test/Rust/src/SingleFileGeneration.lf
+++ b/test/Rust/src/SingleFileGeneration.lf
@@ -6,7 +6,9 @@ target Rust {
 reactor Source {
   output out: i32
 
-  reaction(startup) -> out {= ctx.set(out, 76600) =}
+  reaction(startup) -> out {=
+    ctx.set(out, 76600)
+  =}
 }
 
 reactor Sink {

--- a/test/Rust/src/StopNoEvent.lf
+++ b/test/Rust/src/StopNoEvent.lf
@@ -2,5 +2,7 @@
 target Rust
 
 main reactor StopNoEvent {
-  reaction(shutdown) {= println!("success"); =}
+  reaction(shutdown) {=
+    println!("success");
+  =}
 }

--- a/test/Rust/src/StructAsType.lf
+++ b/test/Rust/src/StructAsType.lf
@@ -20,9 +20,7 @@ reactor Source {
 
 // expected parameter is for testing.
 reactor Print(expected: i32 = 42) {
-  input inp: {=
-    super::source::Hello
-  =}
+  input inp: {= super::source::Hello =}
   state expected: i32 = expected
 
   reaction(inp) {=

--- a/test/Rust/src/StructAsType.lf
+++ b/test/Rust/src/StructAsType.lf
@@ -20,7 +20,9 @@ reactor Source {
 
 // expected parameter is for testing.
 reactor Print(expected: i32 = 42) {
-  input inp: {= super::source::Hello =}
+  input inp: {=
+    super::source::Hello
+  =}
   state expected: i32 = expected
 
   reaction(inp) {=

--- a/test/Rust/src/TimeState.lf
+++ b/test/Rust/src/TimeState.lf
@@ -3,7 +3,9 @@ target Rust
 reactor Foo {
   state baz: time = 500 msec
 
-  reaction(startup) {= assert_eq!(500, self.baz.as_millis()); =}
+  reaction(startup) {=
+    assert_eq!(500, self.baz.as_millis());
+  =}
 }
 
 main reactor TimeState {

--- a/test/Rust/src/Timers.lf
+++ b/test/Rust/src/Timers.lf
@@ -8,9 +8,13 @@ main reactor Timers {
   timer t2(0, 2 sec)
   state counter: i32 = 0
 
-  reaction(t2) {= self.counter += 2; =}
+  reaction(t2) {=
+    self.counter += 2;
+  =}
 
-  reaction(t) {= self.counter -= 1; =}
+  reaction(t) {=
+    self.counter -= 1;
+  =}
 
   reaction(shutdown) {=
     assert_eq!(1, self.counter);

--- a/test/Rust/src/concurrent/AsyncCallback.lf
+++ b/test/Rust/src/concurrent/AsyncCallback.lf
@@ -5,7 +5,9 @@ target Rust {
 }
 
 main reactor AsyncCallback(period: time = 10 msec) {
-  preamble {= use std::thread; =}
+  preamble {=
+    use std::thread;
+  =}
 
   timer t(0, period)
   state thread: Option<thread::JoinHandle<unit>>

--- a/test/Rust/src/generics/CtorParamGeneric.lf
+++ b/test/Rust/src/generics/CtorParamGeneric.lf
@@ -1,8 +1,9 @@
 // tests that ctor parameters may refer to type parameters.
 target Rust
 
-reactor Generic<{= T: Default + Eq + Sync + std::fmt::Debug =}>(
-    value: T = {= Default::default() =}) {
+reactor Generic<{=
+  T: Default + Eq + Sync + std::fmt::Debug
+=}>(value: T = {= Default::default() =}) {
   input in: T
   state v: T = value
 
@@ -17,5 +18,7 @@ reactor Generic<{= T: Default + Eq + Sync + std::fmt::Debug =}>(
 main reactor {
   p = new Generic<u32>(value=23)
 
-  reaction(startup) -> p.in {= ctx.set(p__in, 23); =}
+  reaction(startup) -> p.in {=
+    ctx.set(p__in, 23);
+  =}
 }

--- a/test/Rust/src/generics/CtorParamGeneric.lf
+++ b/test/Rust/src/generics/CtorParamGeneric.lf
@@ -1,9 +1,8 @@
 // tests that ctor parameters may refer to type parameters.
 target Rust
 
-reactor Generic<{=
-  T: Default + Eq + Sync + std::fmt::Debug
-=}>(value: T = {= Default::default() =}) {
+reactor Generic<{= T: Default + Eq + Sync + std::fmt::Debug =}>(
+    value: T = {= Default::default() =}) {
   input in: T
   state v: T = value
 

--- a/test/Rust/src/generics/CtorParamGenericInst.lf
+++ b/test/Rust/src/generics/CtorParamGenericInst.lf
@@ -2,9 +2,8 @@
 // argument list of a further child instance.
 target Rust
 
-reactor Generic2<{=
-  T: Default + Eq + Sync + std::fmt::Debug + Send + 'static
-=}>(value: T = {= Default::default() =}) {
+reactor Generic2<{= T: Default + Eq + Sync + std::fmt::Debug + Send + 'static =}>(
+    value: T = {= Default::default() =}) {
   input in: T
   state v: T = value
 
@@ -16,9 +15,8 @@ reactor Generic2<{=
   =}
 }
 
-reactor Generic<{=
-  T: Default + Eq + Sync + std::fmt::Debug + Copy + Send + 'static
-=}>(value: T = {= Default::default() =}) {
+reactor Generic<{= T: Default + Eq + Sync + std::fmt::Debug + Copy + Send + 'static =}>(
+    value: T = {= Default::default() =}) {
   input in: T
 
   inner = new Generic2<T>(value=value)

--- a/test/Rust/src/generics/CtorParamGenericInst.lf
+++ b/test/Rust/src/generics/CtorParamGenericInst.lf
@@ -2,8 +2,9 @@
 // argument list of a further child instance.
 target Rust
 
-reactor Generic2<{= T: Default + Eq + Sync + std::fmt::Debug + Send + 'static =}>(
-    value: T = {= Default::default() =}) {
+reactor Generic2<{=
+  T: Default + Eq + Sync + std::fmt::Debug + Send + 'static
+=}>(value: T = {= Default::default() =}) {
   input in: T
   state v: T = value
 
@@ -15,8 +16,9 @@ reactor Generic2<{= T: Default + Eq + Sync + std::fmt::Debug + Send + 'static =}
   =}
 }
 
-reactor Generic<{= T: Default + Eq + Sync + std::fmt::Debug + Copy + Send + 'static =}>(
-    value: T = {= Default::default() =}) {
+reactor Generic<{=
+  T: Default + Eq + Sync + std::fmt::Debug + Copy + Send + 'static
+=}>(value: T = {= Default::default() =}) {
   input in: T
 
   inner = new Generic2<T>(value=value)
@@ -27,5 +29,7 @@ reactor Generic<{= T: Default + Eq + Sync + std::fmt::Debug + Copy + Send + 'sta
 main reactor {
   p = new Generic<u32>(value=23)
 
-  reaction(startup) -> p.in {= ctx.set(p__in, 23); =}
+  reaction(startup) -> p.in {=
+    ctx.set(p__in, 23);
+  =}
 }

--- a/test/Rust/src/generics/GenericComplexType.lf
+++ b/test/Rust/src/generics/GenericComplexType.lf
@@ -18,5 +18,7 @@ reactor R {
 main reactor {
   p = new R()
 
-  reaction(startup) -> p.in {= ctx.set(p__in, vec![delay!(20 ms)]); =}
+  reaction(startup) -> p.in {=
+    ctx.set(p__in, vec![delay!(20 ms)]);
+  =}
 }

--- a/test/Rust/src/generics/GenericReactor.lf
+++ b/test/Rust/src/generics/GenericReactor.lf
@@ -1,7 +1,9 @@
 // Tests a port connection between (input of self -> input of child)
 target Rust
 
-reactor Box<{= T: Sync =}> {
+reactor Box<{=
+  T: Sync
+=}> {
   input inp: T
   output out: T
 
@@ -16,9 +18,13 @@ main reactor {
 
   box0.out -> box1.inp
 
-  reaction(startup) -> box0.inp {= ctx.set(box0__inp, 444); =}
+  reaction(startup) -> box0.inp {=
+    ctx.set(box0__inp, 444);
+  =}
 
-  reaction(box1.out) {= assert!(ctx.get_elapsed_logical_time().is_zero()); self.done = true; =}
+  reaction(box1.out) {=
+    assert!(ctx.get_elapsed_logical_time().is_zero()); self.done = true;
+  =}
 
   reaction(shutdown) {=
     assert!(self.done, "reaction was not executed");

--- a/test/Rust/src/generics/GenericReactor.lf
+++ b/test/Rust/src/generics/GenericReactor.lf
@@ -1,9 +1,7 @@
 // Tests a port connection between (input of self -> input of child)
 target Rust
 
-reactor Box<{=
-  T: Sync
-=}> {
+reactor Box<{= T: Sync =}> {
   input inp: T
   output out: T
 

--- a/test/Rust/src/lib/Imported.lf
+++ b/test/Rust/src/lib/Imported.lf
@@ -8,5 +8,7 @@ reactor Imported {
   input x: u32
   a = new ImportedAgain()
 
-  reaction(x) -> a.x {= ctx.set(a__x, ctx.get(x).unwrap()); =}
+  reaction(x) -> a.x {=
+    ctx.set(a__x, ctx.get(x).unwrap());
+  =}
 }

--- a/test/Rust/src/multiport/ConnectionToSelfBank.lf
+++ b/test/Rust/src/multiport/ConnectionToSelfBank.lf
@@ -6,7 +6,9 @@ reactor Node(bank_index: usize = 0, num_nodes: usize = 4) {
   state bank_index = bank_index
   state num_nodes = num_nodes
 
-  reaction(startup) -> out {= ctx.set(out, self.bank_index); =}
+  reaction(startup) -> out {=
+    ctx.set(out, self.bank_index);
+  =}
 
   reaction(in) {=
     let count = r#in.iterate_set().count();

--- a/test/Rust/src/multiport/CycledLhs_SelfLoop.lf
+++ b/test/Rust/src/multiport/CycledLhs_SelfLoop.lf
@@ -10,9 +10,13 @@ reactor Test {
   logical action act: u32
   state last: u32 = 1
 
-  reaction(startup) -> act {= ctx.schedule_with_v(act, Some(1), after!(1 us)); =}
+  reaction(startup) -> act {=
+    ctx.schedule_with_v(act, Some(1), after!(1 us));
+  =}
 
-  reaction(act) -> out {= ctx.set_opt(out, ctx.get(act)); =}
+  reaction(act) -> out {=
+    ctx.set_opt(out, ctx.get(act));
+  =}
 
   reaction(in) -> act {=
     let sum: u32 = r#in.iterate_values().sum();

--- a/test/Rust/src/multiport/CycledLhs_Single.lf
+++ b/test/Rust/src/multiport/CycledLhs_Single.lf
@@ -7,10 +7,14 @@ target Rust {
 reactor Test {
   output[2] out: u32
   input[4] in: u32
-  logical action act: {= (u32, u32) =}
+  logical action act: {=
+    (u32, u32)
+  =}
   state last: u32 = 1
 
-  reaction(startup) -> act {= ctx.schedule_with_v(act, Some((0, 1)), after!(1 us)); =}
+  reaction(startup) -> act {=
+    ctx.schedule_with_v(act, Some((0, 1)), after!(1 us));
+  =}
 
   reaction(act) -> out {=
     let (a, b) = ctx.get(act).unwrap();

--- a/test/Rust/src/multiport/CycledLhs_Single.lf
+++ b/test/Rust/src/multiport/CycledLhs_Single.lf
@@ -7,9 +7,7 @@ target Rust {
 reactor Test {
   output[2] out: u32
   input[4] in: u32
-  logical action act: {=
-    (u32, u32)
-  =}
+  logical action act: {= (u32, u32) =}
   state last: u32 = 1
 
   reaction(startup) -> act {=

--- a/test/Rust/src/multiport/FullyConnected.lf
+++ b/test/Rust/src/multiport/FullyConnected.lf
@@ -5,7 +5,9 @@ reactor Left(bank_index: usize = 0) {
   output out: usize
   state bank_index = bank_index
 
-  reaction(startup) -> out {= ctx.set(out, self.bank_index); =}
+  reaction(startup) -> out {=
+    ctx.set(out, self.bank_index);
+  =}
 }
 
 reactor Right(bank_index: usize = 0, num_nodes: usize = 4) {

--- a/test/Rust/src/multiport/MultiportFromBank.lf
+++ b/test/Rust/src/multiport/MultiportFromBank.lf
@@ -7,7 +7,9 @@ reactor Source(bank_index: usize = 0) {
   output out: usize
   state bank_index = bank_index
 
-  reaction(startup) -> out {= ctx.set(out, self.bank_index); =}
+  reaction(startup) -> out {=
+    ctx.set(out, self.bank_index);
+  =}
 }
 
 reactor Destination(port_width: usize = 2) {

--- a/test/Rust/src/multiport/ReadOutputOfContainedBank.lf
+++ b/test/Rust/src/multiport/ReadOutputOfContainedBank.lf
@@ -6,7 +6,9 @@ reactor Contained(bank_index: usize = 0) {
 
   output out: usize
 
-  reaction(startup) -> out {= ctx.set(out, 42 * self.bank_index); =}
+  reaction(startup) -> out {=
+    ctx.set(out, 42 * self.bank_index);
+  =}
 }
 
 main reactor {

--- a/test/Rust/src/multiport/WidthWithParameter.lf
+++ b/test/Rust/src/multiport/WidthWithParameter.lf
@@ -13,5 +13,7 @@ reactor Some(value: usize = 30) {
 main reactor {
   some = new Some(value=20)
 
-  reaction(some.finished) {= println!("success"); =}
+  reaction(some.finished) {=
+    println!("success");
+  =}
 }

--- a/test/Rust/src/multiport/WriteInputOfContainedBank.lf
+++ b/test/Rust/src/multiport/WriteInputOfContainedBank.lf
@@ -14,7 +14,9 @@ reactor Contained(bank_index: usize = 0) {
     self.count += 1;
   =}
 
-  reaction(shutdown) {= assert_eq!(self.count, 1, "One of the reactions failed to trigger"); =}
+  reaction(shutdown) {=
+    assert_eq!(self.count, 1, "One of the reactions failed to trigger");
+  =}
 }
 
 main reactor {

--- a/test/Rust/src/target/CargoDependencyOnRuntime.lf
+++ b/test/Rust/src/target/CargoDependencyOnRuntime.lf
@@ -8,5 +8,7 @@ target Rust {
 }
 
 main reactor {
-  reaction(startup) {= println!("success") =}
+  reaction(startup) {=
+    println!("success")
+  =}
 }

--- a/test/Rust/src/target/CliFeature.lf
+++ b/test/Rust/src/target/CliFeature.lf
@@ -5,5 +5,7 @@ target Rust {
 
 // todo allow test framework to pass CLI arguments.
 main reactor CliFeature(size: u32 = 4, t: time = 4 sec) {
-  reaction(startup) {= println!("success"); =}
+  reaction(startup) {=
+    println!("success");
+  =}
 }

--- a/test/TypeScript/src/ActionDelay.lf
+++ b/test/TypeScript/src/ActionDelay.lf
@@ -12,13 +12,17 @@ reactor GeneratedDelay {
     actions.act.schedule(0, null);
   =}
 
-  reaction(act) -> y_out {= y_out = y_state; =}
+  reaction(act) -> y_out {=
+    y_out = y_state;
+  =}
 }
 
 reactor Source {
   output out: number
 
-  reaction(startup) -> out {= out = 1; =}
+  reaction(startup) -> out {=
+    out = 1;
+  =}
 }
 
 reactor Sink {

--- a/test/TypeScript/src/ActionWithNoReaction.lf
+++ b/test/TypeScript/src/ActionWithNoReaction.lf
@@ -32,5 +32,7 @@ main reactor {
   timer t(0, 1 sec)
   f.y -> p.x after 10 msec
 
-  reaction(t) -> f.x {= f.x = 42; =}
+  reaction(t) -> f.x {=
+    f.x = 42;
+  =}
 }

--- a/test/TypeScript/src/After.lf
+++ b/test/TypeScript/src/After.lf
@@ -8,7 +8,9 @@ reactor Foo {
   input x: number
   output y: number
 
-  reaction(x) -> y {= y = 2 * (x as number); =}
+  reaction(x) -> y {=
+    y = 2 * (x as number);
+  =}
 }
 
 reactor Print {
@@ -33,5 +35,7 @@ main reactor {
   timer t(0, 1 sec)
   f.y -> p.x after 10 msec
 
-  reaction(t) -> f.x {= f.x = 42; =}
+  reaction(t) -> f.x {=
+    f.x = 42;
+  =}
 }

--- a/test/TypeScript/src/ArrayAsParameter.lf
+++ b/test/TypeScript/src/ArrayAsParameter.lf
@@ -1,9 +1,7 @@
 // Source has an array as a parameter, the elements of which it passes to Print.
 target TypeScript
 
-reactor Source(sequence: {=
-  Array<number>
-=} = {= [0, 1, 2] =}) {
+reactor Source(sequence: {= Array<number> =} = {= [0, 1, 2] =}) {
   output out: number
   state count: number = 0
   logical action next

--- a/test/TypeScript/src/ArrayAsParameter.lf
+++ b/test/TypeScript/src/ArrayAsParameter.lf
@@ -1,7 +1,9 @@
 // Source has an array as a parameter, the elements of which it passes to Print.
 target TypeScript
 
-reactor Source(sequence: {= Array<number> =} = {= [0, 1, 2] =}) {
+reactor Source(sequence: {=
+  Array<number>
+=} = {= [0, 1, 2] =}) {
   output out: number
   state count: number = 0
   logical action next

--- a/test/TypeScript/src/ArrayAsType.lf
+++ b/test/TypeScript/src/ArrayAsType.lf
@@ -3,7 +3,9 @@
 target TypeScript
 
 reactor Source {
-  output out: {= Array<number> =}
+  output out: {=
+    Array<number>
+  =}
 
   reaction(startup) -> out {=
     let toSend = [];
@@ -16,7 +18,9 @@ reactor Source {
 
 // The scale parameter is just for testing.
 reactor Print(scale: number = 1) {
-  input x: {= Array<number> =}
+  input x: {=
+    Array<number>
+  =}
 
   reaction(x) {=
     let count = 0;     // For testing.

--- a/test/TypeScript/src/ArrayAsType.lf
+++ b/test/TypeScript/src/ArrayAsType.lf
@@ -3,9 +3,7 @@
 target TypeScript
 
 reactor Source {
-  output out: {=
-    Array<number>
-  =}
+  output out: {= Array<number> =}
 
   reaction(startup) -> out {=
     let toSend = [];
@@ -18,9 +16,7 @@ reactor Source {
 
 // The scale parameter is just for testing.
 reactor Print(scale: number = 1) {
-  input x: {=
-    Array<number>
-  =}
+  input x: {= Array<number> =}
 
   reaction(x) {=
     let count = 0;     // For testing.

--- a/test/TypeScript/src/ArrayPrint.lf
+++ b/test/TypeScript/src/ArrayPrint.lf
@@ -3,7 +3,9 @@
 target TypeScript
 
 reactor Source {
-  output out: {= Array<number> =}
+  output out: {=
+    Array<number>
+  =}
 
   reaction(startup) -> out {=
     let toSend = new Array<number>();
@@ -16,7 +18,9 @@ reactor Source {
 
 // The scale parameter is just for testing.
 reactor Print(scale: number = 1) {
-  input x: {= Array<number> =}
+  input x: {=
+    Array<number>
+  =}
 
   reaction(x) {=
     let count = 0;     // For testing.

--- a/test/TypeScript/src/ArrayPrint.lf
+++ b/test/TypeScript/src/ArrayPrint.lf
@@ -3,9 +3,7 @@
 target TypeScript
 
 reactor Source {
-  output out: {=
-    Array<number>
-  =}
+  output out: {= Array<number> =}
 
   reaction(startup) -> out {=
     let toSend = new Array<number>();
@@ -18,9 +16,7 @@ reactor Source {
 
 // The scale parameter is just for testing.
 reactor Print(scale: number = 1) {
-  input x: {=
-    Array<number>
-  =}
+  input x: {= Array<number> =}
 
   reaction(x) {=
     let count = 0;     // For testing.

--- a/test/TypeScript/src/ArrayScale.lf
+++ b/test/TypeScript/src/ArrayScale.lf
@@ -6,8 +6,12 @@ target TypeScript
 import Source, Print from "ArrayPrint.lf"
 
 reactor Scale(scale: number = 2) {
-  mutable input x: {= Array<number> =}
-  output out: {= Array<number> =}
+  mutable input x: {=
+    Array<number>
+  =}
+  output out: {=
+    Array<number>
+  =}
 
   reaction(x) -> out {=
     x = x as Array<number>;

--- a/test/TypeScript/src/ArrayScale.lf
+++ b/test/TypeScript/src/ArrayScale.lf
@@ -6,12 +6,8 @@ target TypeScript
 import Source, Print from "ArrayPrint.lf"
 
 reactor Scale(scale: number = 2) {
-  mutable input x: {=
-    Array<number>
-  =}
-  output out: {=
-    Array<number>
-  =}
+  mutable input x: {= Array<number> =}
+  output out: {= Array<number> =}
 
   reaction(x) -> out {=
     x = x as Array<number>;

--- a/test/TypeScript/src/DanglingOutput.lf
+++ b/test/TypeScript/src/DanglingOutput.lf
@@ -6,7 +6,9 @@ reactor Source {
   output out: number
   timer t
 
-  reaction(t) -> out {= out = 1; =}
+  reaction(t) -> out {=
+    out = 1;
+  =}
 }
 
 reactor Gain {

--- a/test/TypeScript/src/DelayInt.lf
+++ b/test/TypeScript/src/DelayInt.lf
@@ -7,7 +7,9 @@ reactor Delay(delay: time = 100 msec) {
   output out: number
   logical action a: number
 
-  reaction(x) -> a {= actions.a.schedule( delay, x as number); =}
+  reaction(x) -> a {=
+    actions.a.schedule( delay, x as number);
+  =}
 
   reaction(a) -> out {=
     if (a !== null){
@@ -54,5 +56,7 @@ main reactor DelayInt {
   t = new Test()
   d.out -> t.x
 
-  reaction(startup) -> d.x {= d.x = 42; =}
+  reaction(startup) -> d.x {=
+    d.x = 42;
+  =}
 }

--- a/test/TypeScript/src/DelayedAction.lf
+++ b/test/TypeScript/src/DelayedAction.lf
@@ -7,7 +7,9 @@ main reactor DelayedAction {
   logical action a
   state count: number = 0
 
-  reaction(t) -> a {= actions.a.schedule(TimeValue.msec(100), null); =}
+  reaction(t) -> a {=
+    actions.a.schedule(TimeValue.msec(100), null);
+  =}
 
   reaction(a) {=
     let elapsedLogical = util.getElapsedLogicalTime();

--- a/test/TypeScript/src/DelayedReaction.lf
+++ b/test/TypeScript/src/DelayedReaction.lf
@@ -5,7 +5,9 @@ reactor Source {
   output out: number
   timer t
 
-  reaction(t) -> out {= out = 1; =}
+  reaction(t) -> out {=
+    out = 1;
+  =}
 }
 
 reactor Sink {

--- a/test/TypeScript/src/Determinism.lf
+++ b/test/TypeScript/src/Determinism.lf
@@ -4,7 +4,9 @@ reactor Source {
   output y: number
   timer t
 
-  reaction(t) -> y {= y = 1; =}
+  reaction(t) -> y {=
+    y = 1;
+  =}
 }
 
 reactor Destination {
@@ -30,7 +32,9 @@ reactor Pass {
   input x: number
   output y: number
 
-  reaction(x) -> y {= y = x as number; =}
+  reaction(x) -> y {=
+    y = x as number;
+  =}
 }
 
 main reactor Determinism {

--- a/test/TypeScript/src/Gain.lf
+++ b/test/TypeScript/src/Gain.lf
@@ -5,7 +5,9 @@ reactor Scale(scale: number = 2) {
   input x: number
   output y: number
 
-  reaction(x) -> y {= y = (x as number) * scale; =}
+  reaction(x) -> y {=
+    y = (x as number) * scale;
+  =}
 }
 
 reactor Test {
@@ -34,5 +36,7 @@ main reactor Gain {
   d = new Test()
   g.y -> d.x
 
-  reaction(startup) -> g.x {= g.x = 1; =}
+  reaction(startup) -> g.x {=
+    g.x = 1;
+  =}
 }

--- a/test/TypeScript/src/HelloWorld.lf
+++ b/test/TypeScript/src/HelloWorld.lf
@@ -3,7 +3,9 @@ target TypeScript
 reactor HelloWorldInside {
   timer t
 
-  reaction(t) {= console.log("Hello World."); =}
+  reaction(t) {=
+    console.log("Hello World.");
+  =}
 }
 
 main reactor HelloWorld {

--- a/test/TypeScript/src/Hierarchy2.lf
+++ b/test/TypeScript/src/Hierarchy2.lf
@@ -8,7 +8,9 @@ reactor Source {
   output out: number
   timer t(0, 1 sec)
 
-  reaction(t) -> out {= out = 1; =}
+  reaction(t) -> out {=
+    out = 1;
+  =}
 }
 
 reactor Count {

--- a/test/TypeScript/src/Import.lf
+++ b/test/TypeScript/src/Import.lf
@@ -9,5 +9,7 @@ main reactor Import {
   timer t
   a = new Imported()
 
-  reaction(t) -> a.x {= a.x = 42; =}
+  reaction(t) -> a.x {=
+    a.x = 42;
+  =}
 }

--- a/test/TypeScript/src/Microsteps.lf
+++ b/test/TypeScript/src/Microsteps.lf
@@ -35,5 +35,7 @@ main reactor Microsteps {
     actions.repeat.schedule(0, null);
   =}
 
-  reaction(repeat) -> d.y {= d.y = 1; =}
+  reaction(repeat) -> d.y {=
+    d.y = 1;
+  =}
 }

--- a/test/TypeScript/src/Minimal.lf
+++ b/test/TypeScript/src/Minimal.lf
@@ -4,5 +4,7 @@ target TypeScript
 main reactor Minimal {
   timer t
 
-  reaction(t) {= console.log("Hello World."); =}
+  reaction(t) {=
+    console.log("Hello World.");
+  =}
 }

--- a/test/TypeScript/src/MovingAverage.lf
+++ b/test/TypeScript/src/MovingAverage.lf
@@ -17,7 +17,9 @@ reactor Source {
 }
 
 reactor MovingAverageImpl {
-  state delay_line: {= Array<number> =} = {= [0.0, 0.0, 0.0] =}
+  state delay_line: {=
+    Array<number>
+  =} = {= [0.0, 0.0, 0.0] =}
   state index: number = 0
   input x: number
   output out: number

--- a/test/TypeScript/src/MovingAverage.lf
+++ b/test/TypeScript/src/MovingAverage.lf
@@ -17,9 +17,7 @@ reactor Source {
 }
 
 reactor MovingAverageImpl {
-  state delay_line: {=
-    Array<number>
-  =} = {= [0.0, 0.0, 0.0] =}
+  state delay_line: {= Array<number> =} = {= [0.0, 0.0, 0.0] =}
   state index: number = 0
   input x: number
   output out: number

--- a/test/TypeScript/src/MultipleContained.lf
+++ b/test/TypeScript/src/MultipleContained.lf
@@ -6,7 +6,9 @@ reactor Contained {
   input in1: number
   input in2: number
 
-  reaction(startup) -> trigger {= trigger = 42; =}
+  reaction(startup) -> trigger {=
+    trigger = 42;
+  =}
 
   reaction(in1) {=
     in1 = in1 as number;

--- a/test/TypeScript/src/ParameterizedState.lf
+++ b/test/TypeScript/src/ParameterizedState.lf
@@ -3,7 +3,9 @@ target TypeScript
 reactor Foo(bar: number = 42) {
   state baz = bar
 
-  reaction(startup) {= console.log("Baz: " + baz); =}
+  reaction(startup) {=
+    console.log("Baz: " + baz);
+  =}
 }
 
 main reactor {

--- a/test/TypeScript/src/PhysicalConnection.lf
+++ b/test/TypeScript/src/PhysicalConnection.lf
@@ -4,7 +4,9 @@ target TypeScript
 reactor Source {
   output y: number
 
-  reaction(startup) -> y {= y = 42 =}
+  reaction(startup) -> y {=
+    y = 42
+  =}
 }
 
 reactor Destination {

--- a/test/TypeScript/src/ReadOutputOfContainedReactor.lf
+++ b/test/TypeScript/src/ReadOutputOfContainedReactor.lf
@@ -4,7 +4,9 @@ target TypeScript
 reactor Contained {
   output out: number
 
-  reaction(startup) -> out {= out = 42; =}
+  reaction(startup) -> out {=
+    out = 42;
+  =}
 }
 
 main reactor ReadOutputOfContainedReactor {

--- a/test/TypeScript/src/Schedule.lf
+++ b/test/TypeScript/src/Schedule.lf
@@ -5,7 +5,9 @@ reactor ScheduleLogicalAction {
   input x: number
   logical action a
 
-  reaction(x) -> a {= actions.a.schedule(TimeValue.msec(200), null) =}
+  reaction(x) -> a {=
+    actions.a.schedule(TimeValue.msec(200), null)
+  =}
 
   reaction(a) {=
     let elapsedTime = util.getElapsedLogicalTime();
@@ -22,5 +24,7 @@ main reactor {
   a = new ScheduleLogicalAction()
   timer t
 
-  reaction(t) -> a.x {= a.x = 1; =}
+  reaction(t) -> a.x {=
+    a.x = 1;
+  =}
 }

--- a/test/TypeScript/src/ScheduleLogicalAction.lf
+++ b/test/TypeScript/src/ScheduleLogicalAction.lf
@@ -17,7 +17,9 @@ reactor foo {
     actions.a.schedule(TimeValue.msec(500), null);
   =}
 
-  reaction(a) -> y {= y = -42; =}
+  reaction(a) -> y {=
+    y = -42;
+  =}
 }
 
 reactor print {
@@ -42,5 +44,7 @@ main reactor {
   timer t(0, 1 sec)
   f.y -> p.x
 
-  reaction(t) -> f.x {= f.x = 42; =}
+  reaction(t) -> f.x {=
+    f.x = 42;
+  =}
 }

--- a/test/TypeScript/src/SendingInside2.lf
+++ b/test/TypeScript/src/SendingInside2.lf
@@ -15,5 +15,7 @@ main reactor SendingInside2 {
   timer t
   p = new Printer()
 
-  reaction(t) -> p.x {= p.x = 1; =}
+  reaction(t) -> p.x {=
+    p.x = 1;
+  =}
 }

--- a/test/TypeScript/src/SendsPointerTest.lf
+++ b/test/TypeScript/src/SendsPointerTest.lf
@@ -3,7 +3,9 @@
 target TypeScript
 
 reactor SendsPointer {
-  output out: {= {value: number} =}
+  output out: {=
+    {value: number}
+  =}
 
   reaction(startup) -> out {=
     let my_object = { value: 42 };
@@ -12,8 +14,12 @@ reactor SendsPointer {
 }
 
 // expected parameter is for testing.
-reactor Print(expected: {= {value: number} =} = {= { value: 42 } =}) {
-  input x: {= {value: number} =}
+reactor Print(expected: {=
+  {value: number}
+=} = {= { value: 42 } =}) {
+  input x: {=
+    {value: number}
+  =}
 
   reaction(x) {=
     x = x as {value: number};

--- a/test/TypeScript/src/SendsPointerTest.lf
+++ b/test/TypeScript/src/SendsPointerTest.lf
@@ -3,9 +3,7 @@
 target TypeScript
 
 reactor SendsPointer {
-  output out: {=
-    {value: number}
-  =}
+  output out: {= {value: number} =}
 
   reaction(startup) -> out {=
     let my_object = { value: 42 };
@@ -14,12 +12,8 @@ reactor SendsPointer {
 }
 
 // expected parameter is for testing.
-reactor Print(expected: {=
-  {value: number}
-=} = {= { value: 42 } =}) {
-  input x: {=
-    {value: number}
-  =}
+reactor Print(expected: {= {value: number} =} = {= { value: 42 } =}) {
+  input x: {= {value: number} =}
 
   reaction(x) {=
     x = x as {value: number};

--- a/test/TypeScript/src/SlowingClock.lf
+++ b/test/TypeScript/src/SlowingClock.lf
@@ -8,7 +8,9 @@ main reactor SlowingClock {
   state interval: time = 100 msec
   state expected_time: time = 100 msec
 
-  reaction(startup) -> a {= actions.a.schedule(0, null); =}
+  reaction(startup) -> a {=
+    actions.a.schedule(0, null);
+  =}
 
   reaction(a) -> a {=
     let elapsed_logical_time : TimeValue = util.getElapsedLogicalTime();

--- a/test/TypeScript/src/Stride.lf
+++ b/test/TypeScript/src/Stride.lf
@@ -19,7 +19,9 @@ reactor Count(stride: number = 1) {
 reactor Display {
   input x: number
 
-  reaction(x) {= console.log("Received: " + x); =}
+  reaction(x) {=
+    console.log("Received: " + x);
+  =}
 }
 
 main reactor Stride {

--- a/test/TypeScript/src/TimeLimit.lf
+++ b/test/TypeScript/src/TimeLimit.lf
@@ -37,5 +37,7 @@ main reactor TimeLimit(period: time = 1 msec) {
   d = new Destination()
   c.y -> d.x
 
-  reaction(stop) {= util.requestStop() =}
+  reaction(stop) {=
+    util.requestStop()
+  =}
 }

--- a/test/TypeScript/src/TimeState.lf
+++ b/test/TypeScript/src/TimeState.lf
@@ -3,7 +3,9 @@ target TypeScript
 reactor Foo(bar: number = 42) {
   state baz: time = 500 msec
 
-  reaction(startup) {= console.log("Baz: " + baz); =}
+  reaction(startup) {=
+    console.log("Baz: " + baz);
+  =}
 }
 
 main reactor {

--- a/test/TypeScript/src/Wcet.lf
+++ b/test/TypeScript/src/Wcet.lf
@@ -31,7 +31,9 @@ reactor Work {
 reactor Print {
   input x: number
 
-  reaction(x) {= console.log("Received: " + x); =}
+  reaction(x) {=
+    console.log("Received: " + x);
+  =}
 }
 
 main reactor Wcet {

--- a/test/TypeScript/src/federated/DistributedDoublePort.lf
+++ b/test/TypeScript/src/federated/DistributedDoublePort.lf
@@ -21,9 +21,13 @@ reactor CountMicrostep {
   logical action act: number
   timer t(0, 1 sec)
 
-  reaction(t) -> act {= actions.act.schedule(0, count++); =}
+  reaction(t) -> act {=
+    actions.act.schedule(0, count++);
+  =}
 
-  reaction(act) -> out {= out = act; =}
+  reaction(act) -> out {=
+    out = act;
+  =}
 }
 
 reactor Print {
@@ -39,7 +43,9 @@ reactor Print {
     }
   =}
 
-  reaction(shutdown) {= console.log("SUCCESS: messages were at least one microstep apart."); =}
+  reaction(shutdown) {=
+    console.log("SUCCESS: messages were at least one microstep apart.");
+  =}
 }
 
 federated reactor DistributedDoublePort {

--- a/test/TypeScript/src/federated/HelloDistributed.lf
+++ b/test/TypeScript/src/federated/HelloDistributed.lf
@@ -21,7 +21,9 @@ reactor Destination {
   input inp: string
   state received: boolean = false
 
-  reaction(startup) {= console.log("Destination started."); =}
+  reaction(startup) {=
+    console.log("Destination started.");
+  =}
 
   reaction(inp) {=
     console.log(`At logical time ${util.getElapsedLogicalTime()}, destination received: ` + inp);
@@ -44,5 +46,7 @@ federated reactor HelloDistributed at localhost {
   d = new Destination()  // Reactor d is in federate Destination
   s.out -> d.inp         // This version preserves the timestamp.
 
-  reaction(startup) {= console.log("Printing something in top-level federated reactor."); =}
+  reaction(startup) {=
+    console.log("Printing something in top-level federated reactor.");
+  =}
 }

--- a/test/TypeScript/src/federated/SpuriousDependency.lf
+++ b/test/TypeScript/src/federated/SpuriousDependency.lf
@@ -35,7 +35,9 @@ reactor Check {
 
   state count: number = 0
 
-  reaction(inp) {= console.log("count is now " + ++count); =}
+  reaction(inp) {=
+    console.log("count is now " + ++count);
+  =}
 
   reaction(shutdown) {=
     console.log("******* Shutdown invoked.");
@@ -55,5 +57,7 @@ federated reactor {
 
   t1.out0 -> check.inp
 
-  reaction(startup) -> t0.in1 {= t0.in1 = 0; =}
+  reaction(startup) -> t0.in1 {=
+    t0.in1 = 0;
+  =}
 }

--- a/test/TypeScript/src/federated/StopAtShutdown.lf
+++ b/test/TypeScript/src/federated/StopAtShutdown.lf
@@ -10,20 +10,30 @@ target TypeScript {
 reactor A {
   input inp: number
 
-  reaction(startup) {= console.log("Hello World!"); =}
+  reaction(startup) {=
+    console.log("Hello World!");
+  =}
 
-  reaction(inp) {= console.log("Got it"); =}
+  reaction(inp) {=
+    console.log("Got it");
+  =}
 
-  reaction(shutdown) {= util.requestStop(); =}
+  reaction(shutdown) {=
+    util.requestStop();
+  =}
 }
 
 reactor B {
   output out: number
   timer t(1 sec)
 
-  reaction(t) -> out {= out = 1; =}
+  reaction(t) -> out {=
+    out = 1;
+  =}
 
-  reaction(shutdown) {= util.requestStop(); =}
+  reaction(shutdown) {=
+    util.requestStop();
+  =}
 }
 
 federated reactor {

--- a/test/TypeScript/src/federated/TopLevelArtifacts.lf
+++ b/test/TypeScript/src/federated/TopLevelArtifacts.lf
@@ -23,14 +23,18 @@ federated reactor {
   tc = new TestCount()
   c.out -> tc.inp
 
-  reaction(startup) {= successes++; =}
+  reaction(startup) {=
+    successes++;
+  =}
 
   reaction(t) -> act {=
     successes++;
     actions.act.schedule(0, null);
   =}
 
-  reaction(act) {= successes++; =}
+  reaction(act) {=
+    successes++;
+  =}
 
   reaction(shutdown) {=
     if (successes != 3) {

--- a/test/TypeScript/src/lib/Count.lf
+++ b/test/TypeScript/src/lib/Count.lf
@@ -5,5 +5,7 @@ reactor Count(offset: time = 0, period: time = 1 sec) {
   timer t(offset, period)
   state count: number = 1
 
-  reaction(t) -> out {= out = count++; =}
+  reaction(t) -> out {=
+    out = count++;
+  =}
 }

--- a/test/TypeScript/src/lib/Imported.lf
+++ b/test/TypeScript/src/lib/Imported.lf
@@ -10,5 +10,7 @@ reactor Imported {
   input x: number
   a = new ImportedAgain()
 
-  reaction(x) -> a.x {= a.x = (x as number); =}
+  reaction(x) -> a.x {=
+    a.x = (x as number);
+  =}
 }

--- a/test/TypeScript/src/lib/InternalDelay.lf
+++ b/test/TypeScript/src/lib/InternalDelay.lf
@@ -6,7 +6,11 @@ reactor InternalDelay(delay: TimeValue = 10 msec) {
   output out: number
   logical action d: number
 
-  reaction(inp) -> d {= actions.d.schedule(delay, inp as number); =}
+  reaction(inp) -> d {=
+    actions.d.schedule(delay, inp as number);
+  =}
 
-  reaction(d) -> out {= out = d; =}
+  reaction(d) -> out {=
+    out = d;
+  =}
 }

--- a/test/TypeScript/src/multiport/BankSelfBroadcast.lf
+++ b/test/TypeScript/src/multiport/BankSelfBroadcast.lf
@@ -14,7 +14,9 @@ reactor A {
   output out: number
   state received: boolean = false
 
-  reaction(startup) -> out {= out = this.getBankIndex(); =}
+  reaction(startup) -> out {=
+    out = this.getBankIndex();
+  =}
 
   reaction(inp) {=
     for (let i = 0; i < inp.length; i++) {

--- a/test/TypeScript/src/multiport/BankToMultiport.lf
+++ b/test/TypeScript/src/multiport/BankToMultiport.lf
@@ -4,7 +4,9 @@ target TypeScript
 reactor Source {
   output out: number
 
-  reaction(startup) -> out {= out = this.getBankIndex(); =}
+  reaction(startup) -> out {=
+    out = this.getBankIndex();
+  =}
 }
 
 reactor Sink {

--- a/test/TypeScript/src/multiport/Broadcast.lf
+++ b/test/TypeScript/src/multiport/Broadcast.lf
@@ -3,7 +3,9 @@ target TypeScript
 reactor Source {
   output out: number
 
-  reaction(startup) -> out {= out = 42; =}
+  reaction(startup) -> out {=
+    out = 42;
+  =}
 }
 
 reactor Sink {

--- a/test/TypeScript/src/multiport/BroadcastAfter.lf
+++ b/test/TypeScript/src/multiport/BroadcastAfter.lf
@@ -5,7 +5,9 @@ target TypeScript {
 reactor Source {
   output out: number
 
-  reaction(startup) -> out {= out = 42; =}
+  reaction(startup) -> out {=
+    out = 42;
+  =}
 }
 
 reactor Destination {

--- a/test/TypeScript/src/multiport/BroadcastMultipleAfter.lf
+++ b/test/TypeScript/src/multiport/BroadcastMultipleAfter.lf
@@ -5,7 +5,9 @@ target TypeScript {
 reactor Source(value: number = 42) {
   output out: number
 
-  reaction(startup) -> out {= out = value; =}
+  reaction(startup) -> out {=
+    out = value;
+  =}
 }
 
 reactor Destination {

--- a/test/TypeScript/src/multiport/MultiportFromBank.lf
+++ b/test/TypeScript/src/multiport/MultiportFromBank.lf
@@ -7,7 +7,9 @@ target TypeScript {
 reactor Source {
   output out: number
 
-  reaction(startup) -> out {= out = this.getBankIndex(); =}
+  reaction(startup) -> out {=
+    out = this.getBankIndex();
+  =}
 }
 
 reactor Destination(portWidth: number = 3) {

--- a/test/TypeScript/src/multiport/MultiportIn.lf
+++ b/test/TypeScript/src/multiport/MultiportIn.lf
@@ -9,14 +9,18 @@ reactor Source {
   output out: number
   state s: number = 0
 
-  reaction(t) -> out {= out = s++; =}
+  reaction(t) -> out {=
+    out = s++;
+  =}
 }
 
 reactor Computation {
   input inp: number
   output out: number
 
-  reaction(inp) -> out {= out = inp; =}
+  reaction(inp) -> out {=
+    out = inp;
+  =}
 }
 
 reactor Destination {

--- a/test/TypeScript/src/multiport/MultiportInParameterized.lf
+++ b/test/TypeScript/src/multiport/MultiportInParameterized.lf
@@ -19,7 +19,9 @@ reactor Computation {
   input inp: number
   output out: number
 
-  reaction(inp) -> out {= out = inp; =}
+  reaction(inp) -> out {=
+    out = inp;
+  =}
 }
 
 reactor Destination(width: number = 1) {

--- a/test/TypeScript/src/multiport/MultiportMutableInputArray.lf
+++ b/test/TypeScript/src/multiport/MultiportMutableInputArray.lf
@@ -4,9 +4,7 @@
 target TypeScript
 
 reactor Source {
-  output[2] out: {=
-    Array<number>
-  =}
+  output[2] out: {= Array<number> =}
 
   reaction(startup) -> out {=
     // Dynamically allocate an output array of length 3.
@@ -29,9 +27,7 @@ reactor Source {
 
 // The scale parameter is just for testing.
 reactor Print(scale: number = 1) {
-  input[2] inp: {=
-    Array<number>
-  =}
+  input[2] inp: {= Array<number> =}
 
   reaction(inp) {=
     let count = 0;     // For testing.
@@ -60,12 +56,8 @@ reactor Print(scale: number = 1) {
 }
 
 reactor Scale(scale: number = 2) {
-  mutable input[2] inp: {=
-    Array<number>
-  =}
-  output[2] out: {=
-    Array<number>
-  =}
+  mutable input[2] inp: {= Array<number> =}
+  output[2] out: {= Array<number> =}
 
   reaction(inp) -> out {=
     for (let j = 0; j < inp.length; j++) {

--- a/test/TypeScript/src/multiport/MultiportMutableInputArray.lf
+++ b/test/TypeScript/src/multiport/MultiportMutableInputArray.lf
@@ -4,7 +4,9 @@
 target TypeScript
 
 reactor Source {
-  output[2] out: {= Array<number> =}
+  output[2] out: {=
+    Array<number>
+  =}
 
   reaction(startup) -> out {=
     // Dynamically allocate an output array of length 3.
@@ -27,7 +29,9 @@ reactor Source {
 
 // The scale parameter is just for testing.
 reactor Print(scale: number = 1) {
-  input[2] inp: {= Array<number> =}
+  input[2] inp: {=
+    Array<number>
+  =}
 
   reaction(inp) {=
     let count = 0;     // For testing.
@@ -56,8 +60,12 @@ reactor Print(scale: number = 1) {
 }
 
 reactor Scale(scale: number = 2) {
-  mutable input[2] inp: {= Array<number> =}
-  output[2] out: {= Array<number> =}
+  mutable input[2] inp: {=
+    Array<number>
+  =}
+  output[2] out: {=
+    Array<number>
+  =}
 
   reaction(inp) -> out {=
     for (let j = 0; j < inp.length; j++) {

--- a/test/TypeScript/src/multiport/MultiportToMultiportArray.lf
+++ b/test/TypeScript/src/multiport/MultiportToMultiportArray.lf
@@ -5,7 +5,9 @@ target TypeScript {
 
 reactor Source {
   timer t(0, 200 msec)
-  output[2] out: {= Array<number> =}
+  output[2] out: {=
+    Array<number>
+  =}
   state s: number = 0
 
   reaction(t) -> out {=
@@ -24,7 +26,9 @@ reactor Source {
 
 reactor Destination {
   state s: number = 15
-  input[2] inp: {= Array<number> =}
+  input[2] inp: {=
+    Array<number>
+  =}
 
   reaction(inp) {=
     let sum = 0;

--- a/test/TypeScript/src/multiport/MultiportToMultiportArray.lf
+++ b/test/TypeScript/src/multiport/MultiportToMultiportArray.lf
@@ -5,9 +5,7 @@ target TypeScript {
 
 reactor Source {
   timer t(0, 200 msec)
-  output[2] out: {=
-    Array<number>
-  =}
+  output[2] out: {= Array<number> =}
   state s: number = 0
 
   reaction(t) -> out {=
@@ -26,9 +24,7 @@ reactor Source {
 
 reactor Destination {
   state s: number = 15
-  input[2] inp: {=
-    Array<number>
-  =}
+  input[2] inp: {= Array<number> =}
 
   reaction(inp) {=
     let sum = 0;

--- a/test/TypeScript/src/multiport/PipelineAfter.lf
+++ b/test/TypeScript/src/multiport/PipelineAfter.lf
@@ -3,14 +3,18 @@ target TypeScript
 reactor Source {
   output out: number
 
-  reaction(startup) -> out {= out = 40; =}
+  reaction(startup) -> out {=
+    out = 40;
+  =}
 }
 
 reactor Compute {
   input inp: number
   output out: number
 
-  reaction(inp) -> out {= out = (inp as number) + 2; =}
+  reaction(inp) -> out {=
+    out = (inp as number) + 2;
+  =}
 }
 
 reactor Sink {

--- a/test/TypeScript/src/multiport/ReactionsToNested.lf
+++ b/test/TypeScript/src/multiport/ReactionsToNested.lf
@@ -32,7 +32,11 @@ reactor D {
 main reactor {
   d = new D()
 
-  reaction(startup) -> d.y {= d.y[0] = 42; =}
+  reaction(startup) -> d.y {=
+    d.y[0] = 42;
+  =}
 
-  reaction(startup) -> d.y {= d.y[1] = 43; =}
+  reaction(startup) -> d.y {=
+    d.y[1] = 43;
+  =}
 }


### PR DESCRIPTION
Fixes  #1975.

This is in response to readability issues. Additionally, I personally find that when statements are put on one line, that makes refactoring more cumbersome because one must add newlines before adding additional statements to a reaction.

An example of a project that made a similar decision to this is `rustfmt`, which never seems to put if statements all on one line.

~~This change has a code smell -- it does matching on raw strings without parsing them. Also it only has effects in the case where the target language has semicolons, which may or may not be what we want. I am thinking about changing the implementation of this to be based on whether the code is a reaction body instead of whether it has a semicolon.~~ This is now resolved.

Since this change is late, we do not need to squeeze it into the 0.5.0 release. However, it might behoove us to release it soon, e.g. in 0.5.1, because the changes to the appearance of LF code could be highly disruptive; ideally users could transition straight from the 0.4.0 format to the 0.5.1 format without bothering with the 0.5.0 format in between.