### PR TITLE
Fixed `hashCode()` implementation in `TimeValue` class

### DIFF
--- a/core/src/main/java/org/lflang/TimeValue.java
+++ b/core/src/main/java/org/lflang/TimeValue.java
@@ -74,6 +74,11 @@ public final class TimeValue implements Comparable<TimeValue> {
     return false;
   }
 
+  @Override
+  public int hashCode() {
+    return (int) this.toNanoSeconds();
+  }
+
   public static int compare(TimeValue t1, TimeValue t2) {
     if (t1.isEarlierThan(t2)) {
       return -1;

--- a/test/C/src/federated/MultipleSTP.lf
+++ b/test/C/src/federated/MultipleSTP.lf
@@ -1,0 +1,36 @@
+/**
+ * This test checks for a bug that was triggered when two STP offsets happened to have equal values.
+ * The problem was that TimeValue did not override hashCode() even though it had implemented
+ * equals().
+ */
+target C {
+  timeout: 1 s,
+  coordination: decentralized
+}
+
+reactor Sensor(period: time = 500 ms) {
+  output y: int
+
+  reaction(startup) -> y {=
+    lf_set(y, 42);
+  =}
+}
+
+reactor Print {
+  input x: int
+  input z: int
+
+  reaction(x) {=
+    lf_print("****** Received %d", x->value);
+  =} STP(20 ms) {=  =}
+
+  reaction(z) {=  =} STP(20 ms) {=  =}
+}
+
+federated reactor {
+  s = new Sensor()
+  p = new Print()
+
+  s.y -> p.x
+  s.y -> p.z
+}


### PR DESCRIPTION
Cherry-picked fix contributed by @edwardalee. Fixes #2155.