### PR TITLE
fix: cmake code generation of target_link_library

### DIFF
--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppStandaloneCmakeGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppStandaloneCmakeGenerator.kt
@@ -165,7 +165,7 @@ class CppStandaloneCmakeGenerator(private val targetConfig: TargetConfig, privat
                 |    "$S{PROJECT_SOURCE_DIR}"
                 |    "$S{PROJECT_SOURCE_DIR}/__include__"
                 |)
-                |target_link_libraries($S{LF_MAIN_TARGET} $reactorCppTarget)
+                |target_link_libraries($S{LF_MAIN_TARGET} PUBLIC $reactorCppTarget)
                 |
                 |if(MSVC)
                 |  target_compile_options($S{LF_MAIN_TARGET} PRIVATE /W4)


### PR DESCRIPTION
During my endeavors to build lingo, I encountered that cmake doesn't like mixing old and new `target_link_libraries` statements. 

See: https://stackoverflow.com/questions/59522267/cmake-rejects-a-second-target-link-libraries-talking-about-keyword-vs-plain

```
target_link_libraries(my_prog PRIVATE foo bar)
target_link_libraries(my_prog baz)
```
