### PR TITLE
Added newline after trailing slash

### DIFF
--- a/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
+++ b/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
@@ -401,7 +401,7 @@ public class FedLauncherGenerator {
         "        echo \"The source code can be found in org.lflang/src/lib/core/federated/RTI\"",
         "        exit 1",
         "    fi",
-        "    " + rtiLaunchString + " 2>&1 | tee -a " + logFileName + "' &",
+        "    " + rtiLaunchString + "\n 2>&1 | tee -a " + logFileName + "' &",
         "# Store the PID of the channel to RTI",
         "RTI=$!",
         "# Wait for the RTI to boot up before",


### PR DESCRIPTION
This fixes a bug in the command to remotely launch an RTI by inserting a newline after the trailing slash.

There is still a problem, however, which is that `ssh` with a command does not source any bash profile files, so the PATH never gets set, so the RTI will likely not be found on the remote machine.  The "right" fix, IMHO, is that we should code generate the RTI just like a federate and launch it just like a federate.  But short of that, it would be better if FedLauncherGenerator created a bash script in a local file, then copied it to the remote machine and launched it there.