### PR TITLE
Fixed clang warnings in generated C++ code

### DIFF
--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppAssembleMethodGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppAssembleMethodGenerator.kt
@@ -197,7 +197,7 @@ class CppAssembleMethodGenerator(private val reactor: Reactor) {
 
     private fun Connection.getConnectionLambda(portType: String): String {
         return """
-            [this]($portType left, $portType right) {
+            [&]($portType left, $portType right) {
                 left->environment()->draw_connection(left, right, $properties);
             }
         """.trimIndent()

--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppParameterGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppParameterGenerator.kt
@@ -67,5 +67,7 @@ class CppParameterGenerator(private val reactor: Reactor) {
      *  This is required for some code bodies (e.g. target code in parameter initializers) to have access to the local parameters.
      */
     fun generateOuterAliasDeclarations() =
-        reactor.parameters.joinToString(separator = "") { "const typename Parameters::${it.typeAlias}& ${it.name} = __lf_inner.${it.name};\n" }
+        reactor.parameters.joinToString(prefix = "// parameter aliases for use in the outer scope\n", separator = "") {
+            "[[maybe_unused]] const typename Parameters::${it.typeAlias}& ${it.name} = __lf_inner.${it.name};\n"
+        }
 }

--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppReactorGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppReactorGenerator.kt
@@ -94,8 +94,8 @@ class CppReactorGenerator(private val reactor: Reactor, fileConfig: CppFileConfi
         ${" |  "..reactions.generateReactionViewForwardDeclarations()}
             |
             |  class Inner: public lfutil::LFScope {
-            |    const Inner& __lf_inner = *this;
-            |    const Parameters __lf_parameters;
+            |    [[maybe_unused]] const Inner& __lf_inner = *this;
+            |    [[maybe_unused]] const Parameters __lf_parameters;
         ${" |    "..parameters.generateInnerAliasDeclarations()}
         ${" |    "..state.generateDeclarations()}
         ${" |    "..methods.generateDeclarations()}

--- a/test/Cpp/src/multiport/MultiportToMultiportAfterParameterized.lf
+++ b/test/Cpp/src/multiport/MultiportToMultiportAfterParameterized.lf
@@ -1,0 +1,42 @@
+// Test multiport to multiport connections. See also MultiportToMultiport.
+target Cpp
+
+reactor Source(width: size_t = 2) {
+  output[width] out: size_t
+
+  reaction(startup) -> out {=
+    for (size_t i = 0; i < out.size(); i++) {
+      out[i].set(i);
+    }
+  =}
+}
+
+reactor Destination(width: size_t = 2) {
+  input[width] in: size_t
+
+  reaction(in) {=
+    for (size_t i = 0; i < in.size(); i++) {
+      if (in[i].is_present()) {
+        size_t value = *in[i].get();
+        std::cout << "Received on channel " << i << ": " << value << '\n';
+        // NOTE: For testing purposes, this assumes the specific
+        // widths instantiated below.
+        if (value != i % 3) {
+          std::cerr << "ERROR: expected " << i % 3 << '\n';
+          exit(1);
+        }
+      }
+    }
+    if (get_elapsed_logical_time() != 1s) {
+      std::cerr << "ERROR: Expected to receive input after one second.\n";
+      exit(2);
+    }
+  =}
+}
+
+main reactor(delay: time = 1 sec) {
+  a1 = new Source(width=3)
+  a2 = new Source(width=2)
+  b = new Destination(width=5)
+  a1.out, a2.out -> b.in after delay
+}


### PR DESCRIPTION
This avoids the warnings reported in https://github.com/lf-lang/playground-lingua-franca/issues/99.

Fixes https://github.com/lf-lang/lingua-franca/issues/2189