### PR TITLE
Renaming `Latest Tag Completed` to `Latest Tag Confirmed`

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -635,7 +635,7 @@ public class CGenerator extends GeneratorBase {
               "\n",
               "void logical_tag_complete(tag_t tag_to_send) {",
               CExtensionUtils.surroundWithIfElseFederatedCentralized(
-                  "    lf_latest_tag_complete(tag_to_send);", "    (void) tag_to_send;"),
+                  "    lf_latest_tag_confirmed(tag_to_send);", "    (void) tag_to_send;"),
               "}"));
 
       // Generate an empty termination function for non-federated


### PR DESCRIPTION
This PR is a companion to [lf-lang/reactor-c#445](https://github.com/lf-lang/reactor-c/pull/445). This PR simply renames the name of the LTC signal.