### PR TITLE
Ability to specify rti image for dockerized federated programs

### DIFF
--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -189,6 +189,11 @@ public class FedGenerator {
     return false;
   }
 
+  /**
+   * Prepare a build environment for the rti alongside the generated sources of the federates.
+   *
+   * @param context The generator context.
+   */
   private void prepareRtiBuildEnvironment(LFGeneratorContext context) {
     var rtiImage = context.getTargetConfig().get(DockerProperty.INSTANCE).rti();
     if (rtiImage.equals(DockerOptions.LOCAL_RTI_IMAGE)) {

--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -1,10 +1,11 @@
 package org.lflang.federated.generator;
 
-import static org.lflang.generator.DockerGenerator.dockerGeneratorFactory;
+import static org.lflang.generator.docker.DockerGenerator.dockerGeneratorFactory;
 
 import com.google.inject.Injector;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,8 +32,6 @@ import org.lflang.ast.ASTUtils;
 import org.lflang.federated.launcher.FedLauncherGenerator;
 import org.lflang.federated.launcher.RtiConfig;
 import org.lflang.generator.CodeMap;
-import org.lflang.generator.DockerData;
-import org.lflang.generator.FedDockerComposeGenerator;
 import org.lflang.generator.GeneratorArguments;
 import org.lflang.generator.GeneratorResult.Status;
 import org.lflang.generator.GeneratorUtils;
@@ -46,6 +45,9 @@ import org.lflang.generator.ReactorInstance;
 import org.lflang.generator.RuntimeRange;
 import org.lflang.generator.SendRange;
 import org.lflang.generator.SubContext;
+import org.lflang.generator.docker.DockerData;
+import org.lflang.generator.docker.FedDockerComposeGenerator;
+import org.lflang.generator.docker.RtiDockerGenerator;
 import org.lflang.lf.Expression;
 import org.lflang.lf.Input;
 import org.lflang.lf.Instantiation;
@@ -57,10 +59,12 @@ import org.lflang.target.Target;
 import org.lflang.target.TargetConfig;
 import org.lflang.target.property.CoordinationProperty;
 import org.lflang.target.property.DockerProperty;
+import org.lflang.target.property.DockerProperty.DockerOptions;
 import org.lflang.target.property.KeepaliveProperty;
 import org.lflang.target.property.NoCompileProperty;
 import org.lflang.target.property.type.CoordinationModeType.CoordinationMode;
 import org.lflang.util.Averager;
+import org.lflang.util.FileUtil;
 
 public class FedGenerator {
 
@@ -159,6 +163,9 @@ public class FedGenerator {
       return false;
     }
 
+    // If the RTI is to be built locally, set up a build environment for it.
+    prepareRtiBuildEnvironment(context);
+
     Map<Path, CodeMap> codeMapMap =
         compileFederates(
             context,
@@ -182,6 +189,24 @@ public class FedGenerator {
     return false;
   }
 
+  private void prepareRtiBuildEnvironment(LFGeneratorContext context) {
+    var rtiImage = context.getTargetConfig().get(DockerProperty.INSTANCE).rti();
+    if (rtiImage.equals(DockerOptions.LOCAL_RTI_IMAGE)) {
+      var dest = context.getFileConfig().getSrcGenPath().resolve("rti");
+      // 1. Create the "rti" directory
+      try {
+        Files.createDirectories(dest);
+        // 2. Copy reactor-c source files into it
+        FileUtil.copyFromClassPath("/lib/c/reactor-c/core", dest, true, false);
+        FileUtil.copyFromClassPath("/lib/c/reactor-c/include", dest, true, false);
+        // 3. Generate a Dockerfile for the rti
+        new RtiDockerGenerator(context).generateDockerData(dest).writeDockerFile();
+      } catch (IOException e) {
+        context.getErrorReporter().nowhere().error("Error while copying files: " + e.getMessage());
+      }
+    }
+  }
+
   private void generateLaunchScript() {
     new FedLauncherGenerator(this.targetConfig, this.fileConfig, this.messageReporter)
         .doGenerate(federates, rtiConfig);
@@ -194,7 +219,7 @@ public class FedGenerator {
    * @param subContexts The subcontexts in which the federates have been compiled.
    */
   private void createDockerFiles(LFGeneratorContext context, List<SubContext> subContexts) {
-    if (!context.getTargetConfig().get(DockerProperty.INSTANCE).enabled) return;
+    if (!context.getTargetConfig().get(DockerProperty.INSTANCE).enabled()) return;
     final List<DockerData> services = new ArrayList<>();
     // 1. create a Dockerfile for each federate
     for (SubContext subContext : subContexts) { // Inherit Docker options from main context
@@ -292,11 +317,12 @@ public class FedGenerator {
             TargetConfig subConfig =
                 new TargetConfig(
                     subFileConfig.resource, GeneratorArguments.none(), subContextMessageReporter);
-            if (targetConfig.get(DockerProperty.INSTANCE).enabled
+            if (targetConfig.get(DockerProperty.INSTANCE).enabled()
                 && targetConfig.target.buildsUsingDocker()) {
               NoCompileProperty.INSTANCE.override(subConfig, true);
             }
-            subConfig.get(DockerProperty.INSTANCE).enabled = false;
+            // Disabled Docker for the federate and put federation in charge.
+            DockerProperty.INSTANCE.override(subConfig, new DockerOptions(false));
 
             SubContext subContext =
                 new SubContext(context, IntegratedBuilder.VALIDATED_PERCENT_PROGRESS, 100) {
@@ -404,7 +430,7 @@ public class FedGenerator {
 
     // If the federation is dockerized, use "rti" as the hostname.
     if (rtiConfig.getHost().equals("localhost")
-        && targetConfig.get(DockerProperty.INSTANCE).enabled) {
+        && targetConfig.get(DockerProperty.INSTANCE).enabled()) {
       rtiConfig.setHost("rti");
     }
 

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -57,8 +57,6 @@ import org.lflang.federated.extensions.CExtensionUtils;
 import org.lflang.generator.ActionInstance;
 import org.lflang.generator.CodeBuilder;
 import org.lflang.generator.DelayBodyGenerator;
-import org.lflang.generator.DockerComposeGenerator;
-import org.lflang.generator.DockerGenerator;
 import org.lflang.generator.GeneratorBase;
 import org.lflang.generator.GeneratorResult;
 import org.lflang.generator.GeneratorUtils;
@@ -71,6 +69,9 @@ import org.lflang.generator.ReactorInstance;
 import org.lflang.generator.TargetTypes;
 import org.lflang.generator.TimerInstance;
 import org.lflang.generator.TriggerInstance;
+import org.lflang.generator.docker.CDockerGenerator;
+import org.lflang.generator.docker.DockerComposeGenerator;
+import org.lflang.generator.docker.DockerGenerator;
 import org.lflang.generator.python.PythonGenerator;
 import org.lflang.lf.Action;
 import org.lflang.lf.ActionOrigin;
@@ -435,7 +436,7 @@ public class CGenerator extends GeneratorBase {
     }
 
     // Create docker file.
-    if (targetConfig.get(DockerProperty.INSTANCE).enabled && mainDef != null) {
+    if (targetConfig.get(DockerProperty.INSTANCE).enabled() && mainDef != null) {
       try {
         var dockerData = getDockerGenerator(context).generateDockerData();
         dockerData.writeDockerFile();
@@ -511,7 +512,7 @@ public class CGenerator extends GeneratorBase {
     // If this code generator is directly compiling the code, compile it now so that we
     // clean it up after, removing the #line directives after errors have been reported.
     if (!targetConfig.get(NoCompileProperty.INSTANCE)
-        && !targetConfig.get(DockerProperty.INSTANCE).enabled
+        && !targetConfig.get(DockerProperty.INSTANCE).enabled()
         && IterableExtensions.isNullOrEmpty(targetConfig.get(BuildCommandsProperty.INSTANCE))
         // This code is unreachable in LSP_FAST mode, so that check is omitted.
         && context.getMode() != LFGeneratorContext.Mode.LSP_MEDIUM) {

--- a/core/src/main/java/org/lflang/generator/docker/CDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/CDockerGenerator.java
@@ -1,11 +1,11 @@
-package org.lflang.generator.c;
+package org.lflang.generator.docker;
 
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.lflang.generator.DockerGenerator;
 import org.lflang.generator.LFGeneratorContext;
 import org.lflang.target.Target;
 import org.lflang.target.property.BuildCommandsProperty;
 import org.lflang.target.property.DockerProperty;
+import org.lflang.target.property.DockerProperty.DockerOptions;
 import org.lflang.util.StringUtil;
 
 /**
@@ -14,7 +14,6 @@ import org.lflang.util.StringUtil;
  * @author Hou Seng Wong
  */
 public class CDockerGenerator extends DockerGenerator {
-  private static final String DEFAULT_BASE_IMAGE = "alpine:latest";
 
   /**
    * The constructor for the base docker file generation class.
@@ -35,10 +34,10 @@ public class CDockerGenerator extends DockerGenerator {
             ? generateDefaultCompileCommand()
             : StringUtil.joinObjects(config.get(BuildCommandsProperty.INSTANCE), " ");
     var compiler = config.target == Target.CCPP ? "g++" : "gcc";
-    var baseImage = DEFAULT_BASE_IMAGE;
+    var baseImage = DockerOptions.DEFAULT_BASE_IMAGE;
     var dockerConf = config.get(DockerProperty.INSTANCE);
-    if (dockerConf.enabled && dockerConf.from != null) {
-      baseImage = dockerConf.from;
+    if (dockerConf.enabled() && dockerConf.from() != null) {
+      baseImage = dockerConf.from();
     }
     return String.join(
         "\n",

--- a/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
@@ -1,9 +1,10 @@
-package org.lflang.generator;
+package org.lflang.generator.docker;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.lflang.generator.LFGeneratorContext;
 import org.lflang.util.FileUtil;
 
 /**

--- a/core/src/main/java/org/lflang/generator/docker/DockerData.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerData.java
@@ -1,8 +1,9 @@
-package org.lflang.generator;
+package org.lflang.generator.docker;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.lflang.generator.LFGeneratorContext;
 import org.lflang.util.FileUtil;
 
 /**

--- a/core/src/main/java/org/lflang/generator/docker/DockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerGenerator.java
@@ -1,8 +1,7 @@
-package org.lflang.generator;
+package org.lflang.generator.docker;
 
-import org.lflang.generator.c.CDockerGenerator;
-import org.lflang.generator.python.PythonDockerGenerator;
-import org.lflang.generator.ts.TSDockerGenerator;
+import java.nio.file.Path;
+import org.lflang.generator.LFGeneratorContext;
 
 /**
  * A class for generating docker files.
@@ -28,17 +27,18 @@ public abstract class DockerGenerator {
   protected abstract String generateDockerFileContent();
 
   /**
-   * Produce a DockerData object. If the returned object is to be used in a federated context, pass
-   * in the file configuration of the federated generator, null otherwise.
+   * Produce a DockerData object, which bundles all information needed to output a Dockerfile.
    *
    * @return docker data created based on the context in this instance
    */
   public DockerData generateDockerData() {
-    var name = context.getFileConfig().name;
-    var dockerFilePath = context.getFileConfig().getSrcGenPath().resolve("Dockerfile");
-    var dockerFileContent = generateDockerFileContent();
+    return generateDockerData(context.getFileConfig().getSrcGenPath());
+  }
 
-    return new DockerData(name, dockerFilePath, dockerFileContent, context);
+  public DockerData generateDockerData(Path path) {
+    var name = context.getFileConfig().name;
+    var dockerFileContent = generateDockerFileContent();
+    return new DockerData(name, path.resolve("Dockerfile"), dockerFileContent, context);
   }
 
   public static DockerGenerator dockerGeneratorFactory(LFGeneratorContext context) {

--- a/core/src/main/java/org/lflang/generator/docker/PythonDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/PythonDockerGenerator.java
@@ -1,7 +1,6 @@
-package org.lflang.generator.python;
+package org.lflang.generator.docker;
 
 import org.lflang.generator.LFGeneratorContext;
-import org.lflang.generator.c.CDockerGenerator;
 
 /**
  * Generates the docker file related code for the Python target.

--- a/core/src/main/java/org/lflang/generator/docker/RtiDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/RtiDockerGenerator.java
@@ -3,22 +3,16 @@ package org.lflang.generator.docker;
 import org.lflang.generator.LFGeneratorContext;
 
 /**
- * Generate the docker file related code for the C and CCpp target.
+ * Generate a Dockerfile for building the rti provided by reactor-c.
  *
- * @author Hou Seng Wong
+ * @author Marten Lohstroh
  */
 public class RtiDockerGenerator extends DockerGenerator {
 
-  /**
-   * The constructor for the base docker file generation class.
-   *
-   * @param context The context of the code generator.
-   */
   public RtiDockerGenerator(LFGeneratorContext context) {
     super(context);
   }
 
-  /** Generate the contents of the docker file. */
   @Override
   protected String generateDockerFileContent() {
     return """

--- a/core/src/main/java/org/lflang/generator/docker/RtiDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/RtiDockerGenerator.java
@@ -1,0 +1,41 @@
+package org.lflang.generator.docker;
+
+import org.lflang.generator.LFGeneratorContext;
+
+/**
+ * Generate the docker file related code for the C and CCpp target.
+ *
+ * @author Hou Seng Wong
+ */
+public class RtiDockerGenerator extends DockerGenerator {
+
+  /**
+   * The constructor for the base docker file generation class.
+   *
+   * @param context The context of the code generator.
+   */
+  public RtiDockerGenerator(LFGeneratorContext context) {
+    super(context);
+  }
+
+  /** Generate the contents of the docker file. */
+  @Override
+  protected String generateDockerFileContent() {
+    return """
+        # Docker file for building the image of the rti
+        FROM alpine:latest
+        COPY core /reactor-c/core
+        COPY include /reactor-c/include
+        WORKDIR /reactor-c/core/federated/RTI
+        RUN set -ex && apk add --no-cache gcc musl-dev cmake make && \\
+            mkdir build && \\
+            cd build && \\
+            cmake ../ && \\
+            make && \\
+            make install
+
+        # Use ENTRYPOINT not CMD so that command-line arguments go through
+        ENTRYPOINT ["RTI"]
+        """;
+  }
+}

--- a/core/src/main/java/org/lflang/generator/docker/TSDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/TSDockerGenerator.java
@@ -1,6 +1,5 @@
-package org.lflang.generator.ts;
+package org.lflang.generator.docker;
 
-import org.lflang.generator.DockerGenerator;
 import org.lflang.generator.LFGeneratorContext;
 
 /**

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -51,6 +51,7 @@ import org.lflang.generator.c.CCmakeGenerator;
 import org.lflang.generator.c.CGenerator;
 import org.lflang.generator.c.CUtil;
 import org.lflang.generator.c.TypeParameterizedReactor;
+import org.lflang.generator.docker.PythonDockerGenerator;
 import org.lflang.lf.Action;
 import org.lflang.lf.Input;
 import org.lflang.lf.Model;

--- a/core/src/main/kotlin/org/lflang/generator/ts/TSGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/ts/TSGenerator.kt
@@ -32,6 +32,8 @@ import org.lflang.TimeValue
 import org.lflang.ast.DelayedConnectionTransformation
 import org.lflang.generator.*
 import org.lflang.generator.GeneratorUtils.canGenerate
+import org.lflang.generator.docker.DockerComposeGenerator
+import org.lflang.generator.docker.TSDockerGenerator
 import org.lflang.lf.Preamble
 import org.lflang.model
 import org.lflang.target.property.DockerProperty

--- a/test/C/src/docker/federated/DistributedCountContainerized.lf
+++ b/test/C/src/docker/federated/DistributedCountContainerized.lf
@@ -8,7 +8,9 @@ target C {
   timeout: 5 sec,
   logging: DEBUG,
   coordination: centralized,
-  docker: true
+  docker: {
+    rti-image: "rti:local"
+  }
 }
 
 import Count from "../../lib/Count.lf"

--- a/test/C/src/docker/federated/DistributedDoublePortContainerized.lf
+++ b/test/C/src/docker/federated/DistributedDoublePortContainerized.lf
@@ -8,7 +8,9 @@ target C {
   timeout: 900 msec,
   logging: DEBUG,
   coordination: centralized,
-  docker: true
+  docker: {
+    rti-image: "rti:local"
+  }
 }
 
 import Count from "../../lib/Count.lf"

--- a/test/C/src/docker/federated/DistributedMultiportContainerized.lf
+++ b/test/C/src/docker/federated/DistributedMultiportContainerized.lf
@@ -2,7 +2,9 @@
 target C {
   timeout: 1 sec,
   coordination: centralized,
-  docker: true
+  docker: {
+    rti-image: "rti:local"
+  }
 }
 
 import Source, Destination from "../../federated/DistributedMultiport.lf"

--- a/test/C/src/docker/federated/DistributedStopDecentralizedContainerized.lf
+++ b/test/C/src/docker/federated/DistributedStopDecentralizedContainerized.lf
@@ -5,7 +5,9 @@
  */
 target C {
   coordination: decentralized,
-  docker: true
+  docker: {
+    rti-image: "rti:latest"
+  }
 }
 
 import Sender, Receiver from "../../federated/DistributedStop.lf"

--- a/test/TypeScript/src/docker/federated/DistributedCountContainerized.lf
+++ b/test/TypeScript/src/docker/federated/DistributedCountContainerized.lf
@@ -5,7 +5,9 @@
  */
 target TypeScript {
   timeout: 5 sec,
-  docker: true
+  docker: {
+    rti-image: "rti:local"
+  }
 }
 
 import Count from "../../lib/Count.lf"


### PR DESCRIPTION
- [x] Add `rti-image` attribute and identify locally-build rti as `rti:local`
- [x] Update all federated tests that use docker to use `rti:local`
- [x] Update docs (https://github.com/lf-lang/lf-lang.github.io/pull/180)

Note that the `FROM` attribute should be lowercase, but this won't work until #2136 is merged due to a collision with the `from` keyword.
