### PR TITLE
Use more explicit include guards for Arduino

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -948,7 +948,7 @@ public class CGenerator extends GeneratorBase {
     CodeBuilder header = new CodeBuilder();
     CodeBuilder src = new CodeBuilder();
     final String headerName = CUtil.getName(tpr) + ".h";
-    var guardMacro = headerName.toUpperCase().replace(".", "_");
+    var guardMacro = CUtil.internalIncludeGuard(tpr);
     header.pr("#ifndef " + guardMacro);
     header.pr("#define " + guardMacro);
     generateReactorClassHeaders(tpr, headerName, header, src);

--- a/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
@@ -55,7 +55,7 @@ public class CReactorHeaderFileGenerator {
       GenerateAuxiliaryStructs generator,
       String topLevelPreamble) {
     CodeBuilder builder = new CodeBuilder();
-    appendIncludeGuard(builder, tpr);
+    appendIncludeGuards(builder, tpr);
     builder.pr(topLevelPreamble);
     appendPoundIncludes(builder);
     tpr.doDefines(builder);
@@ -64,14 +64,20 @@ public class CReactorHeaderFileGenerator {
     for (Reaction reaction : tpr.reactor().getReactions()) {
       appendSignature(builder, types, reaction, tpr);
     }
-    builder.pr("#endif");
+    closeIncludeGuards(builder);
     return builder.getCode();
   }
 
-  private static void appendIncludeGuard(CodeBuilder builder, TypeParameterizedReactor r) {
+  private static void appendIncludeGuards(CodeBuilder builder, TypeParameterizedReactor r) {
     String macro = CUtil.getName(r) + "_H";
     builder.pr("#ifndef " + macro);
     builder.pr("#define " + macro);
+    builder.pr("#ifndef " + CUtil.internalIncludeGuard(r));
+  }
+
+  private static void closeIncludeGuards(CodeBuilder builder) {
+    builder.pr("#endif");
+    builder.pr("#endif");
   }
 
   private static void appendPoundIncludes(CodeBuilder builder) {

--- a/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
@@ -72,7 +72,11 @@ public class CReactorHeaderFileGenerator {
     String macro = CUtil.getName(r) + "_H";
     builder.pr("#ifndef " + macro);
     builder.pr("#define " + macro);
-    builder.pr("#ifndef " + CUtil.internalIncludeGuard(r));
+    builder.pr(
+        "#ifndef "
+            + CUtil.internalIncludeGuard(r)
+            + " // necessary for arduino-cli, which automatically includes headers that are not"
+            + " used");
   }
 
   private static void closeIncludeGuards(CodeBuilder builder) {

--- a/core/src/main/java/org/lflang/generator/c/CUtil.java
+++ b/core/src/main/java/org/lflang/generator/c/CUtil.java
@@ -148,6 +148,12 @@ public class CUtil {
     return name;
   }
 
+  /** Return the name used in the internal (non-user-facing) include guard for the given reactor. */
+  public static String internalIncludeGuard(TypeParameterizedReactor tpr) {
+    final String headerName = CUtil.getName(tpr) + ".h";
+    return headerName.toUpperCase().replace(".", "_");
+  }
+
   /**
    * Return a reference to the specified port.
    *

--- a/test/C/src/arduino/DualReactorBlink.lf
+++ b/test/C/src/arduino/DualReactorBlink.lf
@@ -1,0 +1,35 @@
+target C {
+  platform: {
+    name: "arduino",
+    board: "arduino:avr:mega"
+  }
+}
+
+reactor Blinker {
+  input in_port: bool
+
+  reaction(startup) {=
+    pinMode(LED_BUILTIN, OUTPUT);
+  =}
+
+  reaction(in_port) {=
+    digitalWrite(LED_BUILTIN, in_port->value ? HIGH : LOW);
+  =}
+}
+
+reactor Timer {
+  timer t1(0, 500 msec)
+  state on_off: bool = false
+  output out_port: bool
+
+  reaction(t1) -> out_port {=
+    self->on_off = !self->on_off;
+    lf_set(out_port, self->on_off);
+  =}
+}
+
+main reactor {
+  the_blinker = new Blinker()
+  the_timer = new Timer()
+  the_timer.out_port -> the_blinker.in_port
+}


### PR DESCRIPTION
I believe that this is only a problem for Arduino because Arduino brings in header files that are not actually `#include`d. This solution is a little bit of a hack because it should not be necessary to add this extra `#ifndef`, but it solves the problem and it should be mostly harmless for users who do not target Arduino.

Closes #2062. Note that the test case originally used in #2062 would not have worked because Arduino Uno does not have enough memory for our runtime.