### PR TITLE
Temporarily disable GEDF_NP scheduler

### DIFF
--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -153,7 +153,7 @@ public class ASTUtils {
    * Get the main reactor defined in the given resource.
    *
    * @param resource the resource to extract reactors from
-   * @return An iterable over all reactors found in the resource
+   * @return The top-level main reactor, or null if there is no main or federated reactor or the top-level is federated.
    */
   public static Optional<Reactor> getMainReactor(Resource resource) {
     return StreamSupport.stream(

--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -153,8 +153,7 @@ public class ASTUtils {
    * Get the main reactor defined in the given resource.
    *
    * @param resource the resource to extract reactors from
-   * @return The top-level main reactor, or null if there is no main or federated reactor or the
-   *     top-level is federated.
+   * @return A top-level main reactor presented as an {@code Optional} that is present if such top-level reactor exists.
    */
   public static Optional<Reactor> getMainReactor(Resource resource) {
     return StreamSupport.stream(

--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -153,7 +153,8 @@ public class ASTUtils {
    * Get the main reactor defined in the given resource.
    *
    * @param resource the resource to extract reactors from
-   * @return The top-level main reactor, or null if there is no main or federated reactor or the top-level is federated.
+   * @return The top-level main reactor, or null if there is no main or federated reactor or the
+   *     top-level is federated.
    */
   public static Optional<Reactor> getMainReactor(Resource resource) {
     return StreamSupport.stream(

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -694,6 +694,9 @@ public class CGenerator extends GeneratorBase {
   private void pickScheduler() {
     // Don't use a scheduler that does not prioritize reactions based on deadlines
     // if the program contains a deadline (handler). Use the GEDF_NP scheduler instead.
+    // FIXME: GEDF_NP doesn't work for federated, at least, and perhaps has race conditions for others.
+    // See https://github.com/lf-lang/lingua-franca/issues/2026
+    /*
     if (!targetConfig.schedulerType.prioritizesDeadline()) {
       // Check if a deadline is assigned to any reaction
       if (hasDeadlines(reactors)) {
@@ -701,7 +704,7 @@ public class CGenerator extends GeneratorBase {
           targetConfig.schedulerType = TargetProperty.SchedulerOption.GEDF_NP;
         }
       }
-    }
+    */
   }
 
   private boolean hasDeadlines(List<Reactor> reactors) {

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -694,7 +694,8 @@ public class CGenerator extends GeneratorBase {
   private void pickScheduler() {
     // Don't use a scheduler that does not prioritize reactions based on deadlines
     // if the program contains a deadline (handler). Use the GEDF_NP scheduler instead.
-    // FIXME: GEDF_NP doesn't work for federated, at least, and perhaps has race conditions for others.
+    // FIXME: GEDF_NP doesn't work for federated, at least, and perhaps has race conditions for
+    // others.
     // See https://github.com/lf-lang/lingua-franca/issues/2026
     /*
     if (!targetConfig.schedulerType.prioritizesDeadline()) {


### PR DESCRIPTION
As reported in #2026, the GEDF_NP scheduler incorrectly executes LF code at least for federated reactors. This PR disables the automatic selection of GEDF_NP when there are deadlines.  You can still set a target property to choose this scheduler, but until we fix this scheduler, it should never be automatically selected.