### PR TITLE
Prevent hanging on waiting for timeout time

### DIFF
--- a/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
@@ -73,6 +73,11 @@ public class CExtensionUtils {
                 + "] = (lf_action_base_t*)&"
                 + trigger
                 + "; \\");
+        // Set the ID of the source federate.
+        code.pr(
+                trigger + ".source_id = "
+                + federate.networkMessageSourceFederate.get(i).id
+                + "; \\");
         if (federate.zeroDelayCycleNetworkMessageActions.contains(action)) {
           code.pr(
               "_lf_zero_delay_cycle_action_table["

--- a/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
@@ -75,9 +75,7 @@ public class CExtensionUtils {
                 + "; \\");
         // Set the ID of the source federate.
         code.pr(
-                trigger + ".source_id = "
-                + federate.networkMessageSourceFederate.get(i).id
-                + "; \\");
+            trigger + ".source_id = " + federate.networkMessageSourceFederate.get(i).id + "; \\");
         if (federate.zeroDelayCycleNetworkMessageActions.contains(action)) {
           code.pr(
               "_lf_zero_delay_cycle_action_table["

--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -284,6 +284,7 @@ public class FedASTUtils {
 
     // Keep track of this action in the destination federate.
     connection.dstFederate.networkMessageActions.add(networkAction);
+    connection.dstFederate.networkMessageSourceFederate.add(connection.srcFederate);
     connection.dstFederate.networkMessageActionDelays.add(connection.getDefinition().getDelay());
     if (connection.srcFederate.isInZeroDelayCycle()
         && connection.getDefinition().getDelay() == null)

--- a/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
+++ b/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
@@ -172,6 +172,11 @@ public class FederateInstance {
   public List<Action> networkMessageActions = new ArrayList<>();
 
   /**
+   * List of source federate IDs for networkMessage actions.
+   */
+  public List<FederateInstance> networkMessageSourceFederate = new ArrayList<>();
+
+  /**
    * List of after delay values of the corresponding entries of {@code networkMessageActions}. These
    * will be {@code null} in the case of zero-delay connections and {@code 0} in the case of
    * microstep-delay connections.

--- a/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
+++ b/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
@@ -171,9 +171,7 @@ public class FederateInstance {
    */
   public List<Action> networkMessageActions = new ArrayList<>();
 
-  /**
-   * List of source federate IDs for networkMessage actions.
-   */
+  /** List of source federate IDs for networkMessage actions. */
   public List<FederateInstance> networkMessageSourceFederate = new ArrayList<>();
 
   /**

--- a/core/src/main/java/org/lflang/generator/c/CActionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CActionGenerator.java
@@ -110,6 +110,7 @@ public class CActionGenerator {
       constructorCode.pr(
           "self->_lf_" + actionName + "._base.trigger = &self->_lf__" + actionName + ";");
       constructorCode.pr("self->_lf_" + actionName + ".parent = (self_base_t*)self;");
+      constructorCode.pr("self->_lf_" + actionName + ".source_id = -1;"); // Default value.
     }
   }
 
@@ -145,7 +146,8 @@ public class CActionGenerator {
             "bool is_present;", // From lf_port_or_action_t
             "lf_action_internal_t _base;", // internal substruct
             "self_base_t* parent;", // From lf_port_or_action_t
-            "bool has_value;" // From lf_action_base_t
+            "bool has_value;", // From lf_action_base_t
+            "int source_id;" // From lf_action_base_t
             ));
     code.pr(valueDeclaration(tpr, action, target, types));
     code.pr(federatedExtension.toString());

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -197,7 +197,7 @@ import org.lflang.util.FlexPRETUtil;
  *       in the self struct named <code>_lf_a</code> and another named <code>_lf__a</code>. The type
  *       of the first is specific to the action and contains a <code>value</code> field with the
  *       type and value of the action (if it has a value). That struct also has a <code>has_value
- *       </code> field, an <code>is_present</code> field, and a <code>token</code> field (which is
+ *       </code> field, a <code>source_id</code> field, </code>an <code>is_present</code> field, and a <code>token</code> field (which is
  *       NULL if the action carries no value). The <code>_lf__a</code> field is of type trigger_t.
  *       That struct contains various things, including an array of reactions sensitive to this
  *       trigger and a lf_token_t struct containing the value of the action, if it has a value. See

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -197,11 +197,11 @@ import org.lflang.util.FlexPRETUtil;
  *       in the self struct named <code>_lf_a</code> and another named <code>_lf__a</code>. The type
  *       of the first is specific to the action and contains a <code>value</code> field with the
  *       type and value of the action (if it has a value). That struct also has a <code>has_value
- *       </code> field, a <code>source_id</code> field, </code>an <code>is_present</code> field, and a <code>token</code> field (which is
- *       NULL if the action carries no value). The <code>_lf__a</code> field is of type trigger_t.
- *       That struct contains various things, including an array of reactions sensitive to this
- *       trigger and a lf_token_t struct containing the value of the action, if it has a value. See
- *       reactor.h in the C library for details.
+ *       </code> field, a <code>source_id</code> field, </code>an <code>is_present</code> field, and
+ *       a <code>token</code> field (which is NULL if the action carries no value). The <code>_lf__a
+ *       </code> field is of type trigger_t. That struct contains various things, including an array
+ *       of reactions sensitive to this trigger and a lf_token_t struct containing the value of the
+ *       action, if it has a value. See reactor.h in the C library for details.
  *   <li>Reactions: Each reaction will have several fields in the self struct. Each of these has a
  *       name that begins with <code>_lf__reaction_i</code>, where i is the number of the reaction,
  *       starting with 0. The fields are:

--- a/test/C/src/federated/DecentralizedTimeout.lf
+++ b/test/C/src/federated/DecentralizedTimeout.lf
@@ -1,0 +1,26 @@
+/**
+ * This test checks that a timeout time without any events does not cause a federate to hang.
+ * Success is simply exiting.
+ */
+target C {
+  coordination: decentralized,
+  timeout: 7ms
+}
+
+import Count from "../lib/Count.lf"
+
+reactor PrintLag(STA: time = 100 weeks) {
+  input in: int
+
+  reaction(in) {=
+    interval_t lag = lf_time_physical() - lf_time_logical();
+    lf_print("**** Reaction to network input %d lag is " PRINTF_TIME "us at logical time " PRINTF_TIME "us, microstep %d.",
+        in->value, lag/1000, lf_time_logical_elapsed()/1000, lf_tag().microstep);
+  =}
+}
+
+federated reactor {
+  c = new Count(offset = 0, period = 3 ms)
+  p = new PrintLag()
+  c.out -> p.in
+}

--- a/test/C/src/federated/DecentralizedTimeout.lf
+++ b/test/C/src/federated/DecentralizedTimeout.lf
@@ -4,7 +4,7 @@
  */
 target C {
   coordination: decentralized,
-  timeout: 7ms
+  timeout: 7 ms
 }
 
 import Count from "../lib/Count.lf"
@@ -20,7 +20,7 @@ reactor PrintLag(STA: time = 100 weeks) {
 }
 
 federated reactor {
-  c = new Count(offset = 0, period = 3 ms)
+  c = new Count(offset=0, period = 3 ms)
   p = new PrintLag()
   c.out -> p.in
 }


### PR DESCRIPTION
This PR fixes a corner case where a federate with decentralized coordination that had no events at the timeout tag and has a large STA would hang even when its upstream federates exit and close the socket connection. The fix is to set the last known tag for input federates to FOREVER_TAG when a socket connection is closed.

It has a [companion PR in reactor-c](https://github.com/lf-lang/reactor-c/pull/477)