### PR TITLE
Python tests to use an rti that matches the reactor-c checkout

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -33,16 +33,6 @@ jobs:
           fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
-      - name: Check out specific ref of reactor-c
-        uses: actions/checkout@v3
-        with:
-          repository: lf-lang/reactor-c
-          path: core/src/main/resources/lib/c/reactor-c
-          ref: ${{ inputs.runtime-ref }}
-        if: ${{ inputs.runtime-ref }}
-      - name: Install RTI
-        uses: ./.github/actions/install-rti
-        if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -56,19 +46,22 @@ jobs:
       - name: Install Google API Python Client
         run: pip3 install --upgrade google-api-python-client
       - name: Check out specific ref of reactor-c
-        uses: actions/checkout@v2
+        uses: actions/checkout@v
         with:
           repository: lf-lang/reactor-c
           path: core/src/main/resources/lib/c/reactor-c
           ref: ${{ inputs.reactor-c-ref }}
         if: ${{ inputs.reactor-c-ref }}
       - name: Check out specific ref of reactor-c-py
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: lf-lang/reactor-c-py
           path: core/src/main/resources/lib/py/reactor-c-py
           ref: ${{ inputs.reactor-c-py-ref }}
         if: ${{ inputs.reactor-c-py-ref }}
+      - name: Install RTI
+        uses: ./.github/actions/install-rti
+        if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
       - name: Run Python tests
         run: ./gradlew targetTest -Ptarget=Python
       - name: Report to CodeCov

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -33,6 +33,13 @@ jobs:
           fetch-depth: 0
       - name: Prepare build environment
         uses: ./.github/actions/prepare-build-env
+      - name: Check out specific ref of reactor-c
+        uses: actions/checkout@v3
+        with:
+          repository: lf-lang/reactor-c
+          path: core/src/main/resources/lib/c/reactor-c
+          ref: ${{ inputs.runtime-ref }}
+        if: ${{ inputs.runtime-ref }}
       - name: Install RTI
         uses: ./.github/actions/install-rti
         if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Google API Python Client
         run: pip3 install --upgrade google-api-python-client
       - name: Check out specific ref of reactor-c
-        uses: actions/checkout@v
+        uses: actions/checkout@v3
         with:
           repository: lf-lang/reactor-c
           path: core/src/main/resources/lib/c/reactor-c


### PR DESCRIPTION
The python test's yml file is in wrong order.

The RTI is installed before updating the reactor-c to the latest version.

I changed the order of the Install RTI below checkout to the newest reactor-c version.

Found this bug during debugging lf-lang/reactor-c#392