### PR TITLE
Unhook LSP tests from CI

### DIFF
--- a/.github/workflows/all-misc.yml
+++ b/.github/workflows/all-misc.yml
@@ -41,14 +41,6 @@ jobs:
     with:
       all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
-  # Run language server tests.
-  lsp:
-    if: ${{ needs.check-diff.outputs.run_misc == 'true' }}
-    needs: check-diff
-    uses: ./.github/workflows/lsp-tests.yml
-    with:
-      all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-
   check-labels:
     uses: ./.github/workflows/check-labels.yml
     if:  ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -1,6 +1,7 @@
 name: Language server tests
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       all-platforms:

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -1,6 +1,9 @@
 name: Language server tests
 
 on:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+    - cron: '0 8 * * 6'
   workflow_dispatch:
   workflow_call:
     inputs:


### PR DESCRIPTION
The LSP tests are randomized tests and not a good fit for the merge-queue setup that we have, because they could flake and result in things being pulled off the merge queue. Instead, we'll run them once weekly along with the macOS and Windows tests.