### PR TITLE
Making timing of test more realistic

### DIFF
--- a/test/C/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
+++ b/test/C/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
@@ -7,7 +7,7 @@
  * between source and destination.
  */
 target C {
-  timeout: 1 msec,
+  timeout: 10 msec,
   coordination: decentralized
 }
 
@@ -27,25 +27,29 @@ reactor Clock(offset: time = 0, period: time = 1 sec) {
   =}
 }
 
-reactor Destination {
+reactor Destination(STP_offset: time = 10 ms) {
   input x: int
   state s: int = 1
 
   reaction(x) {=
-    // printf("%d\n", x->value);
+    lf_print("Received %d", x->value);
     if (x->value != self->s) {
       lf_print_error_and_exit("Expected %d and got %d.", self->s, x->value);
     }
     self->s++;
+  =} STP(10 ms) {=
+    lf_print_error_and_exit("***** STP Violation. This should not occur with a physical connection");
   =}
 
   reaction(shutdown) {=
     lf_print("**** shutdown reaction invoked.");
-    lf_print("Approx. time per reaction: %lldns", lf_time_physical_elapsed()/(self->s+1));
+    lf_print("Approx. time per reaction: %lld ns for %d reactions",
+        lf_time_physical_elapsed()/(self->s), self->s - 1
+    );
   =}
 }
 
-federated reactor(period: time = 10 usec) {
+federated reactor(period: time = 100 usec) {
   c = new Clock(period=period)
   d = new Destination()
   c.y ~> d.x


### PR DESCRIPTION
The `DecentralizedP2PUnbalancedTimeoutPhysical.lf` has been failing nondeterministically. I believe this may due to the lack of STP offsets and the extremely short timeout (1 ms).  This frequently the destination to shut down before receiving any messages at all and possibly before the source has even been able to get itself fully set up. This PR changes the timing so that the receiving federate has STP offsets. The sending federate sends 100 messages with a spacing of 100us. Because the connection is physical, the receiving federate may not receive all of them, but any that it receives will be in order.  This makes the test more realistic and hopefully less flaky.