### PR TITLE
[C-Target] Tracing

### DIFF
--- a/core/src/main/java/org/lflang/TargetConfig.java
+++ b/core/src/main/java/org/lflang/TargetConfig.java
@@ -428,6 +428,8 @@ public class TargetConfig {
      */
     public String traceFileName = null;
 
+    public boolean traceSystem = true;
+
     @Override
     public boolean equals(Object o) {
       if (this == o) {

--- a/core/src/main/java/org/lflang/TargetProperty.java
+++ b/core/src/main/java/org/lflang/TargetProperty.java
@@ -647,6 +647,11 @@ public enum TargetProperty {
               case TRACE_FILE_NAME:
                 if (config.tracing.traceFileName == null) continue;
                 pair.setValue(ASTUtils.toElement(config.tracing.traceFileName));
+                break;
+              case TRACE_SYSTEM_FLAG:
+                  pair.setValue(ASTUtils.toElement(config.tracing.traceSystem));
+                  break;
+
             }
             kvp.getPairs().add(pair);
           }
@@ -670,6 +675,9 @@ public enum TargetProperty {
             switch (option) {
               case TRACE_FILE_NAME:
                 config.tracing.traceFileName = ASTUtils.elementToSingleString(entry.getValue());
+                break;
+            case TRACE_SYSTEM_FLAG:
+                config.tracing.traceSystem = ASTUtils.toBoolean(entry.getValue());
                 break;
               default:
                 break;
@@ -1838,7 +1846,9 @@ public enum TargetProperty {
    * @author Edward A. Lee
    */
   public enum TracingOption implements DictionaryElement {
-    TRACE_FILE_NAME("trace-file-name", PrimitiveType.STRING);
+    TRACE_FILE_NAME("trace-file-name", PrimitiveType.STRING),
+
+    TRACE_SYSTEM_FLAG("system-trace", PrimitiveType.BOOLEAN);
 
     public final PrimitiveType type;
 

--- a/core/src/main/java/org/lflang/generator/c/CPreambleGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CPreambleGenerator.java
@@ -71,6 +71,9 @@ public class CPreambleGenerator {
 
     if (tracing != null) {
       targetConfig.compileDefinitions.put("LF_TRACE", tracing.traceFileName);
+      if (tracing.traceSystem) {
+        targetConfig.compileDefinitions.put("LF_TRACE_SYSTEM", "1");
+      }
     }
     // if (clockSyncIsOn) {
     //     code.pr(generateClockSyncDefineDirective(


### PR DESCRIPTION
Allows user to disable system-tracing when tracing feature is enabled for C-Target

User can now specify system trace option with
```
target C {
    tracing: {
        trace-file-name:"sometrace",
        system-trace: true,
    },
    fast: true
}
```