### PR TITLE
Fixed build script support in C++ docker generation

### DIFF
--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppGenerator.kt
@@ -96,6 +96,7 @@ class CppGenerator(
             )
             if (targetConfig.get(DockerProperty.INSTANCE).enabled) {
                 copySrcGenBaseDirIntoDockerDir()
+                FileUtil.copyDirectoryContents(context.fileConfig.srcPkgPath.resolve("src"), context.fileConfig.srcGenPath.resolve("src"), true)
                 buildUsingDocker()
             } else {
                 if (platformGenerator.doCompile(context)) {

--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppRos2Generator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppRos2Generator.kt
@@ -116,7 +116,7 @@ class CppRos2Generator(generator: CppGenerator) : CppPlatformGenerator(generator
             if (script.isNotEmpty()) {
                 return mutableListOf(". src/" + StringEscapeUtils.escapeXSI(script))
             }
-            return mutableListOf(".", "/opt/ros/rolling/setup.sh")
+            return mutableListOf(". /opt/ros/rolling/setup.sh")
         }
 
         override fun getPostBuildCommand(): MutableList<String> {

--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppRos2Generator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppRos2Generator.kt
@@ -1,9 +1,9 @@
 package org.lflang.generator.cpp
 
+import org.apache.commons.text.StringEscapeUtils
 import org.lflang.generator.LFGeneratorContext
 import org.lflang.generator.docker.DockerGenerator
 import org.lflang.target.property.DockerProperty
-import org.lflang.toUnixString
 import org.lflang.util.FileUtil
 import java.nio.file.Path
 
@@ -83,6 +83,7 @@ class CppRos2Generator(generator: CppGenerator) : CppPlatformGenerator(generator
     inner class CppDockerGenerator(context: LFGeneratorContext?) : DockerGenerator(context) {
         override fun generateCopyForSources() =
             """
+                COPY src src
                 COPY src-gen src-gen
                 COPY bin bin
             """.trimIndent()
@@ -104,11 +105,26 @@ class CppRos2Generator(generator: CppGenerator) : CppPlatformGenerator(generator
 
         override fun defaultBuildCommands(): List<String> {
             val commands = listOf(
-                listOf(".", "/opt/ros/rolling/setup.sh"),
                 listOf("mkdir", "-p", "build"),
                 listOf("colcon") + colconArgs(),
             )
             return commands.map { argListToCommand(it) }
+        }
+
+        override fun getPreBuildCommand(): MutableList<String> {
+            val script = context.targetConfig.get(DockerProperty.INSTANCE).preBuildScript
+            if (script.isNotEmpty()) {
+                return mutableListOf(". src/" + StringEscapeUtils.escapeXSI(script))
+            }
+            return mutableListOf(".", "/opt/ros/rolling/setup.sh")
+        }
+
+        override fun getPostBuildCommand(): MutableList<String> {
+            val script = context.targetConfig.get(DockerProperty.INSTANCE).postBuildScript
+            if (script.isNotEmpty()) {
+                return mutableListOf(". src/" + StringEscapeUtils.escapeXSI(script))
+            }
+            return mutableListOf()
         }
     }
 


### PR DESCRIPTION
This fix implements proper support for pre and post build scripts in the C++ targets and ensures that the src directory is available in the container