### PR TITLE
Fixed docker compose script so that it fails if any container fails

### DIFF
--- a/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
@@ -138,7 +138,7 @@ public class DockerComposeGenerator {
         set -euo pipefail
         cd $(dirname "$0")
         cd "%s/%s"
-        docker compose up
+        docker compose up --abort-on-container-failure
         """
             .formatted(relPath, packageRoot.relativize(srcGenPath));
     var messageReporter = context.getErrorReporter();


### PR DESCRIPTION
Addresses https://github.com/lf-lang/lingua-franca/pull/2328#pullrequestreview-2131194763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Docker Compose behavior by adding the `--abort-on-container-failure` flag to ensure that all containers are stopped if one fails.
  - Added `--abort-on-container-exit` flag to the `docker compose up` command to ensure the service stops if any container exits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->