### PR TITLE
Cleaner source directories copied to remote hosts

### DIFF
--- a/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
+++ b/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
@@ -513,26 +513,6 @@ public class FedLauncherGenerator {
             + "'");
   }
 
-  /** Return the body of a shell script file to compile the specified federate. */
-  private String getCompileScript(Path remoteBase, FederateInstance federate) {
-    String baseDir = "~/" + remoteBase + "/" + fileConfig.name;
-    return String.join(
-        "\n",
-        "#!/bin/bash -l", // The -l argument makes this a login shell so PATH etc are inherited.
-        // FIXME: Put copied files in subdirectory federate.name
-        "cd " + remoteBase + "/fed-gen/" + fileConfig.name + "/src-gen/" + federate.name,
-        "rm -rf build",
-        "mkdir -p ~/" + remoteBase + "/log",
-        // >> appends stdout to the specified file, and 2>&1 appends stderr to the same file.
-        "mkdir -p build && cd build && cmake .. && make >> "
-            + baseDir
-            + "/"
-            + federate.name
-            + ".log 2>&1",
-        "mkdir -p ~/" + remoteBase + "/bin;\\",
-        "mv " + federate.name + " ~/" + remoteBase + "/bin;'");
-  }
-
   private String getUserHost(Object user, Object host) {
     if (user == null) {
       return host.toString();


### PR DESCRIPTION
Before this change, source files would be copied to a remote host one-by-one and would include files within build directories, which are not needed.  This PR uses tar to bundle the source files, which makes distributing them much faster and allows excluding build directories.