### PR TITLE
RTI Docker Hub Continuous Deployment with Multiplatform Support

### DIFF
--- a/.github/actions/push-rti-docker/action.yml
+++ b/.github/actions/push-rti-docker/action.yml
@@ -1,0 +1,35 @@
+name: Push RTI to Docker Hub
+description: Build and push the RTI image to Docker Hub
+inputs:
+  tag:
+    description: 'The tag of the RTI image to build and push'
+    required: true
+    default: 'latest'
+  DOCKERHUB_USERNAME:
+    description: 'The username to log in to Docker Hub'
+    required: true
+  DOCKERHUB_TOKEN:
+    description: 'The token to log in to Docker Hub'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.DOCKERHUB_USERNAME }}
+        password: ${{ inputs.DOCKERHUB_TOKEN }}
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Check out lingua-franca repository
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        file: ./core/src/main/resources/lib/c/reactor-c/core/federated/RTI/rti.Dockerfile
+        context: ./core/src/main/resources/lib/c/reactor-c
+        push: true
+        tags: lflang/rti:${{ inputs.tag }}

--- a/.github/actions/push-rti-docker/action.yml
+++ b/.github/actions/push-rti-docker/action.yml
@@ -31,5 +31,6 @@ runs:
       with:
         file: ./core/src/main/resources/lib/c/reactor-c/core/federated/RTI/rti.Dockerfile
         context: ./core/src/main/resources/lib/c/reactor-c
+        platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/riscv64
         push: true
         tags: lflang/rti:${{ inputs.tag }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -41,3 +41,9 @@ jobs:
           title: "Lingua Franca Nightly"
           files: |
             build/distributions/*
+      - name: Build and push RTI to Docker Hub
+        uses: ./.github/actions/push-rti-docker
+        with:
+          tag: nightly
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -41,9 +41,3 @@ jobs:
           title: "Lingua Franca Nightly"
           files: |
             build/distributions/*
-      - name: Build and push RTI to Docker Hub
-        uses: ./.github/actions/push-rti-docker
-        with:
-          tag: nightly
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/rti-docker.yml
+++ b/.github/workflows/rti-docker.yml
@@ -1,0 +1,23 @@
+name: Push RTI Image to Docker Hub
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    name: Build and push RTI to Docker Hub
+    steps:
+      - name: Check out lingua-franca repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Build and push RTI to Docker Hub
+        uses: ./.github/actions/push-rti-docker
+        with:
+          tag: master
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/rti-docker.yml
+++ b/.github/workflows/rti-docker.yml
@@ -15,9 +15,16 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+      - name: Check Lingua Franca Version
+        id: check_version
+        run: |
+          export LF_VERSION=$(cat core/src/main/resources/org/lflang/StringsBundle.properties | sed 's/VERSION = \([0-9]*\.[0-9]*\.[0-9]*\)-SNAPSHOT/\1/')
+          echo "lf_version=$LF_VERSION"
+          echo "lf_version=$LF_VERSION" >> $GITHUB_ENV
+
       - name: Build and push RTI to Docker Hub
         uses: ./.github/actions/push-rti-docker
         with:
-          tag: master
+          tag: ${{ env.lf_version }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/rti-docker.yml
+++ b/.github/workflows/rti-docker.yml
@@ -15,13 +15,11 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-      - name: Check Lingua Franca Version
-        id: check_version
+      - name: Look up the current version and export as environment variable
         run: |
-          export LF_VERSION=$(cat core/src/main/resources/org/lflang/StringsBundle.properties | sed 's/VERSION = \([0-9]*\.[0-9]*\.[0-9]*\)-SNAPSHOT/\1/')
+          export LF_VERSION=$(cat core/src/main/resources/org/lflang/StringsBundle.properties | sed -n 's/.*VERSION = \(.*\)/\1/p' | tr '[:upper:]' '[:lower:]')
           echo "lf_version=$LF_VERSION"
           echo "lf_version=$LF_VERSION" >> $GITHUB_ENV
-
       - name: Build and push RTI to Docker Hub
         uses: ./.github/actions/push-rti-docker
         with:

--- a/core/src/main/java/org/lflang/target/property/DockerProperty.java
+++ b/core/src/main/java/org/lflang/target/property/DockerProperty.java
@@ -1,5 +1,6 @@
 package org.lflang.target.property;
 
+import org.lflang.LocalStrings;
 import org.lflang.MessageReporter;
 import org.lflang.ast.ASTUtils;
 import org.lflang.lf.Element;
@@ -149,7 +150,8 @@ public final class DockerProperty extends TargetProperty<DockerOptions, UnionTyp
       String dockerConfigFile) {
 
     /** Default location to pull the rti from. */
-    public static final String DOCKERHUB_RTI_IMAGE = "lflang/rti:rti";
+    public static final String DOCKERHUB_RTI_IMAGE =
+        "lflang/rti:" + LocalStrings.VERSION.toLowerCase();
 
     public static final String DEFAULT_SHELL = "/bin/sh";
 

--- a/test/Python/src/docker/FilesPropertyContainerized.lf
+++ b/test/Python/src/docker/FilesPropertyContainerized.lf
@@ -1,6 +1,8 @@
 target Python {
   files: "../include/hello.py",
-  docker: true
+  docker: {
+    rti-image: "rti:local"
+  }
 }
 
 preamble {=

--- a/test/Python/src/docker/HelloWorldContainerized.lf
+++ b/test/Python/src/docker/HelloWorldContainerized.lf
@@ -1,5 +1,7 @@
 target Python {
-  docker: true
+  docker: {
+    rti-image: "rti:local"
+  }
 }
 
 import HelloWorld2 from "../HelloWorld.lf"

--- a/test/Python/src/docker/PingPongContainerized.lf
+++ b/test/Python/src/docker/PingPongContainerized.lf
@@ -19,7 +19,9 @@
  */
 target Python {
   fast: true,
-  docker: true
+  docker: {
+    rti-image: "rti:local"
+  }
 }
 
 import Ping from "../PingPong.lf"

--- a/test/Python/src/docker/federated/DistributedCountContainerized.lf
+++ b/test/Python/src/docker/federated/DistributedCountContainerized.lf
@@ -8,7 +8,9 @@ target Python {
   timeout: 5 sec,
   logging: DEBUG,
   coordination: centralized,
-  docker: true
+  docker: {
+    rti-image: "rti:local"
+  }
 }
 
 import Count from "../../lib/Count.lf"

--- a/test/Python/src/docker/federated/DistributedMultiportContainerized.lf
+++ b/test/Python/src/docker/federated/DistributedMultiportContainerized.lf
@@ -2,7 +2,9 @@
 target Python {
   timeout: 1 sec,
   coordination: centralized,
-  docker: true
+  docker: {
+    rti-image: "rti:local"
+  }
 }
 
 import Source, Destination from "../../federated/DistributedMultiport.lf"

--- a/test/Python/src/docker/federated/DistributedSendClassContainerized.lf
+++ b/test/Python/src/docker/federated/DistributedSendClassContainerized.lf
@@ -1,6 +1,8 @@
 target Python {
   coordination: centralized,
-  docker: true
+  docker: {
+    rti-image: "rti:local"
+  }
 }
 
 import A, B from "../../federated/DistributedSendClass.lf"


### PR DESCRIPTION
This PR partially resolves https://github.com/lf-lang/reactor-c/issues/470 by continuously deploying RTI images on Docker Hub with `nightly` and `master` tag.

- RTI image with `nightly` tag is deployed to Docker Hub along publishing the nightly release.
- RTI image with `master` tag is deployed to Docker Hub when a new commit is pushed to the `master` branch. This happens when a PR is merged.

To facilitate the continuous deployment process, two GitHub secrets need to be added:

- DOCKERHUB_USERNAME: Docker Hub username, in this case it should be an account with push access to `lflang/rti`
- DOCKERHUB_TOKEN: Corresponding [Docker Hub Access Token](https://docs.docker.com/security/for-developers/access-tokens/).

The RTI image is built for the following platforms:

- linux/amd64
- linux/arm64
- linux/arm/v7
- linux/riscv64