### PR TITLE
Updated CI workflow for LSP tests with to remove all g++/clang++ in `PATH`

### DIFF
--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -34,10 +34,10 @@ jobs:
         run: brew uninstall --ignore-dependencies gcc
         if: ${{ runner.os == 'macOS' }}
       - name: Uninstall packages Windows
+        shell: pwsh
         run: |
-          del "C:\ProgramData\Chocolatey\bin\g++.exe"
-          del "C:\Strawberry\c\bin\g++.exe"
-          del "C:\Program Files\LLVM\bin\clang++.exe"
+          try { $exes=Get-Command "g++" -All; $exes | Remove-Item; } catch { "There is no g++ present in pwsh PATH." }
+          try { $exes=Get-Command "clang++" -All; $exes | Remove-Item; } catch { "There is no clang++ present in pwsh PATH." }
         if: ${{ runner.os == 'Windows' }}
       - name: Setup Node.js environment
         uses: actions/setup-node@v3


### PR DESCRIPTION
After GitHub bumped its Windows Actions runner image, our LSP CI is failing, because Chololatey doesn't have g++ anymore. While the runner image is an absolute disaster (refusal to remove Strawberry Perl being one, see https://github.com/actions/runner-images/issues/5459), we still need to use it, and thus still need to come up with a more robust way of uninstalling g++/clang++.

This commit removes hardcoded g++ locations, instead it uses `Get-Command` in powershell to locate all `g++` in PATH, and delete all of them.

This should hopefully solve https://github.com/lf-lang/lingua-franca/pull/2008 CI failure. 