### PR TITLE
bug fix in the Patmos platform

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -233,6 +233,8 @@ public class CCmakeGenerator {
             "find_program(CLANG_EXECUTABLE NAMES patmos-clang REQUIRED DOC \"Path to the clang"
                 + " front-end.\")");
         cMakeCode.pr("set(CMAKE_C_COMPILER ${CLANG_EXECUTABLE})");
+        cMakeCode.pr(
+            "set(CMAKE_C_FLAGS_RELEASE \"-O2 -DNDEBUG\")"); // patmos-clang cannot compiler -O3
         cMakeCode.pr("project(" + executableName + " LANGUAGES C)");
         cMakeCode.newLine();
         break;


### PR DESCRIPTION
Cmake uses -O3 when build type is "release" by default, while patmos-clang doesn't support this optimization. Therefore, I set CMAKE_C_FLAGS_RELEASE to -O2 in the cmakelist file to fix it.