### PR TITLE
CI updated to include commit SHA in version number when creating nightly build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -17,6 +17,10 @@ jobs:
           fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
+      - name: Modify property file to contain the commit SHA
+        shell: bash
+        run: >
+          sed --regexp-extended --in-place "s/^(VERSION = .*)$/\1@$(git rev-parse --short HEAD)/" core/src/main/resources/org/lflang/StringsBundle.properties
       - name: Build and package lf cli tools (nightly build)
         shell: bash
         run: |

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -19,8 +19,10 @@ jobs:
         uses: ./.github/actions/prepare-build-env
       - name: Modify property file to contain the commit SHA
         shell: bash
-        run: >
-          sed --regexp-extended --in-place "s/^(VERSION = .*)$/\1@$(git rev-parse --short HEAD)/" core/src/main/resources/org/lflang/StringsBundle.properties
+        run: |
+          TIMESTAMP="$(date +'%Y-%m-%d')"
+          SHA="$(git rev-parse --short HEAD)"
+          sed --regexp-extended --in-place "s/^(VERSION = .*)$/\1 ${SHA} ${TIMESTAMP}/" core/src/main/resources/org/lflang/StringsBundle.properties
       - name: Build and package lf cli tools (nightly build)
         shell: bash
         run: |


### PR DESCRIPTION
This looks like sticking a big piece of duct tape on a giant pile of duct tapes, but I think this is the only way I could think of that could fix https://github.com/lf-lang/lingua-franca/issues/2066.

If there are ways to pass the commit SHA in as gradle/compiler property for the compiler to use, I'm all ears.

Result:
![image](https://github.com/lf-lang/lingua-franca/assets/6500159/8ea14a41-dd9b-4c09-9303-4372cb78df69)
