### PR TITLE
Docker compose also create bin directory if not present

### DIFF
--- a/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
@@ -144,7 +144,9 @@ public class DockerComposeGenerator {
       writer.write(script);
       writer.close();
     } catch (IOException e) {
-      messageReporter.nowhere().warning("Unable to write launcher to: " + file.getAbsolutePath()+ " with error: " + e);
+      messageReporter
+          .nowhere()
+          .warning("Unable to write launcher to: " + file.getAbsolutePath() + " with error: " + e);
     }
 
     if (!file.setExecutable(true, false)) {

--- a/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
@@ -125,7 +125,9 @@ public class DockerComposeGenerator {
     var fileConfig = context.getFileConfig();
     var packageRoot = fileConfig.srcPkgPath;
     var srcGenPath = fileConfig.getSrcGenPath();
-    var file = fileConfig.binPath.resolve(fileConfig.name).toFile();
+    var binPath = fileConfig.binPath;
+    FileUtil.createDirectoryIfDoesNotExist(binPath.toFile());
+    var file = binPath.resolve(fileConfig.name).toFile();
     var script =
         """
         #!/bin/bash
@@ -142,7 +144,7 @@ public class DockerComposeGenerator {
       writer.write(script);
       writer.close();
     } catch (IOException e) {
-      messageReporter.nowhere().warning("Unable to write launcher to: " + file.getAbsolutePath());
+      messageReporter.nowhere().warning("Unable to write launcher to: " + file.getAbsolutePath()+ " with error: " + e);
     }
 
     if (!file.setExecutable(true, false)) {

--- a/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
@@ -146,7 +146,7 @@ public class DockerComposeGenerator {
     } catch (IOException e) {
       messageReporter
           .nowhere()
-          .warning("Unable to write launcher to: " + file.getAbsolutePath() + " with error: " + e);
+          .warning("Unable to write launcher to " + file.getAbsolutePath() + " with error: " + e);
     }
 
     if (!file.setExecutable(true, false)) {


### PR DESCRIPTION
This solves an issue where the docker compose generator fails to create the launcher because the bin directory was cleaned and is not present. I might only have surfaced now due to Peter making sure we checked the return value from the docker tests. (I am not sure because I did not look at those changes though)