### PR TITLE
Effects made accessible in watchdog handlers

### DIFF
--- a/core/src/main/java/org/lflang/diagram/synthesis/util/ReactorIcons.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/util/ReactorIcons.java
@@ -106,7 +106,7 @@ public class ReactorIcons extends AbstractSynthesisExtensions {
         //                if (error != null) {
         //                    var errorText = _kContainerRenderingExtensions.addText(rendering,
         // "Icon not found!\n"+error);
-        //                    _kRenderingExtensions.setForeground(errorText, Colors.RED);
+        //                    _kRenderingExtensions.setForeground(errorText, Colors.BLUE);
         //                    _kRenderingExtensions.setFontBold(errorText, true);
         //                    _kRenderingExtensions.setSurroundingSpaceGrid(errorText, 8, 0);
         //                }

--- a/core/src/main/java/org/lflang/diagram/synthesis/util/ReactorIcons.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/util/ReactorIcons.java
@@ -106,7 +106,7 @@ public class ReactorIcons extends AbstractSynthesisExtensions {
         //                if (error != null) {
         //                    var errorText = _kContainerRenderingExtensions.addText(rendering,
         // "Icon not found!\n"+error);
-        //                    _kRenderingExtensions.setForeground(errorText, Colors.BLUE);
+        //                    _kRenderingExtensions.setForeground(errorText, Colors.RED);
         //                    _kRenderingExtensions.setFontBold(errorText, true);
         //                    _kRenderingExtensions.setSurroundingSpaceGrid(errorText, 8, 0);
         //                }

--- a/core/src/main/java/org/lflang/generator/WatchdogInstance.java
+++ b/core/src/main/java/org/lflang/generator/WatchdogInstance.java
@@ -9,7 +9,10 @@
 package org.lflang.generator;
 
 import org.lflang.TimeValue;
-import org.lflang.lf.Watchdog;
+import org.lflang.lf.*;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Instance of a watchdog. Upon creation the actual delay is converted into a proper time value. If
@@ -33,6 +36,17 @@ public class WatchdogInstance extends TriggerInstance<Watchdog> {
     this.name = definition.getName().toString();
     this.definition = definition;
     this.reactor = reactor;
+    for (VarRef effect : definition.getEffects()) {
+      Variable variable = effect.getVariable();
+      if (variable instanceof Action) {
+        // Effect is an Action.
+        var actionInstance = reactor.lookupActionInstance((Action) variable);
+        if (actionInstance != null) this.effects.add(actionInstance);
+      } else {
+        // Effect is either a mode or an unresolved reference.
+        // Do nothing, transitions will be set up by the ModeInstance.
+      }
+    }
   }
 
   //////////////////////////////////////////////////////
@@ -58,6 +72,12 @@ public class WatchdogInstance extends TriggerInstance<Watchdog> {
   public String toString() {
     return "WatchdogInstance " + name + "(" + timeout.toString() + ")";
   }
+
+  //////////////////////////////////////////////////////
+  //// Public fields.
+
+  /** The ports or actions that this reaction may write to. */
+  public Set<TriggerInstance<? extends Variable>> effects = new LinkedHashSet<>();
 
   //////////////////////////////////////////////////////
   //// Private fields.

--- a/core/src/main/java/org/lflang/generator/WatchdogInstance.java
+++ b/core/src/main/java/org/lflang/generator/WatchdogInstance.java
@@ -8,17 +8,19 @@
  */
 package org.lflang.generator;
 
-import org.lflang.TimeValue;
-import org.lflang.lf.*;
-
 import java.util.LinkedHashSet;
 import java.util.Set;
+import org.lflang.TimeValue;
+import org.lflang.lf.Action;
+import org.lflang.lf.VarRef;
+import org.lflang.lf.Variable;
+import org.lflang.lf.Watchdog;
 
 /**
  * Instance of a watchdog. Upon creation the actual delay is converted into a proper time value. If
  * a parameter is referenced, it is looked up in the given (grand)parent reactor instance.
  *
- * @author{Benjamin Asch <benjamintasch@berkeley.edu>}
+ * @author Benjamin Asch
  */
 public class WatchdogInstance extends TriggerInstance<Watchdog> {
 
@@ -33,7 +35,7 @@ public class WatchdogInstance extends TriggerInstance<Watchdog> {
       this.timeout = TimeValue.ZERO;
     }
 
-    this.name = definition.getName().toString();
+    this.name = definition.getName();
     this.definition = definition;
     this.reactor = reactor;
     for (VarRef effect : definition.getEffects()) {
@@ -42,10 +44,8 @@ public class WatchdogInstance extends TriggerInstance<Watchdog> {
         // Effect is an Action.
         var actionInstance = reactor.lookupActionInstance((Action) variable);
         if (actionInstance != null) this.effects.add(actionInstance);
-      } else {
-        // Effect is either a mode or an unresolved reference.
-        // Do nothing, transitions will be set up by the ModeInstance.
       }
+      // Otherwise, do nothing (effect is either a mode or an unresolved reference).
     }
   }
 
@@ -61,7 +61,7 @@ public class WatchdogInstance extends TriggerInstance<Watchdog> {
   }
 
   public TimeValue getTimeout() {
-    return (TimeValue) this.timeout;
+    return this.timeout;
   }
 
   public ReactorInstance getReactor() {

--- a/core/src/main/java/org/lflang/generator/c/CWatchdogGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CWatchdogGenerator.java
@@ -177,13 +177,10 @@ public class CWatchdogGenerator {
 
     // Define the "self" struct.
     String structType = CUtil.selfType(tpr);
-    code.pr(
-        String.join(
-            "\n",
-            structType
-                + "* self = ("
-                + structType
-                + "*)instance_args; SUPPRESS_UNUSED_WARNING(self);"));
+    code.pr(structType
+        + "* self = ("
+        + structType
+        + "*)instance_args; SUPPRESS_UNUSED_WARNING(self);");
 
     // Declare mode if in effects field of watchdog
     if (watchdog.getEffects() != null) {

--- a/core/src/main/java/org/lflang/generator/c/CWatchdogGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CWatchdogGenerator.java
@@ -177,10 +177,8 @@ public class CWatchdogGenerator {
 
     // Define the "self" struct.
     String structType = CUtil.selfType(tpr);
-    code.pr(structType
-        + "* self = ("
-        + structType
-        + "*)instance_args; SUPPRESS_UNUSED_WARNING(self);");
+    code.pr(
+        structType + "* self = (" + structType + "*)instance_args; SUPPRESS_UNUSED_WARNING(self);");
 
     // Declare mode if in effects field of watchdog
     if (watchdog.getEffects() != null) {

--- a/core/src/main/java/org/lflang/scoping/LFScopeProviderImpl.java
+++ b/core/src/main/java/org/lflang/scoping/LFScopeProviderImpl.java
@@ -49,6 +49,7 @@ import org.lflang.lf.Reaction;
 import org.lflang.lf.Reactor;
 import org.lflang.lf.ReactorDecl;
 import org.lflang.lf.VarRef;
+import org.lflang.lf.Watchdog;
 
 /**
  * This class enforces custom rules. In particular, it resolves references to parameters, ports,
@@ -272,6 +273,11 @@ public class LFScopeProviderImpl extends AbstractLFScopeProvider {
         return RefType.CLEFT;
       } else if (conn.getRightPorts().contains(variable)) {
         return RefType.CRIGHT;
+      }
+    } else if (variable.eContainer() instanceof Watchdog) {
+      var watchdog = (Watchdog) variable.eContainer();
+      if (watchdog.getEffects().contains(variable)) {
+        return RefType.EFFECT;
       }
     }
     return RefType.NULL;

--- a/test/C/src/concurrent/Watchdog.lf
+++ b/test/C/src/concurrent/Watchdog.lf
@@ -10,7 +10,7 @@ target C {
 }
 
 reactor Watcher(timeout: time = 1500 ms) {
-  // Offset ameliorates startup time.
+  // Offset may reduce the likelihood of flakiness if long startup times occur.
   timer t(1 s, 1 s)
   // Period has to be smaller than watchdog timeout. Produced if the watchdog triggers.
   output d: int

--- a/test/C/src/concurrent/WatchdogAction.lf
+++ b/test/C/src/concurrent/WatchdogAction.lf
@@ -1,0 +1,74 @@
+/**
+ * Test watchdog. This test starts a watchdog timer of 1500ms every 1s. Half the time, it then
+ * sleeps after starting the watchdog so that the watchdog expires. There should be a total of two
+ * watchdog expirations. This version uses an action instead of a reaction to the watchdog.
+ * @author Benjamin Asch
+ * @author Edward A. Lee
+ */
+target C {
+  timeout: 11000 ms
+}
+
+reactor Watcher(timeout: time = 1500 ms) {
+  // Offset ameliorates startup time.
+  timer t(1 s, 1 s)
+  // Period has to be smaller than watchdog timeout. Produced if the watchdog triggers.
+  output d: int
+  state count: int = 0
+  logical action a
+
+  watchdog poodle(timeout) -> a {=
+    instant_t p = lf_time_physical_elapsed();
+    lf_print("******** Watchdog timed out at elapsed physical time: " PRINTF_TIME, p);
+    self->count++;
+    lf_schedule(a, 0);
+  =}
+
+  reaction(t) -> poodle, d {=
+    lf_watchdog_start(poodle, 0);
+    lf_print("Watchdog started at physical time " PRINTF_TIME, lf_time_physical_elapsed());
+    lf_print("Will expire at " PRINTF_TIME, lf_time_logical_elapsed() + self->timeout);
+    lf_set(d, 42);
+  =}
+
+  reaction(a) -> d {=
+    lf_print("Reaction poodle was called.");
+    lf_set(d, 1);
+  =}
+
+  reaction(shutdown) -> poodle {=
+    lf_watchdog_stop(poodle);
+    // Watchdog may expire in tests even without the sleep, but it should at least expire twice.
+    if (self->count < 2) {
+      lf_print_error_and_exit("Watchdog expired %d times. Expected at least 2.", self->count);
+    }
+  =}
+}
+
+main reactor {
+  logical action a
+  state count: int = 0
+
+  w = new Watcher()
+
+  reaction(startup) {=
+    if (NUMBER_OF_WATCHDOGS != 1) {
+      lf_print_error_and_exit("NUMBER_OF_WATCHDOGS was %d", NUMBER_OF_WATCHDOGS);
+    }
+  =}
+
+  reaction(w.d) {=
+    lf_print("Watcher reactor produced an output. %d", self->count % 2);
+    self->count++;
+    if (self->count % 4 == 0) {
+      lf_print(">>>>>> Taking a long time to process that output!");
+      lf_sleep(MSEC(1600));
+    }
+  =}
+
+  reaction(shutdown) {=
+    if (self->count < 12) {
+      lf_print_error_and_exit("Watchdog produced output %d times. Expected at least 12.", self->count);
+    }
+  =}
+}

--- a/test/C/src/concurrent/WatchdogAction.lf
+++ b/test/C/src/concurrent/WatchdogAction.lf
@@ -10,7 +10,7 @@ target C {
 }
 
 reactor Watcher(timeout: time = 1500 ms) {
-  // Offset ameliorates startup time.
+  // Offset may reduce the likelihood of flakiness if long startup times occur.
   timer t(1 s, 1 s)
   // Period has to be smaller than watchdog timeout. Produced if the watchdog triggers.
   output d: int


### PR DESCRIPTION
The grammar allows effects to be specified for a watchdog, but the compiler wasn't resolving effects correctly and the code generator needed to be updated to ensure that effects are brought into scope. This PR also updates the diagram synthesis to render watchdog effects correctly.