### PR TITLE
Added reactions to test

### DIFF
--- a/test/C/src/multiport/BankOfActionsIsPresentSetup.lf
+++ b/test/C/src/multiport/BankOfActionsIsPresentSetup.lf
@@ -5,6 +5,16 @@ target C
 reactor R1 {
   logical action a1
   logical action a2
+  reaction(startup) -> a1, a2 {=
+    lf_schedule(a1, MSEC(10));
+    lf_schedule(a2, MSEC(10));
+  =}
+  reaction(a1) {=
+    lf_print("a1");
+  =}
+  reaction(a2) {=
+    lf_print("a2");
+  =}
 }
 
 reactor R2 {

--- a/test/C/src/multiport/BankOfActionsIsPresentSetup.lf
+++ b/test/C/src/multiport/BankOfActionsIsPresentSetup.lf
@@ -5,13 +5,16 @@ target C
 reactor R1 {
   logical action a1
   logical action a2
+
   reaction(startup) -> a1, a2 {=
     lf_schedule(a1, MSEC(10));
     lf_schedule(a2, MSEC(10));
   =}
+
   reaction(a1) {=
     lf_print("a1");
   =}
+
   reaction(a2) {=
     lf_print("a2");
   =}


### PR DESCRIPTION
A test newly added in merged #2409 had no reactions.  Apparently, on Windows only, this results in running forever.  I have opened an [issue in reactor-c](https://github.com/lf-lang/reactor-c/issues/485) and propose updating the test here to add reactions.