### PR TITLE
Define self variable so it can be used in instantiations

### DIFF
--- a/core/src/main/java/org/lflang/generator/python/PythonReactorGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonReactorGenerator.java
@@ -124,10 +124,10 @@ public class PythonReactorGenerator {
       // Non-bank reactor instances will be a list of size 1.
       String fullName = instance.getFullName();
       code.pr(
-              String.join(
-                      "\n",
-                      "# Start initializing " + fullName + " of class " + className,
-                      "for " + PyUtil.bankIndexName(instance) + " in range(" + instance.getWidth() + "):"));
+          String.join(
+              "\n",
+              "# Start initializing " + fullName + " of class " + className,
+              "for " + PyUtil.bankIndexName(instance) + " in range(" + instance.getWidth() + "):"));
       code.indent();
       // Define a bank_index local variable so that it can be used while
       // setting parameter values.

--- a/test/Python/src/BankIndex.lf
+++ b/test/Python/src/BankIndex.lf
@@ -1,0 +1,14 @@
+target Python;
+reactor A(bank_index = 0, value = 0) {
+  reaction (startup) {=
+    print("bank_index: {:d}, value: {:d}".format(self.bank_index, self.value))
+    if (self.value != 4 - self.bank_index):
+      sys.stderr.write("ERROR: Expected value to be 3 - bank_index.\n")
+      exit(1)
+  =}
+}
+main reactor(
+  table = [4, 3, 2, 1]
+) {
+  a = new[4] A(value = {= self.table[bank_index] =})
+}

--- a/test/Python/src/BankIndex.lf
+++ b/test/Python/src/BankIndex.lf
@@ -4,7 +4,7 @@ reactor A(bank_index=0, value=0) {
   reaction(startup) {=
     print("bank_index: {:d}, value: {:d}".format(self.bank_index, self.value))
     if (self.value != 4 - self.bank_index):
-      sys.stderr.write("ERROR: Expected value to be 3 - bank_index.\n")
+      sys.stderr.write("ERROR: Expected value to be 4 - bank_index.\n")
       exit(1)
   =}
 }

--- a/test/Python/src/BankIndex.lf
+++ b/test/Python/src/BankIndex.lf
@@ -1,14 +1,14 @@
-target Python;
-reactor A(bank_index = 0, value = 0) {
-  reaction (startup) {=
+target Python
+
+reactor A(bank_index=0, value=0) {
+  reaction(startup) {=
     print("bank_index: {:d}, value: {:d}".format(self.bank_index, self.value))
     if (self.value != 4 - self.bank_index):
       sys.stderr.write("ERROR: Expected value to be 3 - bank_index.\n")
       exit(1)
   =}
 }
-main reactor(
-  table = [4, 3, 2, 1]
-) {
+
+main reactor(table = [4, 3, 2, 1]) {
   a = new[4] A(value = {= self.table[bank_index] =})
 }


### PR DESCRIPTION
In the Python target, when setting parameters of an instance, it is not possible in native initializer code to reference the parameters of the container. This PR fixes that and adds a test.