### PR TITLE
Fixed cmake deprecation warnings in the C target

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -231,17 +231,6 @@ public class CCmakeGenerator {
     cMakeCode.pr("set(CMAKE_CXX_STANDARD 17)");
     cMakeCode.pr("set(CMAKE_CXX_STANDARD_REQUIRED ON)");
     cMakeCode.newLine();
-    if (!targetConfig.getOrDefault(CmakeIncludeProperty.INSTANCE).isEmpty()) {
-      // The user might be using the non-keyword form of
-      // target_link_libraries. Ideally we would detect whether they are
-      // doing that, but it is easier to just always have a deprecation
-      // warning.
-      cMakeCode.pr(
-          """
-                cmake_policy(SET CMP0023 OLD)  # This causes deprecation warnings
-
-                """);
-    }
 
     // Set the build type
     cMakeCode.pr("set(DEFAULT_BUILD_TYPE " + targetConfig.get(BuildTypeProperty.INSTANCE) + ")\n");


### PR DESCRIPTION
The C code generator set the [CMP0023 Policy](https://cmake.org/cmake/help/latest/policy/CMP0023.html) to `OLD` for an inexplicable reason. This PR simply removes that code. 

Likely the old policy setting was needed as some kind of workaround. If some of the tests fail, we will need to find an actual solution to the underlying problem.

Fixes #2120