### PR TITLE
Fixed null pointer exception in message reporting

### DIFF
--- a/core/src/main/java/org/lflang/MessageReporterBase.java
+++ b/core/src/main/java/org/lflang/MessageReporterBase.java
@@ -40,11 +40,17 @@ public abstract class MessageReporterBase implements MessageReporter {
 
   @Override
   public Stage2 at(EObject node) {
+    if (node == null) {
+      return nowhere();
+    }
     return wrap((severity, message) -> reportOnNode(node, severity, message));
   }
 
   @Override
   public Stage2 at(EObject node, EStructuralFeature feature) {
+    if (node == null) {
+      return nowhere();
+    }
     return wrap((severity, message) -> reportOnNode(node, feature, severity, message));
   }
 


### PR DESCRIPTION
This fixes https://github.com/lf-lang/lingua-franca/issues/2228. When a message is reported on an eObject, but the object is null, this let to a null pointer exception. This change falls back to reporting nowhere, if the given object is null.

This generalizes and replaces the fix in https://github.com/lf-lang/lingua-franca/pull/2229.