### PR TITLE
Disambiguate set(0) for C++ ports

### DIFF
--- a/test/Cpp/src/SetZero.lf
+++ b/test/Cpp/src/SetZero.lf
@@ -1,0 +1,27 @@
+target Cpp
+
+reactor Source {
+  output out: unsigned
+
+  reaction(startup) -> out {=
+    out.set(0);
+  =}
+}
+
+reactor Sink {
+  input in: unsigned
+
+  reaction(startup, in) {=
+    if (!in.is_present() || *in.get() != 0) {
+      std::cerr << "Expected to receive 0\n";
+      exit(1);
+    }
+    std::cout << "Success!\n";
+  =}
+}
+
+main reactor {
+  source = new Source()
+  sink = new Sink()
+  source.out -> sink.in
+}


### PR DESCRIPTION
This pulls in https://github.com/lf-lang/reactor-cpp/pull/57 and adds a new test case.

Fixes https://github.com/lf-lang/lingua-franca/issues/2280