### PR TITLE
Suppress deprecation warnings so arrays work in Python

### DIFF
--- a/core/src/main/java/org/lflang/Target.java
+++ b/core/src/main/java/org/lflang/Target.java
@@ -516,7 +516,7 @@ public enum Target {
    * reactor constructor call, regardless of this method.
    */
   public boolean mandatesEqualsInitializers() {
-    return this != CPP;
+    return this != CPP && this != Python;
   }
 
   /** Allow expressions of the form {@code {a, b, c}}. */

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -173,7 +173,7 @@ public class LFValidator extends BaseLFValidator {
         message += " (run the formatter to fix this automatically)";
       }
       warning(message, Literals.INITIALIZER__PARENS);
-    } else if (!init.isAssign() && init.eContainer() instanceof Assignment) {
+    } else if (!init.isAssign() && init.eContainer() instanceof Assignment && target.mandatesEqualsInitializers()) {
       var feature = init.isBraces() ? Literals.INITIALIZER__BRACES : Literals.INITIALIZER__PARENS;
       var message =
           "This syntax is deprecated, do not use parentheses or braces but an equal sign.";


### PR DESCRIPTION
To work around bug #1981, this PR allows the old syntax for array parameters and states in the Python target, which is the only syntax that currently works.