### PR TITLE
Use nowhere() when reporting scheduler warnings

### DIFF
--- a/core/src/main/java/org/lflang/target/property/SchedulerProperty.java
+++ b/core/src/main/java/org/lflang/target/property/SchedulerProperty.java
@@ -63,7 +63,7 @@ public final class SchedulerProperty extends TargetProperty<Scheduler, Scheduler
                   ASTUtils.allReactions(reactor).stream()
                       .anyMatch(reaction -> reaction.getDeadline() != null))) {
         reporter
-            .at(config.lookup(this), Literals.KEY_VALUE_PAIR__VALUE)
+            .nowhere()
             .warning(
                 "This program contains deadlines, but the chosen "
                     + scheduler


### PR DESCRIPTION
This should fix #2228 .