### PR TITLE
Native `forever` and `never` time literal

### DIFF
--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -393,7 +393,7 @@ SignedInt:
 ;
 
 Forever:
-    'FOREVER' | 'forever'
+    'forever'
 ;
 
 Literal:

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -393,11 +393,11 @@ SignedInt:
 ;
 
 Forever:
-    'forever' | 'FOREVER'
+    'forever'
 ;
 
 Never:
-    'never' | 'NEVER'
+    'never'
 ;
 
 Literal:
@@ -529,7 +529,7 @@ Token:
     'startup' | 'shutdown' | 'after' | 'deadline' | 'mutation' | 'preamble' |
     'new' | 'federated' | 'at' | 'as' | 'from' | 'widthof' | 'const' | 'method' |
     'interleaved' | 'mode' | 'initial' | 'reset' | 'history' | 'watchdog' |
-    'extends' | 'forever' | 'FOREVER' | 'never' | 'NEVER' |
+    'extends' | 'forever' | 'never' |
 
     // Other terminals
     NEGINT | TRUE | FALSE |

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -339,7 +339,7 @@ ParameterReference:
 ;
 
 Time:
-    (interval=INT unit=TimeUnit)
+    (interval=INT unit=TimeUnit) | Forever | Never
 ;
 
 Port:
@@ -396,8 +396,12 @@ Forever:
     'forever'
 ;
 
+Never:
+    'never'
+;
+
 Literal:
-    STRING | CHAR_LIT | SignedFloat | SignedInt | Boolean | Forever
+    STRING | CHAR_LIT | SignedFloat | SignedInt | Boolean | Forever | Never
 ;
 
 Boolean:
@@ -525,7 +529,7 @@ Token:
     'startup' | 'shutdown' | 'after' | 'deadline' | 'mutation' | 'preamble' |
     'new' | 'federated' | 'at' | 'as' | 'from' | 'widthof' | 'const' | 'method' |
     'interleaved' | 'mode' | 'initial' | 'reset' | 'history' | 'watchdog' |
-    'extends' | 'forever' |
+    'extends' | 'forever' | 'never' |
 
     // Other terminals
     NEGINT | TRUE | FALSE |

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -339,7 +339,7 @@ ParameterReference:
 ;
 
 Time:
-    (interval=INT unit=TimeUnit) | Forever | Never
+    (interval=INT unit=TimeUnit)
 ;
 
 Port:
@@ -393,11 +393,11 @@ SignedInt:
 ;
 
 Forever:
-    'forever'
+    'forever' | 'FOREVER'
 ;
 
 Never:
-    'never'
+    'never' | 'NEVER'
 ;
 
 Literal:
@@ -529,7 +529,7 @@ Token:
     'startup' | 'shutdown' | 'after' | 'deadline' | 'mutation' | 'preamble' |
     'new' | 'federated' | 'at' | 'as' | 'from' | 'widthof' | 'const' | 'method' |
     'interleaved' | 'mode' | 'initial' | 'reset' | 'history' | 'watchdog' |
-    'extends' | 'forever' | 'never' |
+    'extends' | 'forever' | 'FOREVER' | 'never' | 'NEVER' |
 
     // Other terminals
     NEGINT | TRUE | FALSE |

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -525,7 +525,7 @@ Token:
     'startup' | 'shutdown' | 'after' | 'deadline' | 'mutation' | 'preamble' |
     'new' | 'federated' | 'at' | 'as' | 'from' | 'widthof' | 'const' | 'method' |
     'interleaved' | 'mode' | 'initial' | 'reset' | 'history' | 'watchdog' |
-    'extends' |
+    'extends' | 'forever' |
 
     // Other terminals
     NEGINT | TRUE | FALSE |

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -392,8 +392,12 @@ SignedInt:
     INT | NEGINT
 ;
 
+Forever:
+    'FOREVER' | 'forever'
+;
+
 Literal:
-    STRING | CHAR_LIT | SignedFloat | SignedInt | Boolean
+    STRING | CHAR_LIT | SignedFloat | SignedInt | Boolean | Forever
 ;
 
 Boolean:

--- a/core/src/main/java/org/lflang/TimeValue.java
+++ b/core/src/main/java/org/lflang/TimeValue.java
@@ -36,6 +36,9 @@ public final class TimeValue implements Comparable<TimeValue> {
   /** The maximum value of this type. This is approximately equal to 292 years. */
   public static final TimeValue MAX_VALUE = new TimeValue(Long.MAX_VALUE, TimeUnit.NANO);
 
+  /** The minimum value of this type. */
+  public static final TimeValue MIN_VALUE = new TimeValue(Long.MIN_VALUE, TimeUnit.NANO);
+
   /** A time value equal to zero. */
   public static final TimeValue ZERO = new TimeValue(0, null);
 

--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -948,22 +948,20 @@ public class ASTUtils {
    * Report whether the given literal is forever or not.
    *
    * @param literal AST node to inspect.
-   * @return True if the given literal denotes the constant {@code forever} or {@code FOREVER},
-   *     false otherwise.
+   * @return True if the given literal denotes the constant {@code forever}, false otherwise.
    */
   public static boolean isForever(String literal) {
-    return literal != null && (literal.equals("forever") || literal.equals("FOREVER"));
+    return literal != null && literal.equals("forever");
   }
 
   /**
    * Report whether the given literal is never or not.
    *
    * @param literal AST node to inspect.
-   * @return True if the given literal denotes the constant {@code never} or {@code NEVER}, false
-   *     otherwise.
+   * @return True if the given literal denotes the constant {@code never}, false otherwise.
    */
   public static boolean isNever(String literal) {
-    return literal != null && (literal.equals("never") || literal.equals("NEVER"));
+    return literal != null && literal.equals("never");
   }
 
   /**

--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -945,6 +945,17 @@ public class ASTUtils {
   }
 
   /**
+   * Report whether the given literal is forever or not.
+   *
+   * @param literal AST node to inspect.
+   * @return True if the given literal denotes the constant {@code FOREVER} or {@code forever}, false otherwise.
+   */
+  public static boolean isForever(String literal) {
+      return literal != null && (literal.equals("FOREVER") || literal.equals("forever"));
+  }
+
+
+  /**
    * Report whether the given expression is zero or not.
    *
    * @param expr AST node to inspect.
@@ -953,6 +964,19 @@ public class ASTUtils {
   public static boolean isZero(Expression expr) {
     if (expr instanceof Literal) {
       return isZero(((Literal) expr).getLiteral());
+    }
+    return false;
+  }
+
+  /**
+   * Report whether the given expression is forever or not.
+   *
+   * @param expr AST node to inspect.
+   * @return True if the given value denotes the constant {@code FOREVER} or {@code forever}, false otherwise.
+   */
+  public static boolean isForever(Expression expr) {
+    if (expr instanceof Literal) {
+      return isForever(((Literal) expr).getLiteral());
     }
     return false;
   }
@@ -1137,6 +1161,8 @@ public class ASTUtils {
       return toTimeValue((Time) expr);
     } else if (expr instanceof Literal && isZero(((Literal) expr).getLiteral())) {
       return TimeValue.ZERO;
+    } else if (expr instanceof Literal && isForever(((Literal) expr).getLiteral())) {
+      return TimeValue.MAX_VALUE;
     } else {
       return null;
     }

--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -948,23 +948,24 @@ public class ASTUtils {
    * Report whether the given literal is forever or not.
    *
    * @param literal AST node to inspect.
-   * @return True if the given literal denotes the constant {@code forever}, false otherwise.
+   * @return True if the given literal denotes the constant {@code forever} or {@code FOREVER},
+   *     false otherwise.
    */
   public static boolean isForever(String literal) {
-    return literal != null && literal.equals("forever");
+    return literal != null && (literal.equals("forever") || literal.equals("FOREVER"));
   }
-
 
   /**
    * Report whether the given literal is never or not.
    *
    * @param literal AST node to inspect.
-   * @return True if the given literal denotes the constant {@code never}, false otherwise.
+   * @return True if the given literal denotes the constant {@code never} or {@code NEVER}, false
+   *     otherwise.
    */
   public static boolean isNever(String literal) {
-    return literal != null && literal.equals("never");
+    return literal != null && (literal.equals("never") || literal.equals("NEVER"));
   }
-  
+
   /**
    * Report whether the given expression is zero or not.
    *
@@ -1187,7 +1188,7 @@ public class ASTUtils {
     } else if (expr instanceof Literal && isForever(((Literal) expr).getLiteral())) {
       return TimeValue.MAX_VALUE;
     } else if (expr instanceof Literal && isNever(((Literal) expr).getLiteral())) {
-        return TimeValue.MIN_VALUE;
+      return TimeValue.MIN_VALUE;
     } else {
       return null;
     }

--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -948,12 +948,12 @@ public class ASTUtils {
    * Report whether the given literal is forever or not.
    *
    * @param literal AST node to inspect.
-   * @return True if the given literal denotes the constant {@code FOREVER} or {@code forever}, false otherwise.
+   * @return True if the given literal denotes the constant {@code FOREVER} or {@code forever},
+   *     false otherwise.
    */
   public static boolean isForever(String literal) {
-      return literal != null && (literal.equals("FOREVER") || literal.equals("forever"));
+    return literal != null && (literal.equals("FOREVER") || literal.equals("forever"));
   }
-
 
   /**
    * Report whether the given expression is zero or not.
@@ -972,7 +972,8 @@ public class ASTUtils {
    * Report whether the given expression is forever or not.
    *
    * @param expr AST node to inspect.
-   * @return True if the given value denotes the constant {@code FOREVER} or {@code forever}, false otherwise.
+   * @return True if the given value denotes the constant {@code FOREVER} or {@code forever}, false
+   *     otherwise.
    */
   public static boolean isForever(Expression expr) {
     if (expr instanceof Literal) {

--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -948,11 +948,10 @@ public class ASTUtils {
    * Report whether the given literal is forever or not.
    *
    * @param literal AST node to inspect.
-   * @return True if the given literal denotes the constant {@code FOREVER} or {@code forever},
-   *     false otherwise.
+   * @return True if the given literal denotes the constant {@code forever}, false otherwise.
    */
   public static boolean isForever(String literal) {
-    return literal != null && (literal.equals("FOREVER") || literal.equals("forever"));
+    return literal != null && literal.equals("forever");
   }
 
   /**
@@ -972,8 +971,7 @@ public class ASTUtils {
    * Report whether the given expression is forever or not.
    *
    * @param expr AST node to inspect.
-   * @return True if the given value denotes the constant {@code FOREVER} or {@code forever}, false
-   *     otherwise.
+   * @return True if the given value denotes the constant {@code forever}, false otherwise.
    */
   public static boolean isForever(Expression expr) {
     if (expr instanceof Literal) {

--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -954,6 +954,17 @@ public class ASTUtils {
     return literal != null && literal.equals("forever");
   }
 
+
+  /**
+   * Report whether the given literal is never or not.
+   *
+   * @param literal AST node to inspect.
+   * @return True if the given literal denotes the constant {@code never}, false otherwise.
+   */
+  public static boolean isNever(String literal) {
+    return literal != null && literal.equals("never");
+  }
+  
   /**
    * Report whether the given expression is zero or not.
    *
@@ -976,6 +987,19 @@ public class ASTUtils {
   public static boolean isForever(Expression expr) {
     if (expr instanceof Literal) {
       return isForever(((Literal) expr).getLiteral());
+    }
+    return false;
+  }
+
+  /**
+   * Report whether the given expression is never or not.
+   *
+   * @param expr AST node to inspect.
+   * @return True if the given value denotes the constant {@code never}, false otherwise.
+   */
+  public static boolean isNever(Expression expr) {
+    if (expr instanceof Literal) {
+      return isNever(((Literal) expr).getLiteral());
     }
     return false;
   }
@@ -1162,6 +1186,8 @@ public class ASTUtils {
       return TimeValue.ZERO;
     } else if (expr instanceof Literal && isForever(((Literal) expr).getLiteral())) {
       return TimeValue.MAX_VALUE;
+    } else if (expr instanceof Literal && isNever(((Literal) expr).getLiteral())) {
+        return TimeValue.MIN_VALUE;
     } else {
       return null;
     }

--- a/core/src/main/java/org/lflang/generator/TargetTypes.java
+++ b/core/src/main/java/org/lflang/generator/TargetTypes.java
@@ -2,6 +2,7 @@ package org.lflang.generator;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.lflang.InferredType;
 import org.lflang.TimeValue;
 import org.lflang.ast.ASTUtils;
@@ -178,6 +179,8 @@ public interface TargetTypes {
       return getTargetTimeExpr(TimeValue.ZERO);
     } else if (ASTUtils.isForever(expr) && type != null) {
       return getTargetTimeExpr(TimeValue.MAX_VALUE);
+    } else if (ASTUtils.isNever(expr) && type != null) {
+        return getTargetTimeExpr(TimeValue.MIN_VALUE);
     } else if (expr instanceof ParameterReference) {
       return getTargetParamRef((ParameterReference) expr, type);
     } else if (expr instanceof Time) {

--- a/core/src/main/java/org/lflang/generator/TargetTypes.java
+++ b/core/src/main/java/org/lflang/generator/TargetTypes.java
@@ -2,7 +2,6 @@ package org.lflang.generator;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.lflang.InferredType;
 import org.lflang.TimeValue;
 import org.lflang.ast.ASTUtils;
@@ -180,7 +179,7 @@ public interface TargetTypes {
     } else if (ASTUtils.isForever(expr) && type != null) {
       return getTargetTimeExpr(TimeValue.MAX_VALUE);
     } else if (ASTUtils.isNever(expr) && type != null) {
-        return getTargetTimeExpr(TimeValue.MIN_VALUE);
+      return getTargetTimeExpr(TimeValue.MIN_VALUE);
     } else if (expr instanceof ParameterReference) {
       return getTargetParamRef((ParameterReference) expr, type);
     } else if (expr instanceof Time) {

--- a/core/src/main/java/org/lflang/generator/TargetTypes.java
+++ b/core/src/main/java/org/lflang/generator/TargetTypes.java
@@ -176,7 +176,7 @@ public interface TargetTypes {
   default String getTargetExpr(Expression expr, InferredType type) {
     if (ASTUtils.isZero(expr) && type != null && type.isTime) {
       return getTargetTimeExpr(TimeValue.ZERO);
-    } else if (ASTUtils.isForever(expr) && type != null && type.isTime) {
+    } else if (ASTUtils.isForever(expr) && type != null) {
       return getTargetTimeExpr(TimeValue.MAX_VALUE);
     } else if (expr instanceof ParameterReference) {
       return getTargetParamRef((ParameterReference) expr, type);

--- a/core/src/main/java/org/lflang/generator/TargetTypes.java
+++ b/core/src/main/java/org/lflang/generator/TargetTypes.java
@@ -176,6 +176,8 @@ public interface TargetTypes {
   default String getTargetExpr(Expression expr, InferredType type) {
     if (ASTUtils.isZero(expr) && type != null && type.isTime) {
       return getTargetTimeExpr(TimeValue.ZERO);
+    } else if (ASTUtils.isForever(expr) && type != null && type.isTime) {
+      return getTargetTimeExpr(TimeValue.MAX_VALUE);
     } else if (expr instanceof ParameterReference) {
       return getTargetParamRef((ParameterReference) expr, type);
     } else if (expr instanceof Time) {

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -1594,6 +1594,14 @@ public class LFValidator extends BaseLFValidator {
         return;
       }
 
+      if (ASTUtils.isForever(((Literal) value).getLiteral())) {
+        return;
+      }
+
+      if (ASTUtils.isNever(((Literal) value).getLiteral())) {
+        return;
+      }
+
       if (ASTUtils.isInteger(((Literal) value).getLiteral())) {
         error("Missing time unit.", feature);
         return;

--- a/test/C/src/LastTimeDefer.lf
+++ b/test/C/src/LastTimeDefer.lf
@@ -9,13 +9,7 @@ main reactor {
   logical action a(1 ms, 300 ms): int
   state c: int = 0
   state c2: int = 0  // For expected values.
-  state last: time = 0
-
-  reaction(startup) {=
-    // Unfortunately, a time state variable cannot be initialized with NEVER.
-    // So we do that here.
-    self->last = NEVER;
-  =}
+  state last: time = never
 
   reaction(t) -> a {=
     tag_t now = lf_tag();

--- a/test/C/src/LastTimeDrop.lf
+++ b/test/C/src/LastTimeDrop.lf
@@ -8,13 +8,7 @@ main reactor {
   timer t(0, 100 ms)
   logical action a(1 ms, 300 ms, "drop"): int
   state c: int = 0
-  state last: time = 0
-
-  reaction(startup) {=
-    // Unfortunately, a time state variable cannot be initialized with NEVER.
-    // So we do that here.
-    self->last = NEVER;
-  =}
+  state last: time = never
 
   reaction(t) -> a {=
     tag_t now = lf_tag();

--- a/test/C/src/LastTimeReplace.lf
+++ b/test/C/src/LastTimeReplace.lf
@@ -8,13 +8,7 @@ main reactor {
   timer t(0, 100 ms)
   logical action a(1 ms, 300 ms, "replace"): int
   state c: int = 0
-  state last: time = 0
-
-  reaction(startup) {=
-    // Unfortunately, a time state variable cannot be initialized with NEVER.
-    // So we do that here.
-    self->last = NEVER;
-  =}
+  state last: time = never
 
   reaction(t) -> a {=
     tag_t now = lf_tag();

--- a/test/C/src/modal_models/BanksCount3ModesComplex.lf
+++ b/test/C/src/modal_models/BanksCount3ModesComplex.lf
@@ -12,7 +12,7 @@ reactor MetaCounter {
   output[2] always: int
   output[2] mode1: int
   output[2] mode2: int
-  output[2] never: int
+  output[2] neverp: int
 
   outer_counters = new[2] CounterCycle()
   (next)+ -> outer_counters.next
@@ -46,7 +46,7 @@ reactor MetaCounter {
     mode3_counters = new[2] CounterCycle()
 
     (next)+ -> mode3_counters.next
-    mode3_counters.count -> never
+    mode3_counters.count -> neverp
   }
 }
 
@@ -72,7 +72,7 @@ main reactor {
       250000000,1,1,1,1,1,1,1,1,0,3,0,3,0,3,0,3,1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0
     }, training = false)
 
-  counters.always, counters.mode1, counters.mode2, counters.never -> test.events
+  counters.always, counters.mode1, counters.mode2, counters.neverp -> test.events
 
   // Trigger
   reaction(stepper) -> counters.next {=

--- a/test/C/src/modal_models/ModalNestedReactions.lf
+++ b/test/C/src/modal_models/ModalNestedReactions.lf
@@ -9,7 +9,7 @@ reactor CounterCycle {
 
   output count: int
   output only_in_two: bool
-  output never: int
+  output neverp: int
 
   initial mode One {
     reaction(next) -> count, reset(Two) {=
@@ -29,8 +29,8 @@ reactor CounterCycle {
   }
 
   mode Three {
-    reaction(next) -> never {=
-      lf_set(never, true);
+    reaction(next) -> neverp {=
+      lf_set(neverp, true);
     =}
   }
 }
@@ -69,7 +69,7 @@ main reactor {
     }
   =}
 
-  reaction(counter.never) {=
+  reaction(counter.neverp) {=
     printf("ERROR: Detected output from unreachable mode.\n");
     exit(4);
   =}

--- a/test/Python/src/federated/Dataflow.lf
+++ b/test/Python/src/federated/Dataflow.lf
@@ -6,7 +6,7 @@ preamble {=
   import time
 =}
 
-reactor Client(STP_offset = {= FOREVER =}) {
+reactor Client(STP_offset = FOREVER) {
   input server_message
   output client_message
 
@@ -24,13 +24,13 @@ reactor Client(STP_offset = {= FOREVER =}) {
         request_stop()
     # Need to unconditionally produce output or downstream could lock up waiting for it.
     client_message.set(val)
-  =} STP(10 s) {=
+  =} STP(FOREVER) {=
     print("Client STP Violated!")
     exit(1)
   =}
 }
 
-reactor Server(STP_offset = {= FOREVER =}) {
+reactor Server(STP_offset = FOREVER) {
   output server_message
   input client_message1
   input client_message2
@@ -51,13 +51,13 @@ reactor Server(STP_offset = {= FOREVER =}) {
         request_stop()
     # Need to unconditionally produce output or downstream could lock up waiting for it.
     server_message.set(val)
-  =} STP(10 s) {=
+  =} STP(FOREVER) {=
     print("Server STP Violated!")
     exit(1)
   =}
 }
 
-federated reactor(STP_offset = {= FOREVER =}) {
+federated reactor(STP_offset = FOREVER) {
   client1 = new Client()
   client2 = new Client()
   server = new Server()

--- a/test/Python/src/federated/Dataflow.lf
+++ b/test/Python/src/federated/Dataflow.lf
@@ -6,7 +6,7 @@ preamble {=
   import time
 =}
 
-reactor Client(STP_offset = FOREVER) {
+reactor Client(STA=FOREVER) {
   input server_message
   output client_message
 
@@ -25,12 +25,12 @@ reactor Client(STP_offset = FOREVER) {
     # Need to unconditionally produce output or downstream could lock up waiting for it.
     client_message.set(val)
   =} STP(FOREVER) {=
-    print("Client STP Violated!")
+    print("Client STAA Violated!")
     exit(1)
   =}
 }
 
-reactor Server(STP_offset = FOREVER) {
+reactor Server(STA=FOREVER) {
   output server_message
   input client_message1
   input client_message2
@@ -52,12 +52,12 @@ reactor Server(STP_offset = FOREVER) {
     # Need to unconditionally produce output or downstream could lock up waiting for it.
     server_message.set(val)
   =} STP(FOREVER) {=
-    print("Server STP Violated!")
+    print("Server STAA Violated!")
     exit(1)
   =}
 }
 
-federated reactor(STP_offset = FOREVER) {
+federated reactor(STA=FOREVER) {
   client1 = new Client()
   client2 = new Client()
   server = new Server()

--- a/test/Python/src/federated/Dataflow.lf
+++ b/test/Python/src/federated/Dataflow.lf
@@ -6,7 +6,7 @@ preamble {=
   import time
 =}
 
-reactor Client(STA=FOREVER) {
+reactor Client(STA=forever) {
   input server_message
   output client_message
 
@@ -24,13 +24,13 @@ reactor Client(STA=FOREVER) {
         request_stop()
     # Need to unconditionally produce output or downstream could lock up waiting for it.
     client_message.set(val)
-  =} STP(FOREVER) {=
+  =} STP(forever) {=
     print("Client STAA Violated!")
     exit(1)
   =}
 }
 
-reactor Server(STA=FOREVER) {
+reactor Server(STA=forever) {
   output server_message
   input client_message1
   input client_message2
@@ -51,13 +51,13 @@ reactor Server(STA=FOREVER) {
         request_stop()
     # Need to unconditionally produce output or downstream could lock up waiting for it.
     server_message.set(val)
-  =} STP(FOREVER) {=
+  =} STP(forever) {=
     print("Server STAA Violated!")
     exit(1)
   =}
 }
 
-federated reactor(STA=FOREVER) {
+federated reactor(STA=forever) {
   client1 = new Client()
   client2 = new Client()
   server = new Server()

--- a/test/Python/src/modal_models/BanksCount3ModesComplex.lf
+++ b/test/Python/src/modal_models/BanksCount3ModesComplex.lf
@@ -12,7 +12,7 @@ reactor MetaCounter {
   output[2] always
   output[2] mode1
   output[2] mode2
-  output[2] never
+  output[2] neverp
 
   outer_counters = new[2] CounterCycle()
   (next)+ -> outer_counters.next
@@ -46,7 +46,7 @@ reactor MetaCounter {
     mode3_counters = new[2] CounterCycle()
 
     (next)+ -> mode3_counters.next
-    mode3_counters.count -> never
+    mode3_counters.count -> neverp
   }
 }
 
@@ -69,7 +69,7 @@ main reactor {
     250000000,1,1,1,1,1,1,1,1,0,3,0,3,0,3,0,3,1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0
   ], training = False)
 
-  counters.always, counters.mode1, counters.mode2, counters.never -> test.events
+  counters.always, counters.mode1, counters.mode2, counters.neverp -> test.events
 
   # Trigger
   reaction(stepper) -> counters.next {=

--- a/test/Python/src/modal_models/ModalNestedReactions.lf
+++ b/test/Python/src/modal_models/ModalNestedReactions.lf
@@ -9,7 +9,7 @@ reactor CounterCycle {
 
   output count
   output only_in_two
-  output never
+  output neverp
 
   initial mode One {
     reaction(next) -> count, reset(Two) {=
@@ -29,8 +29,8 @@ reactor CounterCycle {
   }
 
   mode Three {
-    reaction(next) -> never {=
-      never.set(True)
+    reaction(next) -> neverp {=
+      neverp.set(True)
     =}
   }
 }
@@ -68,7 +68,7 @@ main reactor {
       exit(3)
   =}
 
-  reaction(counter.never) {=
+  reaction(counter.neverp) {=
     sys.stderr.write("ERROR: Detected output from unreachable mode.\n")
     exit(4)
   =}


### PR DESCRIPTION
This PR introduces a new `forever` time literal that can be used as STA and STAA in decentralized execution. This PR is related to #2368 and closes #2374.
This PR also introduces a new `never` time literal that can be used to initialize state values.