### PR TITLE
Stabilized LSP diagram genenation and added default expansion option

### DIFF
--- a/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -257,6 +257,9 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
       SynthesisOption.<Integer>createRangeOption("Reactor Parameter/Variable Columns", 1, 10, 1)
           .setCategory(APPEARANCE);
 
+  public static final SynthesisOption DEFAULT_EXPAND_ALL =
+      SynthesisOption.createCheckOption("Expand reactors by default", false);
+
   public static final SynthesisOption FIXED_PORT_SIDE =
       SynthesisOption.createCheckOption("Fixed Port Sides", true).setCategory(LAYOUT);
   public static final SynthesisOption SPACING =
@@ -273,6 +276,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
   public List<SynthesisOption> getDisplayedSynthesisOptions() {
     return List.of(
         SHOW_ALL_REACTORS,
+        DEFAULT_EXPAND_ALL,
         MemorizingExpandCollapseAction.MEMORIZE_EXPANSION_STATES,
         CYCLE_DETECTION,
         APPEARANCE,
@@ -1019,18 +1023,16 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
     TriggerInstance<?> reset = null;
 
     // Transform instances
-    int index = 0;
     for (ReactorInstance child : reactorInstance.children) {
       Boolean expansionState = MemorizingExpandCollapseAction.getExpansionState(child);
       Collection<KNode> rNodes =
           createReactorNode(
               child,
-              expansionState != null ? expansionState : false,
+              expansionState != null ? expansionState : getBooleanValue(DEFAULT_EXPAND_ALL),
               inputPorts,
               outputPorts,
               allReactorNodes);
       nodes.addAll(rNodes);
-      index++;
     }
 
     // Create timers

--- a/lsp/build.gradle
+++ b/lsp/build.gradle
@@ -10,6 +10,13 @@ dependencies {
         exclude group: 'org.eclipse.platform', module: 'org.eclipse.swt.*'
         exclude group: 'org.eclipse.platform', module: 'org.eclipse.swt'
     }
+
+    // This dependency ensures correct animations and bookkeeping during updates
+    // See https://github.com/lf-lang/vscode-lingua-franca/issues/103#issuecomment-1731023470
+    implementation ("de.cau.cs.kieler.klighd:de.cau.cs.kieler.klighd.incremental:$klighdVersion") {
+        exclude group: 'org.eclipse.platform', module: 'org.eclipse.swt.*'
+        exclude group: 'org.eclipse.platform', module: 'org.eclipse.swt'
+    }
 }
 
 application {


### PR DESCRIPTION
This PR adds a dependency of the language server on `de.cau.cs.kieler.klighd.incremental` as suggested in this comment: https://github.com/lf-lang/vscode-lingua-franca/issues/103#issuecomment-1731023470. This seems to indeed stabilize the diagram generation. 

It further adds a new synthesis options that allows to control if new reactors should be expanded or contracted when added. This setting also influences if all reactors are expanded or contracted when opening a new LF file.

Closes https://github.com/lf-lang/vscode-lingua-franca/issues/103 

Perhaps this change also addresses https://github.com/lf-lang/vscode-lingua-franca/issues/142, but we will need further testing.