### PR TITLE
Fix remote launch and add -l option to log to files

### DIFF
--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -293,7 +293,7 @@ public class FedGenerator {
                 new TargetConfig(
                     subFileConfig.resource, GeneratorArguments.none(), subContextMessageReporter);
             if (targetConfig.get(DockerProperty.INSTANCE).enabled
-                && targetConfig.target.buildsUsingDocker()
+                    && targetConfig.target.buildsUsingDocker()
                 || fed.isRemote) {
               NoCompileProperty.INSTANCE.override(subConfig, true);
             }

--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -293,7 +293,8 @@ public class FedGenerator {
                 new TargetConfig(
                     subFileConfig.resource, GeneratorArguments.none(), subContextMessageReporter);
             if (targetConfig.get(DockerProperty.INSTANCE).enabled
-                && targetConfig.target.buildsUsingDocker()) {
+                && targetConfig.target.buildsUsingDocker()
+                || fed.isRemote) {
               NoCompileProperty.INSTANCE.override(subConfig, true);
             }
             subConfig.get(DockerProperty.INSTANCE).enabled = false;

--- a/core/src/main/java/org/lflang/federated/launcher/BuildConfig.java
+++ b/core/src/main/java/org/lflang/federated/launcher/BuildConfig.java
@@ -40,12 +40,4 @@ public abstract class BuildConfig {
    * locally, assuming that the current directory is the top-level project folder.
    */
   public abstract String localExecuteCommand();
-
-  /**
-   * Return the command that will execute the federate that this build configuration belongs to
-   * remotely, assuming that the current directory is the top-level project folder.
-   */
-  public String remoteExecuteCommand() {
-    throw new UnsupportedOperationException();
-  }
 }

--- a/core/src/main/java/org/lflang/federated/launcher/CBuildConfig.java
+++ b/core/src/main/java/org/lflang/federated/launcher/CBuildConfig.java
@@ -48,26 +48,13 @@ public class CBuildConfig extends BuildConfig {
   @Override
   public String compileCommand() {
     // This generates the compile command to execute remotely via ssh.
-
     String commandToReturn;
-    // FIXME: Hack to add platform support only for linux systems.
-    // We need to fix the CMake build command for remote federates.
-    String linuxPlatformSupport =
-        "core" + File.separator + "platform" + File.separator + "lf_linux_support.c";
-    if (!federate.targetConfig.compileAdditionalSources.contains(linuxPlatformSupport)) {
-      federate.targetConfig.compileAdditionalSources.add(linuxPlatformSupport);
-    }
     CCompiler cCompiler = new CCompiler(federate.targetConfig, fileConfig, messageReporter, false);
     commandToReturn =
         String.join(
             " ",
-            cCompiler.compileCCommand(fileConfig.name + "_" + federate.name, false).toString());
+            cCompiler.buildCmakeCommand().toString());
     return commandToReturn;
-  }
-
-  @Override
-  public String remoteExecuteCommand() {
-    return "bin/" + fileConfig.name + "_" + federate.name + " -i '$FEDERATION_ID'";
   }
 
   @Override

--- a/core/src/main/java/org/lflang/federated/launcher/CBuildConfig.java
+++ b/core/src/main/java/org/lflang/federated/launcher/CBuildConfig.java
@@ -25,7 +25,6 @@
 
 package org.lflang.federated.launcher;
 
-import java.io.File;
 import org.lflang.MessageReporter;
 import org.lflang.federated.generator.FederateInstance;
 import org.lflang.federated.generator.FederationFileConfig;
@@ -50,10 +49,7 @@ public class CBuildConfig extends BuildConfig {
     // This generates the compile command to execute remotely via ssh.
     String commandToReturn;
     CCompiler cCompiler = new CCompiler(federate.targetConfig, fileConfig, messageReporter, false);
-    commandToReturn =
-        String.join(
-            " ",
-            cCompiler.buildCmakeCommand().toString());
+    commandToReturn = String.join(" ", cCompiler.buildCmakeCommand().toString());
     return commandToReturn;
   }
 

--- a/core/src/main/java/org/lflang/federated/launcher/CBuildConfig.java
+++ b/core/src/main/java/org/lflang/federated/launcher/CBuildConfig.java
@@ -47,6 +47,7 @@ public class CBuildConfig extends BuildConfig {
 
   @Override
   public String compileCommand() {
+    // This generates the compile command to execute remotely via ssh.
 
     String commandToReturn;
     // FIXME: Hack to add platform support only for linux systems.

--- a/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
+++ b/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
@@ -384,9 +384,9 @@ public class FedLauncherGenerator {
         "# to be responsive to user inputs after all federates",
         "# are launched.",
         "if [ \"$1\" = \"-l\" ]; then",
-            launchCodeWithLogging,
+        launchCodeWithLogging,
         "else",
-            launchCodeWithoutLogging,
+        launchCodeWithoutLogging,
         "fi",
         "# Store the PID of the RTI",
         "RTI=$!",
@@ -516,14 +516,15 @@ public class FedLauncherGenerator {
 
   private String getFedLocalLaunchCode(
       FederateInstance federate, String executeCommand, int federateIndex) {
-    return String.join("\n",
-                "echo \"#### Launching the federate " + federate.name + ".\"",
-                "if [ \"$1\" = \"-l\" ]; then",
-                "    " + executeCommand + " >& " + federate.name + ".log &",
-                "else",
-                "    " + executeCommand + " &",
-                "fi",
-                "pids[" + federateIndex + "]=$!");
+    return String.join(
+        "\n",
+        "echo \"#### Launching the federate " + federate.name + ".\"",
+        "if [ \"$1\" = \"-l\" ]; then",
+        "    " + executeCommand + " >& " + federate.name + ".log &",
+        "else",
+        "    " + executeCommand + " &",
+        "fi",
+        "pids[" + federateIndex + "]=$!");
   }
 
   /**

--- a/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
+++ b/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
@@ -169,11 +169,7 @@ public class FedLauncherGenerator {
         String logFileName = String.format("log/%s_%s.log", fileConfig.name, federate.name);
         distCode.append(getDistCode(rtiConfig.getDirectory(), federate)).append("\n");
         shCode
-            .append(
-                getFedRemoteLaunchCode(
-                        rtiConfig.getDirectory(),
-                        federate,
-                        federateIndex++))
+            .append(getFedRemoteLaunchCode(rtiConfig.getDirectory(), federate, federateIndex++))
             .append("\n");
       } else {
         String executeCommand = buildConfig.localExecuteCommand();
@@ -411,12 +407,12 @@ public class FedLauncherGenerator {
   }
 
   /**
-   * Return the shell commands that copy the generated source files for the specified
-   * federate onto the remote host and compiles them on that host.  When the shell
-   * script is executed on the local machine, the source files will be put in
-   * `remoteBase/programName/federateName`. Also, a `build.sh` script will be put
-   * in `remoteBase/programName/bin`.  This script will be executed, and its output
-   * will be put into a log file in `remoteBase/programName/log`.
+   * Return the shell commands that copy the generated source files for the specified federate onto
+   * the remote host and compiles them on that host. When the shell script is executed on the local
+   * machine, the source files will be put in `remoteBase/programName/federateName`. Also, a
+   * `build.sh` script will be put in `remoteBase/programName/bin`. This script will be executed,
+   * and its output will be put into a log file in `remoteBase/programName/log`.
+   *
    * @param remoteBase The root directory on the remote machine.
    * @param federate The federate to distribute.
    */
@@ -428,60 +424,109 @@ public class FedLauncherGenerator {
     return String.join(
         "\n",
         "echo \"Making directory "
-                + remoteBase
-                + " and subdirectories federate_name, bin, and log on host "
-                + getUserHost(federate.user, federate.host)
-                + "\"",
+            + remoteBase
+            + " and subdirectories federate_name, bin, and log on host "
+            + getUserHost(federate.user, federate.host)
+            + "\"",
         "ssh " + getUserHost(federate.user, federate.host) + " '\\",
         "    mkdir -p " + binDirectory + " " + logDirectory + "; \\",
-        "    echo \"------Build of " + fileConfig.name + " " + federate.name +"\" >> " + remoteBuildLogFileName + "; \\",
+        "    echo \"------Build of "
+            + fileConfig.name
+            + " "
+            + federate.name
+            + "\" >> "
+            + remoteBuildLogFileName
+            + "; \\",
         "    date >> " + remoteBuildLogFileName + ";",
         "'",
         "pushd " + fileConfig.getSrcGenPath() + "/" + federate.name + " > /dev/null",
-        "echo \"**** Copying source files to host " + getUserHost(federate.user, federate.host) + "\"",
+        "echo \"**** Copying source files to host "
+            + getUserHost(federate.user, federate.host)
+            + "\"",
         "scp -r * "
             + getUserHost(federate.user, federate.host)
             + ":"
-            + remoteBase + "/" + fileConfig.name + "/" + federate.name,
+            + remoteBase
+            + "/"
+            + fileConfig.name
+            + "/"
+            + federate.name,
         "popd > /dev/null",
-        "echo \"**** Generating and executing compile.sh on host " + getUserHost(federate.user, federate.host) + "\"",
-        "ssh " + getUserHost(federate.user, federate.host) + " '"
-                + "cd " + remoteBase + "/" + fileConfig.name + "/bin; "
-                + "rm -rf " + buildShellFileName + "; "
-                // -l option ensures that the script runs as a login shell, getting PATh, etc.
-                + "echo \"#!/bin/bash -l\" >> " + buildShellFileName + "; "
-                + "chmod +x " + buildShellFileName + "; "
-                + "echo \"# Build commands for " + fileConfig.name + " " + federate.name + "\" >> " + buildShellFileName + "; "
-                + "echo \"cd ~/" + remoteBase + "/" + fileConfig.name + "/" + federate.name + "\" >> " + buildShellFileName + "; "
-                // The >> syntax appends stdout to a file. The 2>&1 appends stderr to the same file. tee sens to stdout and file.
-                + "echo \"rm -rf build && mkdir -p build && cd build && cmake .. && make 2>&1 | tee -a "
-                        + remoteBuildLogFileName + "\" >> " + buildShellFileName + "; "
-                + "echo \"mv " + federate.name + " " + binDirectory + "\" >>  " + buildShellFileName + "; "
-                + binDirectory + "/" + buildShellFileName
-                + "'"
-    );
+        "echo \"**** Generating and executing compile.sh on host "
+            + getUserHost(federate.user, federate.host)
+            + "\"",
+        "ssh "
+            + getUserHost(federate.user, federate.host)
+            + " '"
+            + "cd "
+            + remoteBase
+            + "/"
+            + fileConfig.name
+            + "/bin; "
+            + "rm -rf "
+            + buildShellFileName
+            + "; "
+            // -l option ensures that the script runs as a login shell, getting PATh, etc.
+            + "echo \"#!/bin/bash -l\" >> "
+            + buildShellFileName
+            + "; "
+            + "chmod +x "
+            + buildShellFileName
+            + "; "
+            + "echo \"# Build commands for "
+            + fileConfig.name
+            + " "
+            + federate.name
+            + "\" >> "
+            + buildShellFileName
+            + "; "
+            + "echo \"cd ~/"
+            + remoteBase
+            + "/"
+            + fileConfig.name
+            + "/"
+            + federate.name
+            + "\" >> "
+            + buildShellFileName
+            + "; "
+            // The >> syntax appends stdout to a file. The 2>&1 appends stderr to the same file. tee
+            // sens to stdout and file.
+            + "echo \"rm -rf build && mkdir -p build && cd build && cmake .. && make 2>&1 | tee -a "
+            + remoteBuildLogFileName
+            + "\" >> "
+            + buildShellFileName
+            + "; "
+            + "echo \"mv "
+            + federate.name
+            + " "
+            + binDirectory
+            + "\" >>  "
+            + buildShellFileName
+            + "; "
+            + binDirectory
+            + "/"
+            + buildShellFileName
+            + "'");
   }
 
-  /**
-   * Return the body of a shell script file to compile the specified federate.
-   */
-  private String getCompileScript(
-          Path remoteBase,
-          FederateInstance federate
-  ) {
+  /** Return the body of a shell script file to compile the specified federate. */
+  private String getCompileScript(Path remoteBase, FederateInstance federate) {
     String baseDir = "~/" + remoteBase + "/" + fileConfig.name;
     return String.join(
-            "\n",
-            "#!/bin/bash -l",  // The -l argument makes this a login shell so PATH etc are inherited.
-            // FIXME: Put copied files in subdirectory federate.name
-            "cd " + remoteBase + "/fed-gen/" + fileConfig.name + "/src-gen/" + federate.name,
-            "rm -rf build",
-            "mkdir -p ~/" + remoteBase + "/log",
-            // >> appends stdout to the specified file, and 2>&1 appends stderr to the same file.
-            "mkdir -p build && cd build && cmake .. && make >> " + baseDir + "/" + federate.name + ".log 2>&1",
-            "mkdir -p ~/" + remoteBase + "/bin;\\",
-            "mv " + federate.name + " ~/" + remoteBase + "/bin;'"
-    );
+        "\n",
+        "#!/bin/bash -l", // The -l argument makes this a login shell so PATH etc are inherited.
+        // FIXME: Put copied files in subdirectory federate.name
+        "cd " + remoteBase + "/fed-gen/" + fileConfig.name + "/src-gen/" + federate.name,
+        "rm -rf build",
+        "mkdir -p ~/" + remoteBase + "/log",
+        // >> appends stdout to the specified file, and 2>&1 appends stderr to the same file.
+        "mkdir -p build && cd build && cmake .. && make >> "
+            + baseDir
+            + "/"
+            + federate.name
+            + ".log 2>&1",
+        "mkdir -p ~/" + remoteBase + "/bin;\\",
+        "mv " + federate.name + " ~/" + remoteBase + "/bin;'");
   }
 
   private String getUserHost(Object user, Object host) {
@@ -493,14 +538,13 @@ public class FedLauncherGenerator {
 
   /**
    * Return shell script code that launches the federate and captures its output to a log file.
+   *
    * @param remoteBase The root directory on the remote machine.
    * @param federate The federate to distribute.
    * @param federateIndex The index of the federate in the order of launch.
    */
   private String getFedRemoteLaunchCode(
-          Path remoteBase,
-          FederateInstance federate,
-          int federateIndex) {
+      Path remoteBase, FederateInstance federate, int federateIndex) {
     String logDirectory = "~/" + remoteBase + "/" + fileConfig.name + "/log";
     String runLogFileName = logDirectory + "/" + federate.name + ".log";
     String binDirectory = "~/" + remoteBase + "/" + fileConfig.name + "/bin";

--- a/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
+++ b/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
@@ -165,9 +165,8 @@ public class FedLauncherGenerator {
       if (federate.isRemote) {
         Path fedRelSrcGenPath =
             fileConfig.getOutPath().relativize(fileConfig.getSrcGenPath()).resolve(federate.name);
-        if (distCode.length() == 0) distCode.append(distHeader).append("\n");
+        if (distCode.isEmpty()) distCode.append(distHeader).append("\n");
         String logFileName = String.format("log/%s_%s.log", fileConfig.name, federate.name);
-        String compileCommand = buildConfig.compileCommand();
         // FIXME: Should $FEDERATION_ID be used to ensure unique directories, executables, on the
         // remote host?
         distCode
@@ -178,7 +177,7 @@ public class FedLauncherGenerator {
                     fedRelSrcGenPath,
                     logFileName,
                     fileConfig.getSrcGenPath(),
-                    compileCommand))
+                    buildConfig.compileCommand()))
             .append("\n");
         String executeCommand = buildConfig.remoteExecuteCommand();
         shCode

--- a/core/src/main/java/org/lflang/federated/launcher/PyBuildConfig.java
+++ b/core/src/main/java/org/lflang/federated/launcher/PyBuildConfig.java
@@ -12,11 +12,6 @@ public class PyBuildConfig extends BuildConfig {
   }
 
   @Override
-  public String remoteExecuteCommand() {
-    return "bin/" + fileConfig.name + "_" + federate.name + " -i '$FEDERATION_ID'";
-  }
-
-  @Override
   public String localExecuteCommand() {
     return fileConfig.getFedBinPath().resolve(federate.name) + " -i $FEDERATION_ID";
   }

--- a/core/src/main/java/org/lflang/generator/c/CCompiler.java
+++ b/core/src/main/java/org/lflang/generator/c/CCompiler.java
@@ -370,6 +370,7 @@ public class CCompiler {
    *     the compile command will produce a binary.
    */
   public LFCommand compileCCommand(String fileToCompile, boolean noBinary) {
+    // FIXME: This is obsolete.
     String cFilename = getTargetFileName(fileToCompile, cppMode, targetConfig);
 
     Path relativeSrcPath =


### PR DESCRIPTION
This modifies the run script for federated programs so that if you give a `-l` argument then stdout and stderr from the RTI and each federate are captured into log files. These go into the cwd and have names `RTI.log` and `federate_name.log`, so they will get overwritten if multiple runs are performed in the same directory.

@lhstrh : can you see what we can do in CI to use this to report all the outputs from federated tests?  I don't think we need persistent artifacts here and in fact would prefer not because we clutter user's disks if they use this and the file names will have to become much more complicated.

The larger part of this PR is to fix the remote launching of federates, which hasn't worked for a while.  It now works.
