### PR TITLE
Parallel compilation disabled to avoid triggering deadlock in concurrent invocations of CMake

### DIFF
--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -297,9 +297,13 @@ public class FedGenerator {
     JavaIoFileSystemAccess fsa = inj.getInstance(JavaIoFileSystemAccess.class);
     fsa.setOutputPath("DEFAULT_OUTPUT", fileConfig.getSrcGenPath().toString());
 
-    var numOfCompileThreads =
+    var numOfCompileThreads = 1;
+    /* NOTE: Used to compile in parallel using the following. This causes the compiler to
+       to nondeterministically lock up on MacOS, which causes the tests to fail after the total
+       time allowed for the test expires (currently two hours).
         Math.min(
             6, Math.min(Math.max(federates.size(), 1), Runtime.getRuntime().availableProcessors()));
+    */
     var compileThreadPool = Executors.newFixedThreadPool(numOfCompileThreads);
     messageReporter
         .nowhere()


### PR DESCRIPTION
In CI, macOS tests have been nondeterministically failing because the federated tests lock up and get cancelled after a long time (originally 6 hours, recently modified to 2 hours).  It turns out that these failures were due to the compiler locking up, not the generated federated programs.  This PR disables parallel compilation of the federated programs, which apparently can cause such lock ups.