### PR TITLE
Bumped Gradle and Gradle plugin versions

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -18,5 +18,5 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     implementation "com.diffplug.spotless:spotless-plugin-gradle:$spotlessVersion"
 
-    implementation "gradle.plugin.com.github.johnrengelman:shadow:$shadowJarVersion"
+    implementation "com.github.johnrengelman:shadow:$shadowJarVersion"
 }

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,6 +1,6 @@
 [versions]
-spotlessVersion=6.11.0
+spotlessVersion=6.21.0
 spotlessLibVersion=2.30.0
-kotlinVersion=1.6.21
-shadowJarVersion=7.1.2
+kotlinVersion=1.9.0
+shadowJarVersion=8.1.1
 spotbugsPluginVersion=5.1.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=e111cb9948407e26351227dabce49822fb88c37ee72f1d1582a69c68af2e702f
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionSha256Sum=591855b517fc635b9e04de1d05d5e76ada3f89f5fc76f87978d1b245b4f69225
+distributionUrl=https://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Gradle 8.1.1 -> 8.3
- Spotless 6.11.0 -> 6.21.0
- Kotlin 1.6.21 -> 1.9.0
- Shadow Jar 7.1.2 -> 8.1.1

This fixes the deprecation warnings that Gradle produces currently.