### PR TITLE
Fix mistake in code-generated reaction preamble.

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
@@ -595,8 +595,8 @@ public class CReactionGenerator {
       }
       builder.unindent();
       builder.pr("}");
-      builder.pr("lf_critical_section_exit(self->base.environment);");
     }
+    builder.pr("lf_critical_section_exit(self->base.environment);");
     return builder.toString();
   }
 

--- a/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
@@ -569,8 +569,7 @@ public class CReactionGenerator {
                 + action.getName()
                 + ", "
                 + tokenPointer
-                + ");",
-            "lf_critical_section_exit(self->base.environment);"));
+                + ");"));
     // Set the value field only if there is a type.
     if (!type.isUndefined()) {
       // The value field will either be a copy (for primitive types)
@@ -596,6 +595,7 @@ public class CReactionGenerator {
       }
       builder.unindent();
       builder.pr("}");
+      builder.pr("lf_critical_section_exit(self->base.environment);");
     }
     return builder.toString();
   }


### PR DESCRIPTION
This is  a race condition that I tried addressing in #2082 but I didn't do it properly. This PR finally makes the critical section include all accesses to the state shared between the reaction body and the async context scheduling a physical action.