### PR TITLE
Fix failing Zephyr tests in CI

### DIFF
--- a/.github/scripts/run-zephyr-tests.sh
+++ b/.github/scripts/run-zephyr-tests.sh
@@ -7,7 +7,7 @@ find_kconfig_folders() {
     if [ -f "$folder/CMakeLists.txt" ]; then
         echo "-----------------------------------------------------------------------------------------------------------"
         test_name=$(basename $folder)
-      
+
         if [[ " ${skip[*]} " == *" $test_name "* ]]; then
             echo "Skipping: $test_name"
         else
@@ -50,7 +50,7 @@ run_qemu_zephyr_test() {
     while [ "$wait_count" -le "$timeout" ]; do
         sleep 1
         if grep --quiet 'FATAL ERROR' "$res"
-        then 
+        then
             cat $res
             echo "-----------------------------------------------------------------------------------------------------------"
             echo "ERROR: Found 'FATAL ERROR'"

--- a/.github/scripts/run-zephyr-tests.sh
+++ b/.github/scripts/run-zephyr-tests.sh
@@ -1,36 +1,26 @@
 #!/bin/bash
-timeout=300 # 5min timeout is hopefully enough
-verbose=false
 
-# Function to recursively find all folders containing the top-level CMakeLists.txt
-overall_success=true
-num_successes=0
-num_failures=0
-failed_tests=""
-
-# Skip tests doing file IO and tracing
-skip=("FileReader" "FilePkgReader" "Tracing" "ThreadedThreaded" "CountTest" "AsyncCallback")
+# Skip
+skip=("FileReader" "FilePkgReader")
 
 find_kconfig_folders() {
     if [ -f "$folder/CMakeLists.txt" ]; then
         echo "-----------------------------------------------------------------------------------------------------------"
         test_name=$(basename $folder)
-
+      
         if [[ " ${skip[*]} " == *" $test_name "* ]]; then
             echo "Skipping: $test_name"
         else
             echo "Running: $test_name"
-            if run_qemu_zephyr_test "$folder"; then
-                echo "Test $test_name successful"
+            run_qemu_zephyr_test $folder
+            if [ "$?" -eq 0 ]; then
+                echo "Test passed"
                 let "num_successes+=1"
             else
-                echo "Test $test_name failed"
-                let "num_failures+=1"
-                failed_tests+="$test_name, "
-                overall_success=false
+                echo "Test failed."
+                exit 1
             fi
         fi
-
       return
     fi
     for folder in "$1"/*; do
@@ -40,88 +30,55 @@ find_kconfig_folders() {
     done
 }
 
-run_native_zephyr_test() {
-    return_val=0
-    pushd $1/build
-
-    rm -f res.text
-
-    timeout 60s make run | tee res.txt
-    result=$?
-
-    if [ $result -eq 0 ]; then
-        echo "Command completed within the timeout."
-        return_val=0
-    else
-        echo "Command terminated or timed out."
-        echo "Test output:"
-        echo "----------------------------------------------------------------"
-        cat res.txt
-        echo "----------------------------------------------------------------"
-        return_val=1
-    fi
-
-    popd
-    return "$return_val"
-
-
-
-
-}
-
-# Run Zephyr test until either: Timeout or finds match in output
-# https://www.unix.com/shell-programming-and-scripting/171401-kill-process-if-grep-match-found.html
+# Run Zephyr test until either: Timeout or finds match in output using expect
+# https://spin.atomicobject.com/monitoring-stdout-with-a-timeout/
 run_qemu_zephyr_test() {
     success=false
     pushd $1/build
-
-    rm -f /tmp/procfifo
-    rm -f res.text
-    mkfifo /tmp/procfifo
-
-    make run | tee res.txt >  /tmp/procfifo &
-    PID=$!
-    SECONDS=0
-    while IFS= read -t $timeout line
-    do
-        if [ "$verbose" = "true" ]; then  echo $line; fi
-
-        if echo "$line" | grep -q 'FATAL ERROR';
+    res="_res.txt"
+    # Run test program in background and pipe results to a file.
+    make run > $res &
+    if [ $? -ne 0 ]; then
+        echo "ERROR: make run failed."
+        exit 1
+    fi
+    pid=$!
+    return_val=2
+    wait_count=0
+    timeout=60
+    # Parse the file and match on known outputs. With timeout.
+    while [ "$wait_count" -le "$timeout" ]; do
+        sleep 1
+        if grep --quiet 'FATAL ERROR' "$res"
+        then 
+            cat $res
+            echo "-----------------------------------------------------------------------------------------------------------"
+            echo "ERROR: Found 'FATAL ERROR'"
+            return_val=1
+            break
+        fi
+        if grep --quiet '^exit' "$res"
         then
-            echo "Matched on ERROR"
-            echo $line
-            success=false
-            pkill -P $$
+            cat $res
+            echo "-----------------------------------------------------------------------------------------------------------"
+            echo "SUCCESS: Found 'exit'"
+            return_val=0
             break
         fi
 
-        if echo "$line" | grep -q '^exit';
-        then
-                echo "Matched on exit"
-                success=true
-                pkill -P $$
-                break
-        fi
-
-        if (($SECONDS > $timeout)) ; then
-            echo "Timeout without freeze"
-            success=false
-            break
-        fi
-    done < /tmp/procfifo
-
-    return_val=0
-    if [ "$success" = false ]; then
-        echo "General Timeout"
-        pkill -P $$
-        echo "Test output:"
-        echo "----------------------------------------------------------------"
-        cat res.txt
-        echo "----------------------------------------------------------------"
-        return_val=1
+        ((wait_count++))
+    done
+    kill $pid
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Could not kill qemu process"
+        exit 1
     fi
 
-    rm -f /tmp/procfifo
+    if [ "$return_val" -eq 2 ]; then
+        cat $res
+        echo "-----------------------------------------------------------------------------------------------------------"
+        echo "ERROR: Timed out"
+    fi
     popd
     return "$return_val"
 }
@@ -137,14 +94,8 @@ cd -
 
 # Print report
 echo "================================================================================================================"
-
-if [ "$overall_success" = false ]; then
-    echo "Results: FAIL"
-else
-    echo "Results: PASS"
-fi
+echo "Tests passed!"
 echo "Number of passes: $num_successes"
-echo "Number of fails: $num_failures"
 echo "Skipped tests: ${skip[@]}"
 
 if [ "$overall_success" = false ]; then


### PR DESCRIPTION
This PR tries to address the recent failing Zephyr tests. Unfortunately it was not clear exactly what was happening and I was not able to reproduce the failure, not locally and not when ssh'ing into Github Actions and running the gradle script manually.

The Zephyr CI stuff is complicated since we must launch a QEMU emulation and match the output of the QEMU emulation to look for an FATAL ERROR or a termination. When either is detected we must kill the process running the QEMU emulation. Also we must have a timeout.

I think the error was because a QEMU process was not successfully killed. I added checks to verify that we indeed were able to kill it, and then it started working again.