### PR TITLE
Matching image digest between `latest` tag and latest release tag of `rti` image on DockerHub

### DIFF
--- a/.github/actions/push-rti-docker/action.yml
+++ b/.github/actions/push-rti-docker/action.yml
@@ -11,6 +11,9 @@ inputs:
   DOCKERHUB_TOKEN:
     description: 'The token to log in to Docker Hub'
     required: true
+  latest:
+    description: 'Also push as latest tag if true'
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -34,3 +37,13 @@ runs:
         platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/riscv64
         push: true
         tags: lflang/rti:${{ inputs.tag }}
+      if: ${{ inputs.latest == 'false' }}
+    - name: Build and push as latest
+      uses: docker/build-push-action@v6
+      with:
+        file: ./core/src/main/resources/lib/c/reactor-c/core/federated/RTI/rti.Dockerfile
+        context: ./core/src/main/resources/lib/c/reactor-c
+        platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/riscv64
+        push: true
+        tags: lflang/rti:${{ inputs.tag }}, lflang/rti:latest
+      if: ${{ inputs.latest == 'true' }}

--- a/.github/workflows/rti-docker.yml
+++ b/.github/workflows/rti-docker.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   workflow_dispatch:
+  workflow_call:
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -13,6 +15,7 @@ jobs:
       - name: Check out lingua-franca repository
         uses: actions/checkout@v3
         with:
+          repository: lf-lang/lingua-franca
           submodules: recursive
           fetch-depth: 0
       - name: Look up the current version and export as environment variable

--- a/.github/workflows/rti-docker.yml
+++ b/.github/workflows/rti-docker.yml
@@ -27,12 +27,16 @@ jobs:
         uses: ./.github/actions/push-rti-docker
         with:
           tag: ${{ env.lf_version }}
+          latest: false
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: ${{ endsWith(env.lf_version, '-snapshot') }}
+
       - name: Update latest (released versions only)
         uses: ./.github/actions/push-rti-docker
         with:
-          tag: latest
+          tag: ${{ env.lf_version }}
+          latest: true
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         if: ${{ !endsWith(env.lf_version, '-snapshot') }}


### PR DESCRIPTION
Match RTI docker image digest by building only once and push to Docker Hub as two tags when doing release