### PR TITLE
Changes to Codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,14 +13,14 @@ coverage:
     project: # settings affecting project coverage
       default:
         enabled: true
-        target: auto # auto % coverage target
-        threshold: 5%  # allow for 100% reduction of coverage without failing
+        target: auto
+        threshold: 5% # max reduction
 
     patch:
       default:
         enabled: true
         target: auto
-        threshold: 50%
+        threshold: 50% # max reduction
     changes: false # do not run coverage on changes
 
 ignore: ['**/org/lflang/services/**',

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,9 +14,13 @@ coverage:
       default:
         enabled: true
         target: auto # auto % coverage target
-        threshold: 100%  # allow for 100% reduction of coverage without failing
+        threshold: 5%  # allow for 100% reduction of coverage without failing
 
-    patch: true
+    patch:
+      default:
+        enabled: true
+        target: auto
+        threshold: 50%
     changes: false # do not run coverage on changes
 
 ignore: ['**/org/lflang/services/**',
@@ -24,3 +28,8 @@ ignore: ['**/org/lflang/services/**',
          '**/org/lflang/ide/**',
          '**/org/lflang/serializer/**',
          '**/org/lflang/parser/antlr/**']
+
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true


### PR DESCRIPTION
These changes are meant to instruct Codecov to wait until CI has finished (and not error out prematurely). It also tightens the threshold of allowable reductions in code coverage to -5% overall (and -50% for the diff) with respect to the current coverage (which is about 75%).