### PR TITLE
No longer attempt to push RTI Image to Docker Hub when CI is run in fork

### DIFF
--- a/.github/workflows/rti-docker.yml
+++ b/.github/workflows/rti-docker.yml
@@ -30,7 +30,7 @@ jobs:
           latest: false
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: ${{ endsWith(env.lf_version, '-snapshot') }}
+        if: ${{ endsWith(env.lf_version, '-snapshot') && github.repository_owner  == 'lf-lang' }}
 
       - name: Update latest (released versions only)
         uses: ./.github/actions/push-rti-docker
@@ -39,4 +39,4 @@ jobs:
           latest: true
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: ${{ !endsWith(env.lf_version, '-snapshot') }}
+        if: ${{ !endsWith(env.lf_version, '-snapshot') && github.repository_owner  == 'lf-lang' }}


### PR DESCRIPTION
A small fix that only pushes the RTI image to Docker Hub if the repo owner is `lf-lang`