### PR TITLE
Parameterized default branch in check-diff script

### DIFF
--- a/.github/scripts/check-diff.sh
+++ b/.github/scripts/check-diff.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 changes() {
-  git diff --name-only HEAD $(git merge-base HEAD origin/master)
+  git diff --name-only HEAD $(git merge-base HEAD origin/$1)
 }
 
-if changes | grep "$1" | grep -q -v "^.*md\|txt$"; then
-  echo "changed_$2=1" >> $GITHUB_OUTPUT
+if changes $1 | grep "$2" | grep -q -v "^.*md\|txt$"; then
+  echo "changed_$3=1" >> $GITHUB_OUTPUT
 else
-  echo "changed_$2=0" >> $GITHUB_OUTPUT
+  echo "changed_$3=0" >> $GITHUB_OUTPUT
 fi

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -53,13 +53,13 @@ jobs:
       - id: do
         name: Check which targets have changes
         run: |
-          ./check-diff.sh "lflang/generator/c\|resources/lib/c\|resources/lib/platform\|test/C" c
-          ./check-diff.sh "lflang/generator/cpp\|resources/lib/cpp\|test/Cpp" cpp
-          ./check-diff.sh "lflang/generator/python\|resources/lib/py\|test/Python" py
-          ./check-diff.sh "lflang/generator/rust\|resources/lib/rs\|test/Rust" rs
-          ./check-diff.sh "lflang/generator/ts\|resources/lib/ts\|test/TypeScript" ts
-          ./check-diff.sh "util/tracing" tracing
-          ./check-diff.sh ".*" any
+          ./check-diff.sh master "lflang/generator/c\|resources/lib/c\|resources/lib/platform\|test/C" c
+          ./check-diff.sh master "lflang/generator/cpp\|resources/lib/cpp\|test/Cpp" cpp
+          ./check-diff.sh master "lflang/generator/python\|resources/lib/py\|test/Python" py
+          ./check-diff.sh master "lflang/generator/rust\|resources/lib/rs\|test/Rust" rs
+          ./check-diff.sh master "lflang/generator/ts\|resources/lib/ts\|test/TypeScript" ts
+          ./check-diff.sh master "util/tracing" tracing
+          ./check-diff.sh master ".*" any
         shell: bash
         working-directory: .github/scripts
       - id: summarize


### PR DESCRIPTION
This script is used in `reactor-c` now, but the main branch in `reactor-c` is `main`, not `master`.