### PR TITLE
Platform name changed from `Nrf52` to `nRF52`

### DIFF
--- a/core/src/main/java/org/lflang/target/property/type/PlatformType.java
+++ b/core/src/main/java/org/lflang/target/property/type/PlatformType.java
@@ -13,7 +13,7 @@ public class PlatformType extends OptionsType<Platform> {
   public enum Platform {
     AUTO,
     ARDUINO, // FIXME: not multithreaded
-    NRF52("Nrf52", false),
+    NRF52("nRF52", false),
     RP2040("Rp2040", true),
     LINUX("Linux", true),
     MAC("Darwin", true),


### PR DESCRIPTION
This PR changes the capitalization of `nRF52` to match what is used for CMake in reactor-c and what is the standard capitalization for this device.