### PR TITLE
Use lf_combine_deadline_and_level function

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
@@ -230,7 +230,12 @@ public class CTriggerObjectsGenerator {
 
       if (levelSet.size() == 1 && deadlineSet.size() == 1) {
         // Scenario (1)
-        var reactionIndex = "lf_combine_deadline_and_level(" + inferredDeadline.toNanoSeconds() + ", " + level + ")";
+        var reactionIndex =
+            "lf_combine_deadline_and_level("
+                + inferredDeadline.toNanoSeconds()
+                + ", "
+                + level
+                + ")";
 
         temp.pr(
             String.join(

--- a/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
@@ -230,10 +230,7 @@ public class CTriggerObjectsGenerator {
 
       if (levelSet.size() == 1 && deadlineSet.size() == 1) {
         // Scenario (1)
-
-        var indexValue = inferredDeadline.toNanoSeconds() << 16 | level;
-
-        var reactionIndex = "0x" + Long.toUnsignedString(indexValue, 16) + "LL";
+        var reactionIndex = "lf_combine_deadline_and_level(" + inferredDeadline.toNanoSeconds() + ", " + level + ")";
 
         temp.pr(
             String.join(
@@ -251,13 +248,13 @@ public class CTriggerObjectsGenerator {
                 "// index is the OR of levels[" + runtimeIdx + "] and ",
                 "// deadlines[" + runtimeIdx + "] shifted left 16 bits.",
                 CUtil.reactionRef(r)
-                    + ".index = ("
+                    + ".index = inferredDeadline.toNanoSeconds("
                     + r.uniqueID()
                     + "_inferred_deadlines["
                     + runtimeIdx
-                    + "] << 16) | "
+                    + "], "
                     + level
-                    + ";"));
+                    + ");"));
 
       } else if (levelSet.size() > 1 && deadlineSet.size() == 1) {
         // Scenarion (3)
@@ -268,13 +265,13 @@ public class CTriggerObjectsGenerator {
                 "// index is the OR of levels[" + runtimeIdx + "] and ",
                 "// deadlines[" + runtimeIdx + "] shifted left 16 bits.",
                 CUtil.reactionRef(r)
-                    + ".index = ("
+                    + ".index = lf_combine_deadline_and_level("
                     + inferredDeadline.toNanoSeconds()
-                    + " << 16) | "
+                    + ", "
                     + r.uniqueID()
                     + "_levels["
                     + runtimeIdx
-                    + "];"));
+                    + "]);"));
 
       } else if (levelSet.size() > 1 && deadlineSet.size() > 1) {
         // Scenario (4)
@@ -285,15 +282,15 @@ public class CTriggerObjectsGenerator {
                 "// index is the OR of levels[" + runtimeIdx + "] and ",
                 "// deadlines[" + runtimeIdx + "] shifted left 16 bits.",
                 CUtil.reactionRef(r)
-                    + ".index = ("
+                    + ".index = inferredDeadline.toNanoSeconds("
                     + r.uniqueID()
                     + "_inferred_deadlines["
                     + runtimeIdx
-                    + "] << 16) | "
+                    + "], "
                     + r.uniqueID()
                     + "_levels["
                     + runtimeIdx
-                    + "];"));
+                    + "]);"));
       }
     }
     for (ReactorInstance child : reactor.children) {

--- a/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
@@ -253,7 +253,7 @@ public class CTriggerObjectsGenerator {
                 "// index is the OR of levels[" + runtimeIdx + "] and ",
                 "// deadlines[" + runtimeIdx + "] shifted left 16 bits.",
                 CUtil.reactionRef(r)
-                    + ".index = inferredDeadline.toNanoSeconds("
+                    + ".index = lf_combine_deadline_and_level("
                     + r.uniqueID()
                     + "_inferred_deadlines["
                     + runtimeIdx


### PR DESCRIPTION
This PR suppresses a warning (below) and consolidates the mechanism that is used to combine a deadline with a level into a single C function.  As usual, there is a companion PR in reactor-c. The warning was as follows:

```
/Users/edwardlee/git/epoch/org.lflang.ui/src/org/lflang/ui/wizard/templates/c/src-gen/Pipeline/Pipeline.c:562:91: warning: signed shift result (0x7FFFFFFFFFFFFFFF0000) requires 80 bits to represent, but 'long' only has 64 bits [-Wshift-overflow]
            pipeline_rp_self[pipeline_rp_i]->_lf__reaction_0.index = (9223372036854775807 << 16) | pipeline_rp_reaction_1_levels[pipeline_rp_i];
                                                                      ~~~~~~~~~~~~~~~~~~~ ^  ~~
1 warning generated.
```
