### PR TITLE
Fix race-condition in _lf_replace_template_token

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -973,7 +973,7 @@ public class CGenerator extends GeneratorBase {
     }
     header.pr("#include \"include/core/reactor.h\"");
     src.pr("#include \"include/api/api.h\"");
-    src.pr("#include \"platform.h\"");
+    src.pr("#include \"include/core/platform.h\"");
     generateIncludes(tpr);
     if (cppMode) {
       src.pr("}");

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -973,6 +973,7 @@ public class CGenerator extends GeneratorBase {
     }
     header.pr("#include \"include/core/reactor.h\"");
     src.pr("#include \"include/api/api.h\"");
+    src.pr("#include \"platform.h\"");
     generateIncludes(tpr);
     if (cppMode) {
       src.pr("}");

--- a/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
@@ -336,6 +336,7 @@ public class CReactionGenerator {
         ? String.join(
             "\n",
             DISABLE_REACTION_INITIALIZATION_MARKER,
+            "lf_critical_section_enter(self->base.environment);",
             "self->_lf_"
                 + outputName
                 + ".value = ("
@@ -343,14 +344,13 @@ public class CReactionGenerator {
                 + ")self->_lf__"
                 + actionName
                 + ".tmplt.token->value;",
-            "lf_critical_section_enter(self->base.environment);",
             "_lf_replace_template_token((token_template_t*)&self->_lf_"
                 + outputName
                 + ", (lf_token_t*)self->_lf__"
                 + actionName
                 + ".tmplt.token);",
-            "lf_critical_section_exit(self->base.environment);",
-            "self->_lf_" + outputName + ".is_present = true;")
+            "self->_lf_" + outputName + ".is_present = true;",
+            "lf_critical_section_exit(self->base.environment);")
         : "lf_set(" + outputName + ", " + actionName + "->value);";
   }
 
@@ -553,6 +553,7 @@ public class CReactionGenerator {
     builder.pr(
         String.join(
             "\n",
+            "lf_critical_section_enter(self->base.environment);",
             "// Expose the action struct as a local variable whose name matches the action name.",
             structType + "* " + action.getName() + " = &self->_lf_" + action.getName() + ";",
             "// Set the fields of the action struct to match the current trigger.",
@@ -563,7 +564,6 @@ public class CReactionGenerator {
                 + " != NULL && "
                 + tokenPointer
                 + "->value != NULL);",
-            "lf_critical_section_enter(self->base.environment);",
             "_lf_replace_template_token((token_template_t*)"
                 + action.getName()
                 + ", "

--- a/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
@@ -343,11 +343,13 @@ public class CReactionGenerator {
                 + ")self->_lf__"
                 + actionName
                 + ".tmplt.token->value;",
+            "lf_critical_section_enter(self->base.environment);",
             "_lf_replace_template_token((token_template_t*)&self->_lf_"
                 + outputName
                 + ", (lf_token_t*)self->_lf__"
                 + actionName
                 + ".tmplt.token);",
+            "lf_critical_section_exit(self->base.environment);",
             "self->_lf_" + outputName + ".is_present = true;")
         : "lf_set(" + outputName + ", " + actionName + "->value);";
   }
@@ -561,11 +563,13 @@ public class CReactionGenerator {
                 + " != NULL && "
                 + tokenPointer
                 + "->value != NULL);",
+            "lf_critical_section_enter(self->base.environment);",
             "_lf_replace_template_token((token_template_t*)"
                 + action.getName()
                 + ", "
                 + tokenPointer
-                + ");"));
+                + ");",
+            "lf_critical_section_exit(self->base.environment);"));
     // Set the value field only if there is a type.
     if (!type.isUndefined()) {
       // The value field will either be a copy (for primitive types)


### PR DESCRIPTION
This addresses the problem described in #2081 

The problem was that we moved tokens from the trigger structs to the action structs outside a critical section. This created a race condition with external asynchronus contexts trying to schedule events onto the very same action struct.

This simple solution does the moving of tokens inside i critical section. I think another solution might be to re-think the design. Particularily. 
1. Why does `lf_schedule` put the token on BOTH the event queue AND the action struct? The runtime will later move the token from event queue -> trigger struct and then in the reaction preambles, it moves it from the trigger struct to the action struct.
2. Why is the token moved from trigger-struct to action-struct in the code-generated preamble. It would be more natural to do that from wihin the runtime (which is in a critical section)

