### PR TITLE
Fixed docker generation for images that use /bin/sh

### DIFF
--- a/core/src/main/java/org/lflang/generator/docker/DockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerGenerator.java
@@ -88,7 +88,7 @@ public abstract class DockerGenerator {
   protected List<String> getPreBuildCommand() {
     var script = context.getTargetConfig().get(DockerProperty.INSTANCE).preBuildScript();
     if (!script.isEmpty()) {
-      return List.of("source src-gen/" + StringEscapeUtils.escapeXSI(script));
+      return List.of(". src-gen/" + StringEscapeUtils.escapeXSI(script));
     }
     return List.of();
   }
@@ -97,7 +97,7 @@ public abstract class DockerGenerator {
   protected List<String> getPostBuildCommand() {
     var script = context.getTargetConfig().get(DockerProperty.INSTANCE).postBuildScript();
     if (!script.isEmpty()) {
-      return List.of("source src-gen/" + StringEscapeUtils.escapeXSI(script));
+      return List.of(". src-gen/" + StringEscapeUtils.escapeXSI(script));
     }
     return List.of();
   }
@@ -198,7 +198,7 @@ public abstract class DockerGenerator {
       return List.of(
           DockerOptions.DEFAULT_SHELL,
           "-c",
-          "source scripts/"
+          ". scripts/"
               + StringEscapeUtils.escapeXSI(script)
               + " && "
               + entryPoint().stream().collect(Collectors.joining(" ")));


### PR DESCRIPTION
Some images, like debian slim, use the `/bin/sh` which does not provide a `source` command. This PR replaces `source` with `.`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved script execution by updating command paths to use `.` instead of `source`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->