### PR TITLE
Use login shell so ~/.bash_profile is sourced

### DIFF
--- a/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
+++ b/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
@@ -268,7 +268,7 @@ public class FedLauncherGenerator {
   private String getSetupCode() {
     return String.join(
         "\n",
-        "#!/bin/bash",
+        "#!/bin/bash -l",
         "# Launcher for federated " + fileConfig.name + ".lf Lingua Franca program.",
         "# Uncomment to specify to behave as close as possible to the POSIX standard.",
         "# set -o posix",


### PR DESCRIPTION
In resurrecting the MQTT examples in the playground, I realized that the shell script that we generate to launch a federate does not source `~/.bash_profile`, which makes it much more difficult to use external libraries with federated programs.  The federates can be launched manually, but the shell script to launch them will not work. In the case of MQTT, it needs to find the Paho MQTT dynamically linked libraries, and without this change, there is no way to tell the script where to find them.