### PR TITLE
Directory definitions corrected and made to work for federated.

### DIFF
--- a/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
@@ -303,7 +303,8 @@ public class CExtensionUtils {
         "add_compile_definitions(LF_SOURCE_DIRECTORY=\"" + fileConfig.srcPath + "\")");
     cmakeIncludeCode.pr(
         "add_compile_definitions(LF_PACKAGE_DIRECTORY=\"" + fileConfig.srcPkgPath + "\")");
-
+    cmakeIncludeCode.pr(
+        "add_compile_definitions(LF_SOURCE_GEN_DIRECTORY=\"" + fileConfig.getSrcGenPath() + "\")");
     try (var srcWriter = Files.newBufferedWriter(cmakeIncludePath)) {
       srcWriter.write(cmakeIncludeCode.getCode());
     }

--- a/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
+++ b/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
@@ -124,7 +124,7 @@ public class FedLauncherGenerator {
       target = user + "@" + host;
     }
 
-    shCode.append("#### Host is ").append(host);
+    shCode.append("#### Host is ").append(host).append("\n");
 
     // Launch the RTI in the foreground.
     if (host.equals("localhost") || host.equals("0.0.0.0")) {

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -422,6 +422,11 @@ public class CCmakeGenerator {
     }
     cMakeCode.newLine();
 
+    // Add definition of directory where the main CMakeLists.txt file resides because this is where
+    // any files specified by the `file` target directive will be put.
+    cMakeCode.pr("# Define directory in which files from the 'files' target directive will be put.");
+    cMakeCode.pr("target_compile_definitions(${LF_MAIN_TARGET} PUBLIC LF_TARGET_FILES_DIRECTORY=\"${CMAKE_CURRENT_LIST_DIR}\")");
+
     cMakeCode.pr(cMakeExtras);
     cMakeCode.newLine();
 

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -424,8 +424,11 @@ public class CCmakeGenerator {
 
     // Add definition of directory where the main CMakeLists.txt file resides because this is where
     // any files specified by the `file` target directive will be put.
-    cMakeCode.pr("# Define directory in which files from the 'files' target directive will be put.");
-    cMakeCode.pr("target_compile_definitions(${LF_MAIN_TARGET} PUBLIC LF_TARGET_FILES_DIRECTORY=\"${CMAKE_CURRENT_LIST_DIR}\")");
+    cMakeCode.pr(
+        "# Define directory in which files from the 'files' target directive will be put.");
+    cMakeCode.pr(
+        "target_compile_definitions(${LF_MAIN_TARGET} PUBLIC"
+            + " LF_TARGET_FILES_DIRECTORY=\"${CMAKE_CURRENT_LIST_DIR}\")");
 
     cMakeCode.pr(cMakeExtras);
     cMakeCode.newLine();

--- a/core/src/main/java/org/lflang/generator/c/CCompiler.java
+++ b/core/src/main/java/org/lflang/generator/c/CCompiler.java
@@ -219,11 +219,13 @@ public class CCompiler {
     String maybeQuote = ""; // Windows seems to require extra level of quoting.
     String srcPath = fileConfig.srcPath.toString(); // Windows requires escaping the backslashes.
     String rootPath = fileConfig.srcPkgPath.toString();
+    String srcGenPath = fileConfig.getSrcGenPath().toString();
     if (separator.equals("\\")) {
       separator = "\\\\\\\\";
       maybeQuote = "\\\"";
       srcPath = srcPath.replaceAll("\\\\", "\\\\\\\\");
       rootPath = rootPath.replaceAll("\\\\", "\\\\\\\\");
+      srcGenPath = srcGenPath.replaceAll("\\\\", "\\\\\\\\");
     }
     arguments.addAll(
         List.of(
@@ -242,6 +244,7 @@ public class CCompiler {
       // Do not convert to Unix path
       arguments.add("-DLF_SOURCE_DIRECTORY=\"" + maybeQuote + srcPath + maybeQuote + "\"");
       arguments.add("-DLF_PACKAGE_DIRECTORY=\"" + maybeQuote + rootPath + maybeQuote + "\"");
+      arguments.add("-DLF_SOURCE_GEN_DIRECTORY=\"" + maybeQuote + srcGenPath + maybeQuote + "\"");
     }
     arguments.add(FileUtil.toUnixString(fileConfig.getSrcGenPath()));
 

--- a/core/src/main/java/org/lflang/generator/c/CPreambleGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CPreambleGenerator.java
@@ -1,7 +1,5 @@
 package org.lflang.generator.c;
 
-import static org.lflang.util.StringUtil.addDoubleQuotes;
-
 import java.nio.file.Path;
 import java.util.HashMap;
 import org.lflang.generator.CodeBuilder;

--- a/core/src/main/java/org/lflang/generator/c/CPreambleGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CPreambleGenerator.java
@@ -76,7 +76,6 @@ public class CPreambleGenerator {
     CodeBuilder code = new CodeBuilder();
     // TODO: Get rid of all of these
     code.pr("#define LOG_LEVEL " + logLevel);
-    code.pr("#define TARGET_FILES_DIRECTORY " + addDoubleQuotes(srcGenPath.toString()));
     final var definitions = new HashMap<String, String>();
     if (tracing.isEnabled()) {
       definitions.put("LF_TRACE", tracing.traceFileName);


### PR DESCRIPTION
This PR makes sure that `LF_SOURCE_GEN_DIRECTORY` and `LF_TARGET_FILES_DIRECTORY` are properly defined using CMake.  The latter in particular is needed for user code to be able to access files that are copied using the `files` target directive. This works for both unfederated and federated, even for remote federates.