### PR TITLE
Fix for validation of target properties dictionaries

### DIFF
--- a/core/src/main/java/org/lflang/target/property/type/DictionaryType.java
+++ b/core/src/main/java/org/lflang/target/property/type/DictionaryType.java
@@ -76,8 +76,8 @@ public enum DictionaryType implements TargetPropertyType {
                       + keysList());
           valid = false;
         }
-        return valid;
       }
+      return valid;
     }
     return false;
   }


### PR DESCRIPTION
Fixes #2266.

The bug was just that `return` was inside the for-loop, so only the first key/value pair would be validated.