### PR TITLE
Report unsupported target properties as errors

### DIFF
--- a/core/src/main/java/org/lflang/target/TargetConfig.java
+++ b/core/src/main/java/org/lflang/target/TargetConfig.java
@@ -173,10 +173,9 @@ public class TargetConfig {
    * @param stage2 The second stage an the error reporter through which to report the warning.
    */
   public void reportUnsupportedTargetProperty(String name, MessageReporter.Stage2 stage2) {
-    stage2.warning(
+    stage2.error(
         String.format(
-            "The target property '%s' is not supported by the %s target and is thus ignored.",
-            name, this.target));
+            "The target property '%s' is not supported by the %s target.", name, this.target));
     stage2.info("Recognized properties are: " + this.listOfRegisteredProperties());
   }
 

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -1905,11 +1905,11 @@ public class LinguaFrancaValidationTest {
     var model = parseWithoutError(testCase);
     List<Issue> issues = validator.validate(model);
     Assertions.assertTrue(issues.size() == 2);
-    validator.assertWarning(
+    validator.assertError(
         model,
         LfPackage.eINSTANCE.getKeyValuePair(),
         null,
-        "The target property 'foobarbaz' is not supported by the C target and is thus ignored.");
+        "The target property 'foobarbaz' is not supported by the C target.");
   }
 
   @Test
@@ -1922,12 +1922,11 @@ public class LinguaFrancaValidationTest {
     var model = parseWithoutError(testCase);
     List<Issue> issues = validator.validate(model);
     Assertions.assertTrue(issues.size() == 2);
-    validator.assertWarning(
+    validator.assertError(
         model,
         LfPackage.eINSTANCE.getKeyValuePair(),
         null,
-        "The target property 'cargo-features' is not supported by the Python target and is thus"
-            + " ignored.");
+        "The target property 'cargo-features' is not supported by the Python target.");
   }
 
   @Test

--- a/test/C/src/concurrent/Threaded.lf
+++ b/test/C/src/concurrent/Threaded.lf
@@ -6,8 +6,7 @@
 // that without threads, this takes more than 800 msec to complete 200 msec of logical time. See
 // ThreadedMultiport for a parameterized version of this.
 target C {
-  timeout: 2 sec,
-  flags: ""  // Disable compiler optimization so that TakeTime actually takes time.
+  timeout: 2 sec
 }
 
 reactor Source {

--- a/test/C/src/concurrent/ThreadedMultiport.lf
+++ b/test/C/src/concurrent/ThreadedMultiport.lf
@@ -1,7 +1,6 @@
 // Check multiport capabilities on Outputs.
 target C {
-  timeout: 2 sec,
-  flags: ""  // Disable compiler optimization so that TakeTime actually takes time.
+  timeout: 2 sec
 }
 
 reactor Source(width: int = 4) {

--- a/test/C/src/concurrent/ThreadedThreaded.lf
+++ b/test/C/src/concurrent/ThreadedThreaded.lf
@@ -6,8 +6,7 @@
 // of this.
 target C {
   timeout: 2 sec,
-  tracing: true,
-  flags: ""  // Disable compiler optimization so that TakeTime actually takes time.
+  tracing: true
 }
 
 reactor Source {

--- a/test/C/src/concurrent/Tracing.lf
+++ b/test/C/src/concurrent/Tracing.lf
@@ -2,7 +2,6 @@
 target C {
   timeout: 2 sec,
   tracing: true,
-  flags: "",  // Disable compiler optimization so that TakeTime actually takes time.
   logging: DEBUG
 }
 

--- a/test/C/src/federated/LoopDistributedCentralizedPhysicalAction.lf
+++ b/test/C/src/federated/LoopDistributedCentralizedPhysicalAction.lf
@@ -4,7 +4,6 @@
  * @author Edward A. Lee
  */
 target C {
-  flags: "-Wall",
   coordination: centralized,
   coordination-options: {
     advance-message-interval: 100 msec

--- a/test/C/src/federated/LoopDistributedCentralizedPrecedence.lf
+++ b/test/C/src/federated/LoopDistributedCentralizedPrecedence.lf
@@ -6,7 +6,6 @@
  * @author Soroush Bateni
  */
 target C {
-  flags: "-Wall",
   coordination: centralized,
   coordination-options: {
     advance-message-interval: 100 msec

--- a/test/C/src/federated/LoopDistributedCentralizedPrecedenceHierarchy.lf
+++ b/test/C/src/federated/LoopDistributedCentralizedPrecedenceHierarchy.lf
@@ -6,7 +6,6 @@
  * @author Soroush Bateni
  */
 target C {
-  flags: "-Wall",
   coordination: centralized,
   coordination-options: {
     advance-message-interval: 100 msec


### PR DESCRIPTION
Currently, if the target declaration uses a property that is not supported by the target, this is reported as a warning. This is problematic, as we and potentially users don't notice if a target property is not supported anymore. For instance, we had several uses of the `flags` property in the C tests although it was renamed. Also the benchmarks used properties that we removed (See https://github.com/lf-lang/benchmarks-lingua-franca/pull/61).

This PR converts the warning message into an error, adjusts the unit tests, and fixes some of the C tests. I opted for simply dropping the `flags` property, as apparently it wasn't required and not used for a while. In particular, some tests attempted to avoid optimization, which is not needed as we compile the tests in Debug mode (without optimization) anyway.