### PR TITLE
Fix for handling of target properties in imported files accessed through reactor class inheritance

### DIFF
--- a/core/src/main/java/org/lflang/generator/GeneratorBase.java
+++ b/core/src/main/java/org/lflang/generator/GeneratorBase.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.emf.ecore.EObject;
@@ -227,7 +228,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
     // to validate, which happens in setResources().
     setReactorsAndInstantiationGraph(context.getMode());
 
-    List<Resource> allResources = GeneratorUtils.getResources(reactors);
+    Set<Resource> allResources = GeneratorUtils.getResources(reactors);
 
     GeneratorUtils.accommodatePhysicalActionsIfPresent(
         allResources,
@@ -413,7 +414,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
    * Finds and transforms connections into forwarding reactions iff the connections have the same
    * destination as other connections or reaction in mutually exclusive modes.
    */
-  private void transformConflictingConnectionsInModalReactors(List<Resource> resources) {
+  private void transformConflictingConnectionsInModalReactors(Set<Resource> resources) {
     for (Resource r : resources) {
       var transform = ASTUtils.findConflictingConnectionsInModalReactors(r);
       if (!transform.isEmpty()) {

--- a/core/src/main/java/org/lflang/generator/GeneratorUtils.java
+++ b/core/src/main/java/org/lflang/generator/GeneratorUtils.java
@@ -2,7 +2,6 @@ package org.lflang.generator;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
-
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -80,7 +79,7 @@ public class GeneratorUtils {
   }
 
   /**
-   * Return the resources that provide the given reactors.
+   * Return the resources that provide the given reactors and their ancestors.
    *
    * @param reactors The reactors for which to find containing resources.
    * @return the resources that provide the given reactors.
@@ -96,7 +95,8 @@ public class GeneratorUtils {
     return visited;
   }
 
-  public static void addInheritedResources(Reactor reactor, Set<Resource> resources) {
+  /** Collect all resources associated with reactor through class inheritance. */
+  private static void addInheritedResources(Reactor reactor, Set<Resource> resources) {
     resources.add(reactor.eResource());
     for (var s : reactor.getSuperClasses()) {
       if (!resources.contains(s)) {

--- a/core/src/main/java/org/lflang/generator/GeneratorUtils.java
+++ b/core/src/main/java/org/lflang/generator/GeneratorUtils.java
@@ -87,8 +87,7 @@ public class GeneratorUtils {
   public static Set<Resource> getResources(Iterable<Reactor> reactors) {
     Set<Resource> visited = new LinkedHashSet<>();
     for (Reactor r : reactors) {
-      Resource resource = r.eResource();
-      if (!visited.contains(resource)) {
+      if (!visited.contains(r.eResource())) {
         addInheritedResources(r, visited);
       }
     }

--- a/test/C/src/target/ImportedCMakeInclude.lf
+++ b/test/C/src/target/ImportedCMakeInclude.lf
@@ -1,8 +1,12 @@
 target C {
-    timeout: 1ms
+  timeout: 1 ms
 }
+
 import Foo from "./CMakeInclude.lf"
-reactor Bar extends Foo { }
+
+reactor Bar extends Foo {
+}
+
 main reactor {
   r = new Foo()
 }

--- a/test/C/src/target/ImportedCMakeInclude.lf
+++ b/test/C/src/target/ImportedCMakeInclude.lf
@@ -1,0 +1,8 @@
+target C {
+    timeout: 1ms
+}
+import Foo from "./CMakeInclude.lf"
+reactor Bar extends Foo { }
+main reactor {
+  r = new Foo()
+}


### PR DESCRIPTION
Fixes #2286.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `ImportedCMakeInclude.lf` to support importing and extending reactor definitions with a timeout mechanism.

- **Improvements**
  - Enhanced resource management by switching from `List` to `Set`, ensuring unique resources and improving efficiency in `GeneratorBase` and `GeneratorUtils`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->