### PR TITLE
Reduced scope for conflicting main reactors check

### DIFF
--- a/core/src/main/java/org/lflang/MainConflictChecker.java
+++ b/core/src/main/java/org/lflang/MainConflictChecker.java
@@ -51,7 +51,7 @@ public class MainConflictChecker {
     //  files in the current package (which happens when we get the resources)
     this.fileConfig = fileConfig;
     try {
-      Files.walkFileTree(fileConfig.srcPkgPath, new PackageVisitor());
+      Files.walkFileTree(fileConfig.srcPath, new PackageVisitor());
     } catch (IOException e) {
       System.err.println("Error while checking for name conflicts in package.");
       e.printStackTrace();


### PR DESCRIPTION
We do a check to find conflicting main reactors in the package. We should limit the scope of the search to the `src`directory because there could be other sources present in the package outside of the `src` directory that should not be labeled as conflicting.

This fix was prompted by the use of the `lf-lang/action-check-lf-files` which puts a checkout of `lingua-franca` in the workspace.

~~Required for https://github.com/lf-lang/lf-pico-template/pull/2.~~