### PR TITLE
Bugfix for TypeScript in dev mode

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -20,7 +20,7 @@ coverage:
       default:
         enabled: true
         target: auto
-        threshold: 50% # max reduction
+        threshold: 100% # max reduction
     changes: false # do not run coverage on changes
 
 ignore: ['**/org/lflang/services/**',

--- a/core/src/main/kotlin/org/lflang/generator/ts/TSGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/ts/TSGenerator.kt
@@ -25,6 +25,7 @@
 
 package org.lflang.generator.ts
 
+import com.google.common.base.Strings
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.xtext.util.CancelIndicator
 import org.lflang.target.Target
@@ -183,7 +184,7 @@ class TSGenerator(
         val sb = StringBuffer("");
         val manifest = fileConfig.srcGenPath.resolve("package.json");
         val rtRegex = Regex("(\"@lf-lang/reactor-ts\")(.+)")
-        if (rtUri != null || rtVersion != null) {
+        if (rtUri != null || !Strings.isNullOrEmpty(rtVersion)) {
             devMode = true;
         }
         manifest.toFile().forEachLine {
@@ -193,7 +194,7 @@ class TSGenerator(
             }
             if (rtUri != null) {
                 line = line.replace(rtRegex, "$1: \"$rtUri\",")
-            } else if (rtVersion != null) {
+            } else if (!Strings.isNullOrEmpty(rtVersion)) {
                 line = line.replace(rtRegex, "$1: \"$RUNTIME_URL#$rtVersion\",")
             }
             sb.appendLine(line)


### PR DESCRIPTION
Ensures that when an alternative reactor-ts runtime is pointed to, it is actually used.