### PR TITLE
Fixed NRF52 support

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -558,9 +558,9 @@ public class CCmakeGenerator {
     code.pr("pico_sdk_init()");
     code.newLine();
     code.pr("add_subdirectory(core)");
-    code.pr("target_link_libraries(core PUBLIC pico_stdlib)");
-    code.pr("target_link_libraries(core PUBLIC pico_multicore)");
-    code.pr("target_link_libraries(core PUBLIC pico_sync)");
+    code.pr("target_link_libraries(reactor-c PUBLIC pico_stdlib)");
+    code.pr("target_link_libraries(reactor-c PUBLIC pico_multicore)");
+    code.pr("target_link_libraries(reactor-c PUBLIC pico_sync)");
     code.newLine();
     code.pr("set(LF_MAIN_TARGET " + executableName + ")");
 

--- a/core/src/main/java/org/lflang/target/property/type/PlatformType.java
+++ b/core/src/main/java/org/lflang/target/property/type/PlatformType.java
@@ -13,7 +13,7 @@ public class PlatformType extends OptionsType<Platform> {
   public enum Platform {
     AUTO,
     ARDUINO, // FIXME: not multithreaded
-    NRF52("Nrf52", true),
+    NRF52("Nrf52", false),
     RP2040("Rp2040", false),
     LINUX("Linux", true),
     MAC("Darwin", true),


### PR DESCRIPTION
With the refactoring of platform support, code generation for NRF52 stopped working. This is a first step towards getting it working again.

Currently, NRF52 examples do not compile for failing to find "nrf.h". I could use some help figuring out how to properly handle integrating the NRF52 SDK into our CMake build system.

This PR depends on branch rp2040-fixes which should be merged first. See PR #2303.