### PR TITLE
Codecov coverage annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,6 @@
-# Configuration related to pull request comments
+# Configuration for CodeCov.
+# To verify, run:
+# curl -X POST --data-binary @codecov.yml https://codecov.io/validate
 comment: false # do not comment PR with the result
 
 github_checks:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,9 @@
 # Configuration related to pull request comments
 comment: false # do not comment PR with the result
 
+github_checks:
+  annotations: true
+
 coverage:
   range: 50..90 # coverage lower than 50 is red, higher than 90 green, between color code
 
@@ -11,9 +14,8 @@ coverage:
         target: auto # auto % coverage target
         threshold: 100%  # allow for 100% reduction of coverage without failing
 
-    # do not run coverage on patch nor changes
-    patch: no
-    changes: no
+    patch: true
+    changes: false # do not run coverage on changes
 
 ignore: ['**/org/lflang/services/**',
          '**/org/lflang/lf/**',


### PR DESCRIPTION
Fixes #2094.

**Note that this also reverses #571, with the note that when the annotations make the PR hard to read, you can always just [toggle them on and off](https://twitter.com/natfriedman/status/1366417484698578953?s=21) with the "a" key.**