### PR TITLE
Set Java version to 17 in gradle configuration

### DIFF
--- a/buildSrc/src/main/groovy/org.lflang.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.lflang.java-conventions.gradle
@@ -29,6 +29,11 @@ spotbugs {
 }
 
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
 configurations.all {
     resolutionStrategy {
         dependencySubstitution {


### PR DESCRIPTION
This addresses an issue where the target jvm version used for Java code would differ from the one used for the Kotlin code.