### PR TITLE
Fix in error handling for Docker builds

### DIFF
--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -222,7 +222,10 @@ public class FedGenerator {
         context.getErrorReporter().nowhere().error("Docker build failed.");
       }
     } catch (IOException e) {
-      context.getErrorReporter().nowhere().error("Docker build failed due to invalid file system state.");
+      context
+          .getErrorReporter()
+          .nowhere()
+          .error("Docker build failed due to invalid file system state.");
     }
   }
 
@@ -239,8 +242,7 @@ public class FedGenerator {
       try {
         Files.createDirectories(dest);
         // 2. Copy reactor-c source files into it
-        FileUtil.copyFromClassPath("/lib/c/reactor-c/core", dest, true, false);
-        FileUtil.copyFromClassPath("/lib/c/reactor-c/include", dest, true, false);
+        FileUtil.copyFromClassPath("/lib/c/reactor-c", dest, true, true);
         // 3. Generate a Dockerfile for the rti
         new RtiDockerGenerator(context).generateDockerData(dest).writeDockerFile();
       } catch (IOException e) {

--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -203,7 +203,7 @@ public class FedGenerator {
             });
 
     context.finish(Status.COMPILED, codeMapMap);
-    return false;
+    return context.getErrorReporter().getErrorsOccurred();
   }
 
   /**
@@ -218,9 +218,11 @@ public class FedGenerator {
       dockerGen.writeDockerComposeFile(createDockerFiles(context, subContexts));
       if (dockerGen.build()) {
         dockerGen.createLauncher();
+      } else {
+        context.getErrorReporter().nowhere().error("Docker build failed.");
       }
     } catch (IOException e) {
-      context.getErrorReporter().nowhere().error("Unsuccessful Docker build.");
+      context.getErrorReporter().nowhere().error("Docker build failed due to invalid file system state.");
     }
   }
 

--- a/core/src/main/java/org/lflang/generator/docker/RtiDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/RtiDockerGenerator.java
@@ -1,5 +1,9 @@
 package org.lflang.generator.docker;
 
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
 import org.lflang.generator.LFGeneratorContext;
 
 /**
@@ -15,24 +19,12 @@ public class RtiDockerGenerator extends CDockerGenerator {
 
   @Override
   protected String generateDockerFileContent() {
-    return """
-        # Docker file for building the image of the rti
-        FROM %s
-        COPY core /reactor-c/core
-        COPY include /reactor-c/include
-        WORKDIR /reactor-c/core/federated/RTI
-        %s
-        RUN rm -rf build && \\
-            mkdir build && \\
-            cd build && \\
-            cmake ../ && \\
-            make && \\
-            make install
-
-        # Use ENTRYPOINT not CMD so that command-line arguments go through
-        ENTRYPOINT ["RTI"]
-        """
-        .formatted(baseImage(), generateRunForBuildDependencies());
+    InputStream stream =
+        RtiDockerGenerator.class.getResourceAsStream(
+            "/lib/c/reactor-c/core/federated/RTI/rti.Dockerfile");
+    return new BufferedReader(new InputStreamReader(stream))
+        .lines()
+        .collect(Collectors.joining("\n"));
   }
 
   @Override

--- a/core/src/main/java/org/lflang/generator/docker/TSDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/TSDockerGenerator.java
@@ -17,11 +17,11 @@ public class TSDockerGenerator extends DockerGenerator {
   /** Return the content of the docker file for [tsFileName]. */
   public String generateDockerFileContent() {
     return """
-        |FROM %s
-        |WORKDIR /linguafranca/$name
-        |%s
-        |COPY . .
-        |ENTRYPOINT ["node", "dist/%s.js"]
+        FROM %s
+        WORKDIR /linguafranca/$name
+        %s
+        COPY . .
+        ENTRYPOINT ["node", "dist/%s.js"]
         """
         .formatted(baseImage(), generateRunForBuildDependencies(), context.getFileConfig().name);
   }

--- a/core/src/testFixtures/java/org/lflang/tests/TestBase.java
+++ b/core/src/testFixtures/java/org/lflang/tests/TestBase.java
@@ -381,6 +381,13 @@ public abstract class TestBase extends LfInjectedTestBase {
         FileConfig.findPackageRoot(test.getSrcPath(), s -> {})
             .resolve(FileConfig.DEFAULT_SRC_GEN_DIR)
             .toString());
+
+    // Update the test by applying the transformation.
+    if (transformer != null) {
+      if (!transformer.transform(resource)) {
+        throw new TestError("Test transformation unsuccessful.", Result.TRANSFORM_FAIL);
+      }
+    }
     var context =
         new MainContext(
             LFGeneratorContext.Mode.STANDALONE,
@@ -390,13 +397,6 @@ public abstract class TestBase extends LfInjectedTestBase {
             resource,
             fileAccess,
             fileConfig -> new DefaultMessageReporter());
-
-    // Update the test by applying the transformation.
-    if (transformer != null) {
-      if (!transformer.transform(resource)) {
-        throw new TestError("Test transformation unsuccessful.", Result.TRANSFORM_FAIL);
-      }
-    }
 
     // Reload the context because properties may have changed as part of the transformation.
     test.loadContext(context);


### PR DESCRIPTION
We were always returning false for whether errors occurred in federated docker builds, but we should be checking the context to see whether an error was reported.