### PR TITLE
Python docker parent image fixed at version `3.10`

### DIFF
--- a/core/src/main/java/org/lflang/generator/docker/PythonDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/PythonDockerGenerator.java
@@ -8,7 +8,7 @@ import org.lflang.generator.LFGeneratorContext;
  * @author Hou Seng Wong
  */
 public class PythonDockerGenerator extends CDockerGenerator {
-  final String defaultBaseImage = "python:slim";
+  final String defaultBaseImage = "python:3.10-slim";
 
   public PythonDockerGenerator(LFGeneratorContext context) {
     super(context);


### PR DESCRIPTION
Fixes a version mismatch that causes a failure when compiling with CMake because we do not get support Python versions later than 3.10.