### PR TITLE
Bumped the google-java-format version to 1.22.0

### DIFF
--- a/cli/lfc/src/main/java/org/lflang/cli/Lfc.java
+++ b/cli/lfc/src/main/java/org/lflang/cli/Lfc.java
@@ -364,6 +364,7 @@ public class Lfc extends CliBase {
     }
     return workers;
   }
+
   /** Check the values of the commandline arguments and return them. */
   public GeneratorArguments getArgs() {
 

--- a/cli/lfc/src/test/java/org/lflang/cli/LfcCliTest.java
+++ b/cli/lfc/src/test/java/org/lflang/cli/LfcCliTest.java
@@ -66,35 +66,35 @@ public class LfcCliTest {
 
   static final String LF_PYTHON_FILE =
       """
-        target Python
-        main reactor {
-            reaction(startup) {==}
-        }
-        """;
+      target Python
+      main reactor {
+          reaction(startup) {==}
+      }
+      """;
 
   static final String JSON_STRING =
       """
-        {
-            "src": "src/File.lf",
-            "out": "src",
-            "properties": {
-                "build-type": "Release",
-                "clean": true,
-                "compiler": "gcc",
-                "external-runtime-path": "src",
-                "federated": true,
-                "logging": "info",
-                "lint": true,
-                "no-compile": true,
-                "print-statistics": true,
-                "quiet": true,
-                "rti": "path/to/rti",
-                "runtime-version": "rs",
-                "scheduler": "GEDF_NP",
-                "single-threaded": true
-            }
-        }
-        """;
+      {
+          "src": "src/File.lf",
+          "out": "src",
+          "properties": {
+              "build-type": "Release",
+              "clean": true,
+              "compiler": "gcc",
+              "external-runtime-path": "src",
+              "federated": true,
+              "logging": "info",
+              "lint": true,
+              "no-compile": true,
+              "print-statistics": true,
+              "quiet": true,
+              "rti": "path/to/rti",
+              "runtime-version": "rs",
+              "scheduler": "GEDF_NP",
+              "single-threaded": true
+          }
+      }
+      """;
 
   @Test
   public void testHelpArg() {

--- a/cli/lfd/src/test/java/org/lflang/cli/LfdCliTest.java
+++ b/cli/lfd/src/test/java/org/lflang/cli/LfdCliTest.java
@@ -46,11 +46,11 @@ public class LfdCliTest {
 
   private static final String VALID_FILE =
       """
-        target Python
-        main reactor {
-          reaction(startup) {==}
-        }
-        """;
+      target Python
+      main reactor {
+        reaction(startup) {==}
+      }
+      """;
   LfdTestFixture lfdTester = new LfdTestFixture();
 
   @Test

--- a/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
+++ b/cli/lff/src/test/java/org/lflang/cli/LffCliTest.java
@@ -45,133 +45,133 @@ public class LffCliTest {
 
   private static final String FILE_BEFORE_REFORMAT =
       """
-        target Python;
-        main   reactor {
-            reaction(startup) {=
-               =}
-        }
-        """;
+      target Python;
+      main   reactor {
+          reaction(startup) {=
+             =}
+      }
+      """;
   private static final String FILE_AFTER_REFORMAT =
       """
-        target Python
+      target Python
 
-        main reactor {
-          reaction(startup) {=  =}
-        }
-        """;
+      main reactor {
+        reaction(startup) {=  =}
+      }
+      """;
 
   private static final List<List<String>> TEST_CASES =
       List.of(
           List.of(
               """
-                  target C
-                  reactor Test { // this is a test
-                  logical action a # this is an a
-                  output humbug: int
-                  reaction (a) -> /* moo */ humbug {=  // this is a humbug reaction
-                    /* it reacts like this*/ react react
-                  =}
-                  }
-                  """,
+              target C
+              reactor Test { // this is a test
+              logical action a # this is an a
+              output humbug: int
+              reaction (a) -> /* moo */ humbug {=  // this is a humbug reaction
+                /* it reacts like this*/ react react
+              =}
+              }
+              """,
               """
-                  target C
+              target C
 
-                  // this is a test
-                  reactor Test {
-                    logical action a  // this is an a
-                    output humbug: int
+              // this is a test
+              reactor Test {
+                logical action a  // this is an a
+                output humbug: int
 
-                    /** moo */
-                    // this is a humbug reaction
-                    reaction(a) -> humbug {=
-                      /* it reacts like this*/ react react
-                    =}
-                  }
-                  """),
+                /** moo */
+                // this is a humbug reaction
+                reaction(a) -> humbug {=
+                  /* it reacts like this*/ react react
+                =}
+              }
+              """),
           List.of(
               """
-                  target C
-                  // Documentation
-                   @icon("Variables.png")
-                   reactor Variables {}
-                  """,
+              target C
+              // Documentation
+               @icon("Variables.png")
+               reactor Variables {}
+              """,
               """
-                  target C
+              target C
 
-                  // Documentation
-                  @icon("Variables.png")
-                  reactor Variables {
-                  }
-                  """),
+              // Documentation
+              @icon("Variables.png")
+              reactor Variables {
+              }
+              """),
           List.of(
               """
-                  target C
-                  reactor Filter(period: int = 0, b: double[] = {0, 0}) {}
-                  main reactor {
-                  az_f = new Filter(
-                       period = 100,
-                       b = {0.229019233988375, 0.421510777305010}
-                   )
-                   }
-                   """,
+              target C
+              reactor Filter(period: int = 0, b: double[] = {0, 0}) {}
+              main reactor {
+              az_f = new Filter(
+                   period = 100,
+                   b = {0.229019233988375, 0.421510777305010}
+               )
+               }
+              """,
               """
-                  target C
+              target C
 
-                  reactor Filter(period: int = 0, b: double[] = {0, 0}) {
-                  }
+              reactor Filter(period: int = 0, b: double[] = {0, 0}) {
+              }
 
-                  main reactor {
-                    az_f = new Filter(period=100, b = {0.229019233988375, 0.421510777305010})
-                  }
-                  """),
+              main reactor {
+                az_f = new Filter(period=100, b = {0.229019233988375, 0.421510777305010})
+              }
+              """),
           List.of(
               """
-                  target Rust
-                  reactor Snake {  // q
-                  state grid: SnakeGrid = {= /* foo */ SnakeGrid::new(grid_side, &snake) =}; // note that this one borrows snake temporarily
-                  state grid2: SnakeGrid = {= // baz
-                  SnakeGrid::new(grid_side, &snake) =};
-                  }
-                  """,
+target Rust
+reactor Snake {  // q
+state grid: SnakeGrid = {= /* foo */ SnakeGrid::new(grid_side, &snake) =}; // note that this one borrows snake temporarily
+state grid2: SnakeGrid = {= // baz
+SnakeGrid::new(grid_side, &snake) =};
+}
+""",
               """
-                  target Rust
+              target Rust
 
-                  // q
-                  reactor Snake {
-                    // note that this one borrows snake temporarily
-                    state grid: SnakeGrid = {= /* foo */ SnakeGrid::new(grid_side, &snake) =}
-                    // baz
-                    state grid2: SnakeGrid = {= SnakeGrid::new(grid_side, &snake) =}
-                  }
-                  """),
+              // q
+              reactor Snake {
+                // note that this one borrows snake temporarily
+                state grid: SnakeGrid = {= /* foo */ SnakeGrid::new(grid_side, &snake) =}
+                // baz
+                state grid2: SnakeGrid = {= SnakeGrid::new(grid_side, &snake) =}
+              }
+              """),
           List.of(
               """
-                  target Cpp
+target Cpp
 
-                  reactor ContextManager<Req, Resp, Ctx> {
+reactor ContextManager<Req, Resp, Ctx> {
 
 
-                     \s
-                  }
+   \s
+}
 
-                  reactor MACService {
-                    mul_cm = new ContextManager<loooooooooooooooooooooooooooooong, looooooooooooooong, loooooooooooooong>()
-                  }
+reactor MACService {
+  mul_cm = new ContextManager<loooooooooooooooooooooooooooooong, looooooooooooooong, loooooooooooooong>()
+}
 
-                  """,
+""",
               """
-                  target Cpp
+              target Cpp
 
-                  reactor ContextManager<Req, Resp, Ctx> {
-                  }
+              reactor ContextManager<Req, Resp, Ctx> {
+              }
 
-                  reactor MACService {
-                    mul_cm = new ContextManager<
-                        loooooooooooooooooooooooooooooong,
-                        looooooooooooooong,
-                        loooooooooooooong>()
-                  }
-                  """));
+              reactor MACService {
+                mul_cm = new ContextManager<
+                    loooooooooooooooooooooooooooooong,
+                    looooooooooooooong,
+                    loooooooooooooong>()
+              }
+              """));
 
   LffTestFixture lffTester = new LffTestFixture();
 

--- a/core/src/integrationTest/java/org/lflang/tests/lsp/ErrorInserter.java
+++ b/core/src/integrationTest/java/org/lflang/tests/lsp/ErrorInserter.java
@@ -76,10 +76,13 @@ class ErrorInserter {
 
     /** The zero-based indices of the touched lines. */
     private final List<Integer> badLines;
+
     /** The original test on which this is based. */
     private final Path srcFile;
+
     /** The content of this test. */
     private final LinkedList<String> lines;
+
     /** Whether the error inserter is permitted to insert a line before the current line. */
     private final Predicate<ListIterator<String>> insertCondition;
 

--- a/core/src/integrationTest/java/org/lflang/tests/lsp/LspTests.java
+++ b/core/src/integrationTest/java/org/lflang/tests/lsp/LspTests.java
@@ -42,6 +42,7 @@ class LspTests extends LfInjectedTestBase {
       diagnosticsHaveKeyword("libprotoc")
           .or(diagnosticsHaveKeyword("protoc-c"))
           .or(diagnosticsIncludeText("could not be found"));
+
   /**
    * The number of samples to take from each test category (with replacement) when doing validation
    * tests.

--- a/core/src/main/java/org/lflang/InferredType.java
+++ b/core/src/main/java/org/lflang/InferredType.java
@@ -49,6 +49,7 @@ public class InferredType {
 
   /** The AST node representing the inferred type if such a node exists. */
   public final Type astType;
+
   /** A flag indicating whether the inferred type has the base type time. */
   public final boolean isTime;
 

--- a/core/src/main/java/org/lflang/TimeValue.java
+++ b/core/src/main/java/org/lflang/TimeValue.java
@@ -35,6 +35,7 @@ public final class TimeValue implements Comparable<TimeValue> {
 
   /** The maximum value of this type. This is approximately equal to 292 years. */
   public static final TimeValue MAX_VALUE = new TimeValue(Long.MAX_VALUE, TimeUnit.NANO);
+
   /** A time value equal to zero. */
   public static final TimeValue ZERO = new TimeValue(0, null);
 

--- a/core/src/main/java/org/lflang/ast/DelayedConnectionTransformation.java
+++ b/core/src/main/java/org/lflang/ast/DelayedConnectionTransformation.java
@@ -59,6 +59,7 @@ public class DelayedConnectionTransformation implements AstTransformation {
 
   private boolean transformAfterDelays = false;
   private boolean transformPhysicalConnection = false;
+
   /** Collection of generated delay classes. */
   private final LinkedHashSet<Reactor> delayClasses = new LinkedHashSet<>();
 

--- a/core/src/main/java/org/lflang/ast/FormattingUtil.java
+++ b/core/src/main/java/org/lflang/ast/FormattingUtil.java
@@ -126,6 +126,7 @@ public class FormattingUtil {
     ret.append(lineWrapComment(current.toString(), width, singleLineCommentPrefix));
     return ret.toString();
   }
+
   /** Wrap lines. Do not merge lines that start with weird characters. */
   private static String lineWrapComment(String comment, int width, String singleLineCommentPrefix) {
     var multiline = MULTILINE_COMMENT.matcher(comment).matches();

--- a/core/src/main/java/org/lflang/diagram/synthesis/util/LayoutPostProcessing.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/util/LayoutPostProcessing.java
@@ -54,16 +54,21 @@ public class LayoutPostProcessing extends AbstractSynthesisExtensions {
 
   /** Synthesis option to control the order of nodes and edges by model order. */
   public static final String MODEL_ORDER_OPTION = "Model Order";
+
   /** Uses semi-automatic layout. */
   public static final String LEGACY = "Legacy";
+
   /** Only reactions are strictly ordered by their model order. */
   public static final String STRICT_REACTION_ONLY = "Reactions Only";
+
   /** Reactions and reactor are strictly ordered by their model order. */
   public static final String STRICT = "Reactions and Reactors";
+
   /**
    * Reactions and reactors are ordered by their model order if no additional crossing are created.
    */
   public static final String TIE_BREAKER = "Optimize Crossings";
+
   /**
    * No crossing minimization is done at all. This requires that actions and timers are sorted based
    * on their model order.

--- a/core/src/main/java/org/lflang/federated/extensions/CExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtension.java
@@ -189,8 +189,8 @@ public class CExtension implements FedTargetExtension {
           result.pr("lf_set(" + receiveRef + ", " + value + ");");
         }
       }
-      case PROTO -> throw new UnsupportedOperationException(
-          "Protobuf serialization is not supported yet.");
+      case PROTO ->
+          throw new UnsupportedOperationException("Protobuf serialization is not supported yet.");
       case ROS2 -> {
         var portType = ASTUtils.getInferredType(((Port) receivingPort.getVariable()));
         var portTypeStr = types.getTargetType(portType);
@@ -221,13 +221,13 @@ public class CExtension implements FedTargetExtension {
   @Override
   public String outputInitializationBody() {
     return """
-    extern reaction_t* port_absent_reaction[];
-    void lf_enqueue_port_absent_reactions(environment_t*);
-    LF_PRINT_DEBUG("Adding network port absent reaction to table.");
-    port_absent_reaction[SENDERINDEXPARAMETER] = &self->_lf__reaction_2;
-    LF_PRINT_DEBUG("Added network output control reaction to table. Enqueueing it...");
-    lf_enqueue_port_absent_reactions(self->base.environment);
-    """;
+           extern reaction_t* port_absent_reaction[];
+           void lf_enqueue_port_absent_reactions(environment_t*);
+           LF_PRINT_DEBUG("Adding network port absent reaction to table.");
+           port_absent_reaction[SENDERINDEXPARAMETER] = &self->_lf__reaction_2;
+           LF_PRINT_DEBUG("Added network output control reaction to table. Enqueueing it...");
+           lf_enqueue_port_absent_reactions(self->base.environment);
+           """;
   }
 
   @Override
@@ -408,8 +408,8 @@ public class CExtension implements FedTargetExtension {
           result.pr(sendingFunction + "(" + commonArgs + ", " + pointerExpression + ");");
         }
       }
-      case PROTO -> throw new UnsupportedOperationException(
-          "Protobuf serialization is not supported yet.");
+      case PROTO ->
+          throw new UnsupportedOperationException("Protobuf serialization is not supported yet.");
       case ROS2 -> {
         var typeStr = types.getTargetType(type);
         if (CUtil.isTokenType(type)) {
@@ -511,10 +511,11 @@ public class CExtension implements FedTargetExtension {
       throws IOException {
     writePreambleFile(federate, fileConfig, rtiConfig, messageReporter);
     var includes = new CodeBuilder();
-    includes.pr("""
-            #ifdef __cplusplus
-            extern "C" {
-            #endif""");
+    includes.pr(
+        """
+        #ifdef __cplusplus
+        extern "C" {
+        #endif""");
     includes.pr("#include \"core/federated/federate.h\"");
     includes.pr("#include \"core/federated/network/net_common.h\"");
     includes.pr("#include \"core/federated/network/net_util.h\"");
@@ -522,10 +523,11 @@ public class CExtension implements FedTargetExtension {
     includes.pr("#include \"core/threaded/reactor_threaded.h\"");
     includes.pr("#include \"core/utils/util.h\"");
     includes.pr("extern federate_instance_t _fed;");
-    includes.pr("""
-            #ifdef __cplusplus
-            }
-            #endif""");
+    includes.pr(
+        """
+        #ifdef __cplusplus
+        }
+        #endif""");
     includes.pr(generateSerializationIncludes(federate, fileConfig));
     return includes.toString();
   }
@@ -578,9 +580,9 @@ public class CExtension implements FedTargetExtension {
     code.pr(
         CExtensionUtils.surroundWithIfFederatedDecentralized(
             """
-            staa_t* staa_lst[%1$s];
-            size_t staa_lst_size = %1$s;
-        """
+                staa_t* staa_lst[%1$s];
+                size_t staa_lst_size = %1$s;
+            """
                 .formatted(numOfSTAAOffsets)));
 
     code.pr(generateExecutablePreamble(federate, rtiConfig, messageReporter));
@@ -626,12 +628,12 @@ public class CExtension implements FedTargetExtension {
     federatedReactor.setName(oldFederatedReactorName);
 
     return """
-            #define initialize_triggers_for_federate() \\
-            do { \\
-            %s
-            } \\
-            while (0)
-            """
+           #define initialize_triggers_for_federate() \\
+           do { \\
+           %s
+           } \\
+           while (0)
+           """
         .formatted((code.getCode().isBlank() ? "\\" : code.getCode()).indent(4).stripTrailing());
   }
 
@@ -644,10 +646,10 @@ public class CExtension implements FedTargetExtension {
 
     code.pr(generateCodeToInitializeFederate(federate, rtiConfig));
     return """
-            void _lf_executable_preamble(environment_t* env) {
-            %s
-            }
-            """
+           void _lf_executable_preamble(environment_t* env) {
+           %s
+           }
+           """
         .formatted(code.toString().indent(4).stripTrailing());
   }
 
@@ -658,10 +660,10 @@ public class CExtension implements FedTargetExtension {
         CExtensionUtils.surroundWithIfFederatedDecentralized(CExtensionUtils.stpStructs(federate)));
 
     return """
-            void staa_initialization() {
-            %s
-            }
-            """
+           void staa_initialization() {
+           %s
+           }
+           """
         .formatted(code.toString().indent(4).stripTrailing());
   }
 

--- a/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
@@ -457,12 +457,12 @@ public class CExtensionUtils {
       return surroundWithIfFederated(insideIf);
     } else {
       return """
-              #ifdef FEDERATED
-              %s
-              #else
-              %s
-              #endif // FEDERATED
-              """
+             #ifdef FEDERATED
+             %s
+             #else
+             %s
+             #endif // FEDERATED
+             """
           .formatted(insideIf, insideElse);
     }
   }
@@ -473,10 +473,10 @@ public class CExtensionUtils {
    */
   public static String surroundWithIfFederated(String code) {
     return """
-            #ifdef FEDERATED
-            %s
-            #endif // FEDERATED
-            """
+           #ifdef FEDERATED
+           %s
+           #endif // FEDERATED
+           """
         .formatted(code);
   }
 
@@ -501,10 +501,10 @@ public class CExtensionUtils {
    */
   public static String surroundWithIfFederatedCentralized(String code) {
     return """
-            #ifdef FEDERATED_CENTRALIZED
-            %s
-            #endif // FEDERATED_CENTRALIZED
-            """
+           #ifdef FEDERATED_CENTRALIZED
+           %s
+           #endif // FEDERATED_CENTRALIZED
+           """
         .formatted(code);
   }
 
@@ -514,10 +514,10 @@ public class CExtensionUtils {
    */
   public static String surroundWithIfFederatedDecentralized(String code) {
     return """
-            #ifdef FEDERATED_DECENTRALIZED
-            %s
-            #endif // FEDERATED_DECENTRALIZED
-            """
+           #ifdef FEDERATED_DECENTRALIZED
+           %s
+           #endif // FEDERATED_DECENTRALIZED
+           """
         .formatted(code);
   }
 

--- a/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
@@ -144,10 +144,10 @@ public class PythonExtension extends CExtension {
         result.pr("lf_set_destructor(" + receiveRef + ", python_count_decrement);\n");
         result.pr("lf_set_token(" + receiveRef + ", token);\n");
       }
-      case PROTO -> throw new UnsupportedOperationException(
-          "Protobuf serialization is not supported yet.");
-      case ROS2 -> throw new UnsupportedOperationException(
-          "ROS2 serialization is not supported yet.");
+      case PROTO ->
+          throw new UnsupportedOperationException("Protobuf serialization is not supported yet.");
+      case ROS2 ->
+          throw new UnsupportedOperationException("ROS2 serialization is not supported yet.");
     }
   }
 
@@ -174,10 +174,10 @@ public class PythonExtension extends CExtension {
         // Decrease the reference count for serialized_pyobject
         result.pr("Py_XDECREF(serialized_pyobject);\n");
       }
-      case PROTO -> throw new UnsupportedOperationException(
-          "Protobuf serialization is not supported yet.");
-      case ROS2 -> throw new UnsupportedOperationException(
-          "ROS2 serialization is not supported yet.");
+      case PROTO ->
+          throw new UnsupportedOperationException("Protobuf serialization is not supported yet.");
+      case ROS2 ->
+          throw new UnsupportedOperationException("ROS2 serialization is not supported yet.");
     }
   }
 
@@ -195,10 +195,10 @@ public class PythonExtension extends CExtension {
       throws IOException {
     writePreambleFile(federate, fileConfig, rtiConfig, messageReporter);
     return """
-      import gc
-      import atexit
-      gc.disable()
-      atexit.register(os._exit, 0)
-      """;
+           import gc
+           import atexit
+           gc.disable()
+           atexit.register(os._exit, 0)
+           """;
   }
 }

--- a/core/src/main/java/org/lflang/federated/extensions/TSExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/TSExtension.java
@@ -49,11 +49,11 @@ public class TSExtension implements FedTargetExtension {
       CoordinationMode coordinationMode,
       MessageReporter messageReporter) {
     return """
-        // generateNetworkReceiverBody
-        if (%1$s !== undefined) {
-            %2$s%3$s = %1$s;
-        }
-        """
+           // generateNetworkReceiverBody
+           if (%1$s !== undefined) {
+               %2$s%3$s = %1$s;
+           }
+           """
         .formatted(
             action.getName(),
             receivingPort.getContainer() == null
@@ -113,10 +113,10 @@ public class TSExtension implements FedTargetExtension {
       CoordinationMode coordinationMode,
       MessageReporter messageReporter) {
     return """
-        if (%1$s%2$s[0] !== undefined) {
-            this.util.sendRTITimedMessage(%1$s%2$s[0], %3$s, %4$s, %5$s);
-        }
-        """
+           if (%1$s%2$s[0] !== undefined) {
+               this.util.sendRTITimedMessage(%1$s%2$s[0], %3$s, %4$s, %5$s);
+           }
+           """
         .formatted(
             sendingPort.getContainer() == null ? "" : sendingPort.getContainer().getName() + ".",
             sendingPort.getVariable().getName(),
@@ -138,12 +138,12 @@ public class TSExtension implements FedTargetExtension {
     int receivingPortID = connection.getDstFederate().networkMessageActions.size();
     var additionalDelayString = getNetworkDelayLiteral(connection.getDefinition().getDelay());
     return """
-        // If the output port has not been set for the current logical time,
-        // send an ABSENT message to the receiving federate
-        if (%1$s%2$s[0] === undefined) {
-          this.util.sendRTIPortAbsent(%3$d, %4$d, %5$s);
-        }
-      """
+             // If the output port has not been set for the current logical time,
+             // send an ABSENT message to the receiving federate
+             if (%1$s%2$s[0] === undefined) {
+               this.util.sendRTIPortAbsent(%3$d, %4$d, %5$s);
+             }
+           """
         .formatted(
             srcOutputPort.getContainer() == null
                 ? ""
@@ -168,21 +168,21 @@ public class TSExtension implements FedTargetExtension {
     var minOutputDelay = getMinOutputDelay(federate, messageReporter);
     var upstreamConnectionDelays = getUpstreamConnectionDelays(federate);
     return """
-        const defaultFederateConfig: __FederateConfig = {
-            dependsOn: [%s],
-            executionTimeout: undefined,
-            fast: false,
-            federateID: %d,
-            federationID: "Unidentified Federation",
-            keepAlive: true,
-            minOutputDelay: %s,
-            networkMessageActions: [%s],
-            rtiHost: "%s",
-            rtiPort: %d,
-            sendsTo: [%s],
-            upstreamConnectionDelays: [%s]
-        }
-            """
+           const defaultFederateConfig: __FederateConfig = {
+               dependsOn: [%s],
+               executionTimeout: undefined,
+               fast: false,
+               federateID: %d,
+               federationID: "Unidentified Federation",
+               keepAlive: true,
+               minOutputDelay: %s,
+               networkMessageActions: [%s],
+               rtiHost: "%s",
+               rtiPort: %d,
+               sendsTo: [%s],
+               upstreamConnectionDelays: [%s]
+           }
+           """
         .formatted(
             federate.dependsOn.keySet().stream()
                 .map(e -> String.valueOf(e.id))

--- a/core/src/main/java/org/lflang/federated/generator/FedMainEmitter.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedMainEmitter.java
@@ -102,9 +102,9 @@ public class FedMainEmitter {
             .collect(Collectors.joining(",", "(", ")"));
 
     return """
-        @_fed_config()
-        main reactor %s {
-        """
+           @_fed_config()
+           main reactor %s {
+           """
         .formatted(paramList.equals("()") ? "" : paramList);
   }
 }

--- a/core/src/main/java/org/lflang/federated/generator/FedPreambleEmitter.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedPreambleEmitter.java
@@ -33,19 +33,19 @@ public class FedPreambleEmitter {
     for (Preamble p : mainModel.getPreambles()) {
       preambleCode.pr(
           """
-            %spreamble {=
-            %s
-            =}
-            """
+          %spreamble {=
+          %s
+          =}
+          """
               .formatted(
                   p.getVisibility() == null ? "" : p.getVisibility() + " ", toText(p.getCode())));
     }
 
     preambleCode.pr(
         """
-            preamble {=
-            %s
-            =}"""
+        preamble {=
+        %s
+        =}"""
             .formatted(
                 FedTargetExtensionFactory.getExtension(federate.targetConfig.target)
                     .generatePreamble(federate, fileConfig, rtiConfig, messageReporter)));

--- a/core/src/main/java/org/lflang/federated/serialization/FedROS2CPPSerialization.java
+++ b/core/src/main/java/org/lflang/federated/serialization/FedROS2CPPSerialization.java
@@ -203,11 +203,11 @@ public class FedROS2CPPSerialization implements FedSerialization {
 
     preamble.append(
         """
-                    #include "rcutils/allocator.h"
-                    #include "rclcpp/rclcpp.hpp"
-                    #include "rclcpp/serialization.hpp"
-                    #include "rclcpp/serialized_message.hpp"
-                    """);
+        #include "rcutils/allocator.h"
+        #include "rclcpp/rclcpp.hpp"
+        #include "rclcpp/serialization.hpp"
+        #include "rclcpp/serialized_message.hpp"
+        """);
 
     return preamble;
   }
@@ -222,16 +222,16 @@ public class FedROS2CPPSerialization implements FedSerialization {
 
     cMakeExtension.append(
         """
-                    enable_language(CXX)
-                    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-write-strings -O2")
+        enable_language(CXX)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-write-strings -O2")
 
-                    find_package(ament_cmake REQUIRED)
-                    find_package(rclcpp REQUIRED)
-                    find_package(rclcpp_components REQUIRED)
-                    find_package(rcutils)
-                    find_package(rmw REQUIRED)
+        find_package(ament_cmake REQUIRED)
+        find_package(rclcpp REQUIRED)
+        find_package(rclcpp_components REQUIRED)
+        find_package(rcutils)
+        find_package(rmw REQUIRED)
 
-                    ament_target_dependencies(${LF_MAIN_TARGET} PUBLIC rclcpp rmw)""");
+        ament_target_dependencies(${LF_MAIN_TARGET} PUBLIC rclcpp rmw)""");
 
     return cMakeExtension;
   }

--- a/core/src/main/java/org/lflang/generator/CodeMap.java
+++ b/core/src/main/java/org/lflang/generator/CodeMap.java
@@ -181,11 +181,13 @@ public class CodeMap {
 
   /** The content of the generated file represented by this. */
   private final String generatedCode;
+
   /**
    * A mapping from Lingua Franca source paths to mappings from ranges in the generated file
    * represented by this to ranges in Lingua Franca files.
    */
   private final Map<Path, NavigableMap<Range, Range>> map;
+
   /**
    * A mapping from Lingua Franca source paths to mappings from ranges in the generated file
    * represented by this to whether those ranges are copied verbatim from the source.

--- a/core/src/main/java/org/lflang/generator/GenerationException.java
+++ b/core/src/main/java/org/lflang/generator/GenerationException.java
@@ -25,6 +25,7 @@
 package org.lflang.generator;
 
 import org.eclipse.emf.ecore.EObject;
+
 // import org.jetbrains.annotations.Nullable;
 
 /** An exception that occurred during code generation. May also wrap another exception. */

--- a/core/src/main/java/org/lflang/generator/HumanReadableReportingStrategy.java
+++ b/core/src/main/java/org/lflang/generator/HumanReadableReportingStrategy.java
@@ -18,10 +18,13 @@ public class HumanReadableReportingStrategy implements DiagnosticReporting.Strat
 
   /** A pattern that matches lines that should be reported via this strategy. */
   private final Pattern diagnosticMessagePattern;
+
   /** A pattern that matches labels that show the exact range to which the diagnostic pertains. */
   private final Pattern labelPattern;
+
   /** The path against which any paths should be resolved. */
   private final Path relativeTo;
+
   /** The next line to be processed, or {@code null}. */
   private String bufferedLine;
 

--- a/core/src/main/java/org/lflang/generator/LanguageServerMessageReporter.java
+++ b/core/src/main/java/org/lflang/generator/LanguageServerMessageReporter.java
@@ -33,6 +33,7 @@ public class LanguageServerMessageReporter extends MessageReporterBase {
 
   /** The document for which this is a diagnostic acceptor. */
   private final EObject parseRoot;
+
   /** The list of all diagnostics since the last reset. */
   private final Map<Path, List<Diagnostic>> diagnostics;
 

--- a/core/src/main/java/org/lflang/generator/MainContext.java
+++ b/core/src/main/java/org/lflang/generator/MainContext.java
@@ -26,6 +26,7 @@ public class MainContext implements LFGeneratorContext {
 
   /** The indicator that shows whether this build process is canceled. */
   private final CancelIndicator cancelIndicator;
+
   /** The {@code ReportProgress} function of {@code this}. */
   private final ReportProgress reportProgress;
 

--- a/core/src/main/java/org/lflang/generator/Range.java
+++ b/core/src/main/java/org/lflang/generator/Range.java
@@ -17,6 +17,7 @@ public class Range implements Comparable<Range> {
 
   /** The start of the Range (INCLUSIVE). */
   private final Position start;
+
   /** The end of the Range (EXCLUSIVE). */
   private final Position end;
 

--- a/core/src/main/java/org/lflang/generator/ReactionInstance.java
+++ b/core/src/main/java/org/lflang/generator/ReactionInstance.java
@@ -178,6 +178,7 @@ public class ReactionInstance extends NamedInstance<Reaction> {
 
   /** The ports, actions, or timers that this reaction is triggered by or uses. */
   public Set<TriggerInstance<? extends Variable>> sources = new LinkedHashSet<>();
+
   // FIXME: Above sources is misnamed because in the grammar,
   // "sources" are only the inputs a reaction reads without being
   // triggered by them. The name "reads" used here would be a better
@@ -490,6 +491,7 @@ public class ReactionInstance extends NamedInstance<Reaction> {
     // reaction (via a port), then the "dominating" field will
     // point to that upstream reaction.
     public Runtime dominating;
+
     /** ID ranging from 0 to parent.getTotalWidth() - 1. */
     public final int id;
 

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -59,11 +59,11 @@ import org.lflang.util.FileUtil;
 public class CCmakeGenerator {
   private static final String DEFAULT_INSTALL_CODE =
       """
-        install(
-            TARGETS ${LF_MAIN_TARGET}
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        )
-    """;
+          install(
+              TARGETS ${LF_MAIN_TARGET}
+              RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          )
+      """;
 
   public static final String MIN_CMAKE_VERSION = "3.19";
 
@@ -435,9 +435,9 @@ public class CCmakeGenerator {
       cMakeCode.pr("FIND_PATH( PROTOBUF_INCLUDE_DIR protobuf-c/protobuf-c.h)");
       cMakeCode.pr(
           """
-                         find_library(PROTOBUF_LIBRARY\s
-                         NAMES libprotobuf-c.a libprotobuf-c.so libprotobuf-c.dylib protobuf-c.lib protobuf-c.dll
-                         )""");
+          find_library(PROTOBUF_LIBRARY\s
+          NAMES libprotobuf-c.a libprotobuf-c.so libprotobuf-c.dylib protobuf-c.lib protobuf-c.dll
+          )""");
       cMakeCode.pr(
           "find_package_handle_standard_args(libprotobuf-c DEFAULT_MSG PROTOBUF_INCLUDE_DIR"
               + " PROTOBUF_LIBRARY)");

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -664,11 +664,11 @@ public class CGenerator extends GeneratorBase {
       // from the federation and close any open sockets.
       code.pr(
           """
-                 #ifndef FEDERATED
-                 void lf_terminate_execution(environment_t* env) {
-                     (void) env;
-                 }
-                 #endif""");
+          #ifndef FEDERATED
+          void lf_terminate_execution(environment_t* env) {
+              (void) env;
+          }
+          #endif""");
     }
   }
 
@@ -1100,13 +1100,13 @@ public class CGenerator extends GeneratorBase {
     federatedExtension.pr(
         String.format(
             """
-             #ifdef FEDERATED
-             #ifdef FEDERATED_DECENTRALIZED
-             %s intended_tag;
-             #endif
-             %s physical_time_of_arrival;
-             #endif
-             """,
+            #ifdef FEDERATED
+            #ifdef FEDERATED_DECENTRALIZED
+            %s intended_tag;
+            #endif
+            %s physical_time_of_arrival;
+            #endif
+            """,
             types.getTargetTagType(), types.getTargetTimeType()));
     for (Port p : allPorts(tpr.reactor())) {
       builder.pr(

--- a/core/src/main/java/org/lflang/generator/c/CMainFunctionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CMainFunctionGenerator.java
@@ -13,6 +13,7 @@ import org.lflang.util.StringUtil;
 
 public class CMainFunctionGenerator {
   private TargetConfig targetConfig;
+
   /** The command to run the generated code if specified in the target directive. */
   private List<String> runCommand;
 

--- a/core/src/main/java/org/lflang/generator/c/CMixedRadixGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CMixedRadixGenerator.java
@@ -3,14 +3,19 @@ package org.lflang.generator.c;
 public class CMixedRadixGenerator {
   /** Standardized name for channel index variable for a source. */
   public static String sc = "src_channel";
+
   /** Standardized name for bank index variable for a source. */
   public static String sb = "src_bank";
+
   /** Standardized name for runtime index variable for a source. */
   public static String sr = "src_runtime";
+
   /** Standardized name for channel index variable for a destination. */
   public static String dc = "dst_channel";
+
   /** Standardized name for bank index variable for a destination. */
   public static String db = "dst_bank";
+
   /** Standardized name for runtime index variable for a destination. */
   public static String dr = "dst_runtime";
 }

--- a/core/src/main/java/org/lflang/generator/c/CPreambleGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CPreambleGenerator.java
@@ -34,6 +34,7 @@ public class CPreambleGenerator {
     return targetConfig.isSet(PlatformProperty.INSTANCE)
         && targetConfig.get(PlatformProperty.INSTANCE).platform() == Platform.ARDUINO;
   }
+
   /** Add necessary source files specific to the target language. */
   public static String generateIncludeStatements(TargetConfig targetConfig, boolean cppMode) {
     CodeBuilder code = new CodeBuilder();

--- a/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
@@ -39,6 +39,7 @@ import org.lflang.util.StringUtil;
 public class CReactionGenerator {
   protected static String DISABLE_REACTION_INITIALIZATION_MARKER =
       "// **** Do not include initialization code in this reaction."; // FIXME: Such markers should
+
   // not exist (#1687)
 
   /**

--- a/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
@@ -87,15 +87,15 @@ public class CReactorHeaderFileGenerator {
   private static void appendPoundIncludes(CodeBuilder builder) {
     builder.pr(
         """
-            #ifdef __cplusplus
-            extern "C" {
-            #endif
-            #include "../include/api/schedule.h"
-            #include "../include/core/reactor.h"
-            #ifdef __cplusplus
-            }
-            #endif
-            """);
+        #ifdef __cplusplus
+        extern "C" {
+        #endif
+        #include "../include/api/schedule.h"
+        #include "../include/core/reactor.h"
+        #ifdef __cplusplus
+        }
+        #endif
+        """);
   }
 
   private static String userFacingSelfType(TypeParameterizedReactor tpr) {
@@ -151,11 +151,11 @@ public class CReactorHeaderFileGenerator {
                             it.getType(false), it.getAlias(), it.getType(false), it.getRvalue())
                         : String.format(
                             """
-                    %s %s[%s];
-                    for (int i = 0; i < %s; i++) {
-                        %s[i] = (%s) self->_lf_%s[i].%s;
-                    }
-                    """,
+                            %s %s[%s];
+                            for (int i = 0; i < %s; i++) {
+                                %s[i] = (%s) self->_lf_%s[i].%s;
+                            }
+                            """,
                             it.getType(true).replaceFirst("\\*", ""),
                             it.getAlias(),
                             CReactionGenerator.maxContainedReactorBankWidth(
@@ -229,20 +229,24 @@ public class CReactorHeaderFileGenerator {
                   .orElseThrow());
       return typeName + "*" + (getWidth() != null ? "*" : "") + (isMultiport ? "*" : "");
     }
+
     /** The name of the variable as it appears in the LF source. */
     String getName() {
       return tv.getName();
     }
+
     /** The alias of the variable that should be used in code generation. */
     String getAlias() {
       return getName(); // TODO: avoid naming conflicts
     }
+
     /** The width of the container, if applicable. */
     String getWidth() {
       return container == null || container.getWidthSpec() == null
           ? null
           : "self->_lf_" + r.getName() + "_width";
     }
+
     /** The representation of this port as used by the LF programmer. */
     String getRvalue() {
       return container == null ? getName() : container.getName() + "." + getName();

--- a/core/src/main/java/org/lflang/generator/c/TypeParameterizedReactor.java
+++ b/core/src/main/java/org/lflang/generator/c/TypeParameterizedReactor.java
@@ -16,6 +16,7 @@ import org.lflang.lf.*;
 public class TypeParameterizedReactor {
   /** The syntactic reactor class definition. */
   private final Reactor reactor;
+
   /** The type arguments associated with this particular variant of the reactor class. */
   private final Map<String, Type> typeArgs;
 

--- a/core/src/main/java/org/lflang/generator/docker/CDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/CDockerGenerator.java
@@ -70,19 +70,19 @@ public class CDockerGenerator extends DockerGenerator {
     var compiler = config.target == Target.CCPP ? "g++" : "gcc";
     if (baseImage().equals(defaultImage())) {
       return """
-          # Install build dependencies
-          RUN set -ex && apk add --no-cache %s musl-dev cmake make
-          # Optional user specified run command
-          %s
-          """
+             # Install build dependencies
+             RUN set -ex && apk add --no-cache %s musl-dev cmake make
+             # Optional user specified run command
+             %s
+             """
           .formatted(compiler, userRunCommand());
     } else {
       return """
-          # Optional user specified run command
-          %s
-          # Check for build dependencies
-          RUN which make && which cmake && which %s
-          """
+             # Optional user specified run command
+             %s
+             # Check for build dependencies
+             RUN which make && which cmake && which %s
+             """
           .formatted(userRunCommand(), compiler);
     }
   }

--- a/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
@@ -32,10 +32,10 @@ public class DockerComposeGenerator {
    */
   protected String generateDockerNetwork(String networkName) {
     return """
-            networks:
-                default:
-                    name: "%s"
-            """
+           networks:
+               default:
+                   name: "%s"
+           """
         .formatted(networkName);
   }
 
@@ -46,10 +46,10 @@ public class DockerComposeGenerator {
    */
   protected String generateDockerServices(List<DockerData> services) {
     return """
-            version: "3.9"
-            services:
-            %s
-            """
+           version: "3.9"
+           services:
+           %s
+           """
         .formatted(
             services.stream().map(this::getServiceDescription).collect(Collectors.joining("\n")));
   }
@@ -57,11 +57,11 @@ public class DockerComposeGenerator {
   /** Turn given docker data into a string. */
   protected String getServiceDescription(DockerData data) {
     return """
-                %s:
-                    build:
-                        context: "%s"
-                    container_name: "%s"
-            """
+               %s:
+                   build:
+                       context: "%s"
+                   container_name: "%s"
+           """
         .formatted(getServiceName(data), getBuildContext(data), getContainerName(data));
   }
 

--- a/core/src/main/java/org/lflang/generator/docker/DockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerGenerator.java
@@ -78,8 +78,8 @@ public abstract class DockerGenerator {
       case C, CCPP -> new CDockerGenerator(context);
       case TS -> new TSDockerGenerator(context);
       case Python -> new PythonDockerGenerator(context);
-      case CPP, Rust -> throw new IllegalArgumentException(
-          "No Docker support for " + target + " yet.");
+      case CPP, Rust ->
+          throw new IllegalArgumentException("No Docker support for " + target + " yet.");
     };
   }
 }

--- a/core/src/main/java/org/lflang/generator/docker/FedDockerComposeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/FedDockerComposeGenerator.java
@@ -44,19 +44,19 @@ public class FedDockerComposeGenerator extends DockerComposeGenerator {
             .formatted(this.rtiImage, this.rtiHost, tracing, services.size(), containerName);
     if (this.rtiImage.equals(DockerOptions.LOCAL_RTI_IMAGE)) {
       return """
-            %s\
-                rti:
-                    build:
-                        context: "rti"
-            %s
-            """
+             %s\
+                 rti:
+                     build:
+                         context: "rti"
+             %s
+             """
           .formatted(super.generateDockerServices(services), attributes);
     } else {
       return """
-            %s\
-                rti:
-            %s
-            """
+             %s\
+                 rti:
+             %s
+             """
           .formatted(super.generateDockerServices(services), attributes);
     }
   }
@@ -64,11 +64,11 @@ public class FedDockerComposeGenerator extends DockerComposeGenerator {
   @Override
   protected String getServiceDescription(DockerData data) {
     return """
-            %s\
-                    command: "-i 1"
-                    depends_on:
-                        - rti
-            """
+           %s\
+                   command: "-i 1"
+                   depends_on:
+                       - rti
+           """
         .formatted(super.getServiceDescription(data));
   }
 

--- a/core/src/main/java/org/lflang/generator/docker/PythonDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/PythonDockerGenerator.java
@@ -23,14 +23,14 @@ public class PythonDockerGenerator extends CDockerGenerator {
   protected String generateRunForBuildDependencies() {
     if (baseImage().equals(defaultImage())) {
       return """
-          # Install build dependencies
-          RUN set -ex && apt-get update && apt-get install -y python3-pip && pip install cmake
-          """;
+             # Install build dependencies
+             RUN set -ex && apt-get update && apt-get install -y python3-pip && pip install cmake
+             """;
     } else {
       return """
-          # Check for build dependencies
-          RUN which make && which cmake && which gcc
-          """;
+             # Check for build dependencies
+             RUN which make && which cmake && which gcc
+             """;
     }
   }
 

--- a/core/src/main/java/org/lflang/generator/docker/TSDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/TSDockerGenerator.java
@@ -17,12 +17,12 @@ public class TSDockerGenerator extends DockerGenerator {
   /** Return the content of the docker file for [tsFileName]. */
   public String generateDockerFileContent() {
     return """
-        FROM %s
-        WORKDIR /linguafranca/$name
-        %s
-        COPY . .
-        ENTRYPOINT ["node", "dist/%s.js"]
-        """
+           FROM %s
+           WORKDIR /linguafranca/$name
+           %s
+           COPY . .
+           ENTRYPOINT ["node", "dist/%s.js"]
+           """
         .formatted(baseImage(), generateRunForBuildDependencies(), context.getFileConfig().name);
   }
 

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -571,19 +571,19 @@ public class PythonGenerator extends CGenerator {
             """
             + cSources.collect(Collectors.joining("\n    ", "    ", "\n"))
             + """
-            )
-            if (MSVC)
-                set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
-                set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_SOURCE_DIR})
-                set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_SOURCE_DIR})
-                set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_SOURCE_DIR})
-                set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_SOURCE_DIR})
-            endif (MSVC)
-            set_target_properties(${LF_MAIN_TARGET} PROPERTIES PREFIX "")
-            include_directories(${Python_INCLUDE_DIRS})
-            target_link_libraries(${LF_MAIN_TARGET} PRIVATE ${Python_LIBRARIES})
-            target_compile_definitions(${LF_MAIN_TARGET} PUBLIC MODULE_NAME=<pyModuleName>)
-            """)
+)
+if (MSVC)
+    set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
+    set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_SOURCE_DIR})
+    set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_SOURCE_DIR})
+    set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_SOURCE_DIR})
+    set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_SOURCE_DIR})
+endif (MSVC)
+set_target_properties(${LF_MAIN_TARGET} PROPERTIES PREFIX "")
+include_directories(${Python_INCLUDE_DIRS})
+target_link_libraries(${LF_MAIN_TARGET} PRIVATE ${Python_LIBRARIES})
+target_compile_definitions(${LF_MAIN_TARGET} PUBLIC MODULE_NAME=<pyModuleName>)
+""")
         .replace("<pyModuleName>", generatePythonModuleName(executableName));
     // The use of fileConfig.name will break federated execution, but that's fine
   }
@@ -594,21 +594,21 @@ public class PythonGenerator extends CGenerator {
     // need to replace '\' with '\\' on Windwos for proper escaping in cmake
     final var pyMainName = pyMainPath.toString().replace("\\", "\\\\");
     return """
-              if(WIN32)
-                file(GENERATE OUTPUT <fileName>.bat CONTENT
-                  "@echo off
-            \
-                  ${Python_EXECUTABLE} <pyMainName> %*"
-                )
-                install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/<fileName>.bat DESTINATION ${CMAKE_INSTALL_BINDIR})
-              else()
-                file(GENERATE OUTPUT <fileName> CONTENT
-                    "#!/bin/sh\\n\\
-                    ${Python_EXECUTABLE} <pyMainName> \\"$@\\""
-                )
-                install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/<fileName> DESTINATION ${CMAKE_INSTALL_BINDIR})
-              endif()
-            """
+  if(WIN32)
+    file(GENERATE OUTPUT <fileName>.bat CONTENT
+      "@echo off
+\
+      ${Python_EXECUTABLE} <pyMainName> %*"
+    )
+    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/<fileName>.bat DESTINATION ${CMAKE_INSTALL_BINDIR})
+  else()
+    file(GENERATE OUTPUT <fileName> CONTENT
+        "#!/bin/sh\\n\\
+        ${Python_EXECUTABLE} <pyMainName> \\"$@\\""
+    )
+    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/<fileName> DESTINATION ${CMAKE_INSTALL_BINDIR})
+  endif()
+"""
         .replace("<fileName>", fileConfig.name)
         .replace("<pyMainName>", pyMainName);
   }

--- a/core/src/main/java/org/lflang/generator/python/PythonValidator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonValidator.java
@@ -35,10 +35,12 @@ public class PythonValidator extends org.lflang.generator.Validator {
   /** The pattern that diagnostics from the Python compiler typically follow. */
   private static final Pattern DIAGNOSTIC_MESSAGE_PATTERN =
       Pattern.compile("(\\*\\*\\*)?\\s*File \"(?<path>.*?\\.py)\", line (?<line>\\d+)");
+
   /**
    * The pattern typically followed by the message that typically follows the main diagnostic line.
    */
   private static final Pattern MESSAGE = Pattern.compile("\\w*Error: .*");
+
   /** An alternative pattern that at least some diagnostics from the Python compiler may follow. */
   private static final Pattern ALT_DIAGNOSTIC_MESSAGE_PATTERN =
       Pattern.compile(".*Error:.*line (?<line>\\d+)\\)");

--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -589,81 +589,86 @@ public enum Target {
 
   public void initialize(TargetConfig config) {
     switch (this) {
-      case C, CCPP -> config.register(
-          AuthProperty.INSTANCE,
-          BuildCommandsProperty.INSTANCE,
-          BuildTypeProperty.INSTANCE,
-          ClockSyncModeProperty.INSTANCE,
-          ClockSyncOptionsProperty.INSTANCE,
-          CmakeIncludeProperty.INSTANCE,
-          CompileDefinitionsProperty.INSTANCE,
-          CompilerProperty.INSTANCE,
-          CoordinationOptionsProperty.INSTANCE,
-          CoordinationProperty.INSTANCE,
-          DockerProperty.INSTANCE,
-          FilesProperty.INSTANCE,
-          KeepaliveProperty.INSTANCE,
-          NoSourceMappingProperty.INSTANCE,
-          PlatformProperty.INSTANCE,
-          ProtobufsProperty.INSTANCE,
-          SchedulerProperty.INSTANCE,
-          SingleThreadedProperty.INSTANCE,
-          TracingProperty.INSTANCE,
-          TracePluginProperty.INSTANCE,
-          VerifyProperty.INSTANCE,
-          WorkersProperty.INSTANCE);
-      case CPP -> config.register(
-          BuildTypeProperty.INSTANCE,
-          CmakeIncludeProperty.INSTANCE,
-          CompilerProperty.INSTANCE,
-          ExportDependencyGraphProperty.INSTANCE,
-          ExportToYamlProperty.INSTANCE,
-          ExternalRuntimePathProperty.INSTANCE,
-          NoRuntimeValidationProperty.INSTANCE,
-          PrintStatisticsProperty.INSTANCE,
-          Ros2DependenciesProperty.INSTANCE,
-          Ros2Property.INSTANCE,
-          RuntimeVersionProperty.INSTANCE,
-          TracingProperty.INSTANCE,
-          WorkersProperty.INSTANCE);
-      case Python -> config.register(
-          AuthProperty.INSTANCE,
-          BuildCommandsProperty.INSTANCE,
-          BuildTypeProperty.INSTANCE,
-          ClockSyncModeProperty.INSTANCE,
-          ClockSyncOptionsProperty.INSTANCE,
-          CompileDefinitionsProperty.INSTANCE,
-          CoordinationOptionsProperty.INSTANCE,
-          CoordinationProperty.INSTANCE,
-          DockerProperty.INSTANCE,
-          FilesProperty.INSTANCE,
-          KeepaliveProperty.INSTANCE,
-          NoSourceMappingProperty.INSTANCE,
-          ProtobufsProperty.INSTANCE,
-          SchedulerProperty.INSTANCE,
-          SingleThreadedProperty.INSTANCE,
-          TracingProperty.INSTANCE,
-          TracePluginProperty.INSTANCE,
-          WorkersProperty.INSTANCE);
-      case Rust -> config.register(
-          BuildTypeProperty.INSTANCE,
-          CargoDependenciesProperty.INSTANCE,
-          CargoFeaturesProperty.INSTANCE,
-          ExportDependencyGraphProperty.INSTANCE,
-          ExternalRuntimePathProperty.INSTANCE,
-          RustIncludeProperty.INSTANCE,
-          KeepaliveProperty.INSTANCE,
-          RuntimeVersionProperty.INSTANCE,
-          SingleFileProjectProperty.INSTANCE,
-          SingleThreadedProperty.INSTANCE,
-          WorkersProperty.INSTANCE);
-      case TS -> config.register(
-          CoordinationOptionsProperty.INSTANCE,
-          CoordinationProperty.INSTANCE,
-          DockerProperty.INSTANCE,
-          KeepaliveProperty.INSTANCE,
-          ProtobufsProperty.INSTANCE,
-          RuntimeVersionProperty.INSTANCE);
+      case C, CCPP ->
+          config.register(
+              AuthProperty.INSTANCE,
+              BuildCommandsProperty.INSTANCE,
+              BuildTypeProperty.INSTANCE,
+              ClockSyncModeProperty.INSTANCE,
+              ClockSyncOptionsProperty.INSTANCE,
+              CmakeIncludeProperty.INSTANCE,
+              CompileDefinitionsProperty.INSTANCE,
+              CompilerProperty.INSTANCE,
+              CoordinationOptionsProperty.INSTANCE,
+              CoordinationProperty.INSTANCE,
+              DockerProperty.INSTANCE,
+              FilesProperty.INSTANCE,
+              KeepaliveProperty.INSTANCE,
+              NoSourceMappingProperty.INSTANCE,
+              PlatformProperty.INSTANCE,
+              ProtobufsProperty.INSTANCE,
+              SchedulerProperty.INSTANCE,
+              SingleThreadedProperty.INSTANCE,
+              TracingProperty.INSTANCE,
+              TracePluginProperty.INSTANCE,
+              VerifyProperty.INSTANCE,
+              WorkersProperty.INSTANCE);
+      case CPP ->
+          config.register(
+              BuildTypeProperty.INSTANCE,
+              CmakeIncludeProperty.INSTANCE,
+              CompilerProperty.INSTANCE,
+              ExportDependencyGraphProperty.INSTANCE,
+              ExportToYamlProperty.INSTANCE,
+              ExternalRuntimePathProperty.INSTANCE,
+              NoRuntimeValidationProperty.INSTANCE,
+              PrintStatisticsProperty.INSTANCE,
+              Ros2DependenciesProperty.INSTANCE,
+              Ros2Property.INSTANCE,
+              RuntimeVersionProperty.INSTANCE,
+              TracingProperty.INSTANCE,
+              WorkersProperty.INSTANCE);
+      case Python ->
+          config.register(
+              AuthProperty.INSTANCE,
+              BuildCommandsProperty.INSTANCE,
+              BuildTypeProperty.INSTANCE,
+              ClockSyncModeProperty.INSTANCE,
+              ClockSyncOptionsProperty.INSTANCE,
+              CompileDefinitionsProperty.INSTANCE,
+              CoordinationOptionsProperty.INSTANCE,
+              CoordinationProperty.INSTANCE,
+              DockerProperty.INSTANCE,
+              FilesProperty.INSTANCE,
+              KeepaliveProperty.INSTANCE,
+              NoSourceMappingProperty.INSTANCE,
+              ProtobufsProperty.INSTANCE,
+              SchedulerProperty.INSTANCE,
+              SingleThreadedProperty.INSTANCE,
+              TracingProperty.INSTANCE,
+              TracePluginProperty.INSTANCE,
+              WorkersProperty.INSTANCE);
+      case Rust ->
+          config.register(
+              BuildTypeProperty.INSTANCE,
+              CargoDependenciesProperty.INSTANCE,
+              CargoFeaturesProperty.INSTANCE,
+              ExportDependencyGraphProperty.INSTANCE,
+              ExternalRuntimePathProperty.INSTANCE,
+              RustIncludeProperty.INSTANCE,
+              KeepaliveProperty.INSTANCE,
+              RuntimeVersionProperty.INSTANCE,
+              SingleFileProjectProperty.INSTANCE,
+              SingleThreadedProperty.INSTANCE,
+              WorkersProperty.INSTANCE);
+      case TS ->
+          config.register(
+              CoordinationOptionsProperty.INSTANCE,
+              CoordinationProperty.INSTANCE,
+              DockerProperty.INSTANCE,
+              KeepaliveProperty.INSTANCE,
+              ProtobufsProperty.INSTANCE,
+              RuntimeVersionProperty.INSTANCE);
     }
   }
 }

--- a/core/src/main/java/org/lflang/target/property/ClockSyncOptionsProperty.java
+++ b/core/src/main/java/org/lflang/target/property/ClockSyncOptionsProperty.java
@@ -40,8 +40,8 @@ public final class ClockSyncOptionsProperty
         switch (option) {
           case ATTENUATION -> options.attenuation = ASTUtils.toInteger(entry.getValue());
           case COLLECT_STATS -> options.collectStats = ASTUtils.toBoolean(entry.getValue());
-          case LOCAL_FEDERATES_ON -> options.localFederatesOn =
-              ASTUtils.toBoolean(entry.getValue());
+          case LOCAL_FEDERATES_ON ->
+              options.localFederatesOn = ASTUtils.toBoolean(entry.getValue());
           case PERIOD -> options.period = ASTUtils.toTimeValue(entry.getValue());
           case TEST_OFFSET -> options.testOffset = ASTUtils.toTimeValue(entry.getValue());
           case TRIALS -> options.trials = ASTUtils.toInteger(entry.getValue());

--- a/core/src/main/java/org/lflang/target/property/type/ClockSyncModeType.java
+++ b/core/src/main/java/org/lflang/target/property/type/ClockSyncModeType.java
@@ -31,6 +31,7 @@ public class ClockSyncModeType extends OptionsType<ClockSyncMode> {
     private ClockSyncMode(int value) {
       this.value = value;
     }
+
     /** Return the name in lower case. */
     @Override
     public String toString() {

--- a/core/src/main/java/org/lflang/util/FileUtil.java
+++ b/core/src/main/java/org/lflang/util/FileUtil.java
@@ -380,6 +380,7 @@ public class FileUtil {
       throw new IllegalArgumentException("Source is neither a directory nor a regular file.");
     }
   }
+
   /**
    * Copy a given input stream to a destination file.
    *

--- a/core/src/main/java/org/lflang/util/LFCommand.java
+++ b/core/src/main/java/org/lflang/util/LFCommand.java
@@ -56,6 +56,7 @@ public class LFCommand {
    * forwarded.
    */
   private static final int PERIOD_MILLISECONDS = 200;
+
   /**
    * The maximum amount of time to wait for the forwarding of output and error streams to finish.
    */

--- a/core/src/main/java/org/lflang/validation/ValidatorMessageReporter.java
+++ b/core/src/main/java/org/lflang/validation/ValidatorMessageReporter.java
@@ -89,12 +89,15 @@ public class ValidatorMessageReporter extends MessageReporterBase {
   protected void reportOnNode(
       EObject node, EStructuralFeature feature, DiagnosticSeverity severity, String message) {
     switch (severity) {
-      case Error -> acceptor.acceptError(
-          message, node, feature, ValidationMessageAcceptor.INSIGNIFICANT_INDEX, null);
-      case Warning -> acceptor.acceptWarning(
-          message, node, feature, ValidationMessageAcceptor.INSIGNIFICANT_INDEX, null);
-      case Information, Hint -> acceptor.acceptInfo(
-          message, node, feature, ValidationMessageAcceptor.INSIGNIFICANT_INDEX, null);
+      case Error ->
+          acceptor.acceptError(
+              message, node, feature, ValidationMessageAcceptor.INSIGNIFICANT_INDEX, null);
+      case Warning ->
+          acceptor.acceptWarning(
+              message, node, feature, ValidationMessageAcceptor.INSIGNIFICANT_INDEX, null);
+      case Information, Hint ->
+          acceptor.acceptInfo(
+              message, node, feature, ValidationMessageAcceptor.INSIGNIFICANT_INDEX, null);
     }
   }
 }

--- a/core/src/test/java/org/lflang/tests/compiler/EquivalenceUnitTests.java
+++ b/core/src/test/java/org/lflang/tests/compiler/EquivalenceUnitTests.java
@@ -18,33 +18,33 @@ public class EquivalenceUnitTests {
   public void testSimple() {
     assertSelfEquivalence(
         """
-                target C
+        target C
 
-                reactor Destination {
-                    input ok: bool
-                    input in: int
-                    state last_invoked: tag_t = {= NEVER_TAG_INITIALIZER =}
-                }
-                """);
+        reactor Destination {
+            input ok: bool
+            input in: int
+            state last_invoked: tag_t = {= NEVER_TAG_INITIALIZER =}
+        }
+        """);
   }
 
   @Test
   public void testCodeExprEqItselfModuloIndent() {
     assertEquivalent(
         """
-                target C
-                reactor Destination {
-                    state s: tag_t = {=
-                        NEVER_TAG_INITIALIZER
-                    =}
-                }
-                """,
+        target C
+        reactor Destination {
+            state s: tag_t = {=
+                NEVER_TAG_INITIALIZER
+            =}
+        }
+        """,
         """
-                target C
-                reactor Destination {
-                    state s: tag_t = {= NEVER_TAG_INITIALIZER =}
-                }
-                """);
+        target C
+        reactor Destination {
+            state s: tag_t = {= NEVER_TAG_INITIALIZER =}
+        }
+        """);
   }
 
   private void assertSelfEquivalence(String input) {

--- a/core/src/test/java/org/lflang/tests/compiler/FormattingUnitTests.java
+++ b/core/src/test/java/org/lflang/tests/compiler/FormattingUnitTests.java
@@ -19,78 +19,78 @@ public class FormattingUnitTests {
   public void testSimple() {
     assertFormatsTo(
         """
-                target C
-                reactor Main{ }
-                """,
+        target C
+        reactor Main{ }
+        """,
         """
-                target C
+        target C
 
-                reactor Main {
-                }
-                """);
+        reactor Main {
+        }
+        """);
   }
 
   @Test
   public void testAssignments() {
     assertFormatsTo(
         """
-                target C
+        target C
 
-                reactor Destination {
-                    input ok: bool
-                    input in: int
-                    state last_invoked: tag_t=   {= NEVER_TAG_INITIALIZER =}
-                }
-                """,
+        reactor Destination {
+            input ok: bool
+            input in: int
+            state last_invoked: tag_t=   {= NEVER_TAG_INITIALIZER =}
+        }
+        """,
         """
-                target C
+        target C
 
-                reactor Destination {
-                  input ok: bool
-                  input in: int
-                  state last_invoked: tag_t = {= NEVER_TAG_INITIALIZER =}
-                }
-                """);
+        reactor Destination {
+          input ok: bool
+          input in: int
+          state last_invoked: tag_t = {= NEVER_TAG_INITIALIZER =}
+        }
+        """);
   }
 
   @Test
   public void testState() {
     assertFormatsTo(
         """
-                target Python
+        target Python
 
-                reactor Destination {
-                    state  one_init: tag_t   = {=NEVER_TAG_INITIALIZER=}
-                    state no_init:   tag_t
-                     state list_init = [1,2] // comment
-                }
-                """,
+        reactor Destination {
+            state  one_init: tag_t   = {=NEVER_TAG_INITIALIZER=}
+            state no_init:   tag_t
+             state list_init = [1,2] // comment
+        }
+        """,
         """
-                target Python
+        target Python
 
-                reactor Destination {
-                  state one_init: tag_t = {= NEVER_TAG_INITIALIZER =}
-                  state no_init: tag_t
-                  state list_init = [1, 2]  # comment
-                }
-                """);
+        reactor Destination {
+          state one_init: tag_t = {= NEVER_TAG_INITIALIZER =}
+          state no_init: tag_t
+          state list_init = [1, 2]  # comment
+        }
+        """);
   }
 
   @Test
   public void testCppInits() {
     assertIsFormatted(
         """
-                target Cpp
+        target Cpp
 
-                reactor Destination {
-                  state one_init: tag_t({= NEVER_TAG_INITIALIZER =})
-                  state no_init: tag_t
-                  state assign: int = 0
-                  state paren: int(0)
-                  state brace: std::vector<int>{1, 2}
-                  state paren_list: std::vector<int>(1, 2)
-                }
-                """);
+        reactor Destination {
+          state one_init: tag_t({= NEVER_TAG_INITIALIZER =})
+          state no_init: tag_t
+          state assign: int = 0
+          state paren: int(0)
+          state brace: std::vector<int>{1, 2}
+          state paren_list: std::vector<int>(1, 2)
+        }
+        """);
   }
 
   @Inject LfParsingTestHelper parser;

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaASTUtilsTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaASTUtilsTest.java
@@ -65,15 +65,15 @@ class LinguaFrancaASTUtilsTest {
     Model model =
         parser.parse(
             """
-            target Cpp;
-            main reactor Foo {
-                state a();
-                state b:int(3);
-                state c:int[](1,2,3);
-                state d(1 sec);
-                state e(1 sec, 2 sec, 3 sec);
-            }
-        """);
+                target Cpp;
+                main reactor Foo {
+                    state a();
+                    state b:int(3);
+                    state c:int[](1,2,3);
+                    state d(1 sec);
+                    state e(1 sec, 2 sec, 3 sec);
+                }
+            """);
 
     Assertions.assertNotNull(model);
     Assertions.assertTrue(
@@ -96,14 +96,14 @@ class LinguaFrancaASTUtilsTest {
     Model model =
         parser.parse(
             """
-            target C;
-            main reactor Foo {
-                state a;
-                state b:int;
-                state c:int[];
-                state d:time;
-            }
-        """);
+                target C;
+                main reactor Foo {
+                    state a;
+                    state b:int;
+                    state c:int[];
+                    state d:time;
+                }
+            """);
 
     Assertions.assertNotNull(model);
     Assertions.assertTrue(
@@ -119,6 +119,7 @@ class LinguaFrancaASTUtilsTest {
               }
             });
   }
+
   /**
    * Return a map from strings to instantiations given a model.
    *
@@ -141,17 +142,17 @@ class LinguaFrancaASTUtilsTest {
     Model model =
         parser.parse(
             """
-           target C;
-           reactor A(x:int = 1) {}
-           reactor B(y:int = 2) {
-               a1 = new A(x = y);
-               a2 = new A(x = -1);
-           }
-           reactor C(z:int = 3) {
-               b1 = new B(y = z);
-               b2 = new B(y = -2);
-           }
-       """);
+                target C;
+                reactor A(x:int = 1) {}
+                reactor B(y:int = 2) {
+                    a1 = new A(x = y);
+                    a2 = new A(x = -1);
+                }
+                reactor C(z:int = 3) {
+                    b1 = new B(y = z);
+                    b2 = new B(y = -2);
+                }
+            """);
 
     Assertions.assertNotNull(model);
     Assertions.assertTrue(

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaDependencyAnalysisTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaDependencyAnalysisTest.java
@@ -153,19 +153,19 @@ class LinguaFrancaDependencyAnalysisTest {
   public void circularInstantiation() throws Exception {
     String testCase =
         """
-             target C;
+            target C;
 
-             reactor X {
-                 reaction() {=
-                 //
-                 =}
-                 p = new Y();
-             }
+            reactor X {
+                reaction() {=
+                //
+                =}
+                p = new Y();
+            }
 
-             reactor Y {
-                 q = new X();
-             }
-         """;
+            reactor Y {
+                q = new X();
+            }
+        """;
     Model model = parser.parse(testCase);
 
     Assertions.assertNotNull(model);

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaParsingTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaParsingTest.java
@@ -58,19 +58,19 @@ class LinguaFrancaParsingTest {
   public void testAttributes() throws Exception {
     String testCase =
         """
-                target C;
-                @label("somethign", "else")
-                @ohio()
-                @a
-                @bdebd(a="b")
-                @bd("abc")
-                @bd("abc",)
-                @a(a="a", b="b")
-                @a(a="a", b="b",)
-                main reactor {
+            target C;
+            @label("somethign", "else")
+            @ohio()
+            @a
+            @bdebd(a="b")
+            @bd("abc")
+            @bd("abc",)
+            @a(a="a", b="b")
+            @a(a="a", b="b",)
+            main reactor {
 
-                }
-            """;
+            }
+        """;
     parseWithoutError(testCase);
   }
 
@@ -78,17 +78,17 @@ class LinguaFrancaParsingTest {
   public void testAttributeContexts() throws Exception {
     String testCase =
         """
-                target C;
-                @a
-                main reactor(@b parm: int) {
+            target C;
+            @a
+            main reactor(@b parm: int) {
 
-                    @ohio reaction() {==}
-                    @ohio logical action f;
-                    @ohio timer t;
-                    @ohio input q: int;
-                    @ohio output q2: int;
-                }
-            """;
+                @ohio reaction() {==}
+                @ohio logical action f;
+                @ohio timer t;
+                @ohio input q: int;
+                @ohio output q2: int;
+            }
+        """;
     parseWithoutError(testCase);
   }
 
@@ -96,12 +96,12 @@ class LinguaFrancaParsingTest {
   public void testTokenizeEmptyWidth() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    state foo: int[];
-                    state foo: int[   ]; //spaces are allowed
-                }
-            """;
+            target C;
+            main reactor {
+                state foo: int[];
+                state foo: int[   ]; //spaces are allowed
+            }
+        """;
     parseWithoutError(testCase);
   }
 

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaScopingTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaScopingTest.java
@@ -120,20 +120,20 @@ public class LinguaFrancaScopingTest {
     Model model =
         parser.parse(
             """
-            target C;
-            reactor From {
-                output y:int;
-            }
-            reactor To {
-                input x:int;
-            }
+                target C;
+                reactor From {
+                    output y:int;
+                }
+                reactor To {
+                    input x:int;
+                }
 
-            main reactor {
-                a = new From();
-                d = new To();
-                a.x -> d.y;
-            }
-        """);
+                main reactor {
+                    a = new From();
+                    d = new To();
+                    a.x -> d.y;
+                }
+            """);
 
     Assertions.assertNotNull(model);
     Assertions.assertTrue(
@@ -155,11 +155,11 @@ public class LinguaFrancaScopingTest {
     Model model =
         parser.parse(
             """
-            target C;
-            main reactor {
-                reaction(unknown) {==}
-            }
-        """);
+                target C;
+                main reactor {
+                    reaction(unknown) {==}
+                }
+            """);
 
     validator.assertError(
         model,
@@ -173,11 +173,11 @@ public class LinguaFrancaScopingTest {
     Model model =
         parser.parse(
             """
-            target C;
-            main reactor {
-                reaction() unknown {==}
-            }
-        """);
+                target C;
+                main reactor {
+                    reaction() unknown {==}
+                }
+            """);
 
     validator.assertError(
         model,
@@ -191,11 +191,11 @@ public class LinguaFrancaScopingTest {
     Model model =
         parser.parse(
             """
-            target C;
-            main reactor {
-                reaction() -> unknown {==}
-            }
-        """);
+                target C;
+                main reactor {
+                    reaction() -> unknown {==}
+                }
+            """);
 
     validator.assertError(
         model,

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -139,11 +139,11 @@ public class LinguaFrancaValidationTest {
   public void tracingOptionsCpp() throws Exception {
     String testCase =
         """
-                target Cpp{
-                  tracing: {trace-file-name: "Bar"}
-                };
-                main reactor {}
-            """;
+            target Cpp{
+              tracing: {trace-file-name: "Bar"}
+            };
+            main reactor {}
+        """;
     validator.assertWarning(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getKeyValuePair(),
@@ -156,12 +156,12 @@ public class LinguaFrancaValidationTest {
   public void duplicateVariable() throws Exception {
     String testCase =
         """
-                target TypeScript;
-                main reactor Foo {
-                    logical action bar;
-                    physical action bar;
-                }
-            """;
+            target TypeScript;
+            main reactor Foo {
+                logical action bar;
+                physical action bar;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getAction(),
@@ -228,24 +228,24 @@ public class LinguaFrancaValidationTest {
   public void requireSemicolonIfAmbiguous() throws Exception {
     String testCase =
         """
-            target C
+        target C
 
-            reactor Foo {
-              output out: int
-              input inp: int
-              reaction(inp) -> out {==}
-            }
+        reactor Foo {
+          output out: int
+          input inp: int
+          reaction(inp) -> out {==}
+        }
 
-            main reactor {
-              f1 = new Foo()
-              f2 = new Foo()
-              f3 = new Foo()
+        main reactor {
+          f1 = new Foo()
+          f2 = new Foo()
+          f3 = new Foo()
 
-              reaction increment(f1.out)
-              f2.out -> f3.inp
-            }
+          reaction increment(f1.out)
+          f2.out -> f3.inp
+        }
 
-            """;
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getReaction(),
@@ -257,16 +257,16 @@ public class LinguaFrancaValidationTest {
   public void noSemicolonIfNotAmbiguous() throws Exception {
     String testCase =
         """
-            target C
+        target C
 
-            main reactor {
-              timer t(0)
+        main reactor {
+          timer t(0)
 
-              reaction increment(t)
-              reaction multiply(t)
-            }
+          reaction increment(t)
+          reaction multiply(t)
+        }
 
-            """;
+        """;
     validator.assertNoErrors(parseWithoutError(testCase));
   }
 
@@ -275,11 +275,11 @@ public class LinguaFrancaValidationTest {
   public void disallowUnderscoreInputs() throws Exception {
     String testCase =
         """
-                target TypeScript;
-                main reactor {
-                    input __bar;
-                }
-            """;
+            target TypeScript;
+            main reactor {
+                input __bar;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getInput(),
@@ -292,9 +292,9 @@ public class LinguaFrancaValidationTest {
   public void disallowMainWithDifferentNameThanFile() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor Foo {}
-            """;
+            target C;
+            main reactor Foo {}
+        """;
 
     validator.assertError(
         parseWithoutError(testCase),
@@ -308,11 +308,11 @@ public class LinguaFrancaValidationTest {
   public void disallowUnderscoreOutputs() throws Exception {
     String testCase =
         """
-            target TypeScript;
-                main reactor Foo {
-                    output __bar;
-                }
-            """;
+        target TypeScript;
+            main reactor Foo {
+                output __bar;
+            }
+        """;
 
     validator.assertError(
         parseWithoutError(testCase),
@@ -327,11 +327,11 @@ public class LinguaFrancaValidationTest {
   public void disallowUnderscoreActions() throws Exception {
     String testCase =
         """
-                target TypeScript;
-                main reactor Foo {
-                    logical action __bar;
-                }
-            """;
+            target TypeScript;
+            main reactor Foo {
+                logical action __bar;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getAction(),
@@ -345,27 +345,27 @@ public class LinguaFrancaValidationTest {
   public void warnAgainstMultipleTypes() throws Exception {
     String testCase =
         """
-            target C
-            reactor A {
-                output request:int
-                input response:float
-            }
+        target C
+        reactor A {
+            output request:int
+            input response:float
+        }
 
-            reactor B {
-                input request:int
-                output response:float
-            }
+        reactor B {
+            input request:int
+            output response:float
+        }
 
-            main reactor {
-                a1 = new A();
-                a2 = new A();
-                b1 = new B();
-                b2 = new B();
+        main reactor {
+            a1 = new A();
+            a2 = new A();
+            b1 = new B();
+            b2 = new B();
 
-                a1.request, b1.response -> b1.request, a1.response
-                a2.request, b2.response -> b2.request, a2.response
-            }
-            """;
+            a1.request, b1.response -> b1.request, a1.response
+            a2.request, b2.response -> b2.request, a2.response
+        }
+        """;
     validator.assertWarning(
         parseWithoutError(testCase), LfPackage.eINSTANCE.getConnection(), null, "multiple types");
   }
@@ -375,11 +375,11 @@ public class LinguaFrancaValidationTest {
   public void disallowUnderscoreTimers() throws Exception {
     String testCase =
         """
-                target TypeScript;
-                main reactor Foo {
-                    timer __bar(0);
-                }
-            """;
+            target TypeScript;
+            main reactor Foo {
+                timer __bar(0);
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getTimer(),
@@ -393,10 +393,10 @@ public class LinguaFrancaValidationTest {
   public void disallowUnderscoreParameters() throws Exception {
     String testCase =
         """
-                target TypeScript;
-                main reactor Foo(__bar) {
-                }
-            """;
+            target TypeScript;
+            main reactor Foo(__bar) {
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getParameter(),
@@ -410,11 +410,11 @@ public class LinguaFrancaValidationTest {
   public void disallowUnderscoreStates() throws Exception {
     String testCase =
         """
-                target TypeScript;
-                main reactor Foo {
-                    state __bar;
-                }
-            """;
+            target TypeScript;
+            main reactor Foo {
+                state __bar;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getStateVar(),
@@ -428,10 +428,10 @@ public class LinguaFrancaValidationTest {
   public void disallowUnderscoreReactorDef() throws Exception {
     String testCase =
         """
-                target TypeScript;
-                reactor __Foo {
-                }
-            """;
+            target TypeScript;
+            reactor __Foo {
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getReactor(),
@@ -445,13 +445,13 @@ public class LinguaFrancaValidationTest {
   public void disallowUnderscoreReactorInstantiation() throws Exception {
     String testCase =
         """
-                target TypeScript;
-                reactor Foo {
-                }
-                main reactor Bar {
-                    __x = new Foo();
-                }
-            """;
+            target TypeScript;
+            reactor Foo {
+            }
+            main reactor Bar {
+                __x = new Foo();
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getInstantiation(),
@@ -465,11 +465,11 @@ public class LinguaFrancaValidationTest {
   public void disallowParenthesisInitialization(String target) throws Exception {
     String testCase =
         """
-                target <target>
-                main reactor {
-                    state foo: int(0)
-                }
-            """
+            target <target>
+            main reactor {
+                state foo: int(0)
+            }
+        """
             .replace("<target>", target);
     String error =
         "The <target> target does not support brace or parenthesis based initialization. Please use the assignment operator '=' instead."
@@ -483,11 +483,11 @@ public class LinguaFrancaValidationTest {
   public void disallowBraceInitialization(String target) throws Exception {
     String testCase =
         """
-                target <target>
-                main reactor {
-                    state foo: int{0}
-                }
-            """
+            target <target>
+            main reactor {
+                state foo: int{0}
+            }
+        """
             .replace("<target>", target);
     String error =
         "The <target> target does not support brace or parenthesis based initialization. Please use the assignment operator '=' instead."
@@ -501,18 +501,18 @@ public class LinguaFrancaValidationTest {
   public void connectionToEffectPort() throws Exception {
     String testCase =
         """
-                target C;
-                reactor Foo {
-                    output out:int;
-                }
-                main reactor Bar {
-                    output out:int;
-                    x = new Foo();
-                    x.out -> out;
-                    reaction(startup) -> out {=
-                    =}
-                }
-            """;
+            target C;
+            reactor Foo {
+                output out:int;
+            }
+            main reactor Bar {
+                output out:int;
+                x = new Foo();
+                x.out -> out;
+                reaction(startup) -> out {=
+                =}
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getConnection(),
@@ -525,21 +525,21 @@ public class LinguaFrancaValidationTest {
   public void connectionToEffectPort2() throws Exception {
     String testCase =
         """
-                target C;
-                reactor Foo {
-                    input inp:int;
-                    output out:int;
-                }
-                main reactor {
-                    output out:int;
-                    x = new Foo();
-                    y = new Foo();
+            target C;
+            reactor Foo {
+                input inp:int;
+                output out:int;
+            }
+            main reactor {
+                output out:int;
+                x = new Foo();
+                y = new Foo();
 
-                    y.out -> x.inp;
-                    reaction(startup) -> x.inp {=
-                    =}
-                }
-            """;
+                y.out -> x.inp;
+                reaction(startup) -> x.inp {=
+                =}
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getConnection(),
@@ -555,20 +555,20 @@ public class LinguaFrancaValidationTest {
   public void connectionToEffectPort3() throws Exception {
     String testCase =
         """
-                target C;
+            target C;
 
-                reactor Foo {
-                    input in:int;
-                }
-                reactor Bar {
-                    input in:int;
-                    x1 = new Foo();
-                    x2 = new Foo();
-                    in -> x1.in;
-                    reaction(startup) -> x2.in {=
-                    =}
-                }
-            """;
+            reactor Foo {
+                input in:int;
+            }
+            reactor Bar {
+                input in:int;
+                x1 = new Foo();
+                x2 = new Foo();
+                in -> x1.in;
+                reaction(startup) -> x2.in {=
+                =}
+            }
+        """;
     validator.assertNoErrors(parseWithoutError(testCase));
   }
 
@@ -580,20 +580,20 @@ public class LinguaFrancaValidationTest {
   public void connectionToEffectPort3_5() throws Exception {
     String testCase =
         """
-                target C;
+            target C;
 
-                reactor Foo {
-                    input in:int;
-                }
-                main reactor {
-                    input in:int;
-                    x1 = new Foo();
-                    x2 = new Foo();
-                    in -> x1.in;
-                    reaction(startup) -> x2.in {=
-                    =}
-                }
-            """;
+            reactor Foo {
+                input in:int;
+            }
+            main reactor {
+                input in:int;
+                x1 = new Foo();
+                x2 = new Foo();
+                in -> x1.in;
+                reaction(startup) -> x2.in {=
+                =}
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getVariable(),
@@ -609,19 +609,19 @@ public class LinguaFrancaValidationTest {
   public void connectionToEffectPort4() throws Exception {
     String testCase =
         """
-                target C;
+            target C;
 
-                reactor Foo {
-                    input in:int;
-                }
-                main reactor {
-                    input in:int;
-                    x1 = new Foo();
-                    in -> x1.in;
-                    reaction(startup) -> x1.in {=
-                    =}
-                }
-            """;
+            reactor Foo {
+                input in:int;
+            }
+            main reactor {
+                input in:int;
+                x1 = new Foo();
+                in -> x1.in;
+                reaction(startup) -> x1.in {=
+                =}
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getConnection(),
@@ -634,21 +634,21 @@ public class LinguaFrancaValidationTest {
   public void multipleConnectionsToInputTest() throws Exception {
     String testCase =
         """
-                target C;
-                reactor Source {
-                    output out:int;
-                }
-                reactor Sink {
-                    input in:int;
-                }
-                main reactor {
-                    input in:int;
-                    src = new Source();
-                    sink = new Sink();
-                    in -> sink.in;
-                    src.out -> sink.in;
-                }
-            """;
+            target C;
+            reactor Source {
+                output out:int;
+            }
+            reactor Sink {
+                input in:int;
+            }
+            main reactor {
+                input in:int;
+                src = new Source();
+                sink = new Sink();
+                in -> sink.in;
+                src.out -> sink.in;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getConnection(),
@@ -661,11 +661,11 @@ public class LinguaFrancaValidationTest {
   public void detectInstantiationCycle() throws Exception {
     String testCase =
         """
-                target C;
-                reactor Contained {
-                    x = new Contained();
-                }
-            """;
+            target C;
+            reactor Contained {
+                x = new Contained();
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getInstantiation(),
@@ -678,14 +678,14 @@ public class LinguaFrancaValidationTest {
   public void detectInstantiationCycle2() throws Exception {
     String testCase =
         """
-                target C;
-                reactor Intermediate {
-                    x = new Contained();
-                }
-                reactor Contained {
-                    x = new Intermediate();
-                }
-            """;
+            target C;
+            reactor Intermediate {
+                x = new Contained();
+            }
+            reactor Contained {
+                x = new Intermediate();
+            }
+        """;
 
     Model model = parseWithoutError(testCase);
     validator.assertError(
@@ -706,22 +706,22 @@ public class LinguaFrancaValidationTest {
 
     String testCase =
         """
-                target C;
+            target C;
 
-                reactor X {
-                    input x:int;
-                    output y:int;
-                    reaction(x) -> y {=
-                    =}
-                }
+            reactor X {
+                input x:int;
+                output y:int;
+                reaction(x) -> y {=
+                =}
+            }
 
-                main reactor {
-                    a = new X()
-                    b = new X()
-                    a.y -> b.x
-                    b.y -> a.x
-                }
-            """;
+            main reactor {
+                a = new X()
+                b = new X()
+                a.y -> b.x
+                b.y -> a.x
+            }
+        """;
     Model model = parseWithoutError(testCase);
     validator.assertError(
         model,
@@ -740,22 +740,22 @@ public class LinguaFrancaValidationTest {
   public void afterBreaksCycle() throws Exception {
     String testCase =
         """
-                target C
+            target C
 
-                reactor X {
-                    input x:int;
-                    output y:int;
-                    reaction(x) -> y {=
-                    =}
-                }
+            reactor X {
+                input x:int;
+                output y:int;
+                reaction(x) -> y {=
+                =}
+            }
 
-                main reactor {
-                    a = new X()
-                    b = new X()
-                    a.y -> b.x after 5 msec
-                    b.y -> a.x
-                }
-            """;
+            main reactor {
+                a = new X()
+                b = new X()
+                a.y -> b.x after 5 msec
+                b.y -> a.x
+            }
+        """;
 
     validator.assertNoErrors(parseWithoutError(testCase));
   }
@@ -765,22 +765,22 @@ public class LinguaFrancaValidationTest {
   public void afterBreaksCycle2() throws Exception {
     String testCase =
         """
-                target C
+            target C
 
-                reactor X {
-                    input x:int;
-                    output y:int;
-                    reaction(x) -> y {=
-                    =}
-                }
+            reactor X {
+                input x:int;
+                output y:int;
+                reaction(x) -> y {=
+                =}
+            }
 
-                main reactor {
-                    a = new X()
-                    b = new X()
-                    a.y -> b.x after 0 sec
-                    b.y -> a.x
-                }
-            """;
+            main reactor {
+                a = new X()
+                b = new X()
+                a.y -> b.x after 0 sec
+                b.y -> a.x
+            }
+        """;
     validator.assertNoErrors(parseWithoutError(testCase));
   }
 
@@ -789,22 +789,22 @@ public class LinguaFrancaValidationTest {
   public void afterBreaksCycle3() throws Exception {
     String testCase =
         """
-                target C
+            target C
 
-                reactor X {
-                    input x:int;
-                    output y:int;
-                    reaction(x) -> y {=
-                    =}
-                }
+            reactor X {
+                input x:int;
+                output y:int;
+                reaction(x) -> y {=
+                =}
+            }
 
-                main reactor {
-                    a = new X()
-                    b = new X()
-                    a.y -> b.x after 0
-                    b.y -> a.x
-                }
-            """;
+            main reactor {
+                a = new X()
+                b = new X()
+                a.y -> b.x after 0
+                b.y -> a.x
+            }
+        """;
     validator.assertNoErrors(parseWithoutError(testCase));
   }
 
@@ -813,21 +813,21 @@ public class LinguaFrancaValidationTest {
   public void nonzeroAfterMustHaveUnits() throws Exception {
     String testCase =
         """
-                target C
+            target C
 
-                reactor X {
-                    input x:int;
-                    output y:int;
-                    reaction(x) -> y {=
-                    =}
-                }
+            reactor X {
+                input x:int;
+                output y:int;
+                reaction(x) -> y {=
+                =}
+            }
 
-                main reactor {
-                    a = new X()
-                    b = new X()
-                    a.y -> b.x after 1
-                }
-            """;
+            main reactor {
+                a = new X()
+                b = new X()
+                a.y -> b.x after 1
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getConnection(),
@@ -840,14 +840,14 @@ public class LinguaFrancaValidationTest {
   public void nonZeroTimeValueWithoutUnits() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    timer t(42, 1 sec);
-                    reaction(t) {=
-                        printf("Hello World.\\n");
-                    =}
-                }
-            """;
+            target C;
+            main reactor {
+                timer t(42, 1 sec);
+                reaction(t) {=
+                    printf("Hello World.\\n");
+                =}
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase), LfPackage.eINSTANCE.getTimer(), null, "Missing time unit.");
   }
@@ -857,14 +857,14 @@ public class LinguaFrancaValidationTest {
   public void parameterTypeMismatch() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor (p:int = 0) {
-                    timer t(p, 1 sec);
-                    reaction(t) {=
-                        printf("Hello World.\\n");
-                    =}
-                }
-            """;
+            target C;
+            main reactor (p:int = 0) {
+                timer t(p, 1 sec);
+                reaction(t) {=
+                    printf("Hello World.\\n");
+                =}
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getTimer(),
@@ -877,14 +877,14 @@ public class LinguaFrancaValidationTest {
   public void targetCodeInTimeArgument() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    timer t({=foo()=}, 1 sec);
-                    reaction(t) {=
-                        printf("Hello World.\\n");
-                    =}
-                }
-            """;
+            target C;
+            main reactor {
+                timer t({=foo()=}, 1 sec);
+                reaction(t) {=
+                    printf("Hello World.\\n");
+                =}
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase), LfPackage.eINSTANCE.getTimer(), null, "Invalid time value.");
   }
@@ -894,15 +894,15 @@ public class LinguaFrancaValidationTest {
   public void overflowingDeadlineC() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                timer t;
-                    reaction(t) {=
-                        printf("Hello World.\\n");
-                    =} deadline (40 hours) {=
-                    =}
-                }
-            """;
+            target C;
+            main reactor {
+            timer t;
+                reaction(t) {=
+                    printf("Hello World.\\n");
+                =} deadline (40 hours) {=
+                =}
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getDeadline(),
@@ -915,15 +915,15 @@ public class LinguaFrancaValidationTest {
   public void overflowingParameterC() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor(d:time = 40 hours) {
-                timer t;
-                    reaction(t) {=
-                        printf("Hello World.\\n");
-                    =} deadline (d) {=
-                    =}
-                }
-            """;
+            target C;
+            main reactor(d:time = 40 hours) {
+            timer t;
+                reaction(t) {=
+                    printf("Hello World.\\n");
+                =} deadline (d) {=
+                =}
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getParameter(),
@@ -938,18 +938,18 @@ public class LinguaFrancaValidationTest {
   public void overflowingAssignmentC() throws Exception {
     String testCase =
         """
-                target C;
-                reactor Print(d:time(39 hours)) {
-                    timer t;
-                    reaction(t) {=
-                        printf("Hello World.\\n");
-                    =} deadline (d) {=
-                    =}
-                }
-                main reactor {
-                    p = new Print(d=40 hours);
-                }
-            """;
+            target C;
+            reactor Print(d:time(39 hours)) {
+                timer t;
+                reaction(t) {=
+                    printf("Hello World.\\n");
+                =} deadline (d) {=
+                =}
+            }
+            main reactor {
+                p = new Print(d=40 hours);
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getAssignment(),
@@ -964,13 +964,13 @@ public class LinguaFrancaValidationTest {
   public void missingTrigger() throws Exception {
     String testCase =
         """
-                target C;
-                reactor X {
-                    reaction() {=
-                        //
-                    =}
-                }
-            """;
+            target C;
+            reactor X {
+                reaction() {=
+                    //
+                =}
+            }
+        """;
     validator.assertWarning(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getReaction(),
@@ -986,30 +986,30 @@ public class LinguaFrancaValidationTest {
         Model model_reactor_scope =
             parseWithoutError(
                 """
-                        target %s;
-                        reactor Foo {
-                            %spreamble {==}
-                        }
-                    """
+                    target %s;
+                    reactor Foo {
+                        %spreamble {==}
+                    }
+                """
                     .formatted(target, visibility != Visibility.NONE ? visibility + " " : ""));
 
         Model model_file_scope =
             parseWithoutError(
                 """
-                        target %s;
-                        %spreamble {==}
-                        reactor Foo {
-                        }
-                    """
+                    target %s;
+                    %spreamble {==}
+                    reactor Foo {
+                    }
+                """
                     .formatted(target, visibility != Visibility.NONE ? visibility + " " : ""));
 
         Model model_no_preamble =
             parseWithoutError(
                 """
-                        target %s;
-                        reactor Foo {
-                        }
-                    """
+                    target %s;
+                    reactor Foo {
+                    }
+                """
                     .formatted(target));
 
         validator.assertNoIssues(model_no_preamble);
@@ -1061,10 +1061,10 @@ public class LinguaFrancaValidationTest {
       Model model =
           parseWithoutError(
               """
-                    target %s
-                    reactor A{}
-                    reactor B extends A{}
-                """
+                  target %s
+                  reactor A{}
+                  reactor B extends A{}
+              """
                   .formatted(target));
 
       if (target.supportsInheritance()) {
@@ -1085,12 +1085,12 @@ public class LinguaFrancaValidationTest {
       Model model =
           parseWithoutError(
               """
-                    target %s
-                    reactor Foo {}
-                    federated reactor {
-                      foo = new Foo()
-                    }
-                """
+                  target %s
+                  reactor Foo {}
+                  federated reactor {
+                    foo = new Foo()
+                  }
+              """
                   .formatted(target));
 
       if (target.supportsFederated()) {
@@ -1110,21 +1110,21 @@ public class LinguaFrancaValidationTest {
   public void stateAndParameterDeclarationsInC() throws Exception {
     String testCase =
         """
-                target C;
-                reactor Bar(a = 0,                // ERROR: type missing
-                            b:int,               // ERROR: uninitialized
-                            t:time = 42,          // ERROR: units missing
-                            x:int = 0,
-                            h:time = "bla",       // ERROR: not a type
-                            q:time = {1 msec, 2 msec},  // ERROR: not a time
-                            y:int = t             // ERROR: init using parameter
-                ) {
-                    state offset:time = 42;       // ERROR: units missing
-                    state w:time = x;             // ERROR: parameter is not a time
-                    state foo:time = "bla";       // ERROR: assigned value not a time;
-                    timer tick(1);               // ERROR: not a time
-                }
-            """;
+            target C;
+            reactor Bar(a = 0,                // ERROR: type missing
+                        b:int,               // ERROR: uninitialized
+                        t:time = 42,          // ERROR: units missing
+                        x:int = 0,
+                        h:time = "bla",       // ERROR: not a type
+                        q:time = {1 msec, 2 msec},  // ERROR: not a time
+                        y:int = t             // ERROR: init using parameter
+            ) {
+                state offset:time = 42;       // ERROR: units missing
+                state w:time = x;             // ERROR: parameter is not a time
+                state foo:time = "bla";       // ERROR: assigned value not a time;
+                timer tick(1);               // ERROR: not a time
+            }
+        """;
 
     Model model = parseWithoutError(testCase);
 
@@ -1163,12 +1163,12 @@ public class LinguaFrancaValidationTest {
 
       String testCase =
           """
-                    target C;
-                    reactor Y {}
-                    federated reactor X at foo@%s:4242 {
-                        y = new Y() at %s:2424;
-                    }
-                """
+              target C;
+              reactor Y {}
+              federated reactor X at foo@%s:4242 {
+                  y = new Y() at %s:2424;
+              }
+          """
               .formatted(addr, addr);
       parseWithoutError(testCase);
     }
@@ -1177,12 +1177,12 @@ public class LinguaFrancaValidationTest {
     for (String addr : parseError) {
       String testCase =
           """
-                    target C;
-                    reactor Y {}
-                    federated reactor X at foo@%s:4242 {
-                        y = new Y() at %s:2424;
-                    }
-                """
+              target C;
+              reactor Y {}
+              federated reactor X at foo@%s:4242 {
+                  y = new Y() at %s:2424;
+              }
+          """
               .formatted(addr, addr);
       parseWithError(testCase);
     }
@@ -1192,12 +1192,12 @@ public class LinguaFrancaValidationTest {
       Model model =
           parseWithoutError(
               """
-                    target C;
-                    reactor Y {}
-                    federated reactor X at foo@%s:4242 {
-                        y = new Y() at %s:2424;
-                    }
-                """
+                  target C;
+                  reactor Y {}
+                  federated reactor X at foo@%s:4242 {
+                      y = new Y() at %s:2424;
+                  }
+              """
                   .formatted(addr, addr));
       validator.assertWarning(model, LfPackage.eINSTANCE.getHost(), null, "Invalid IP address.");
     }
@@ -1268,12 +1268,12 @@ public class LinguaFrancaValidationTest {
     for (String addr : correct) {
       String testCase =
           """
-                    target C;
-                    reactor Y {}
-                    federated reactor at [foo@%s]:4242 {
-                        y = new Y() at [%s]:2424;
-                    }
-                """
+              target C;
+              reactor Y {}
+              federated reactor at [foo@%s]:4242 {
+                  y = new Y() at [%s]:2424;
+              }
+          """
               .formatted(addr, addr);
       Model model = parseWithoutError(testCase);
       validator.assertNoIssues(model);
@@ -1283,12 +1283,12 @@ public class LinguaFrancaValidationTest {
     for (String addr : parseError) {
       String testCase =
           """
-                    target C;
-                    reactor Y {}
-                    federated reactor X at [foo@%s]:4242 {
-                        y = new Y() at [%s]:2424;
-                    }
-                """
+              target C;
+              reactor Y {}
+              federated reactor X at [foo@%s]:4242 {
+                  y = new Y() at [%s]:2424;
+              }
+          """
               .formatted(addr, addr);
       parseWithError(testCase);
     }
@@ -1297,12 +1297,12 @@ public class LinguaFrancaValidationTest {
     for (String addr : validationError) {
       String testCase =
           """
-                    target C;
-                    reactor Y {}
-                    federated reactor X at [foo@%s]:4242 {
-                        y = new Y() at [%s]:2424;
-                    }
-                """
+              target C;
+              reactor Y {}
+              federated reactor X at [foo@%s]:4242 {
+                  y = new Y() at [%s]:2424;
+              }
+          """
               .formatted(addr, addr);
       Model model = parseWithoutError(testCase);
       validator.assertWarning(model, LfPackage.eINSTANCE.getHost(), null, "Invalid IP address.");
@@ -1323,12 +1323,12 @@ public class LinguaFrancaValidationTest {
     for (String addr : correct) {
       String testCase =
           """
-                    target C;
-                    reactor Y {}
-                    federated reactor X at foo@%s:4242 {
-                        y = new Y() at %s:2424;
-                    }
-                """
+              target C;
+              reactor Y {}
+              federated reactor X at foo@%s:4242 {
+                  y = new Y() at %s:2424;
+              }
+          """
               .formatted(addr, addr);
       parseWithoutError(testCase);
     }
@@ -1337,12 +1337,12 @@ public class LinguaFrancaValidationTest {
     for (String addr : parseError) {
       String testCase =
           """
-                    target C;
-                    reactor Y {}
-                    federated reactor X at foo@%s:4242 {
-                        y = new Y() at %s:2424;
-                    }
-                """
+              target C;
+              reactor Y {}
+              federated reactor X at foo@%s:4242 {
+                  y = new Y() at %s:2424;
+              }
+          """
               .formatted(addr, addr);
       parseWithError(testCase);
     }
@@ -1351,12 +1351,12 @@ public class LinguaFrancaValidationTest {
     for (String addr : validationError) {
       String testCase =
           """
-                    target C;
-                    reactor Y {}
-                    federated reactor X at foo@%s:4242 {
-                        y = new Y() at %s:2424;
-                    }
-                """
+              target C;
+              reactor Y {}
+              federated reactor X at foo@%s:4242 {
+                  y = new Y() at %s:2424;
+              }
+          """
               .formatted(addr, addr);
       Model model = parseWithoutError(testCase);
       validator.assertWarning(
@@ -1590,12 +1590,12 @@ public class LinguaFrancaValidationTest {
   private Model createModel(Target target, TargetProperty property, String value) throws Exception {
     return parseWithoutError(
         """
-                target %s {%s: %s};
-                reactor Y {}
-                main reactor {
-                    y = new Y()
-                }
-            """
+            target %s {%s: %s};
+            reactor Y {}
+            main reactor {
+                y = new Y()
+            }
+        """
             .formatted(target, property.name(), value));
   }
 
@@ -1841,11 +1841,11 @@ public class LinguaFrancaValidationTest {
   public void testMissingInputType() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    input i;
-                }
-            """;
+            target C;
+            main reactor {
+                input i;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getInput(),
@@ -1857,11 +1857,11 @@ public class LinguaFrancaValidationTest {
   public void testMissingOutputType() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    output i;
-                }
-            """;
+            target C;
+            main reactor {
+                output i;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getOutput(),
@@ -1873,11 +1873,11 @@ public class LinguaFrancaValidationTest {
   public void testMissingStateType() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    state i;
-                }
-            """;
+            target C;
+            main reactor {
+                state i;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getStateVar(),
@@ -1889,11 +1889,11 @@ public class LinguaFrancaValidationTest {
   public void testCppMutableInput() throws Exception {
     String testCase =
         """
-                target Cpp;
-                main reactor {
-                    mutable input i:int;
-                }
-            """;
+            target Cpp;
+            main reactor {
+                mutable input i:int;
+            }
+        """;
     validator.assertWarning(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getInput(),
@@ -1906,11 +1906,11 @@ public class LinguaFrancaValidationTest {
   public void testOverflowingSTP() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    reaction(startup) {==} STP(2147483648) {==}
-                }
-            """;
+            target C;
+            main reactor {
+                reaction(startup) {==} STP(2147483648) {==}
+            }
+        """;
 
     // TODO: Uncomment and fix failing test. See issue #903 on Github.
     // validator.assertError(parseWithoutError(testCase), LfPackage.eINSTANCE.getSTP(), null,
@@ -1921,11 +1921,11 @@ public class LinguaFrancaValidationTest {
   public void testOverflowingDeadline() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    reaction(startup) {==} STP(2147483648) {==}
-                }
-            """;
+            target C;
+            main reactor {
+                reaction(startup) {==} STP(2147483648) {==}
+            }
+        """;
 
     // TODO: Uncomment and fix failing test. See issue #903 on Github.
     // validator.assertError(parseWithoutError(testCase), LfPackage.eINSTANCE.getDeadline(), null,
@@ -1936,9 +1936,9 @@ public class LinguaFrancaValidationTest {
   public void testInvalidTargetParam() throws Exception {
     String testCase =
         """
-                target C { foobarbaz: true }
-                main reactor {}
-            """;
+            target C { foobarbaz: true }
+            main reactor {}
+        """;
     var model = parseWithoutError(testCase);
     List<Issue> issues = validator.validate(model);
     Assertions.assertTrue(issues.size() == 2);
@@ -1953,9 +1953,9 @@ public class LinguaFrancaValidationTest {
   public void testTargetParamNotSupportedForTarget() throws Exception {
     String testCase =
         """
-                target Python { cargo-features: "" }
-                main reactor {}
-            """;
+            target Python { cargo-features: "" }
+            main reactor {}
+        """;
     var model = parseWithoutError(testCase);
     List<Issue> issues = validator.validate(model);
     Assertions.assertTrue(issues.size() == 2);
@@ -1968,10 +1968,11 @@ public class LinguaFrancaValidationTest {
 
   @Test
   public void testUnnamedReactor() throws Exception {
-    String testCase = """
-                target C;
-                reactor {}
-            """;
+    String testCase =
+        """
+            target C;
+            reactor {}
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getReactor(),
@@ -1983,11 +1984,11 @@ public class LinguaFrancaValidationTest {
   public void testMainHasInput() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    input x:int;
-                }
-            """;
+            target C;
+            main reactor {
+                input x:int;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getInput(),
@@ -2000,11 +2001,11 @@ public class LinguaFrancaValidationTest {
 
     String testCase =
         """
-                target C;
-                federated reactor {
-                    input x:int;
-                }
-            """;
+            target C;
+            federated reactor {
+                input x:int;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getInput(),
@@ -2017,11 +2018,11 @@ public class LinguaFrancaValidationTest {
 
     String testCase =
         """
-                target C;
-                main reactor {
-                    output x:int;
-                }
-            """;
+            target C;
+            main reactor {
+                output x:int;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getOutput(),
@@ -2034,11 +2035,11 @@ public class LinguaFrancaValidationTest {
 
     String testCase =
         """
-                target C;
-                federated reactor {
-                    output x:int;
-                }
-            """;
+            target C;
+            federated reactor {
+                output x:int;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getOutput(),
@@ -2051,10 +2052,10 @@ public class LinguaFrancaValidationTest {
 
     String testCase =
         """
-                target C;
-                main reactor A {}
-                main reactor A {}
-            """;
+            target C;
+            main reactor A {}
+            main reactor A {}
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getReactor(),
@@ -2067,10 +2068,10 @@ public class LinguaFrancaValidationTest {
 
     String testCase =
         """
-                target C;
-                main reactor {}
-                main reactor {}
-            """;
+            target C;
+            main reactor {}
+            main reactor {}
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getReactor(),
@@ -2082,10 +2083,10 @@ public class LinguaFrancaValidationTest {
   public void testMultipleFederatedReactor() throws Exception {
     String testCase =
         """
-                target C;
-                federated reactor A {}
-                federated reactor A {}
-            """;
+            target C;
+            federated reactor A {}
+            federated reactor A {}
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getReactor(),
@@ -2098,10 +2099,10 @@ public class LinguaFrancaValidationTest {
 
     String testCase =
         """
-                target C;
-                federated reactor A {}
-                federated reactor A {}
-            """;
+            target C;
+            federated reactor A {}
+            federated reactor A {}
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getReactor(),
@@ -2113,9 +2114,9 @@ public class LinguaFrancaValidationTest {
   public void testMainReactorHasHost() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor at 127.0.0.1{}
-            """;
+            target C;
+            main reactor at 127.0.0.1{}
+        """;
     // TODO: Uncomment and fix test
     // List<Issue> issues = validator.validate(parseWithoutError(testCase));
     // Assertions.assertTrue(issues.size() == 1 &&
@@ -2128,9 +2129,9 @@ public class LinguaFrancaValidationTest {
 
     String testCase =
         """
-                target Pjthon;
-                main reactor {}
-            """;
+            target Pjthon;
+            main reactor {}
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getTargetDecl(),
@@ -2142,10 +2143,10 @@ public class LinguaFrancaValidationTest {
   public void testWrongStructureForLabelAttribute() throws Exception {
     String testCase =
         """
-                target C;
-                @label(name="something")
-                main reactor { }
-            """;
+            target C;
+            @label(name="something")
+            main reactor { }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getAttribute(),
@@ -2157,10 +2158,10 @@ public class LinguaFrancaValidationTest {
   public void testMissingName() throws Exception {
     String testCase =
         """
-                target C;
-                @label("something", "else")
-                main reactor { }
-            """;
+            target C;
+            @label("something", "else")
+            main reactor { }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getAttribute(),
@@ -2172,10 +2173,10 @@ public class LinguaFrancaValidationTest {
   public void testWrongParamType() throws Exception {
     String testCase =
         """
-                target C;
-                @label(value=1)
-                main reactor { }
-            """;
+            target C;
+            @label(value=1)
+            main reactor { }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getAttribute(),
@@ -2187,11 +2188,11 @@ public class LinguaFrancaValidationTest {
   public void testInitialMode() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    mode M {}
-                }
-            """;
+            target C;
+            main reactor {
+                mode M {}
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getReactor(),
@@ -2203,12 +2204,12 @@ public class LinguaFrancaValidationTest {
   public void testInitialModes() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    initial mode IM1 {}
-                    initial mode IM2 {}
-                }
-            """;
+            target C;
+            main reactor {
+                initial mode IM1 {}
+                initial mode IM2 {}
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getReactor(),
@@ -2220,16 +2221,16 @@ public class LinguaFrancaValidationTest {
   public void testModeStateNamespace() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    initial mode IM {
-                        state s:int;
-                    }
-                    mode M {
-                        state s:int;
-                    }
+            target C;
+            main reactor {
+                initial mode IM {
+                    state s:int;
                 }
-            """;
+                mode M {
+                    state s:int;
+                }
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getStateVar(),
@@ -2242,16 +2243,16 @@ public class LinguaFrancaValidationTest {
   public void testModeTimerNamespace() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    initial mode IM {
-                        timer t;
-                    }
-                    mode M {
-                        timer t;
-                    }
+            target C;
+            main reactor {
+                initial mode IM {
+                    timer t;
                 }
-            """;
+                mode M {
+                    timer t;
+                }
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getTimer(),
@@ -2263,16 +2264,16 @@ public class LinguaFrancaValidationTest {
   public void testModeActionNamespace() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    initial mode IM {
-                        logical action a;
-                    }
-                    mode M {
-                        logical action a;
-                    }
+            target C;
+            main reactor {
+                initial mode IM {
+                    logical action a;
                 }
-            """;
+                mode M {
+                    logical action a;
+                }
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getAction(),
@@ -2284,17 +2285,17 @@ public class LinguaFrancaValidationTest {
   public void testModeInstanceNamespace() throws Exception {
     String testCase =
         """
-                target C;
-                reactor R {}
-                main reactor {
-                    initial mode IM {
-                        r = new R();
-                    }
-                    mode M {
-                        r = new R();
-                    }
+            target C;
+            reactor R {}
+            main reactor {
+                initial mode IM {
+                    r = new R();
                 }
-            """;
+                mode M {
+                    r = new R();
+                }
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getInstantiation(),
@@ -2307,16 +2308,16 @@ public class LinguaFrancaValidationTest {
   public void testMissingModeStateReset() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    initial mode IM {
-                        reaction(startup) -> M {==}
-                    }
-                    mode M {
-                        state s:int(0);
-                    }
+            target C;
+            main reactor {
+                initial mode IM {
+                    reaction(startup) -> M {==}
                 }
-            """;
+                mode M {
+                    state s:int(0);
+                }
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getMode(),
@@ -2329,19 +2330,19 @@ public class LinguaFrancaValidationTest {
   public void testMissingModeStateResetInstance() throws Exception {
     String testCase =
         """
-                target C;
-                reactor R {
-                    state s:int = 0;
+            target C;
+            reactor R {
+                state s:int = 0;
+            }
+            main reactor {
+                initial mode IM {
+                    reaction(startup) -> M {==}
                 }
-                main reactor {
-                    initial mode IM {
-                        reaction(startup) -> M {==}
-                    }
-                    mode M {
-                        r = new R();
-                    }
+                mode M {
+                    r = new R();
                 }
-            """;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getMode(),
@@ -2356,13 +2357,13 @@ public class LinguaFrancaValidationTest {
   public void testModeStateResetWithoutInitialValue() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    initial mode IM {
-                        reset state s:int;
-                    }
+            target C;
+            main reactor {
+                initial mode IM {
+                    reset state s:int;
                 }
-            """;
+            }
+        """;
     validator.assertError(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getStateVar(),
@@ -2374,16 +2375,16 @@ public class LinguaFrancaValidationTest {
   public void testUnspecifiedTransitionType() throws Exception {
     String testCase =
         """
-                target C;
-                main reactor {
-                    initial mode IM {
-                        reaction(startup) -> M {==}
-                    }
-                    mode M {
-                        reset state s:int = 0;
-                    }
+            target C;
+            main reactor {
+                initial mode IM {
+                    reaction(startup) -> M {==}
                 }
-            """;
+                mode M {
+                    reset state s:int = 0;
+                }
+            }
+        """;
     validator.assertWarning(
         parseWithoutError(testCase),
         LfPackage.eINSTANCE.getReaction(),
@@ -2397,9 +2398,9 @@ public class LinguaFrancaValidationTest {
   public void testMutuallyExclusiveThreadingParams() throws Exception {
     String testCase =
         """
-                target C { single-threaded: true, workers: 1 }
-                main reactor {}
-            """;
+            target C { single-threaded: true, workers: 1 }
+            main reactor {}
+        """;
 
     validator.assertError(
         parseWithoutError(testCase),

--- a/core/src/testFixtures/java/org/lflang/tests/TestBase.java
+++ b/core/src/testFixtures/java/org/lflang/tests/TestBase.java
@@ -571,28 +571,28 @@ public abstract class TestBase extends LfInjectedTestBase {
   /** Bash script that is used to execute docker tests. */
   private static final String DOCKER_RUN_SCRIPT =
       """
-            #!/bin/bash
+      #!/bin/bash
 
-            # exit when any command fails
-            set -e
+      # exit when any command fails
+      set -e
 
-            docker compose -f "$1" rm -f
-            docker compose -f "$1" up --build | tee docker_log.txt
-            docker compose -f "$1" down --rmi local
+      docker compose -f "$1" rm -f
+      docker compose -f "$1" up --build | tee docker_log.txt
+      docker compose -f "$1" down --rmi local
 
-            errors=`grep -E "exited with code [1-9]" docker_log.txt | cat`
-            rm docker_log.txt
+      errors=`grep -E "exited with code [1-9]" docker_log.txt | cat`
+      rm docker_log.txt
 
-            if [[ $errors ]]; then
-                echo "===================================================================="
-                echo "ERROR: One or multiple containers exited with a non-zero exit code."
-                echo "       See the log above for details. The following containers failed:"
-                echo $errors
-                exit 1
-            fi
+      if [[ $errors ]]; then
+          echo "===================================================================="
+          echo "ERROR: One or multiple containers exited with a non-zero exit code."
+          echo "       See the log above for details. The following containers failed:"
+          echo $errors
+          exit 1
+      fi
 
-            exit 0
-            """;
+      exit 0
+      """;
 
   /** Path to a bash script containing DOCKER_RUN_SCRIPT. */
   private static Path dockerRunScript = null;

--- a/core/src/testFixtures/java/org/lflang/tests/TestRegistry.java
+++ b/core/src/testFixtures/java/org/lflang/tests/TestRegistry.java
@@ -288,6 +288,7 @@ public class TestRegistry {
       return this.map.get(t).get(c);
     }
   }
+
   /**
    * Enumeration of test categories, used to map tests to categories. The nearest containing
    * directory that matches any of the categories will determine the category that the test is

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ version=0.7.3-SNAPSHOT
 [versions]
 antlrVersion=4.7.2
 fasterxmlVersion=2.12.4
-googleJavaFormatVersion=1.15.0
+googleJavaFormatVersion=1.22.0
 jacocoVersion=0.8.7
 jsonVersion=20200518
 jupiterVersion=5.8.2


### PR DESCRIPTION
This updates the version of the google style that we use for formatting our code. Most importantly, this change makes our code base compatible with newer versions of Java (up to 22). Combined with https://github.com/lf-lang/lingua-franca/pull/2307, this allows compilation with java versions greater than 17.

As a consequence of this change, the formatting in some of our java files gets updated.