### PR TITLE
Labels merge queue fix

### DIFF
--- a/.github/workflows/all-misc.yml
+++ b/.github/workflows/all-misc.yml
@@ -48,3 +48,4 @@ jobs:
 
   check-labels:
     uses: ./.github/workflows/check-labels.yml
+    if:  ${{ github.event_name != 'merge_group' }}


### PR DESCRIPTION
This change is meant to prevent failures for being reported at `merge_group` events (when an PR is on the merge queue).