### PR TITLE
Fixed `#line` directives on Windows

### DIFF
--- a/core/src/main/java/org/lflang/generator/CodeBuilder.java
+++ b/core/src/main/java/org/lflang/generator/CodeBuilder.java
@@ -126,7 +126,8 @@ public class CodeBuilder {
         }
       }
       // Extract the filename from eResource, an astonishingly difficult thing to do.
-      String filePath = CommonPlugin.resolve(eObject.eResource().getURI()).path();
+      String filePath =
+          CommonPlugin.resolve(eObject.eResource().getURI()).path().replace("\\", "\\\\");
       pr("#line " + (node.getStartLine() + offset) + " \"" + filePath + "\"");
     }
   }
@@ -558,7 +559,11 @@ public class CodeBuilder {
     for (var line : (Iterable<String>) () -> s.lines().iterator()) {
       lineNumber++;
       if (line.contains(END_SOURCE_LINE_NUMBER_TAG) && !path.endsWith(".ino")) {
-        out.append("#line ").append(lineNumber).append(" \"").append(path).append("\"");
+        out.append("#line ")
+            .append(lineNumber)
+            .append(" \"")
+            .append(path.replace("\\", "\\\\"))
+            .append("\"");
       } else {
         out.append(line);
       }


### PR DESCRIPTION
This fixes a path separator/escaping issue in `#line` directives on Windows.