### PR TITLE
Output path specified in JSON used correctly

### DIFF
--- a/cli/base/src/main/java/org/lflang/cli/CliBase.java
+++ b/cli/base/src/main/java/org/lflang/cli/CliBase.java
@@ -241,7 +241,7 @@ public abstract class CliBase implements Runnable {
     }
 
     if (path != null) {
-      root = io.getWd().resolve(outputPath).normalize();
+      root = io.getWd().resolve(path).normalize();
       if (!Files.exists(root)) {
         reporter.printFatalErrorAndExit(root + ": Output location does not exist.");
       }


### PR DESCRIPTION
This is to accommodate interactions with `lingo`, which specifies an output directory in JSON.