### PR TITLE
Stop removing GCC on MacOS in CI

### DIFF
--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Uninstall packages Ubuntu
         run: sudo apt-get remove clang-*
         if: ${{ runner.os == 'Linux' }}
-      - name: Uninstall packages MacOS
-        run: sudo rm -f $(which gcc)
-        if: ${{ runner.os == 'macOS' }}
       - name: Uninstall packages Windows
         shell: pwsh
         run: |

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: sudo apt-get remove clang-*
         if: ${{ runner.os == 'Linux' }}
       - name: Uninstall packages MacOS
-        run: brew uninstall --ignore-dependencies gcc
+        run: sudo rm -f $(which gcc)
         if: ${{ runner.os == 'macOS' }}
       - name: Uninstall packages Windows
         shell: pwsh
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Run language server Python tests without PyLint
         run: ./gradlew core:integrationTest --tests org.lflang.tests.lsp.LspTests.pythonValidationTestSyntaxOnly core:integrationTestCodeCoverageReport
       - name: Install pylint


### PR DESCRIPTION
The LSP tests are error prone because they test interactions with external tools. They broke because correct behavior depends on how the external tools are made available on the system.

A robust solution would involve either removing the feature that the LSP tests are designed to test, or dockerizing the LSP tests. However, this PR provides a quick stopgap solution instead so that we can avoid having to force an immediate long-term decision.