### PR TITLE
New target property for specifying Python version

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -310,30 +310,22 @@ public class CCmakeGenerator {
       case ZEPHYR:
         cMakeCode.pr(
             setUpMainTargetZephyr(
-                hasMain,
-                executableName,
-                Stream.concat(additionalSources.stream(), sources.stream())));
+                hasMain, context, Stream.concat(additionalSources.stream(), sources.stream())));
         break;
       case RP2040:
         cMakeCode.pr(
             setUpMainTargetRp2040(
-                hasMain,
-                executableName,
-                Stream.concat(additionalSources.stream(), sources.stream())));
+                hasMain, context, Stream.concat(additionalSources.stream(), sources.stream())));
         break;
       case FLEXPRET:
         cMakeCode.pr(
             setUpMainTargetFlexPRET(
-                hasMain,
-                executableName,
-                Stream.concat(additionalSources.stream(), sources.stream())));
+                hasMain, context, Stream.concat(additionalSources.stream(), sources.stream())));
         break;
       default:
         cMakeCode.pr(
             setUpMainTarget.getCmakeCode(
-                hasMain,
-                executableName,
-                Stream.concat(additionalSources.stream(), sources.stream())));
+                hasMain, context, Stream.concat(additionalSources.stream(), sources.stream())));
     }
 
     // Ensure that the math library is linked
@@ -495,16 +487,16 @@ public class CCmakeGenerator {
   public interface SetUpMainTarget {
     // Implementation note: This indirection is necessary because the Python
     // target produces a shared object file, not an executable.
-    String getCmakeCode(boolean hasMain, String executableName, Stream<String> cSources);
+    String getCmakeCode(boolean hasMain, LFGeneratorContext context, Stream<String> cSources);
   }
 
   /** Generate the C-target-specific code for configuring the executable produced by the build. */
   private static String setUpMainTarget(
-      boolean hasMain, String executableName, Stream<String> cSources) {
+      boolean hasMain, LFGeneratorContext context, Stream<String> cSources) {
     var code = new CodeBuilder();
     code.pr("add_subdirectory(core)");
     code.newLine();
-    code.pr("set(LF_MAIN_TARGET " + executableName + ")");
+    code.pr("set(LF_MAIN_TARGET " + context.getFileConfig().name + ")");
     code.newLine();
 
     if (hasMain) {
@@ -524,7 +516,7 @@ public class CCmakeGenerator {
   }
 
   private static String setUpMainTargetZephyr(
-      boolean hasMain, String executableName, Stream<String> cSources) {
+      boolean hasMain, LFGeneratorContext context, Stream<String> cSources) {
     var code = new CodeBuilder();
     code.pr("add_subdirectory(core)");
     code.newLine();
@@ -535,7 +527,7 @@ public class CCmakeGenerator {
       code.pr("target_sources(");
     } else {
       code.pr("# Declare a new library target and list all its sources");
-      code.pr("set(LF_MAIN_TARGET" + executableName + ")");
+      code.pr("set(LF_MAIN_TARGET" + context.getFileConfig().name + ")");
       code.pr("add_library(");
     }
     code.indent();
@@ -553,7 +545,7 @@ public class CCmakeGenerator {
   }
 
   private static String setUpMainTargetRp2040(
-      boolean hasMain, String executableName, Stream<String> cSources) {
+      boolean hasMain, LFGeneratorContext context, Stream<String> cSources) {
     var code = new CodeBuilder();
     // initialize sdk
     code.pr("pico_sdk_init()");
@@ -563,7 +555,7 @@ public class CCmakeGenerator {
     code.pr("target_link_libraries(reactor-c PUBLIC pico_multicore)");
     code.pr("target_link_libraries(reactor-c PUBLIC pico_sync)");
     code.newLine();
-    code.pr("set(LF_MAIN_TARGET " + executableName + ")");
+    code.pr("set(LF_MAIN_TARGET " + context.getFileConfig().name + ")");
 
     if (hasMain) {
       code.pr("# Declare a new executable target and list all its sources");
@@ -584,7 +576,7 @@ public class CCmakeGenerator {
   }
 
   private static String setUpMainTargetFlexPRET(
-      boolean hasMain, String executableName, Stream<String> cSources) {
+      boolean hasMain, LFGeneratorContext context, Stream<String> cSources) {
     var code = new CodeBuilder();
     code.pr("add_subdirectory(core)");
     code.newLine();
@@ -593,7 +585,7 @@ public class CCmakeGenerator {
     code.pr("add_subdirectory($ENV{FP_SDK_PATH} BINARY_DIR)");
     code.newLine();
 
-    code.pr("set(LF_MAIN_TARGET " + executableName + ")");
+    code.pr("set(LF_MAIN_TARGET " + context.getFileConfig().name + ")");
     code.newLine();
 
     if (hasMain) {

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -278,7 +278,6 @@ public class PythonGenerator extends CGenerator {
 
   @Override
   protected void handleProtoFiles() {
-    pythonVersion = targetConfig.get(PythonVersionProperty.INSTANCE);
     for (String name : targetConfig.get(ProtobufsProperty.INSTANCE)) {
       this.processProtoFile(name);
       int dotIndex = name.lastIndexOf(".");

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -365,6 +365,7 @@ public class PythonGenerator extends CGenerator {
    */
   @Override
   public void doGenerate(Resource resource, LFGeneratorContext context) {
+    setUpPythonVersion();
     int cGeneratedPercentProgress = (IntegratedBuilder.VALIDATED_PERCENT_PROGRESS + 100) / 2;
     code.pr(
         PythonPreambleGenerator.generateCIncludeStatements(
@@ -568,9 +569,14 @@ public class PythonGenerator extends CGenerator {
     PythonModeGenerator.generateResetReactionsIfNeeded(reactors);
   }
 
+  /** Initializes the Python version based on the user's configuration. */
+  protected void setUpPythonVersion() {
+    String property = targetConfig.get(PythonVersionProperty.INSTANCE);
+    pythonVersion = property.isEmpty() ? "3.10.0...<3.11.0" : property + " EXACT";
+  }
+
   private static String setUpMainTarget(
       boolean hasMain, String executableName, Stream<String> cSources) {
-    String pyVersion = pythonVersion.isEmpty() ? "3.10.0...<3.11.0" : pythonVersion + " EXACT";
     return ("""
             set(CMAKE_POSITION_INDEPENDENT_CODE ON)
             add_compile_definitions(_PYTHON_TARGET_ENABLED)
@@ -598,7 +604,7 @@ target_link_libraries(${LF_MAIN_TARGET} PRIVATE ${Python_LIBRARIES})
 target_compile_definitions(${LF_MAIN_TARGET} PUBLIC MODULE_NAME=<pyModuleName>)
 """)
         .replace("<pyModuleName>", generatePythonModuleName(executableName))
-        .replace("<pyVersion>", pyVersion);
+        .replace("<pyVersion>", pythonVersion);
     // The use of fileConfig.name will break federated execution, but that's fine
   }
 

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -569,36 +569,36 @@ public class PythonGenerator extends CGenerator {
   }
 
   private static String setUpMainTarget(
-          boolean hasMain, String executableName, Stream<String> cSources) {
-    String pyVersion = pythonVersion.isEmpty() ? "3.8" : pythonVersion + " EXACT";
+      boolean hasMain, String executableName, Stream<String> cSources) {
+    String pyVersion = pythonVersion.isEmpty() ? "3.10.0...<3.11.0" : pythonVersion + " EXACT";
     return ("""
-        set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-        add_compile_definitions(_PYTHON_TARGET_ENABLED)
-        add_subdirectory(core)
-        set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
-        set(LF_MAIN_TARGET <pyModuleName>)
-        find_package(Python <pyVersion> REQUIRED COMPONENTS Interpreter Development)
-        Python_add_library(
-            ${LF_MAIN_TARGET}
-            MODULE
-        """
+            set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+            add_compile_definitions(_PYTHON_TARGET_ENABLED)
+            add_subdirectory(core)
+            set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
+            set(LF_MAIN_TARGET <pyModuleName>)
+            find_package(Python <pyVersion> REQUIRED COMPONENTS Interpreter Development)
+            Python_add_library(
+                ${LF_MAIN_TARGET}
+                MODULE
+            """
             + cSources.collect(Collectors.joining("\n    ", "    ", "\n"))
             + """
-            )
-            if (MSVC)
-                set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
-                set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_SOURCE_DIR})
-                set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_SOURCE_DIR})
-                set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_SOURCE_DIR})
-                set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_SOURCE_DIR})
-            endif (MSVC)
-            set_target_properties(${LF_MAIN_TARGET} PROPERTIES PREFIX "")
-            include_directories(${Python_INCLUDE_DIRS})
-            target_link_libraries(${LF_MAIN_TARGET} PRIVATE ${Python_LIBRARIES})
-            target_compile_definitions(${LF_MAIN_TARGET} PUBLIC MODULE_NAME=<pyModuleName>)
-            """)
-            .replace("<pyModuleName>", generatePythonModuleName(executableName))
-            .replace("<pyVersion>", pyVersion);
+)
+if (MSVC)
+    set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
+    set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_SOURCE_DIR})
+    set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_SOURCE_DIR})
+    set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_SOURCE_DIR})
+    set_target_properties(${LF_MAIN_TARGET} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_SOURCE_DIR})
+endif (MSVC)
+set_target_properties(${LF_MAIN_TARGET} PROPERTIES PREFIX "")
+include_directories(${Python_INCLUDE_DIRS})
+target_link_libraries(${LF_MAIN_TARGET} PRIVATE ${Python_LIBRARIES})
+target_compile_definitions(${LF_MAIN_TARGET} PUBLIC MODULE_NAME=<pyModuleName>)
+""")
+        .replace("<pyModuleName>", generatePythonModuleName(executableName))
+        .replace("<pyVersion>", pyVersion);
     // The use of fileConfig.name will break federated execution, but that's fine
   }
 

--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -60,6 +60,7 @@ import org.lflang.target.property.TracePluginProperty;
 import org.lflang.target.property.TracingProperty;
 import org.lflang.target.property.VerifyProperty;
 import org.lflang.target.property.WorkersProperty;
+import org.lflang.target.property.PythonVersionProperty;
 
 /**
  * Enumeration of targets and their associated properties.
@@ -640,7 +641,8 @@ public enum Target {
               SingleThreadedProperty.INSTANCE,
               TracingProperty.INSTANCE,
               TracePluginProperty.INSTANCE,
-              WorkersProperty.INSTANCE);
+              WorkersProperty.INSTANCE,
+              PythonVersionProperty.INSTANCE);
       case Rust ->
           config.register(
               BuildTypeProperty.INSTANCE,

--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -49,6 +49,7 @@ import org.lflang.target.property.NoSourceMappingProperty;
 import org.lflang.target.property.PlatformProperty;
 import org.lflang.target.property.PrintStatisticsProperty;
 import org.lflang.target.property.ProtobufsProperty;
+import org.lflang.target.property.PythonVersionProperty;
 import org.lflang.target.property.Ros2DependenciesProperty;
 import org.lflang.target.property.Ros2Property;
 import org.lflang.target.property.RuntimeVersionProperty;
@@ -60,7 +61,6 @@ import org.lflang.target.property.TracePluginProperty;
 import org.lflang.target.property.TracingProperty;
 import org.lflang.target.property.VerifyProperty;
 import org.lflang.target.property.WorkersProperty;
-import org.lflang.target.property.PythonVersionProperty;
 
 /**
  * Enumeration of targets and their associated properties.

--- a/core/src/main/java/org/lflang/target/property/PythonVersionProperty.java
+++ b/core/src/main/java/org/lflang/target/property/PythonVersionProperty.java
@@ -1,19 +1,17 @@
 package org.lflang.target.property;
 
-/**
- * Directive for specifying a specific version of the reactor runtime library.
- */
+/** Directive for specifying a specific version of the reactor runtime library. */
 public final class PythonVersionProperty extends StringProperty {
 
-    /** Singleton target property instance. */
-    public static final PythonVersionProperty INSTANCE = new PythonVersionProperty();
+  /** Singleton target property instance. */
+  public static final PythonVersionProperty INSTANCE = new PythonVersionProperty();
 
-    private PythonVersionProperty() {
-        super();
-    }
+  private PythonVersionProperty() {
+    super();
+  }
 
-    @Override
-    public String name() {
-        return "python-version";
-    }
+  @Override
+  public String name() {
+    return "python-version";
+  }
 }

--- a/core/src/main/java/org/lflang/target/property/PythonVersionProperty.java
+++ b/core/src/main/java/org/lflang/target/property/PythonVersionProperty.java
@@ -1,0 +1,19 @@
+package org.lflang.target.property;
+
+/**
+ * Directive for specifying a specific version of the reactor runtime library.
+ */
+public final class PythonVersionProperty extends StringProperty {
+
+    /** Singleton target property instance. */
+    public static final PythonVersionProperty INSTANCE = new PythonVersionProperty();
+
+    private PythonVersionProperty() {
+        super();
+    }
+
+    @Override
+    public String name() {
+        return "python-version";
+    }
+}

--- a/core/src/main/java/org/lflang/target/property/PythonVersionProperty.java
+++ b/core/src/main/java/org/lflang/target/property/PythonVersionProperty.java
@@ -1,5 +1,9 @@
 package org.lflang.target.property;
 
+import org.lflang.MessageReporter;
+import org.lflang.lf.LfPackage.Literals;
+import org.lflang.target.TargetConfig;
+
 /** Directive for specifying a specific version of the reactor runtime library. */
 public final class PythonVersionProperty extends StringProperty {
 

--- a/core/src/main/java/org/lflang/target/property/PythonVersionProperty.java
+++ b/core/src/main/java/org/lflang/target/property/PythonVersionProperty.java
@@ -14,4 +14,18 @@ public final class PythonVersionProperty extends StringProperty {
   public String name() {
     return "python-version";
   }
+
+  @Override
+  public void validate(TargetConfig config, MessageReporter reporter) {
+    String version = config.get(PythonVersionProperty.INSTANCE);
+    if (!version.isEmpty() && !version.contains("3.10")) {
+      reporter
+          .at(config.lookup(this), Literals.KEY_VALUE_PAIR__NAME)
+          .warning(
+              "Python "
+                  + version
+                  + " is currently unsupported and untested. As such, it may fail in unexpected"
+                  + " ways.");
+    }
+  }
 }


### PR DESCRIPTION
This PR introduces a new target property `python-version` that allows users to explicitly specify the Python version to be used. 

Related Issues and PR:
[Issue #2298](https://github.com/lf-lang/lingua-franca/issues/2298)
[Issue #2299](https://github.com/lf-lang/lingua-franca/issues/2299)
[PR #2292](https://github.com/lf-lang/lingua-franca/pull/2292)

Example:
```
target Python {
  python-version: "3.9.10"
}
```

If `python-version` is not specified, the system will default to using Python 3.10 or newer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a specific Python version when generating Python code, defaulting to Python 3.10 or newer if no version is specified.

- **Improvements**
  - Updated the Python code generation process to allow more precise control over the Python interpreter version used, enhancing compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->