### PR TITLE
Fix undetected `scheduler` and `workers` properties

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1947,6 +1947,15 @@ public class CGenerator extends GeneratorBase {
       // So that each separate compile knows about modal reactors, do this:
       CompileDefinitionsProperty.INSTANCE.update(targetConfig, Map.of("MODAL_REACTORS", "TRUE"));
     }
+    if (!targetConfig.get(
+        SingleThreadedProperty.INSTANCE)) { // FIXME: This logic is duplicated in CMake
+      pickScheduler();
+      // FIXME: this and pickScheduler should be combined.
+      var map = new HashMap<String, String>();
+      map.put("SCHEDULER", targetConfig.get(SchedulerProperty.INSTANCE).getSchedulerCompileDef());
+      map.put("NUMBER_OF_WORKERS", String.valueOf(targetConfig.get(WorkersProperty.INSTANCE)));
+      CompileDefinitionsProperty.INSTANCE.update(targetConfig, map);
+    }
     if (targetConfig.isSet(PlatformProperty.INSTANCE)) {
 
       final var platformOptions = targetConfig.get(PlatformProperty.INSTANCE);
@@ -1987,16 +1996,6 @@ public class CGenerator extends GeneratorBase {
             .warning(
                 "Specifying user threads is only for threaded Lingua Franca on the Zephyr platform."
                     + " This option will be ignored."); // FIXME: do this during validation instead
-      }
-
-      if (!targetConfig.get(
-          SingleThreadedProperty.INSTANCE)) { // FIXME: This logic is duplicated in CMake
-        pickScheduler();
-        // FIXME: this and pickScheduler should be combined.
-        var map = new HashMap<String, String>();
-        map.put("SCHEDULER", targetConfig.get(SchedulerProperty.INSTANCE).getSchedulerCompileDef());
-        map.put("NUMBER_OF_WORKERS", String.valueOf(targetConfig.get(WorkersProperty.INSTANCE)));
-        CompileDefinitionsProperty.INSTANCE.update(targetConfig, map);
       }
       pickCompilePlatform();
     }

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -1947,14 +1946,13 @@ public class CGenerator extends GeneratorBase {
       // So that each separate compile knows about modal reactors, do this:
       CompileDefinitionsProperty.INSTANCE.update(targetConfig, Map.of("MODAL_REACTORS", "TRUE"));
     }
-    if (!targetConfig.get(
-        SingleThreadedProperty.INSTANCE)) { // FIXME: This logic is duplicated in CMake
+    if (!targetConfig.get(SingleThreadedProperty.INSTANCE)) {
       pickScheduler();
-      // FIXME: this and pickScheduler should be combined.
-      var map = new HashMap<String, String>();
-      map.put("SCHEDULER", targetConfig.get(SchedulerProperty.INSTANCE).getSchedulerCompileDef());
-      map.put("NUMBER_OF_WORKERS", String.valueOf(targetConfig.get(WorkersProperty.INSTANCE)));
-      CompileDefinitionsProperty.INSTANCE.update(targetConfig, map);
+      CompileDefinitionsProperty.INSTANCE.update(
+          targetConfig,
+          Map.of(
+              "SCHEDULER", targetConfig.get(SchedulerProperty.INSTANCE).getSchedulerCompileDef(),
+              "NUMBER_OF_WORKERS", String.valueOf(targetConfig.get(WorkersProperty.INSTANCE))));
     }
     if (targetConfig.isSet(PlatformProperty.INSTANCE)) {
 


### PR DESCRIPTION
This PR fixes the problem of the `scheduler` and `workers` target properties being ignored by the compiler. Luckily the fix was straightforward.

However, the fact that `concurrent/Workers.lf` does not detect this problem suggests that its implementation is insufficient, but I am not sure how to implement it correctly at the moment.