### PR TITLE
Include clock sync for federated programs on multiple platforms.

### DIFF
--- a/core/src/main/java/org/lflang/federated/extensions/CExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtension.java
@@ -499,8 +499,8 @@ public class CExtension implements FedTargetExtension {
   }
 
   /**
-   * Add preamble to a separate file to set up federated execution. Return an empty string since no
-   * code generated needs to go in the source.
+   * Add preamble to a separate file to set up federated execution. Return an a string
+   * containing the #includes that are needed by the federate.
    */
   @Override
   public String generatePreamble(
@@ -539,6 +539,7 @@ public class CExtension implements FedTargetExtension {
     code.pr("#include \"core/federated/federate.h\"");
     code.pr("#include \"core/federated/network/net_common.h\"");
     code.pr("#include \"core/federated/network/net_util.h\"");
+    code.pr("#include \"core/federated/clock-sync.h\"");
     code.pr("#include \"core/threaded/reactor_threaded.h\"");
     code.pr("#include \"core/utils/util.h\"");
     code.pr("extern federate_instance_t _fed;");


### PR DESCRIPTION
This PR fixes a compile problem with federated Python reported by @vinzbarbuto where a federated Python program that maps to multiple machines fails to compile because of a missing `#include` of `clock-sync.h`.  I don't know how to add a test because this compilation error does not occur when targeting a single machine.  This PR also fixes a clearly erroneous comment and aligns reactor-c to main.