### PR TITLE
Generate default values for the user-configurable CMake flags

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -255,22 +255,22 @@ public class CCmakeGenerator {
     }
     cMakeCode.newLine();
     cMakeCode.pr("# Set default values for build parameters\n");
-    targetConfig.compileDefinitions.forEach((key, value) -> {
-      if (key.equals("LF_THREADED") || key.equals("LF_UNTHREADED")) {
-        cMakeCode.pr("if (NOT DEFINED LF_THREADED AND NOT DEFINED LF_UNTHREADED)\n");
-        cMakeCode.indent();
-        cMakeCode.pr("set("+key + " " + value + ")\n");
-        cMakeCode.unindent();
-        cMakeCode.pr("endif()\n");
-      } else {
-        cMakeCode.pr("if (NOT DEFINED "+key+")\n");
-        cMakeCode.indent();
-        cMakeCode.pr("set("+key + " " + value + ")\n");
-        cMakeCode.unindent();
-        cMakeCode.pr("endif()\n");
-      }
-    }
-    );
+    targetConfig.compileDefinitions.forEach(
+        (key, value) -> {
+          if (key.equals("LF_THREADED") || key.equals("LF_UNTHREADED")) {
+            cMakeCode.pr("if (NOT DEFINED LF_THREADED AND NOT DEFINED LF_UNTHREADED)\n");
+            cMakeCode.indent();
+            cMakeCode.pr("set(" + key + " " + value + ")\n");
+            cMakeCode.unindent();
+            cMakeCode.pr("endif()\n");
+          } else {
+            cMakeCode.pr("if (NOT DEFINED " + key + ")\n");
+            cMakeCode.indent();
+            cMakeCode.pr("set(" + key + " " + value + ")\n");
+            cMakeCode.unindent();
+            cMakeCode.pr("endif()\n");
+          }
+        });
 
     // Setup main target for different platforms
     switch (targetConfig.platformOptions.platform) {

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -263,10 +263,13 @@ public class CCmakeGenerator {
             cMakeCode.pr("if (NOT DEFINED " + key + ")\n");
           }
           cMakeCode.indent();
-          cMakeCode.pr("set(" + key + " " + (value.isEmpty() ? "TRUE" : value) + ")\n");
+          var v = "TRUE";
+          if (value != null && !value.isEmpty()) {
+            v = value;
+          }
+          cMakeCode.pr("set(" + key + " " + v + ")\n");
           cMakeCode.unindent();
           cMakeCode.pr("endif()\n");
-
         });
 
     // Setup main target for different platforms

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -254,6 +254,23 @@ public class CCmakeGenerator {
           "set(CMAKE_SYSTEM_NAME " + targetConfig.platformOptions.platform.getcMakeName() + ")");
     }
     cMakeCode.newLine();
+    cMakeCode.pr("# Set default values for build parameters\n");
+    targetConfig.compileDefinitions.forEach((key, value) -> {
+      if (key.equals("LF_THREADED") || key.equals("LF_UNTHREADED")) {
+        cMakeCode.pr("if (NOT DEFINED LF_THREADED AND NOT DEFINED LF_UNTHREADED)\n");
+        cMakeCode.indent();
+        cMakeCode.pr("set("+key + " " + value + ")\n");
+        cMakeCode.unindent();
+        cMakeCode.pr("endif()\n");
+      } else {
+        cMakeCode.pr("if (NOT DEFINED "+key+")\n");
+        cMakeCode.indent();
+        cMakeCode.pr("set("+key + " " + value + ")\n");
+        cMakeCode.unindent();
+        cMakeCode.pr("endif()\n");
+      }
+    }
+    );
 
     // Setup main target for different platforms
     switch (targetConfig.platformOptions.platform) {

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -259,17 +259,14 @@ public class CCmakeGenerator {
         (key, value) -> {
           if (key.equals("LF_THREADED") || key.equals("LF_UNTHREADED")) {
             cMakeCode.pr("if (NOT DEFINED LF_THREADED AND NOT DEFINED LF_UNTHREADED)\n");
-            cMakeCode.indent();
-            cMakeCode.pr("set(" + key + " " + value + ")\n");
-            cMakeCode.unindent();
-            cMakeCode.pr("endif()\n");
           } else {
             cMakeCode.pr("if (NOT DEFINED " + key + ")\n");
-            cMakeCode.indent();
-            cMakeCode.pr("set(" + key + " " + value + ")\n");
-            cMakeCode.unindent();
-            cMakeCode.pr("endif()\n");
           }
+          cMakeCode.indent();
+          cMakeCode.pr("set(" + key + " " + (value.isEmpty() ? "TRUE" : value) + ")\n");
+          cMakeCode.unindent();
+          cMakeCode.pr("endif()\n");
+
         });
 
     // Setup main target for different platforms

--- a/core/src/main/java/org/lflang/generator/c/CCompiler.java
+++ b/core/src/main/java/org/lflang/generator/c/CCompiler.java
@@ -216,14 +216,8 @@ public class CCompiler {
     return command;
   }
 
-  static Stream<String> cmakeCompileDefinitions(TargetConfig targetConfig) {
-    return targetConfig.compileDefinitions.entrySet().stream()
-        .map(entry -> "-D" + entry.getKey() + "=" + entry.getValue());
-  }
-
   private static List<String> cmakeOptions(TargetConfig targetConfig, FileConfig fileConfig) {
     List<String> arguments = new ArrayList<>();
-    cmakeCompileDefinitions(targetConfig).forEachOrdered(arguments::add);
     String separator = File.separator;
     String maybeQuote = ""; // Windows seems to require extra level of quoting.
     String srcPath = fileConfig.srcPath.toString(); // Windows requires escaping the backslashes.
@@ -402,10 +396,6 @@ public class CCompiler {
           fileConfig.getOutPath().relativize(fileConfig.getSrcGenPath().resolve(Paths.get(file)));
       compileArgs.add(FileUtil.toUnixString(relativePath));
     }
-
-    // Add compile definitions
-    targetConfig.compileDefinitions.forEach(
-        (key, value) -> compileArgs.add("-D" + key + "=" + value));
 
     // Finally, add the compiler flags in target parameters (if any)
     compileArgs.addAll(targetConfig.compilerFlags);

--- a/core/src/main/java/org/lflang/generator/c/CCompiler.java
+++ b/core/src/main/java/org/lflang/generator/c/CCompiler.java
@@ -32,7 +32,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 import org.lflang.FileConfig;
 import org.lflang.MessageReporter;
 import org.lflang.TargetConfig;

--- a/core/src/main/java/org/lflang/generator/c/CDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CDockerGenerator.java
@@ -68,10 +68,7 @@ public class CDockerGenerator extends DockerGenerator {
         "\n",
         "RUN set -ex && \\",
         "mkdir bin && \\",
-        "cmake "
-            + CCompiler.cmakeCompileDefinitions(context.getTargetConfig())
-                .collect(Collectors.joining(" "))
-            + " -S src-gen -B bin && \\",
+        "cmake -S src-gen -B bin && \\",
         "cd bin && \\",
         "make all");
   }

--- a/core/src/main/java/org/lflang/generator/c/CDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CDockerGenerator.java
@@ -1,6 +1,5 @@
 package org.lflang.generator.c;
 
-import java.util.stream.Collectors;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.lflang.Target;
 import org.lflang.generator.DockerGenerator;

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -496,44 +496,6 @@ public class CGenerator extends GeneratorBase {
       return;
     }
 
-    // Dump the additional compile definitions to a file to keep the generated project
-    // self-contained. In this way, third-party build tools like PlatformIO, west, arduino-cli can
-    // take over and do the rest of compilation.
-    try {
-      String compileDefs =
-          targetConfig.compileDefinitions.keySet().stream()
-                  .map(key -> key + "=" + targetConfig.compileDefinitions.get(key))
-                  .collect(Collectors.joining("\n"))
-              + "\n";
-      FileUtil.writeToFile(
-          compileDefs,
-          Path.of(fileConfig.getSrcGenPath() + File.separator + "CompileDefinitions.txt"));
-    } catch (IOException e) {
-      Exceptions.sneakyThrow(e);
-    }
-
-    // Create a .vscode/settings.json file in the target directory so that VSCode can
-    // immediately compile the generated code.
-    try {
-      String compileDefs =
-          targetConfig.compileDefinitions.keySet().stream()
-              .map(key -> "\"-D" + key + "=" + targetConfig.compileDefinitions.get(key) + "\"")
-              .collect(Collectors.joining(",\n"));
-      String settings = "{\n" + "\"cmake.configureArgs\": [\n" + compileDefs + "\n]\n}\n";
-      Path vscodePath = fileConfig.getSrcGenPath().resolve(".vscode");
-      if (!Files.exists(vscodePath)) Files.createDirectory(vscodePath);
-      FileUtil.writeToFile(
-          settings,
-          Path.of(
-              fileConfig.getSrcGenPath()
-                  + File.separator
-                  + ".vscode"
-                  + File.separator
-                  + "settings.json"));
-    } catch (IOException e) {
-      Exceptions.sneakyThrow(e);
-    }
-
     // If this code generator is directly compiling the code, compile it now so that we
     // clean it up after, removing the #line directives after errors have been reported.
     if (!targetConfig.noCompile

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -38,7 +38,6 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;


### PR DESCRIPTION
This adds default values to the CMake flags which currently is passed over the command line when invoking cmake. This removes the need for:
1. Generating a `.vscode/settings.json` file to open and build generated sources in VScode.
2. The need for `lfc` to invoke `cmake` with all the flags
3. The need to generate `CompileDefinitons.txt` with the default values

Closing #1677  