### PR TITLE
Fixed bug in the C++ reaction dependency analysis

### DIFF
--- a/test/Cpp/src/ReactionOrder.lf
+++ b/test/Cpp/src/ReactionOrder.lf
@@ -1,0 +1,34 @@
+target Cpp
+
+reactor Src {
+  output out: unsigned
+
+  reaction(startup) -> out {=
+    out.set(42);
+  =}
+}
+
+reactor Sink {
+  input in: unsigned
+
+  reaction(startup) in {=
+    if (!in.is_present()) {
+      reactor::log::Error() << "Received no value";
+      exit(1);
+    }
+    if(*in.get() != 42) {
+      reactor::log::Error() << "Received an unexpected value";
+      exit(1);
+    }
+  =}
+
+  reaction(shutdown) {=
+    reactor::log::Info() << "Success!";
+  =}
+}
+
+main reactor ReactionOrder {
+  src = new Src()
+  sink = new Sink()
+  src.out -> sink.in
+}

--- a/test/Cpp/src/enclave/EnclaveCommunicationHierarchy.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationHierarchy.lf
@@ -1,0 +1,52 @@
+target Cpp {
+  timeout: 1 s,
+  workers: 1
+}
+
+reactor Src {
+  timer t(0, 100 ms)
+  output out: int
+  state counter: int = 0
+
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
+}
+
+reactor Sink {
+  input in: int
+  state received: bool = false
+
+  reaction(in) {=
+    received = true;
+    auto value = *in.get();
+    reactor::log::Info() << "Received " << value;
+    auto expected = 100ms * value;
+    if (get_elapsed_logical_time() != expected) {
+      reactor::log::Error() << "Expecded value at " << expected << " but received it at " << get_elapsed_logical_time();
+      exit(1);
+    }
+  =}
+
+  reaction(shutdown) {=
+    if(!received) {
+      reactor::log::Error() << "Nothing received.";
+      exit(1);
+    }
+  =}
+}
+
+reactor WrappedSink {
+  input in: int
+  sinkinner = new Sink()
+  in -> sinkinner.in
+}
+
+main reactor {
+  @enclave
+  src = new Src()
+  @enclave
+  sink = new WrappedSink()
+
+  src.out -> sink.in
+}

--- a/test/Cpp/src/enclave/EnclaveCommunicationPhysicalHierarchy.lf
+++ b/test/Cpp/src/enclave/EnclaveCommunicationPhysicalHierarchy.lf
@@ -1,0 +1,52 @@
+target Cpp {
+  timeout: 1 s,
+  workers: 1
+}
+
+reactor Src {
+  timer t(0, 100 ms)
+  output out: int
+  state counter: int = 0
+
+  reaction(t) -> out {=
+    out.set(counter++);
+  =}
+}
+
+reactor Sink {
+  input in: int
+  state received: bool = false
+
+  reaction(in) {=
+    received = true;
+    auto value = *in.get();
+    reactor::log::Info() << "Received " << value << " at " << get_elapsed_logical_time();
+    auto expected = 100ms * value;
+    if (get_elapsed_logical_time() < expected) {
+      reactor::log::Error() << "Expecded value not before " << expected;
+      exit(1);
+    }
+  =}
+
+  reaction(shutdown) {=
+    if(!received) {
+      reactor::log::Error() << "Nothing received.";
+      exit(1);
+    }
+  =}
+}
+
+reactor WrappedSrc {
+  output out: int
+  @enclave
+  src = new Src()
+  src.out ~> out
+}
+
+main reactor {
+  src = new WrappedSrc()
+  @enclave
+  sink = new Sink()
+
+  src.out -> sink.in
+}

--- a/test/Cpp/src/enclave/EnclaveReactionOrder.lf
+++ b/test/Cpp/src/enclave/EnclaveReactionOrder.lf
@@ -1,0 +1,14 @@
+target Cpp
+
+import Src, Sink from "../ReactionOrder.lf"
+
+reactor ReactionOrder {
+  src = new Src()
+  sink = new Sink()
+  src.out -> sink.in
+}
+
+main reactor {
+  @enclave
+  test = new ReactionOrder()
+}


### PR DESCRIPTION
This pulls in https://github.com/lf-lang/reactor-cpp/pull/54 and adds a couple of testcases.