### PR TITLE
Default hostname for RTI in dockerized federation changed from "localhost" to "rti"

### DIFF
--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -416,6 +416,14 @@ public class FedGenerator {
         && !federation.getHost().getAddr().equals("localhost")) {
       rtiConfig.setHost(federation.getHost().getAddr());
     }
+    // If the federation is dockerized, use "rti" as the hostname.
+    // FIXME: Do we have to check the condition rtiConfig.getHost().equals("localhost")? 
+    // In other words, do we have to preserve the user-specified IP address of the RTI 
+    // when the program is dockerized? 
+    if (rtiConfig.getHost().equals("localhost") 
+        && targetConfig.dockerOptions != null) {
+      rtiConfig.setHost("rti");
+    }
 
     // Since federates are always within the main (federated) reactor,
     // create a list containing just that one containing instantiation.

--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -417,9 +417,6 @@ public class FedGenerator {
       rtiConfig.setHost(federation.getHost().getAddr());
     }
     // If the federation is dockerized, use "rti" as the hostname.
-    // FIXME: Do we have to check the condition rtiConfig.getHost().equals("localhost")?
-    // In other words, do we have to preserve the user-specified IP address of the RTI
-    // when the program is dockerized?
     if (rtiConfig.getHost().equals("localhost") && targetConfig.dockerOptions != null) {
       rtiConfig.setHost("rti");
     }

--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -417,11 +417,10 @@ public class FedGenerator {
       rtiConfig.setHost(federation.getHost().getAddr());
     }
     // If the federation is dockerized, use "rti" as the hostname.
-    // FIXME: Do we have to check the condition rtiConfig.getHost().equals("localhost")? 
-    // In other words, do we have to preserve the user-specified IP address of the RTI 
-    // when the program is dockerized? 
-    if (rtiConfig.getHost().equals("localhost") 
-        && targetConfig.dockerOptions != null) {
+    // FIXME: Do we have to check the condition rtiConfig.getHost().equals("localhost")?
+    // In other words, do we have to preserve the user-specified IP address of the RTI
+    // when the program is dockerized?
+    if (rtiConfig.getHost().equals("localhost") && targetConfig.dockerOptions != null) {
       rtiConfig.setHost("rti");
     }
 

--- a/test/C/src/docker/federated/DistributedCountContainerized.lf
+++ b/test/C/src/docker/federated/DistributedCountContainerized.lf
@@ -14,7 +14,7 @@ target C {
 import Count from "../../lib/Count.lf"
 import Print from "../../federated/DistributedCount.lf"
 
-federated reactor DistributedCountContainerized(offset: time = 200 msec) at rti {
+federated reactor DistributedCountContainerized(offset: time = 200 msec) {
   c = new Count()
   p = new Print()
   c.out -> p.in after offset

--- a/test/C/src/docker/federated/DistributedDoublePortContainerized.lf
+++ b/test/C/src/docker/federated/DistributedDoublePortContainerized.lf
@@ -15,7 +15,7 @@ import Count from "../../lib/Count.lf"
 import CountMicrostep from "../../federated/DistributedDoublePort.lf"
 import Print from "../../federated/DistributedDoublePort.lf"
 
-federated reactor DistributedDoublePortContainerized at rti {
+federated reactor DistributedDoublePortContainerized {
   c = new Count()
   cm = new CountMicrostep()
   p = new Print()

--- a/test/C/src/docker/federated/DistributedMultiportContainerized.lf
+++ b/test/C/src/docker/federated/DistributedMultiportContainerized.lf
@@ -7,7 +7,7 @@ target C {
 
 import Source, Destination from "../../federated/DistributedMultiport.lf"
 
-federated reactor DistributedMultiportContainerized at rti {
+federated reactor DistributedMultiportContainerized {
   s = new Source(width=4)
   d = new Destination(width=4)
   s.out -> d.in

--- a/test/C/src/docker/federated/DistributedStopDecentralizedContainerized.lf
+++ b/test/C/src/docker/federated/DistributedStopDecentralizedContainerized.lf
@@ -10,7 +10,7 @@ target C {
 
 import Sender, Receiver from "../../federated/DistributedStop.lf"
 
-federated reactor DistributedStopDecentralizedContainerized at rti {
+federated reactor DistributedStopDecentralizedContainerized {
   sender = new Sender()
   receiver = new Receiver()
   sender.out -> receiver.in


### PR DESCRIPTION
Dockerized federation programs should use "rti" as the hostname of the RTI as default to get a proper IP address of the RTI. 