### PR TITLE
Fix problems with assignment serialization in diagrams

### DIFF
--- a/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -269,6 +269,12 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
 
   public static final DisplayedActionData EXPAND_ALL =
       DisplayedActionData.create(ExpandAllReactorsAction.ID, "Show all Details");
+  
+  //-------------------------------------------------------------------------
+  
+  private final ToLf serializer = new ToLf();
+    
+  //-------------------------------------------------------------------------
 
   @Override
   public List<SynthesisOption> getDisplayedSynthesisOptions() {
@@ -314,6 +320,9 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
     setLayoutOption(rootNode, CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
     setLayoutOption(rootNode, CoreOptions.DIRECTION, Direction.RIGHT);
     setLayoutOption(rootNode, CoreOptions.PADDING, new ElkPadding(0));
+    
+    // Set target for serializer
+    serializer.setTarget(ASTUtils.getTarget(model));
 
     try {
       // Find main
@@ -1491,7 +1500,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
     if (param.getOverride() != null) {
       b.append(" = ");
       var init = param.getActualValue();
-      b.append(new ToLf().doSwitch(init));
+      b.append(serializer.doSwitch(init));
     }
     return b.toString();
   }
@@ -1522,7 +1531,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
       b.append(":").append(t.toOriginalText());
     }
     if (variable.getInit() != null) {
-      b.append(new ToLf().doSwitch(variable.getInit()));
+      b.append(serializer.doSwitch(variable.getInit()));
     }
     return b.toString();
   }

--- a/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -269,12 +269,12 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
 
   public static final DisplayedActionData EXPAND_ALL =
       DisplayedActionData.create(ExpandAllReactorsAction.ID, "Show all Details");
-  
-  //-------------------------------------------------------------------------
-  
+
+  // -------------------------------------------------------------------------
+
   private final ToLf serializer = new ToLf();
-    
-  //-------------------------------------------------------------------------
+
+  // -------------------------------------------------------------------------
 
   @Override
   public List<SynthesisOption> getDisplayedSynthesisOptions() {
@@ -320,7 +320,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
     setLayoutOption(rootNode, CoreOptions.ALGORITHM, LayeredOptions.ALGORITHM_ID);
     setLayoutOption(rootNode, CoreOptions.DIRECTION, Direction.RIGHT);
     setLayoutOption(rootNode, CoreOptions.PADDING, new ElkPadding(0));
-    
+
     // Set target for serializer
     serializer.setTarget(ASTUtils.getTarget(model));
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -1495,11 +1495,10 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
     b.append(param.getName());
     String t = param.type.toOriginalText();
     if (!StringExtensions.isNullOrEmpty(t)) {
-      b.append(": ").append(t);
+      b.append(":").append(t);
     }
-    if (param.getOverride() != null) {
-      b.append(" = ");
-      var init = param.getActualValue();
+    var init = param.getActualValue();
+    if (init != null) {
       b.append(serializer.doSwitch(init));
     }
     return b.toString();


### PR DESCRIPTION
Fixes handling of `ToLf` class that is used to serialize initialization assignments in parameters and state variables for diagrams.

Closes #2010
Closes #2029 