### PR TITLE
CI for macOS and Windows only ran periodically, not continuously

### DIFF
--- a/.github/workflows/all-misc.yml
+++ b/.github/workflows/all-misc.yml
@@ -2,6 +2,9 @@
 name: CI (misc)
 
 on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 8 * * 6'
   workflow_dispatch:
   push:
     branches:
@@ -27,7 +30,7 @@ jobs:
     needs: check-diff
     uses: ./.github/workflows/build.yml
     with:
-      all-platforms: ${{ !github.event.pull_request.draft }}
+      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     if: ${{ needs.check-diff.outputs.run_build == 'true' }}
 
   # Run tests for the standalone compiler.
@@ -36,7 +39,7 @@ jobs:
     needs: check-diff
     uses: ./.github/workflows/cli-tests.yml
     with:
-      all-platforms: ${{ !github.event.pull_request.draft }}
+      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   # Run language server tests.
   lsp:
@@ -44,7 +47,7 @@ jobs:
     needs: check-diff
     uses: ./.github/workflows/lsp-tests.yml
     with:
-      all-platforms: ${{ !github.event.pull_request.draft }}
+      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   check-labels:
     uses: ./.github/workflows/check-labels.yml

--- a/.github/workflows/all-targets.yml
+++ b/.github/workflows/all-targets.yml
@@ -2,6 +2,9 @@
 name: CI (by target)
 
 on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 8 * * 6'
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/non-target-specific-extended.yml
+++ b/.github/workflows/non-target-specific-extended.yml
@@ -22,18 +22,18 @@ jobs:
     if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: ./.github/workflows/build.yml
     with:
-      all-platforms: ${{ !github.event.pull_request.draft }}
+      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   # Run tests for the standalone compiler.
   cli:
     if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: ./.github/workflows/cli-tests.yml
     with:
-      all-platforms: ${{ !github.event.pull_request.draft  }}
+      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   # Run language server tests.
   lsp:
     if: ${{ inputs.all || github.event.pull_request.draft }}
     uses: ./.github/workflows/lsp-tests.yml
     with:
-      all-platforms: ${{ !github.event.pull_request.draft  }}
+      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/only-c.yml
+++ b/.github/workflows/only-c.yml
@@ -17,7 +17,7 @@ jobs:
   default:
     uses: ./.github/workflows/c-tests.yml
     with:
-      all-platforms: ${{ !github.event.pull_request.draft  }}
+      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   # Run the C benchmark tests.
   benchmarking:
@@ -29,7 +29,7 @@ jobs:
   arduino:
     uses: ./.github/workflows/c-arduino-tests.yml
     with:
-      all-platforms: ${{ !github.event.pull_request.draft  }}
+      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   # Run the C Zephyr integration tests.
   zephyr:
@@ -40,7 +40,7 @@ jobs:
     uses: ./.github/workflows/c-tests.yml
     with:
       use-cpp: true
-      all-platforms: ${{ !github.event.pull_request.draft  }}
+      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   # Run the Uclid-based LF Verifier benchmarks.
   verifier:

--- a/.github/workflows/only-cpp.yml
+++ b/.github/workflows/only-cpp.yml
@@ -23,7 +23,7 @@ jobs:
   cpp-tests:
     uses: ./.github/workflows/cpp-tests.yml
     with:
-      all-platforms: ${{ !github.event.pull_request.draft  }}
+      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   # Run the C++ integration tests on ROS2.
   cpp-ros2-tests:

--- a/.github/workflows/only-py.yml
+++ b/.github/workflows/only-py.yml
@@ -17,4 +17,4 @@ jobs:
   py-tests:
     uses: ./.github/workflows/py-tests.yml
     with:
-      all-platforms: ${{ !github.event.pull_request.draft  }}
+      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/only-rs.yml
+++ b/.github/workflows/only-rs.yml
@@ -17,7 +17,7 @@ jobs:
   rs-tests:
     uses: ./.github/workflows/rs-tests.yml
     with:
-      all-platforms: ${{ !github.event.pull_request.draft  }}
+      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   # Run the Rust benchmark tests.
   rs-benchmark-tests:

--- a/.github/workflows/only-ts.yml
+++ b/.github/workflows/only-ts.yml
@@ -23,4 +23,4 @@ jobs:
   ts-tests:
     uses: ./.github/workflows/ts-tests.yml
     with:
-      all-platforms: ${{ !github.event.pull_request.draft  }}
+      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
~~Soon as we find a fix for the mysterious random hanging in the compiler on macOS we should revert this, but in the interested of not holding up everything else we're doing, I propose we simply disable the macOS tests for the time being.~~

~~I changed this PR from disabling the macOS tests to switching to much faster M1 runners. This does not address the bottleneck problem that motivates my idea to move macOS tests to the weekend, so we could still do this, but it makes the problem less severe. For reference, the `build-toolchain` job took 15 minutes on a regular macOS runner, and only 3 minutes on the M1.~~

~~This likely also makes the dreaded concurrency bug go away, although, of course, it will still lurk somewhere. I think we are better off spending our time on other things; we can attempt to fix the problem once we have a bug report from a user.~~

The experiments in this PR show that we can speed up CI quite a bit by using fancier runners, but that the financial costs are significant. This brings me back to the initial proposal: do not run macOS/Windows tests that clog up the CI pipeline all the time, but only periodically (at least until we have a solution that addresses the bottleneck).