### PR TITLE
Apply spotbugs plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     // https://mvnrepository.com/artifact/com.diffplug.spotless/spotless-lib-extra
     implementation group: 'com.diffplug.spotless', name: 'spotless-lib-extra', version: spotlessLibVersion
 
+    implementation group: 'com.github.spotbugs.snom', name: 'spotbugs-gradle-plugin', version: spotbugsPluginVersion
+
     implementation "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     implementation "com.diffplug.spotless:spotless-plugin-gradle:$spotlessVersion"
 

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -3,3 +3,4 @@ spotlessVersion=6.11.0
 spotlessLibVersion=2.30.0
 kotlinVersion=1.6.21
 shadowJarVersion=7.1.2
+spotbugsPluginVersion=5.1.3

--- a/buildSrc/src/main/groovy/org.lflang.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.lflang.java-conventions.gradle
@@ -25,6 +25,7 @@ spotbugs {
     excludeFilter.set(
         rootProject.file('config/spotbugs/exclude.xml')
     )
+    ignoreFailures = true
 }
 
 

--- a/buildSrc/src/main/groovy/org.lflang.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.lflang.java-conventions.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'com.diffplug.spotless'
     id 'org.lflang.platform'
+    id 'com.github.spotbugs'
 }
 
 repositories {
@@ -18,6 +19,14 @@ spotless {
         formatAnnotations()
     }
 }
+
+spotbugs {
+    toolVersion = spotbugsToolVersion
+    excludeFilter.set(
+        rootProject.file('config/spotbugs/exclude.xml')
+    )
+}
+
 
 configurations.all {
     resolutionStrategy {

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Or>
+            <Package name="org.lflang.dsl*"/>
+            <Package name="org.lflang.parser.antlr"/>
+            <Package name="~org.lflang.parser.antlr\..*"/>
+            <Package name="org.lflang.lf"/>
+            <Package name="~org.lflang.lf\..*"/>
+            <Package name="org.lflang.services"/>
+            <Package name="~org.lflang.services\..*"/>
+            <Package name="org.lflang.serializer"/>
+            <Package name="~org.lflang.serializer\..*"/>
+            <Package name="org.lflang.ide.contentassist"/>
+            <Package name="~org.lflang.ide.contentassist\..*"/>
+            <Class name="org.lflang.ide.AbstractLFIdeModule"/>
+            <Class name="org.lflang.tests.LFInjectorProvider"/>
+        </Or>
+    </Match>
+</FindBugsFilter>

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ xtextVersion=2.31.0
 klighdVersion=2.3.0.v20230606
 freehepVersion=2.4
 swtVersion=3.124.0
+spotbugsToolVersion=4.7.3
 
 [manifestPropertyNames]
 org.eclipse.xtext=xtextVersion


### PR DESCRIPTION
This PR applies the [spotbugs](https://spotbugs.github.io/) gradle plugin. spotbugs is a static code analysis tool that can detect a lot of bug patterns in Java (and Kotlin).

This is a selection of the type of issues reported by spotbugs:
```
H V MS: org.lflang.generator.GeneratorResult.NOTHING isn't final but should be  At GeneratorResult.java:[line 14]
H C HE: org.lflang.TimeValue doesn't define a hashCode() method but it is used in a hashed context in org.lflang.federated.generator.FederateInstance.stpToNetworkActionMap  In FederateInstance.java
M P UuF: Unused field: org.lflang.analyses.c.CToUclidVisitor.unchangedTriggers  In CToUclidVisitor.java
M V EI2: new org.lflang.federated.generator.FedEmitter(FedFileConfig, Reactor, MessageReporter, RtiConfig) may expose internal representation by storing an externally mutable object into FedEmitter.messageReporter  At FedEmitter.java:[line 29]
M D NP: Possible null pointer dereference in org.lflang.generator.cpp.CppStandaloneGenerator.generatePlatformFiles() due to return value of called method  Dereferenced at CppStandaloneGenerator.kt:[line 38]
M D BC: Questionable cast from Collection to abstract class java.util.List in org.lflang.generator.cpp.CppStandaloneGenerator.compareVersion(String, String)  At CppStandaloneGenerator.kt:[line 187]
M B FS: Format string should use %n rather than \n in org.lflang.ast.FormattingUtil.lineWrapComment(String, int, String)  At FormattingUtil.java:[line 172]
M P SBSC: org.lflang.analyses.uclid.UclidGenerator.generateActionAxioms() concatenates strings using + in a loop  At UclidGenerator.java:[line 987]
```

Spotbugs is run automatically as part of the `check` and `build` gradle tasks. The plugin is currently configured to treat all issues that it finds as warnings, not errors. Thus, the build succeeds although spotbugs reports problems.

Fixing all issues reported by spotbugs will keep us busy for a while. To keep this manageable, I think we should fix warnings in several smaller PRs and treat found issues as errors as soon as we have cleaned up the codebase.

This is a first step towards resolving https://github.com/lf-lang/lingua-franca/issues/1806.