### PR TITLE
String literal allowed as property name

### DIFF
--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -263,7 +263,7 @@ KeyValuePairs:
     {KeyValuePairs} '{' (pairs+=KeyValuePair (',' (pairs+=KeyValuePair))* ','?)? '}';
 
 KeyValuePair:
-    name=Kebab ':' value=Element;
+    name=(Kebab|STRING) ':' value=Element;
 
 Array: // todo allow empty array in grammar, replace with validator error
     '[' elements+=Element (',' (elements+=Element))* ','? ']';

--- a/core/src/test/java/org/lflang/tests/LFParsingTest.java
+++ b/core/src/test/java/org/lflang/tests/LFParsingTest.java
@@ -35,9 +35,9 @@ public class LFParsingTest {
 
   @Test
   public void testParsingTargetPropertyAsString() throws Exception {
-    assertNoParsingErrorsIn("target C { \"a c time reactor\": 2 };");
-    assertNoParsingErrorsIn("target C { \"reactor\": 2 };");
-    expectParsingErrorIn("target C { reactor: 2 };");
+    assertNoParsingErrorsIn("target C { \"a c time reactor\": 2 }; reactor Foo{}");
+    assertNoParsingErrorsIn("target C { \"reactor\": 2 }; reactor Foo{}");
+    expectParsingErrorIn("target C { reactor: 2 }; reactor Foo{}");
 
     // array elements
     // assertNoParsingErrorsIn("target C {x:[ ]};  \nreactor Foo {}");

--- a/core/src/test/java/org/lflang/tests/LFParsingTest.java
+++ b/core/src/test/java/org/lflang/tests/LFParsingTest.java
@@ -33,6 +33,19 @@ public class LFParsingTest {
     // assertNoParsingErrorsIn("target C {x:[,]};  \nreactor Foo {}");
   }
 
+
+  @Test
+  public void testParsingTargetPropertyAsString() throws Exception {
+    assertNoParsingErrorsIn("target C { \"a c time reactor\": 2 };");
+    assertNoParsingErrorsIn("target C { \"reactor\": 2 };");
+    expectParsingErrorIn("target C { reactor: 2 };");
+
+    // array elements
+    // assertNoParsingErrorsIn("target C {x:[ ]};  \nreactor Foo {}");
+    // assertNoParsingErrorsIn("target C {x:[]};   \nreactor Foo {}");
+    // assertNoParsingErrorsIn("target C {x:[,]};  \nreactor Foo {}");
+  }
+
   @Test
   public void testLexingLifetimeAnnots() throws Exception {
     assertNoParsingErrorsIn(

--- a/core/src/test/java/org/lflang/tests/LFParsingTest.java
+++ b/core/src/test/java/org/lflang/tests/LFParsingTest.java
@@ -33,7 +33,6 @@ public class LFParsingTest {
     // assertNoParsingErrorsIn("target C {x:[,]};  \nreactor Foo {}");
   }
 
-
   @Test
   public void testParsingTargetPropertyAsString() throws Exception {
     assertNoParsingErrorsIn("target C { \"a c time reactor\": 2 };");


### PR DESCRIPTION
This implements [this solution](https://github.com/lf-lang/lingua-franca/pull/1238#issuecomment-1311553308) to #1194. It would supersede #1238.

This needs an update to the documentation website.