### PR TITLE
Avoidance of random CI failures due to failing Gradle download

### DIFF
--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -11,3 +11,10 @@ runs:
       uses: gradle/gradle-build-action@v2.8.0
       with:
         cache-read-only: false
+   - name: Download Gradle Wrapper and print version
+     run: |
+        # Retry 3 times before the steps actually fails
+        (echo "==== Gradle Wrapper Download Attempt: 1 ====" && ./gradlew --version) || \
+        (echo "==== Gradle Wrapper Download Attempt: 2 ====" && ./gradlew --version) || \
+        (echo "==== Gradle Wrapper Download Attempt: 3 ====" && ./gradlew --version) || \
+        (echo "==== Gradle Wrapper Download Failed ====" && exit 1)

--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -18,3 +18,4 @@ runs:
         (echo "==== Gradle Wrapper Download Attempt: 2 ====" && ./gradlew --version) || \
         (echo "==== Gradle Wrapper Download Attempt: 3 ====" && ./gradlew --version) || \
         (echo "==== Gradle Wrapper Download Failed ====" && exit 1)
+      shell: bash

--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -22,7 +22,7 @@ runs:
       run: |
         # Retry 3 times before the steps actually fails
         (echo "==== Gradle Download Attempt: 1 ====" && ./gradlew --version) || \
-        (echo "==== Gradle Download Attempt: 2 ====" && ./gradlew --version) || \
-        (echo "==== Gradle Download Attempt: 3 ====" && ./gradlew --version) || \
+        (sleep 30 && echo "==== Gradle Download Attempt: 2 ====" && ./gradlew --version) || \
+        (sleep 30 && echo "==== Gradle Download Attempt: 3 ====" && ./gradlew --version) || \
         (echo "==== Gradle Download Failed ====" && exit 1)
       shell: bash

--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -11,8 +11,8 @@ runs:
       uses: gradle/gradle-build-action@v2.8.0
       with:
         cache-read-only: false
-   - name: Download Gradle Wrapper and print version
-     run: |
+    - name: Download Gradle Wrapper and print version
+      run: |
         # Retry 3 times before the steps actually fails
         (echo "==== Gradle Wrapper Download Attempt: 1 ====" && ./gradlew --version) || \
         (echo "==== Gradle Wrapper Download Attempt: 2 ====" && ./gradlew --version) || \

--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -17,12 +17,12 @@ runs:
       uses: gradle/gradle-build-action@v2.8.0
       with:
         cache-read-only: false
-    - name: Download Gradle Wrapper and print version
+    - name: Download Gradle and print version
       working-directory: ${{ inputs.lingua-franca-dir }}
       run: |
         # Retry 3 times before the steps actually fails
-        (echo "==== Gradle Wrapper Download Attempt: 1 ====" && ./gradlew --version) || \
-        (echo "==== Gradle Wrapper Download Attempt: 2 ====" && ./gradlew --version) || \
-        (echo "==== Gradle Wrapper Download Attempt: 3 ====" && ./gradlew --version) || \
-        (echo "==== Gradle Wrapper Download Failed ====" && exit 1)
+        (echo "==== Gradle Download Attempt: 1 ====" && ./gradlew --version) || \
+        (echo "==== Gradle Download Attempt: 2 ====" && ./gradlew --version) || \
+        (echo "==== Gradle Download Attempt: 3 ====" && ./gradlew --version) || \
+        (echo "==== Gradle Download Failed ====" && exit 1)
       shell: bash

--- a/.github/actions/prepare-build-env/action.yml
+++ b/.github/actions/prepare-build-env/action.yml
@@ -1,5 +1,11 @@
 name: Set up build environment
 description: Set up Java and Gradle (including caching).
+
+inputs:
+  lingua-franca-dir:
+    description: 'Path to the lingua-franca directory'
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -12,6 +18,7 @@ runs:
       with:
         cache-read-only: false
     - name: Download Gradle Wrapper and print version
+      working-directory: ${{ inputs.lingua-franca-dir }}
       run: |
         # Retry 3 times before the steps actually fails
         (echo "==== Gradle Wrapper Download Attempt: 1 ====" && ./gradlew --version) || \


### PR DESCRIPTION
Sometimes CI fails because a job fails to download Gradle (which happens upon the first invocation of `gradlew`). This PR adds a step that repeatedly (3x) attempts the download before giving up.