### PR TITLE
Fix action is_present field not being reset 

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1417,7 +1417,8 @@ public class CGenerator extends GeneratorBase {
             temp.startScopedBankChannelIteration(port, null);
           } else {
             // This branch should not occur because if the port's parent is instance and the port
-            // is an effect of a reaction of instance, then the port must be an output, not an input.
+            // is an effect of a reaction of instance, then the port must be an output, not an
+            // input.
             // Nevertheless, leave this here in case we missed something.
             temp.startScopedBankChannelIteration(port, "count");
             width = port.getParent().getWidth();
@@ -1475,10 +1476,8 @@ public class CGenerator extends GeneratorBase {
       // Build the index into `is_present_fields` for this action.
       var indexString =
           String.valueOf(enclaveInfo.numIsPresentFields)
-              + " + ("
-              + CUtil.runtimeIndex(instance.getParent())
-              + ") * "
-              + action.getParent().getWidth();
+              + " + "
+              + CUtil.runtimeIndex(instance.getParent());
 
       if (instance.isBank()) {
         indexString += " +  " + CUtil.bankIndexName(instance);

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1433,7 +1433,7 @@ public class CGenerator extends GeneratorBase {
           var indexString =
               String.valueOf(enclaveInfo.numIsPresentFields)
                   + " + ("
-                  + CUtil.runtimeIndex(instance)
+                  + CUtil.runtimeIndex(instance.getParent())
                   + ") * "
                   + totalChannelCount * port.getParent().getWidth()
                   + " + count";

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1541,7 +1541,7 @@ public class CGenerator extends GeneratorBase {
                         enclaveStruct
                             + "._lf_intended_tag_fields["
                             + CUtil.bankIndex(instance)
-                            + " + rt"
+                            + " + "
                             + enclaveInfo.numIsPresentFields
                             + " + count] = &"
                             + CUtil.portRef(output)

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1516,7 +1516,6 @@ public class CGenerator extends GeneratorBase {
                       + action.getName()
                       + ".intended_tag;")));
 
-      temp.pr("count++;");
       temp.endScopedBlock();
       enclaveInfo.numIsPresentFields += action.getParent().getTotalWidth();
     }

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1490,7 +1490,6 @@ public class CGenerator extends GeneratorBase {
         indexString += " +  " + CUtil.bankIndexName(instance);
       }
 
-      temp.pr("int count = 0; SUPPRESS_UNUSED_WARNING(count);");
       temp.pr("// Add action " + action.getFullName() + " to array of is_present fields.");
       temp.pr(
           String.join(

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1456,9 +1456,9 @@ public class CGenerator extends GeneratorBase {
 
           if (!Objects.equal(port.getParent(), instance)) {
             temp.pr("count++;");
-            temp.endScopedBlock();
-            temp.endScopedBlock();
             temp.endScopedBankChannelIteration(port, null);
+            temp.endScopedBlock();
+            temp.endScopedBlock();
           } else {
             temp.endScopedBankChannelIteration(port, "count");
           }

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1426,6 +1426,8 @@ public class CGenerator extends GeneratorBase {
           temp.pr(
               enclaveStruct
                   + ".is_present_fields["
+                  + CUtil.bankIndex(instance)
+                  + " + "
                   + enclaveInfo.numIsPresentFields
                   + " + count] = &"
                   + portRef
@@ -1436,6 +1438,8 @@ public class CGenerator extends GeneratorBase {
               CExtensionUtils.surroundWithIfFederatedDecentralized(
                   enclaveStruct
                       + "._lf_intended_tag_fields["
+                      + CUtil.bankIndex(instance)
+                      + " + "
                       + enclaveInfo.numIsPresentFields
                       + " + count] = &"
                       + portRef
@@ -1461,13 +1465,14 @@ public class CGenerator extends GeneratorBase {
 
     for (ActionInstance action : instance.actions) {
       foundOne = true;
+      temp.startScopedBlock();
+      temp.pr("int count = 0; SUPPRESS_UNUSED_WARNING(count);");
       temp.startScopedBlock(instance);
-
       temp.pr(
           String.join(
               "\n",
               "// Add action " + action.getFullName() + " to array of is_present fields.",
-              enclaveStruct + ".is_present_fields[" + enclaveInfo.numIsPresentFields + "] ",
+              enclaveStruct + ".is_present_fields[" + CUtil.bankIndex(instance) + " + " + enclaveInfo.numIsPresentFields + " + count] ",
               "        = (bool *) &"
                   + containerSelfStructName
                   + "->_lf__"
@@ -1483,16 +1488,20 @@ public class CGenerator extends GeneratorBase {
                   "// Add action " + action.getFullName() + " to array of intended_tag fields.",
                   enclaveStruct
                       + "._lf_intended_tag_fields["
+                      + CUtil.bankIndex(instance)
+                      + " + "
                       + enclaveInfo.numIsPresentFields
-                      + "] ",
+                      + "+ count] ",
                   "        = &"
                       + containerSelfStructName
                       + "->_lf_"
                       + action.getName()
                       + ".intended_tag;")));
 
-      enclaveInfo.numIsPresentFields += action.getParent().getTotalWidth();
+      temp.pr("count++;");
       temp.endScopedBlock();
+      temp.endScopedBlock();
+      enclaveInfo.numIsPresentFields += action.getParent().getTotalWidth();
     }
     if (foundOne) startTimeStep.pr(temp.toString());
     temp = new CodeBuilder();
@@ -1515,6 +1524,8 @@ public class CGenerator extends GeneratorBase {
             temp.pr(
                 enclaveStruct
                     + ".is_present_fields["
+                    + CUtil.bankIndex(instance)
+                    + " + "
                     + enclaveInfo.numIsPresentFields
                     + " + count] = &"
                     + CUtil.portRef(output)
@@ -1529,6 +1540,8 @@ public class CGenerator extends GeneratorBase {
                         "// Add port " + output.getFullName() + " to array of intended_tag fields.",
                         enclaveStruct
                             + "._lf_intended_tag_fields["
+                            + CUtil.bankIndex(instance)
+                            + " + rt"
                             + enclaveInfo.numIsPresentFields
                             + " + count] = &"
                             + CUtil.portRef(output)

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1468,10 +1468,7 @@ public class CGenerator extends GeneratorBase {
           String.join(
               "\n",
               "// Add action " + action.getFullName() + " to array of is_present fields.",
-              enclaveStruct
-                  + ".is_present_fields["
-                  + enclaveInfo.numIsPresentFields
-                  + " + count] ",
+              enclaveStruct + ".is_present_fields[" + enclaveInfo.numIsPresentFields + " + count] ",
               "        = (bool *) &"
                   + containerSelfStructName
                   + "->_lf__"
@@ -1495,10 +1492,10 @@ public class CGenerator extends GeneratorBase {
                       + action.getName()
                       + ".intended_tag;")));
 
-     temp.pr("count++;");
-     temp.endScopedBlock();
-     temp.endScopedBlock();
-     enclaveInfo.numIsPresentFields += action.getParent().getTotalWidth();
+      temp.pr("count++;");
+      temp.endScopedBlock();
+      temp.endScopedBlock();
+      enclaveInfo.numIsPresentFields += action.getParent().getTotalWidth();
     }
     if (foundOne) startTimeStep.pr(temp.toString());
     temp = new CodeBuilder();

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1465,14 +1465,11 @@ public class CGenerator extends GeneratorBase {
 
     for (ActionInstance action : instance.actions) {
       foundOne = true;
-      temp.startScopedBlock();
-      temp.pr("int count = 0; SUPPRESS_UNUSED_WARNING(count);");
-      temp.startScopedBlock(instance);
       temp.pr(
           String.join(
               "\n",
               "// Add action " + action.getFullName() + " to array of is_present fields.",
-              enclaveStruct + ".is_present_fields[" + CUtil.bankIndex(instance) + " + " + enclaveInfo.numIsPresentFields + " + count] ",
+              enclaveStruct + ".is_present_fields[" + CUtil.bankIndex(instance) + " + " + enclaveInfo.numIsPresentFields + "] ",
               "        = (bool *) &"
                   + containerSelfStructName
                   + "->_lf__"
@@ -1498,9 +1495,6 @@ public class CGenerator extends GeneratorBase {
                       + action.getName()
                       + ".intended_tag;")));
 
-      temp.pr("count++;");
-      temp.endScopedBlock();
-      temp.endScopedBlock();
       enclaveInfo.numIsPresentFields += action.getParent().getTotalWidth();
     }
     if (foundOne) startTimeStep.pr(temp.toString());

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1396,16 +1396,6 @@ public class CGenerator extends GeneratorBase {
     var portsSeen = new LinkedHashSet<PortInstance>();
     for (ReactionInstance reaction : instance.reactions) {
 
-      // Need to find the total number of channels over all output ports of the child before
-      // generating the
-      // iteration.
-      var totalChannelCount = 0;
-      for (PortInstance port : Iterables.filter(reaction.effects, PortInstance.class)) {
-        if (port.getDefinition() instanceof Input && !portsSeen.contains(port)) {
-          totalChannelCount += port.getWidth();
-        }
-      }
-
       for (PortInstance port : Iterables.filter(reaction.effects, PortInstance.class)) {
         if (port.getDefinition() instanceof Input && !portsSeen.contains(port)) {
           portsSeen.add(port);
@@ -1435,7 +1425,7 @@ public class CGenerator extends GeneratorBase {
                   + " + ("
                   + CUtil.runtimeIndex(instance.getParent())
                   + ") * "
-                  + totalChannelCount * port.getParent().getWidth()
+                  + instance.getWidth() * port.getWidth()
                   + " + count";
 
           temp.pr(
@@ -1457,7 +1447,7 @@ public class CGenerator extends GeneratorBase {
                       + con
                       + "intended_tag;"));
 
-          enclaveInfo.numIsPresentFields += port.getWidth() * port.getParent().getTotalWidth();
+          enclaveInfo.numIsPresentFields += instance.getWidth() * port.getWidth();
 
           if (!Objects.equal(port.getParent(), instance)) {
             temp.pr("count++;");

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1510,7 +1510,7 @@ public class CGenerator extends GeneratorBase {
               String.join(
                   "\n",
                   "// Add action " + action.getFullName() + " to array of intended_tag fields.",
-                  enclaveStruct + "._lf_intended_tag_fields[" + indexString,
+                  enclaveStruct + "._lf_intended_tag_fields[" + indexString + "]",
                   "        = &"
                       + containerSelfStructName
                       + "->_lf_"
@@ -1575,13 +1575,7 @@ public class CGenerator extends GeneratorBase {
                             + output.getFullName()
                             + " to array of intended_tag fields.",
                         enclaveStruct
-                            + "._lf_intended_tag_fields["
-                            + CUtil.bankIndex(instance)
-                            + " * "
-                            + totalChannelCount * child.getTotalWidth()
-                            + " + "
-                            + enclaveInfo.numIsPresentFields
-                            + " + count] = &"
+                            + "._lf_intended_tag_fields[" + indexString + "] = &"
                             + CUtil.portRef(output)
                             + ".intended_tag;")));
 

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1575,7 +1575,9 @@ public class CGenerator extends GeneratorBase {
                             + output.getFullName()
                             + " to array of intended_tag fields.",
                         enclaveStruct
-                            + "._lf_intended_tag_fields[" + indexString + "] = &"
+                            + "._lf_intended_tag_fields["
+                            + indexString
+                            + "] = &"
                             + CUtil.portRef(output)
                             + ".intended_tag;")));
 

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1477,10 +1477,10 @@ public class CGenerator extends GeneratorBase {
       // Build the index into `is_present_fields` for this action.
       var indexString =
           String.valueOf(enclaveInfo.numIsPresentFields)
-                  + " + ("
-                  + CUtil.runtimeIndex(instance.getParent())
-                  + ") * "
-                  + action.getParent().getWidth();
+              + " + ("
+              + CUtil.runtimeIndex(instance.getParent())
+              + ") * "
+              + action.getParent().getWidth();
 
       if (instance.isBank()) {
         indexString += " +  " + CUtil.bankIndexName(instance);

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1395,15 +1395,6 @@ public class CGenerator extends GeneratorBase {
     // port so we have to avoid listing the port more than once.
     var portsSeen = new LinkedHashSet<PortInstance>();
     for (ReactionInstance reaction : instance.reactions) {
-
-      // Need to find the total number of channels over all output ports of the child before
-      // generating the iteration.
-      var totalChannelCount = 0;
-      for (PortInstance port : Iterables.filter(reaction.effects, PortInstance.class)) {
-        if (port.getDefinition() instanceof Input && !portsSeen.contains(port)) {
-          totalChannelCount += port.getWidth();
-        }
-      }
       for (PortInstance port : Iterables.filter(reaction.effects, PortInstance.class)) {
         if (port.getDefinition() instanceof Input && !portsSeen.contains(port)) {
           portsSeen.add(port);
@@ -1414,6 +1405,8 @@ public class CGenerator extends GeneratorBase {
           foundOne = true;
 
           temp.pr("// Add port " + port.getFullName() + " to array of is_present fields.");
+
+          var width = instance.getWidth();
 
           if (!Objects.equal(port.getParent(), instance)) {
             // The port belongs to contained reactor, so we also have
@@ -1428,6 +1421,7 @@ public class CGenerator extends GeneratorBase {
             // input.
             // Nevertheless, leave this here in case we missed something.
             temp.startScopedBankChannelIteration(port, "count");
+            width = port.getParent().getWidth();
           }
           var portRef = CUtil.portRefNested(port);
           var con = (port.isMultiport()) ? "->" : ".";
@@ -1437,7 +1431,7 @@ public class CGenerator extends GeneratorBase {
                   + " + ("
                   + CUtil.runtimeIndex(instance.getParent())
                   + ") * "
-                  + totalChannelCount * port.getParent().getWidth()
+                  + width * port.getWidth()
                   + " + count";
 
           temp.pr(
@@ -1459,7 +1453,7 @@ public class CGenerator extends GeneratorBase {
                       + con
                       + "intended_tag;"));
 
-          enclaveInfo.numIsPresentFields += port.getWidth() * port.getParent().getTotalWidth();
+          enclaveInfo.numIsPresentFields += instance.getTotalWidth() * port.getWidth();
 
           if (!Objects.equal(port.getParent(), instance)) {
             temp.pr("count++;");

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1513,11 +1513,14 @@ public class CGenerator extends GeneratorBase {
         for (PortInstance output : child.outputs) {
           if (!output.getDependsOnReactions().isEmpty()) {
             foundOne = true;
-            temp.pr("// Add port " + output.getFullName() + " to array of is_present fields.");
+            temp.pr(
+                "// Add output port " + output.getFullName() + " to array of is_present fields.");
             temp.startChannelIteration(output);
             temp.pr(
                 enclaveStruct
                     + ".is_present_fields["
+                    + CUtil.bankIndex(instance)
+                    + " + "
                     + enclaveInfo.numIsPresentFields
                     + " + count] = &"
                     + CUtil.portRef(output)
@@ -1529,9 +1532,13 @@ public class CGenerator extends GeneratorBase {
                 CExtensionUtils.surroundWithIfFederatedDecentralized(
                     String.join(
                         "\n",
-                        "// Add port " + output.getFullName() + " to array of intended_tag fields.",
+                        "// Add output port "
+                            + output.getFullName()
+                            + " to array of intended_tag fields.",
                         enclaveStruct
                             + "._lf_intended_tag_fields["
+                            + CUtil.bankIndex(instance)
+                            + " + "
                             + enclaveInfo.numIsPresentFields
                             + " + count] = &"
                             + CUtil.portRef(output)

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1471,7 +1471,6 @@ public class CGenerator extends GeneratorBase {
 
     for (ActionInstance action : instance.actions) {
       foundOne = true;
-      temp.startScopedBlock();
 
       // Build the index into `is_present_fields` for this action.
       var indexString =
@@ -1485,7 +1484,6 @@ public class CGenerator extends GeneratorBase {
         indexString += " +  " + CUtil.bankIndexName(instance);
       }
 
-      temp.pr("// Add action " + action.getFullName() + " to array of is_present fields.");
       temp.pr(
           String.join(
               "\n",
@@ -1511,7 +1509,6 @@ public class CGenerator extends GeneratorBase {
                       + action.getName()
                       + ".intended_tag;")));
 
-      temp.endScopedBlock();
       enclaveInfo.numIsPresentFields += action.getParent().getTotalWidth();
     }
     if (foundOne) startTimeStep.pr(temp.toString());

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1468,11 +1468,11 @@ public class CGenerator extends GeneratorBase {
               "\n",
               "// Add action " + action.getFullName() + " to array of is_present fields.",
               enclaveStruct + ".is_present_fields[" + enclaveInfo.numIsPresentFields + "] ",
-              "        = &"
+              "        = (bool *) &"
                   + containerSelfStructName
-                  + "->_lf_"
+                  + "->_lf__"
                   + action.getName()
-                  + ".is_present;"));
+                  + ".status;"));
 
       // Intended_tag is only applicable to actions in federated execution with decentralized
       // coordination.

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1452,7 +1452,7 @@ public class CGenerator extends GeneratorBase {
                       + con
                       + "intended_tag;"));
 
-          enclaveInfo.numIsPresentFields += instance.getWidth() * port.getWidth();
+          enclaveInfo.numIsPresentFields += width * port.getWidth();
 
           if (!Objects.equal(port.getParent(), instance)) {
             temp.pr("count++;");

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1406,7 +1406,8 @@ public class CGenerator extends GeneratorBase {
 
           temp.pr("// Add port " + port.getFullName() + " to array of is_present fields.");
 
-          var width = instance.getWidth();
+          // We will be iterating over instance (if a bank) and the parent of the port (if a bank).
+          var width = instance.getWidth() * port.getParent().getWidth();
 
           if (!Objects.equal(port.getParent(), instance)) {
             // The port belongs to contained reactor, so we also have
@@ -1453,7 +1454,7 @@ public class CGenerator extends GeneratorBase {
                       + con
                       + "intended_tag;"));
 
-          enclaveInfo.numIsPresentFields += instance.getTotalWidth() * port.getWidth();
+          enclaveInfo.numIsPresentFields += port.getParent().getTotalWidth() * port.getWidth();
 
           if (!Objects.equal(port.getParent(), instance)) {
             temp.pr("count++;");

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1476,8 +1476,10 @@ public class CGenerator extends GeneratorBase {
       // Build the index into `is_present_fields` for this action.
       var indexString =
           String.valueOf(enclaveInfo.numIsPresentFields)
-              + " + "
-              + CUtil.runtimeIndex(instance.getParent());
+                  + " + ("
+                  + CUtil.runtimeIndex(instance.getParent())
+                  + ") * "
+                  + action.getParent().getWidth();
 
       if (instance.isBank()) {
         indexString += " +  " + CUtil.bankIndexName(instance);

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1488,7 +1488,7 @@ public class CGenerator extends GeneratorBase {
                       + CUtil.bankIndex(instance)
                       + " + "
                       + enclaveInfo.numIsPresentFields
-                      + "+ count] ",
+                      + "]",
                   "        = &"
                       + containerSelfStructName
                       + "->_lf_"

--- a/core/src/main/java/org/lflang/generator/c/CUtil.java
+++ b/core/src/main/java/org/lflang/generator/c/CUtil.java
@@ -93,8 +93,8 @@ public class CUtil {
   }
 
   /**
-   * Return a default name of a variable to refer to the bank index of a reactor in a bank. This is
-   * has the form uniqueID_i where uniqueID is an identifier for the instance that is guaranteed to
+   * Return a default name of a variable to refer to the bank index of a reactor in a bank. This
+   * has the form uniqueID_i, where uniqueID is an identifier for the instance that is guaranteed to
    * be different from the ID of any other instance in the program. If the instance is not a bank,
    * return "0".
    *
@@ -106,8 +106,8 @@ public class CUtil {
   }
 
   /**
-   * Return a default name of a variable to refer to the bank index of a reactor in a bank. This is
-   * has the form uniqueID_i where uniqueID is an identifier for the instance that is guaranteed to
+   * Return a default name of a variable to refer to the bank index of a reactor in a bank. This
+   * has the form uniqueID_i, where uniqueID is an identifier for the instance that is guaranteed to
    * be different from the ID of any other instance in the program.
    *
    * @param instance A reactor instance.

--- a/core/src/main/java/org/lflang/generator/c/CUtil.java
+++ b/core/src/main/java/org/lflang/generator/c/CUtil.java
@@ -93,9 +93,9 @@ public class CUtil {
   }
 
   /**
-   * Return a default name of a variable to refer to the bank index of a reactor in a bank. This
-   * has the form uniqueID_i, where uniqueID is an identifier for the instance that is guaranteed to
-   * be different from the ID of any other instance in the program. If the instance is not a bank,
+   * Return a default name of a variable to refer to the bank index of a reactor in a bank. This has
+   * the form uniqueID_i, where uniqueID is an identifier for the instance that is guaranteed to be
+   * different from the ID of any other instance in the program. If the instance is not a bank,
    * return "0".
    *
    * @param instance A reactor instance.
@@ -106,9 +106,9 @@ public class CUtil {
   }
 
   /**
-   * Return a default name of a variable to refer to the bank index of a reactor in a bank. This
-   * has the form uniqueID_i, where uniqueID is an identifier for the instance that is guaranteed to
-   * be different from the ID of any other instance in the program.
+   * Return a default name of a variable to refer to the bank index of a reactor in a bank. This has
+   * the form uniqueID_i, where uniqueID is an identifier for the instance that is guaranteed to be
+   * different from the ID of any other instance in the program.
    *
    * @param instance A reactor instance.
    */

--- a/test/C/src/ActionIsPresentReset.lf
+++ b/test/C/src/ActionIsPresentReset.lf
@@ -1,30 +1,30 @@
 target C {
-    timeout: 7 msecs,
-    fast: true
+  timeout: 7 msecs,
+  fast: true
 }
 
 main reactor {
-    logical action a;
-    logical action b;
-        
-    reaction(startup) -> a {=
+  logical action a
+  logical action b
+
+  reaction(startup) -> a {=
+    lf_schedule(a, MSEC(1));
+  =}
+
+  reaction(a, b) -> a, b {=
+    if (a->is_present) {
+        printf("A");
+        lf_schedule(b, MSEC(2));
+    }
+    if (b->is_present) {
+        printf("B");
         lf_schedule(a, MSEC(1));
-    =}
+    }
 
-    reaction(a, b) -> a, b {=
-        if (a->is_present) {
-            printf("A");
-            lf_schedule(b, MSEC(2));
-        }
-        if (b->is_present) {
-            printf("B");
-            lf_schedule(a, MSEC(1));
-        }
+    lf_print(" at %d msecs with triggers (%d,%d)", lf_time_logical_elapsed() / MSEC(1), a->is_present, b->is_present);
 
-        lf_print(" at %d msecs with triggers (%d,%d)", lf_time_logical_elapsed() / MSEC(1), a->is_present, b->is_present);
-
-        if (a->is_present && b->is_present) {
-          lf_print_error_and_exit("Both triggers should not be present");
-        }
-    =}
+    if (a->is_present && b->is_present) {
+      lf_print_error_and_exit("Both triggers should not be present");
+    }
+  =}
 }

--- a/test/C/src/ActionIsPresentReset.lf
+++ b/test/C/src/ActionIsPresentReset.lf
@@ -1,0 +1,30 @@
+target C {
+    timeout: 7 msecs,
+    fast: true
+}
+
+main reactor {
+    logical action a;
+    logical action b;
+        
+    reaction(startup) -> a {=
+        lf_schedule(a, MSEC(1));
+    =}
+
+    reaction(a, b) -> a, b {=
+        if (a->is_present) {
+            printf("A");
+            lf_schedule(b, MSEC(2));
+        }
+        if (b->is_present) {
+            printf("B");
+            lf_schedule(a, MSEC(1));
+        }
+
+        lf_print(" at %d msecs with triggers (%d,%d)", lf_time_logical_elapsed() / MSEC(1), a->is_present, b->is_present);
+
+        if (a->is_present && b->is_present) {
+          lf_print_error_and_exit("Both triggers should not be present");
+        }
+    =}
+}

--- a/test/C/src/multiport/BankMultiportIsPresentSetup.lf
+++ b/test/C/src/multiport/BankMultiportIsPresentSetup.lf
@@ -1,0 +1,29 @@
+// Smoke test for checking that the `is_present_fields` is setup correctly
+// for a complicated hierarchy of banks with multiports and actions.
+target C;
+
+reactor R1 {
+  output [2] out: int
+}
+
+reactor R4 {
+  input [6] in: int
+}
+
+reactor R2 {
+  r1 = new [3] R1()
+  r4 = new R4()
+  r1.out -> r4.in
+}
+
+reactor R3 {
+  r2 = new [4] R2()
+  logical action a1
+  logical action a2
+}
+
+main reactor {
+  r = new [2] R3()
+  logical action a1
+  logical action a2
+}

--- a/test/C/src/multiport/BankMultiportIsPresentSetup.lf
+++ b/test/C/src/multiport/BankMultiportIsPresentSetup.lf
@@ -1,29 +1,29 @@
 // Smoke test for checking that the `is_present_fields` is setup correctly
 // for a complicated hierarchy of banks with multiports and actions.
-target C;
+target C
 
 reactor R1 {
-  output [2] out: int
+  output[2] out: int
 }
 
 reactor R4 {
-  input [6] in: int
+  input[6] in: int
 }
 
 reactor R2 {
-  r1 = new [3] R1()
+  r1 = new[3] R1()
   r4 = new R4()
   r1.out -> r4.in
 }
 
 reactor R3 {
-  r2 = new [4] R2()
+  r2 = new[4] R2()
   logical action a1
   logical action a2
 }
 
 main reactor {
-  r = new [2] R3()
+  r = new[2] R3()
   logical action a1
   logical action a2
 }

--- a/test/C/src/multiport/BankMultiportIsPresentSetup.lf
+++ b/test/C/src/multiport/BankMultiportIsPresentSetup.lf
@@ -3,17 +3,53 @@
 target C
 
 reactor R1 {
+  logical action a1
+  logical action a2
   output[2] out: int
+  reaction(startup) -> out {=
+    lf_set(out[0], 42);
+  =}
+  reaction(startup) -> out {=
+    lf_set(out[1], 43);
+  =}
 }
 
 reactor R4 {
-  input[6] in: int
+  logical action a1
+  logical action a2
+  input[3] in: int
+  input[3] in2: int
+  input[2] in3: int
+  reaction(in) {=
+    lf_print("in = [%d, %d, %d]", in[0]->value, in[1]->value, in[2]->value);
+  =}
+  reaction(in2) {=
+    lf_print("in2 = [%d, %d, %d]", in2[0]->value, in2[1]->value, in2[2]->value);
+  =}
+  reaction(in3) {=
+    lf_print("in3 = [%d, %d]", in3[0]->value, in3[1]->value);
+  =}
 }
 
 reactor R2 {
+  logical action a1
+  logical action a2
   r1 = new[3] R1()
-  r4 = new R4()
+  r4 = new[2] R4()
   r1.out -> r4.in
+  reaction(startup) -> r4.in2, r4.in3 {=
+    lf_set(r4[0].in2[0], 44);
+    lf_set(r4[1].in2[0], 45);
+    lf_set(r4[0].in2[1], 46);
+    lf_set(r4[1].in2[1], 47);
+    lf_set(r4[0].in2[2], 48);
+    lf_set(r4[1].in2[2], 49);
+
+    lf_set(r4[0].in3[0], 50);
+    lf_set(r4[1].in3[0], 51);
+    lf_set(r4[0].in3[1], 52);
+    lf_set(r4[1].in3[1], 53);
+  =}
 }
 
 reactor R3 {

--- a/test/C/src/multiport/BankMultiportIsPresentSetup.lf
+++ b/test/C/src/multiport/BankMultiportIsPresentSetup.lf
@@ -6,9 +6,11 @@ reactor R1 {
   logical action a1
   logical action a2
   output[2] out: int
+
   reaction(startup) -> out {=
     lf_set(out[0], 42);
   =}
+
   reaction(startup) -> out {=
     lf_set(out[1], 43);
   =}
@@ -20,12 +22,15 @@ reactor R4 {
   input[3] in: int
   input[3] in2: int
   input[2] in3: int
+
   reaction(in) {=
     lf_print("in = [%d, %d, %d]", in[0]->value, in[1]->value, in[2]->value);
   =}
+
   reaction(in2) {=
     lf_print("in2 = [%d, %d, %d]", in2[0]->value, in2[1]->value, in2[2]->value);
   =}
+
   reaction(in3) {=
     lf_print("in3 = [%d, %d]", in3[0]->value, in3[1]->value);
   =}
@@ -37,6 +42,7 @@ reactor R2 {
   r1 = new[3] R1()
   r4 = new[2] R4()
   r1.out -> r4.in
+
   reaction(startup) -> r4.in2, r4.in3 {=
     lf_set(r4[0].in2[0], 44);
     lf_set(r4[1].in2[0], 45);

--- a/test/C/src/multiport/BankOfActionsIsPresentSetup.lf
+++ b/test/C/src/multiport/BankOfActionsIsPresentSetup.lf
@@ -1,0 +1,26 @@
+// Smoke test for checking that the `is_present_fields` is setup correctly
+// for a complicated hierarchy of nested banks with actions.
+target C;
+
+reactor R1 {
+  logical action a1
+  logical action a2
+}
+
+reactor R2 {
+  r1 = new [3] R1()
+  logical action a1
+  logical action a2
+}
+
+reactor R3 {
+  r2 = new [4] R2()
+  logical action a1
+  logical action a2
+}
+
+main reactor {
+  r = new [2] R3()
+  logical action a1
+  logical action a2
+}

--- a/test/C/src/multiport/BankOfActionsIsPresentSetup.lf
+++ b/test/C/src/multiport/BankOfActionsIsPresentSetup.lf
@@ -1,6 +1,6 @@
 // Smoke test for checking that the `is_present_fields` is setup correctly
 // for a complicated hierarchy of nested banks with actions.
-target C;
+target C
 
 reactor R1 {
   logical action a1
@@ -8,19 +8,19 @@ reactor R1 {
 }
 
 reactor R2 {
-  r1 = new [3] R1()
+  r1 = new[3] R1()
   logical action a1
   logical action a2
 }
 
 reactor R3 {
-  r2 = new [4] R2()
+  r2 = new[4] R2()
   logical action a1
   logical action a2
 }
 
 main reactor {
-  r = new [2] R3()
+  r = new[2] R3()
   logical action a1
   logical action a2
 }


### PR DESCRIPTION
To correctly reset the `is_present` field of actions we must add a pointer to the `status` field of the associated `trigger_t` to the `is_present_fields` array. This is because, for actions (unlike input ports), the `is_present` field is always overwritten by the `status` field of the `trigger_t` in the reaction preambles.  

UPDATE:
This exposed also an issue with the code-generated setup of the `is_present_fields` array for banks and multiport which is also fixed in this PR

Corresponding reactor-c PR: https://github.com/lf-lang/reactor-c/pull/482

Closing #2300 #2291 