### PR TITLE
API for getting fully-qualified name in Cpp target

### DIFF
--- a/core/src/main/resources/lib/cpp/lfutil.hh
+++ b/core/src/main/resources/lib/cpp/lfutil.hh
@@ -61,6 +61,7 @@ public:
   reactor::Duration get_elapsed_physical_time() const { return reactor->get_elapsed_physical_time(); }
   reactor::Environment* environment() const { return reactor->environment(); }
   const std::string& fqn() const { return reactor->fqn(); }
+  const std::string& name() const { return reactor->name(); }
   void request_stop() const { return environment()->sync_shutdown(); }
 };
 

--- a/core/src/main/resources/lib/cpp/lfutil.hh
+++ b/core/src/main/resources/lib/cpp/lfutil.hh
@@ -60,6 +60,7 @@ public:
   reactor::Duration get_elapsed_logical_time() const { return reactor->get_elapsed_logical_time(); }
   reactor::Duration get_elapsed_physical_time() const { return reactor->get_elapsed_physical_time(); }
   reactor::Environment* environment() const { return reactor->environment(); }
+  const std::string& fqn() const { return reactor->fqn(); }
   void request_stop() const { return environment()->sync_shutdown(); }
 };
 

--- a/test/Cpp/src/FqnTest.lf
+++ b/test/Cpp/src/FqnTest.lf
@@ -2,13 +2,21 @@ target Cpp {
   workers: 1
 }
 
+public preamble {=
+  inline bool name_validation (const std::string& fqn, const std::string& name) {
+      size_t last_dot = fqn.find_last_of('.');
+      return (last_dot == std::string::npos) ? (name == fqn) : (name == fqn.substr(last_dot + 1));
+  }
+=}
+
 reactor A(bank_index: size_t = 0) {
   reaction(startup) {=
-    std::cout << fqn() << " Started\n";
+    std::cout << "fqn:" << fqn() << " name:" << name() << " Started\n";
+    assert (name_validation(fqn(), name()));
   =}
 
   reaction(shutdown) {=
-    std::cout << fqn() << " Terminated\n";
+    std::cout << "fqn:" << fqn() << " name:" << name() << " Terminated\n";
   =}
 }
 
@@ -16,11 +24,12 @@ reactor B(bank_index: size_t = 0) {
   a = new[3] A()
 
   reaction(startup) {=
-    std::cout << fqn() << " Started\n";
+    std::cout << "fqn:" << fqn() << " name:" << name() << " Started\n";
+    assert (name_validation(fqn(), name()));
   =}
 
   reaction(shutdown) {=
-    std::cout << fqn() << " Terminated\n";
+    std::cout << "fqn:" << fqn() << " name:" << name() << " Terminated\n";
   =}
 }
 
@@ -28,11 +37,12 @@ reactor C(bank_index: size_t = 0) {
   b = new[2] B()
 
   reaction(startup) {=
-    std::cout << fqn() << " Started\n";
+    std::cout << "fqn:" << fqn() << " name:" << name() << " Started\n";
+    assert (name_validation(fqn(), name()));
   =}
 
   reaction(shutdown) {=
-    std::cout << fqn() << " Terminated\n";
+    std::cout << "fqn:" << fqn() << " name:" << name() << " Terminated\n";
   =}
 }
 
@@ -40,15 +50,25 @@ reactor D(bank_index: size_t = 0) {
   a = new[2] A()
 
   reaction(startup) {=
-    std::cout << fqn() << " Started\n";
+    std::cout << "fqn:" << fqn() << " name:" << name() << " Started\n";
+    assert (name_validation(fqn(), name()));
   =}
 
   reaction(shutdown) {=
-    std::cout << fqn() << " Terminated\n";
+    std::cout << "fqn:" << fqn() << " name:" << name() << " Terminated\n";
   =}
 }
 
 main reactor {
   c = new[2] C()
   d = new[3] D()
+
+  reaction(startup) {=
+    std::cout << "fqn:" << fqn() << " name:" << name() << " Started\n";
+    assert (name_validation(fqn(), name()));
+  =}
+
+  reaction(shutdown) {=
+    std::cout << "fqn:" << fqn() << " name:" << name() << " Terminated\n";
+  =}
 }

--- a/test/Cpp/src/FqnTest.lf
+++ b/test/Cpp/src/FqnTest.lf
@@ -4,6 +4,9 @@ target Cpp {
 
 public preamble {=
   inline bool name_validation (const std::string& fqn, const std::string& name) {
+      if (fqn.empty() || name.empty()) {
+        return false;
+      }
       size_t last_dot = fqn.find_last_of('.');
       return (last_dot == std::string::npos) ? (name == fqn) : (name == fqn.substr(last_dot + 1));
   }

--- a/test/Cpp/src/FqnTest.lf
+++ b/test/Cpp/src/FqnTest.lf
@@ -1,0 +1,51 @@
+target Cpp {
+    workers: 1
+}
+
+reactor A (bank_index:size_t = 0) {
+    reaction (startup) {=
+        std::cout << fqn() << " Started\n";
+    =}
+
+    reaction (shutdown) {=
+        std::cout << fqn() << " Terminated\n";
+    =}
+}
+
+reactor B (bank_index:size_t = 0) {
+    a = new [3] A();
+    reaction (startup) {=
+        std::cout << fqn() << " Started\n";
+    =}
+
+    reaction (shutdown) {=
+        std::cout << fqn() << " Terminated\n";
+    =}
+}
+
+reactor C (bank_index:size_t = 0) {
+    b = new [2] B();
+    reaction (startup) {=
+        std::cout << fqn() << " Started\n";
+    =}
+
+    reaction (shutdown) {=
+        std::cout << fqn() << " Terminated\n";
+    =}
+}
+
+reactor D (bank_index:size_t = 0) {
+    a = new [2] A();
+    reaction (startup) {=
+        std::cout << fqn() << " Started\n";
+    =}
+
+    reaction (shutdown) {=
+        std::cout << fqn() << " Terminated\n";
+    =}
+}
+
+main reactor {
+    c = new [2] C();
+    d = new [3] D();
+}

--- a/test/Cpp/src/FqnTest.lf
+++ b/test/Cpp/src/FqnTest.lf
@@ -1,51 +1,54 @@
 target Cpp {
-    workers: 1
+  workers: 1
 }
 
-reactor A (bank_index:size_t = 0) {
-    reaction (startup) {=
-        std::cout << fqn() << " Started\n";
-    =}
+reactor A(bank_index: size_t = 0) {
+  reaction(startup) {=
+    std::cout << fqn() << " Started\n";
+  =}
 
-    reaction (shutdown) {=
-        std::cout << fqn() << " Terminated\n";
-    =}
+  reaction(shutdown) {=
+    std::cout << fqn() << " Terminated\n";
+  =}
 }
 
-reactor B (bank_index:size_t = 0) {
-    a = new [3] A();
-    reaction (startup) {=
-        std::cout << fqn() << " Started\n";
-    =}
+reactor B(bank_index: size_t = 0) {
+  a = new[3] A()
 
-    reaction (shutdown) {=
-        std::cout << fqn() << " Terminated\n";
-    =}
+  reaction(startup) {=
+    std::cout << fqn() << " Started\n";
+  =}
+
+  reaction(shutdown) {=
+    std::cout << fqn() << " Terminated\n";
+  =}
 }
 
-reactor C (bank_index:size_t = 0) {
-    b = new [2] B();
-    reaction (startup) {=
-        std::cout << fqn() << " Started\n";
-    =}
+reactor C(bank_index: size_t = 0) {
+  b = new[2] B()
 
-    reaction (shutdown) {=
-        std::cout << fqn() << " Terminated\n";
-    =}
+  reaction(startup) {=
+    std::cout << fqn() << " Started\n";
+  =}
+
+  reaction(shutdown) {=
+    std::cout << fqn() << " Terminated\n";
+  =}
 }
 
-reactor D (bank_index:size_t = 0) {
-    a = new [2] A();
-    reaction (startup) {=
-        std::cout << fqn() << " Started\n";
-    =}
+reactor D(bank_index: size_t = 0) {
+  a = new[2] A()
 
-    reaction (shutdown) {=
-        std::cout << fqn() << " Terminated\n";
-    =}
+  reaction(startup) {=
+    std::cout << fqn() << " Started\n";
+  =}
+
+  reaction(shutdown) {=
+    std::cout << fqn() << " Terminated\n";
+  =}
 }
 
 main reactor {
-    c = new [2] C();
-    d = new [3] D();
+  c = new[2] C()
+  d = new[3] D()
 }


### PR DESCRIPTION
Cpp runtime has support for fully qualified name but is not available to reaction bodies. This PR adds support for fqn() in reactions.