### PR TITLE
Fix Unintended Action Override

### DIFF
--- a/core/src/main/java/org/lflang/federated/extensions/CExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtension.java
@@ -387,7 +387,7 @@ public class CExtension implements FedTargetExtension {
           result.pr(
               "size_t _lf_message_length = "
                   + sendRef
-                  + "->token->length * "
+                  + "->length * "
                   + sendRef
                   + "->token->type->element_size;");
           result.pr(

--- a/test/Python/src/concurrent/ConcurrentActionRepeat.lf
+++ b/test/Python/src/concurrent/ConcurrentActionRepeat.lf
@@ -1,0 +1,45 @@
+target Python
+
+reactor ConcurrentActionTest {
+  state logs
+  physical action addlog_action
+
+  reaction(startup) -> addlog_action {=
+    print("Starting WebServer")
+    import time
+    import threading
+    self.logs = []
+    def testall():
+      def test(i):
+          print(f"Scheduling action {i}")
+          addlog_action.schedule(0, f"{i}")
+
+      threads = []
+      for j in range(100):
+          self.logs = []
+          for i in range(100):
+              test_thread = threading.Thread(target=test, args=(j*100 + i,))
+              test_thread.start()
+              threads.append(test_thread)
+          for thread in threads:
+              thread.join()
+          time.sleep(0.1)
+          print(f"===== Test {j} complete =====")
+      os._exit(0)
+    testall_thread = threading.Thread(target=testall)
+    testall_thread.start()
+  =}
+
+  reaction(addlog_action) {=
+    if addlog_action.value in self.logs:
+        print(f"Duplicate Action: {addlog_action.value}")
+        raise Exception("Duplicate Action")
+    else:
+        print(f"Action: {addlog_action.value}")
+        self.logs.append(addlog_action.value)
+  =}
+}
+
+main reactor {
+  server = new ConcurrentActionTest()
+}


### PR DESCRIPTION
This PR is the companion PR for https://github.com/lf-lang/reactor-c/pull/491. It contains a fix in the code generator that is required for the change in `reactor-c` to pass the tests, and introduces a more aggressive test `ConcurrentActionRepeat.lf` that runs the `ConcurrentAction.lf` introduced in https://github.com/lf-lang/lingua-franca/pull/2423 repeatedly to trigger another concurrency bug.