### PR TITLE
Have colorized outputs from C/Cpp compilers as default

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -252,8 +252,11 @@ public class CCmakeGenerator {
     cMakeCode.pr("endif()\n");
     cMakeCode.newLine();
 
-    cMakeCode.pr("# do not print install messages\n");
+    cMakeCode.pr("# Do not print install messages\n");
     cMakeCode.pr("set(CMAKE_INSTALL_MESSAGE NEVER)\n");
+
+    cMakeCode.pr("# Colorize compilation output\n");
+    cMakeCode.pr("set(CMAKE_COLOR_DIAGNOSTICS ON)\n");
     cMakeCode.newLine();
 
     if (CppMode) {

--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppStandaloneCmakeGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppStandaloneCmakeGenerator.kt
@@ -80,6 +80,9 @@ class CppStandaloneCmakeGenerator(private val targetConfig: TargetConfig, privat
             |# do not print install messages
             |set(CMAKE_INSTALL_MESSAGE NEVER)
             |
+            |# Colorize compilation output
+            |set(CMAKE_COLOR_DIAGNOSTICS ON)
+            |
             |include($S{CMAKE_ROOT}/Modules/ExternalProject.cmake)
             |include(GNUInstallDirs)
             |


### PR DESCRIPTION
This simply adds set(CMAKE_COLOR_DIAGNOSTICS ON) to the CMakeLists.txt generated for C and Cpp programs. This will colorize the compiler output so it is much easier to separate errors from warnings etc. 