### PR TITLE
Draft: Introduce the next downstream tag (NDT) to optimize the communication in centralized federated execution

### DIFF
--- a/.github/actions/install-rti/install.sh
+++ b/.github/actions/install-rti/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 cd core/src/main/resources/lib/c/reactor-c/core/federated/RTI
-docker build -t rti:rti -f rti.Dockerfile ../../../core/
+docker build -t lflang/rti:rti -f rti.Dockerfile ../../../core/
 mkdir build
 cd build
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/.github/actions/install-rti/install.sh
+++ b/.github/actions/install-rti/install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 cd core/src/main/resources/lib/c/reactor-c/core/federated/RTI
+docker build -t rti:rti -f rti.Dockerfile ../../../core/
 mkdir build
 cd build
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
+++ b/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
@@ -40,6 +40,7 @@ import org.lflang.target.TargetConfig;
 import org.lflang.target.property.AuthProperty;
 import org.lflang.target.property.ClockSyncModeProperty;
 import org.lflang.target.property.ClockSyncOptionsProperty;
+import org.lflang.target.property.NDTProperty;
 import org.lflang.target.property.TracingProperty;
 import org.lflang.target.property.type.ClockSyncModeType.ClockSyncMode;
 
@@ -338,6 +339,9 @@ public class FedLauncherGenerator {
     }
     if (targetConfig.getOrDefault(AuthProperty.INSTANCE)) {
       commands.add("                        -a \\");
+    }
+    if (targetConfig.getOrDefault(NDTProperty.INSTANCE)) {
+      commands.add("                     --ndt \\");
     }
     if (targetConfig.getOrDefault(TracingProperty.INSTANCE).isEnabled()) {
       commands.add("                        -t \\");

--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -45,6 +45,7 @@ import org.lflang.target.property.ExportToYamlProperty;
 import org.lflang.target.property.ExternalRuntimePathProperty;
 import org.lflang.target.property.FilesProperty;
 import org.lflang.target.property.KeepaliveProperty;
+import org.lflang.target.property.NDTProperty;
 import org.lflang.target.property.NoRuntimeValidationProperty;
 import org.lflang.target.property.NoSourceMappingProperty;
 import org.lflang.target.property.PlatformProperty;
@@ -599,6 +600,7 @@ public enum Target {
           DockerProperty.INSTANCE,
           FilesProperty.INSTANCE,
           KeepaliveProperty.INSTANCE,
+          NDTProperty.INSTANCE,
           NoSourceMappingProperty.INSTANCE,
           PlatformProperty.INSTANCE,
           ProtobufsProperty.INSTANCE,
@@ -633,6 +635,7 @@ public enum Target {
           DockerProperty.INSTANCE,
           FilesProperty.INSTANCE,
           KeepaliveProperty.INSTANCE,
+          NDTProperty.INSTANCE,
           NoSourceMappingProperty.INSTANCE,
           ProtobufsProperty.INSTANCE,
           SchedulerProperty.INSTANCE,

--- a/core/src/main/java/org/lflang/target/property/NDTProperty.java
+++ b/core/src/main/java/org/lflang/target/property/NDTProperty.java
@@ -1,44 +1,25 @@
 package org.lflang.target.property;
 
-import org.lflang.MessageReporter;
-import org.lflang.ast.ASTUtils;
-import org.lflang.lf.Element;
-import org.lflang.target.property.type.LoggingType;
-import org.lflang.target.property.type.LoggingType.LogLevel;
-
 /**
- * FIXME: Add the NDT property.
+ * If true, the RTI will send NDT messages to federates to reduce the number of messages.
+ * The default is false.
  */
-public final class NDTProperty extends TargetProperty<LogLevel, LoggingType> {
+public final class NDTProperty extends BooleanProperty {
 
   /** Singleton target property instance. */
   public static final NDTProperty INSTANCE = new NDTProperty();
 
   private NDTProperty() {
-    super(new LoggingType());
+    super();
   }
 
-  @Override
-  public LogLevel initialValue() {
-    return LogLevel.getDefault();
-  }
-
-  @Override
-  protected LogLevel fromAst(Element node, MessageReporter reporter) {
-    return fromString(ASTUtils.elementToSingleString(node), reporter);
-  }
-
-  protected LogLevel fromString(String string, MessageReporter reporter) {
-    return LogLevel.valueOf(string.toUpperCase());
-  }
-
-  @Override
-  public Element toAstElement(LogLevel value) {
-    return ASTUtils.toElement(value.toString());
+  @Repeatatable
+  public Boolean initialValue() {
+    return false;
   }
 
   @Override
   public String name() {
-    return "disabled";
+    return "ndt";
   }
 }

--- a/core/src/main/java/org/lflang/target/property/NDTProperty.java
+++ b/core/src/main/java/org/lflang/target/property/NDTProperty.java
@@ -13,9 +13,9 @@ public final class NDTProperty extends BooleanProperty {
     super();
   }
 
-  @Repeatatable
+  @Override
   public Boolean initialValue() {
-    return false;
+    return true;
   }
 
   @Override

--- a/core/src/main/java/org/lflang/target/property/NDTProperty.java
+++ b/core/src/main/java/org/lflang/target/property/NDTProperty.java
@@ -1,0 +1,44 @@
+package org.lflang.target.property;
+
+import org.lflang.MessageReporter;
+import org.lflang.ast.ASTUtils;
+import org.lflang.lf.Element;
+import org.lflang.target.property.type.LoggingType;
+import org.lflang.target.property.type.LoggingType.LogLevel;
+
+/**
+ * FIXME: Add the NDT property.
+ */
+public final class NDTProperty extends TargetProperty<LogLevel, LoggingType> {
+
+  /** Singleton target property instance. */
+  public static final NDTProperty INSTANCE = new NDTProperty();
+
+  private NDTProperty() {
+    super(new LoggingType());
+  }
+
+  @Override
+  public LogLevel initialValue() {
+    return LogLevel.getDefault();
+  }
+
+  @Override
+  protected LogLevel fromAst(Element node, MessageReporter reporter) {
+    return fromString(ASTUtils.elementToSingleString(node), reporter);
+  }
+
+  protected LogLevel fromString(String string, MessageReporter reporter) {
+    return LogLevel.valueOf(string.toUpperCase());
+  }
+
+  @Override
+  public Element toAstElement(LogLevel value) {
+    return ASTUtils.toElement(value.toString());
+  }
+
+  @Override
+  public String name() {
+    return "disabled";
+  }
+}


### PR DESCRIPTION
The goal of this PR is to make the work of this PR (https://github.com/lf-lang/reactor-c/pull/176) optional and merge it.

 - [ ] Make a unit test for testing NDTs. (Add a python script for checking the exchanged messages in the trace)
 - [ ] Define the compile property `FEDERATED_NDT_ENABLED" when the option `--ndt` is set to be true.