### PR TITLE
Test lf_set_array and persistent inputs

### DIFF
--- a/test/C/src/ArraySet.lf
+++ b/test/C/src/ArraySet.lf
@@ -1,0 +1,38 @@
+target C
+
+reactor Source {
+  output out: int[]
+
+  reaction(startup) -> out {=
+    // Dynamically allocate an output array of length 3.
+    int* array = (int*)malloc(3 * sizeof(int));
+    // Populate the array.
+    array[0] = 0;
+    array[1] = 1;
+    array[2] = 2;
+    // Set the output, specifying the array length.
+    lf_set_array(out, array, 3);
+  =}
+}
+
+reactor Print {
+  input in: int[]
+
+  reaction(in) {=
+    printf("Received: [");
+    for (int i = 0; i < in->length; i++) {
+      if (i > 0) printf(", ");
+      printf("%d", in->value[i]);
+      if (in->value[i] != i) {
+        lf_print_error_and_exit("Expected %d.", i);
+      }
+    }
+    printf("]\n");
+  =}
+}
+
+main reactor {
+  s = new Source()
+  p = new Print()
+  s.out -> p.in
+}

--- a/test/C/src/PersistentInputs.lf
+++ b/test/C/src/PersistentInputs.lf
@@ -1,0 +1,33 @@
+target C {
+  timeout: 400 ms,
+  fast: true
+}
+reactor Source {
+  output out: int
+  timer t(100 ms, 200 ms)
+  state count: int = 1
+  reaction(t) -> out {=
+    lf_set(out, self->count++);
+  =}
+}
+reactor Sink {
+  input in: int
+  timer t(0, 100 ms)
+  // For testing, emulate the count variable of Source.
+  state count: int = 0
+  timer t2(100 ms, 200 ms)
+  reaction(t2) {=
+    self->count++;
+  =}
+  reaction(t) in {=
+    printf("Value of the input is %d at time %lld\n", in->value, lf_time_logical_elapsed());
+    if (in->value != self->count) {
+      lf_print_error_and_exit("Expected %d.", self->count);
+    }
+  =}
+}
+main reactor {
+  source = new Source()
+  sink = new Sink()
+  source.out -> sink.in
+}

--- a/test/C/src/PersistentInputs.lf
+++ b/test/C/src/PersistentInputs.lf
@@ -2,23 +2,23 @@ target C {
   timeout: 400 ms,
   fast: true
 }
+
 reactor Source {
   output out: int
   timer t(100 ms, 200 ms)
   state count: int = 1
-  reaction(t) -> out {=
-    lf_set(out, self->count++);
-  =}
+
+  reaction(t) -> out {= lf_set(out, self->count++); =}
 }
+
 reactor Sink {
   input in: int
   timer t(0, 100 ms)
-  // For testing, emulate the count variable of Source.
-  state count: int = 0
+  state count: int = 0  // For testing, emulate the count variable of Source.
   timer t2(100 ms, 200 ms)
-  reaction(t2) {=
-    self->count++;
-  =}
+
+  reaction(t2) {= self->count++; =}
+
   reaction(t) in {=
     printf("Value of the input is %d at time %lld\n", in->value, lf_time_logical_elapsed());
     if (in->value != self->count) {
@@ -26,6 +26,7 @@ reactor Sink {
     }
   =}
 }
+
 main reactor {
   source = new Source()
   sink = new Sink()


### PR DESCRIPTION
I noticed that the lf_set_array function in the C target is not properly tested in the test suite.  This adds a test to test it.

This also adds a test of persistent inputs that matches the documentation.