### PR TITLE
No more support for Python 3.9

### DIFF
--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -564,7 +564,7 @@ public class PythonGenerator extends CGenerator {
             add_subdirectory(core)
             set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
             set(LF_MAIN_TARGET <pyModuleName>)
-            find_package(Python 3.9.0...<3.11.0 REQUIRED COMPONENTS Interpreter Development)
+            find_package(Python 3.10.0...<3.11.0 REQUIRED COMPONENTS Interpreter Development)
             Python_add_library(
                 ${LF_MAIN_TARGET}
                 MODULE


### PR DESCRIPTION
This reverts commit 69c44d5076d99cb61e9b81b7cd06b55dd56ff106.

Fixes https://github.com/lf-lang/lingua-franca/issues/2310 and https://github.com/lf-lang/lingua-franca/issues/2298.

This is not a real fix, however, because the issue due to the interaction between CMake and Python, not because of anything particular to Python 3.9.