### PR TITLE
Do not require libexecinfo in C++ docker images

### DIFF
--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppStandaloneCmakeGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppStandaloneCmakeGenerator.kt
@@ -153,8 +153,6 @@ class CppStandaloneCmakeGenerator(private val targetConfig: TargetConfig, privat
                 |cmake_minimum_required(VERSION 3.5)
                 |project(${fileConfig.name} VERSION 0.0.0 LANGUAGES CXX)
                 |
-                |option(REACTOR_CPP_LINK_EXECINFO "Link against execinfo" OFF)
-                |
                 |${if (targetConfig.get(ExternalRuntimePathProperty.INSTANCE) != null) "find_package(reactor-cpp PATHS ${targetConfig.get(ExternalRuntimePathProperty.INSTANCE)})" else ""}
                 |
                 |set(LF_MAIN_TARGET ${fileConfig.name})
@@ -168,10 +166,6 @@ class CppStandaloneCmakeGenerator(private val targetConfig: TargetConfig, privat
                 |    "$S{PROJECT_SOURCE_DIR}/__include__"
                 |)
                 |target_link_libraries($S{LF_MAIN_TARGET} $reactorCppTarget)
-                |
-                |if(REACTOR_CPP_LINK_EXECINFO)
-                |  target_link_libraries($S{LF_MAIN_TARGET} execinfo)
-                |endif()
                 |
                 |if(MSVC)
                 |  target_compile_options($S{LF_MAIN_TARGET} PRIVATE /W4)

--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppStandaloneGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppStandaloneGenerator.kt
@@ -177,9 +177,8 @@ class CppStandaloneGenerator(generator: CppGenerator) :
     private fun getCmakeArgs(
         buildPath: Path,
         outPath: Path,
-        additionalCmakeArgs: List<String> = listOf(),
         sourcesRoot: String? = null
-    ) = cmakeArgs + additionalCmakeArgs + listOf(
+    ) = cmakeArgs + listOf(
         "-DCMAKE_INSTALL_PREFIX=${outPath.toUnixString()}",
         "-DCMAKE_INSTALL_BINDIR=$relativeBinDir",
         "-S",
@@ -191,12 +190,11 @@ class CppStandaloneGenerator(generator: CppGenerator) :
     private fun createCmakeCommand(
         buildPath: Path,
         outPath: Path,
-        additionalCmakeArgs: List<String> = listOf(),
         sourcesRoot: String? = null
     ): LFCommand {
         val cmd = commandFactory.createCommand(
             "cmake",
-            getCmakeArgs(buildPath, outPath, additionalCmakeArgs, sourcesRoot),
+            getCmakeArgs(buildPath, outPath, sourcesRoot),
             buildPath.parent
         )
 
@@ -219,9 +217,7 @@ class CppStandaloneGenerator(generator: CppGenerator) :
 
         override fun generateRunForInstallingDeps(): String {
             return if (builderBase() == defaultImage()) {
-                ("RUN set -ex && apk add --no-cache g++ musl-dev cmake make && apk add --no-cache"
-                        + " --update --repository=https://dl-cdn.alpinelinux.org/alpine/v3.16/main/"
-                        + " libexecinfo-dev")
+                ("RUN set -ex && apk add --no-cache g++ musl-dev cmake make")
             } else {
                 "# (Skipping installation of build dependencies; custom base image.)"
             }
@@ -246,7 +242,6 @@ class CppStandaloneGenerator(generator: CppGenerator) :
                 listOf("cmake") + getCmakeArgs(
                     Path.of("./build"),
                     Path.of("."),
-                    listOf("-DREACTOR_CPP_LINK_EXECINFO=ON"),
                     "src-gen"
                 ),
                 listOf("cmake") + getMakeArgs(fileConfig.buildPath, true, fileConfig.name),


### PR DESCRIPTION
Alpine has dropped support for libexecinfo since version 3.17. This PR pulls in https://github.com/lf-lang/reactor-cpp/pull/59 which makes the compilation of reactor-cpp more robust, so that it can handle if backtrace support is not available or provided by an alternative implementation. Consequently, we can remove the current workarounds in the LF code generator for docker builds.