### PR TITLE
Update latest rti image for released versions

### DIFF
--- a/.github/workflows/rti-docker.yml
+++ b/.github/workflows/rti-docker.yml
@@ -32,4 +32,4 @@ jobs:
           tag: latest
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: ${{ env.lf_version != *-snapshot }}
+        if: ${{ !endsWith(env.lf_version, '-snapshot') }}

--- a/.github/workflows/rti-docker.yml
+++ b/.github/workflows/rti-docker.yml
@@ -26,3 +26,10 @@ jobs:
           tag: ${{ env.lf_version }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Update latest (released versions only)
+        uses: ./.github/actions/push-rti-docker
+        with:
+          tag: latest
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: ${{ env.lf_version != *-snapshot }}


### PR DESCRIPTION
Upon release, a push to master happens with a version number that does not end with "-snapshot". When this occurs, also update the image associated with the "latest" tag.