### PR TITLE
API to look up source and package directory in Python

### DIFF
--- a/test/Python/src/PythonPaths.lf
+++ b/test/Python/src/PythonPaths.lf
@@ -13,12 +13,10 @@ main reactor {
   state package_path = {= os.path.join(lf.package_directory(), "src", "PythonPaths.lf") =}
 
   reaction(startup) {=
-    file = open(self.source_path, "r");
-    print(file.read());
-    file.close();
+    with open(self.source_path, "r") as file:
+      print(file.read());
     print("----------------");
-    file = open(self.package_path, "r");
-    print(file.read());
-    file.close();
+    with open(self.package_path, "r") as file:
+      print(file.read());
   =}
 }

--- a/test/Python/src/PythonPaths.lf
+++ b/test/Python/src/PythonPaths.lf
@@ -1,0 +1,24 @@
+/**
+ * This tests the functions lf.source_directory() and lf.package_directory(). Success is just
+ * compiling and running without error. The test prints the contents of this file twice.
+ */
+target Python
+
+preamble {=
+  import os
+=}
+
+main reactor {
+  state source_path = {= os.path.join(lf.source_directory(), "PythonPaths.lf") =}
+  state package_path = {= os.path.join(lf.package_directory(), "src", "PythonPaths.lf") =}
+
+  reaction(startup) {=
+    file = open(self.source_path, "r");
+    print(file.read());
+    file.close();
+    print("----------------");
+    file = open(self.package_path, "r");
+    print(file.read());
+    file.close();
+  =}
+}


### PR DESCRIPTION
This PR adds a test for https://github.com/lf-lang/reactor-c/pull/455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to test `lf.source_directory()` and `lf.package_directory()` functions in Python.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->