### PR TITLE
Set CI to allow ssh

### DIFF
--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install RTI
         uses: ./.github/actions/install-rti
         if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
+      - name: Debugging with ssh
+        uses: lhotari/action-upterm@v1
+        if: ${{ runner.os == 'macOS' }}
       - name: Perform tests for C target with default scheduler
         run: ./gradlew targetTest -Ptarget=C
         if: ${{ !inputs.use-cpp && !inputs.scheduler }}


### PR DESCRIPTION
This PR is not meant to be ever merged.  It's here so we can run CI on it and then ssh into a macOS runner.