### PR TITLE
Python 11 and 12 support

### DIFF
--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Run language server Python tests without PyLint
         run: ./gradlew core:integrationTest --tests org.lflang.tests.lsp.LspTests.pythonValidationTestSyntaxOnly core:integrationTestCodeCoverageReport
       - name: Install pylint

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         platform: ${{ (inputs.all-platforms && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]')) || fromJSON('["ubuntu-latest"]') }}
-        python-version: ${{ (inputs.all-platforms && fromJSON('["3.10", "3.11", "3.12"]')) || fromJSON('["3.12"]') }}
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Check out lingua-franca repository
@@ -37,7 +36,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.12'
       - name: Install dependencies OS X
         run: |
           brew install coreutils

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -22,6 +22,7 @@ jobs:
     strategy:
       matrix:
         platform: ${{ (inputs.all-platforms && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]')) || fromJSON('["ubuntu-latest"]') }}
+        python-version: ${{ (inputs.all-platforms && fromJSON('["3.10", "3.11", "3.12"]')) || fromJSON('["3.12"]') }}
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Check out lingua-franca repository
@@ -36,7 +37,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies OS X
         run: |
           brew install coreutils

--- a/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
@@ -86,6 +86,11 @@ public class PythonExtension extends CExtension {
   }
 
   @Override
+  public String getNetworkBufferType() {
+    return "PyObject*";
+  }
+
+  @Override
   public String generateNetworkSenderBody(
       VarRef sendingPort,
       VarRef receivingPort,

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -92,6 +92,7 @@ public class CCmakeGenerator {
 
   /**
    * Set the code generator for the CMake main target.
+   *
    * @param setUpMainTarget
    */
   public void setCmakeGenerator(SetUpMainTarget setUpMainTarget) {

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -69,7 +69,7 @@ public class CCmakeGenerator {
 
   private final FileConfig fileConfig;
   private final List<String> additionalSources;
-  private final SetUpMainTarget setUpMainTarget;
+  private SetUpMainTarget setUpMainTarget;
   private final String installCode;
 
   public CCmakeGenerator(FileConfig fileConfig, List<String> additionalSources) {
@@ -88,6 +88,14 @@ public class CCmakeGenerator {
     this.additionalSources = additionalSources;
     this.setUpMainTarget = setUpMainTarget;
     this.installCode = installCode;
+  }
+
+  /**
+   * Set the code generator for the CMake main target.
+   * @param setUpMainTarget
+   */
+  public void setCmakeGenerator(SetUpMainTarget setUpMainTarget) {
+    this.setUpMainTarget = setUpMainTarget;
   }
 
   /**

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -319,7 +319,7 @@ public class CGenerator extends GeneratorBase {
 
   private final CTypes types;
 
-  private final CCmakeGenerator cmakeGenerator;
+  protected CCmakeGenerator cmakeGenerator;
 
   protected CGenerator(
       LFGeneratorContext context,

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -648,22 +648,19 @@ public class PythonGenerator extends CGenerator {
   private static String setUpMainTarget(
       boolean hasMain, String executableName, Stream<String> cSources) {
     // According to https://cmake.org/cmake/help/latest/module/FindPython.html#hints, the following
-    // should work to select the version of Python given in your virtual environment:
-    //            set(LF_MAIN_TARGET <pyModuleName>)
-    //            set(Python_FIND_VIRTUALENV FIRST)
-    //            set(Python_FIND_STRATEGY LOCATION)
-    //            set(Python_FIND_FRAMEWORK LAST)
-    //            find_package(Python 3.10.0...<3.13.0 REQUIRED COMPONENTS Interpreter Development)
+    // should work to select the version of Python given in your virtual environment.
     // However, this does not work for me (macOS Sequoia 15.0.1).
-    // Hence, we use the command line here to find the Python version in the PATH and specify that
-    // version.
+    // FIXME: Define a target parameter to specify the exact Python version.
     return ("""
             set(CMAKE_POSITION_INDEPENDENT_CODE ON)
             add_compile_definitions(_PYTHON_TARGET_ENABLED)
             add_subdirectory(core)
             set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
             set(LF_MAIN_TARGET <pyModuleName>)
-            find_package(Python 3.10.0...<3.11.0 REQUIRED COMPONENTS Interpreter Development)
+            set(Python_FIND_VIRTUALENV FIRST)
+            set(Python_FIND_STRATEGY LOCATION)
+            set(Python_FIND_FRAMEWORK LAST)
+            find_package(Python 3.10.0 REQUIRED COMPONENTS Interpreter Development)
             Python_add_library(
                 ${LF_MAIN_TARGET}
                 MODULE

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -655,7 +655,7 @@ public class PythonGenerator extends CGenerator {
             add_subdirectory(core)
             set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
             set(LF_MAIN_TARGET <pyModuleName>)
-            find_package(Python 3.10.0 REQUIRED COMPONENTS Interpreter Development)
+            find_package(Python 3.10.0...<3.11.0 REQUIRED COMPONENTS Interpreter Development)
             Python_add_library(
                 ${LF_MAIN_TARGET}
                 MODULE

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -647,13 +647,14 @@ public class PythonGenerator extends CGenerator implements CCmakeGenerator.SetUp
     PythonModeGenerator.generateResetReactionsIfNeeded(reactors);
   }
 
-  public String getCmakeCode(
-      boolean hasMain, String executableName, Stream<String> cSources) {
+  public String getCmakeCode(boolean hasMain, String executableName, Stream<String> cSources) {
     // According to https://cmake.org/cmake/help/latest/module/FindPython.html#hints, the following
     // should work to select the version of Python given in your virtual environment.
     // However, this does not work for me (macOS Sequoia 15.0.1).
-    // As a consequence, the python-version target property can be used to specify the exact Python version.
-    var pythonVersion = "3.10.0"; // Allows 3.10 or later. Change to "3.10.0...<3.11.0" to require 3.10 by default.
+    // As a consequence, the python-version target property can be used to specify the exact Python
+    // version.
+    var pythonVersion =
+        "3.10.0"; // Allows 3.10 or later. Change to "3.10.0...<3.11.0" to require 3.10 by default.
     if (targetConfig.isSet(PythonVersionProperty.INSTANCE)) {
       pythonVersion = targetConfig.get(PythonVersionProperty.INSTANCE) + " EXACT";
     }

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -655,7 +655,7 @@ public class PythonGenerator extends CGenerator {
             add_subdirectory(core)
             set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
             set(LF_MAIN_TARGET <pyModuleName>)
-            find_package(Python 3.10.0...<3.11.0 REQUIRED COMPONENTS Interpreter Development)
+            find_package(Python 3.10.0 REQUIRED COMPONENTS Interpreter Development)
             Python_add_library(
                 ${LF_MAIN_TARGET}
                 MODULE

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -486,9 +486,6 @@ public class PythonGenerator extends CGenerator {
   @Override
   protected void generateReactorClassHeaders(
       TypeParameterizedReactor tpr, String headerName, CodeBuilder header, CodeBuilder src) {
-    header.pr(
-        PythonPreambleGenerator.generateCIncludeStatements(
-            targetConfig, targetLanguageIsCpp(), hasModalReactors));
     super.generateReactorClassHeaders(tpr, headerName, header, src);
   }
 

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -90,6 +90,9 @@ public class PythonGenerator extends CGenerator {
   // Used to add module requirements to setup.py (delimited with ,)
   private final List<String> pythonRequiredModules = new ArrayList<>();
 
+  /** Indicator that we have already generated top-level preambles. */
+  private Set<Model> generatedTopLevelPreambles = new HashSet<Model>();
+
   private final PythonTypes types;
 
   public PythonGenerator(LFGeneratorContext context) {
@@ -271,7 +274,12 @@ public class PythonGenerator extends CGenerator {
       models.add((Model) ASTUtils.toDefinition(this.mainDef.getReactorClass()).eContainer());
     }
     for (Model m : models) {
-      pythonPreamble.pr(PythonPreambleGenerator.generatePythonPreambles(m.getPreambles()));
+      // In the generated Python code, unlike C, all reactors go into the same file.
+      // Therefore, we do not need to generate this if it has already been generated.
+      if (!generatedTopLevelPreambles.contains(m)) {
+        generatedTopLevelPreambles.add(m);
+        pythonPreamble.pr(PythonPreambleGenerator.generatePythonPreambles(m.getPreambles()));
+      }
     }
     return PythonPreambleGenerator.generateCIncludeStatements(
         targetConfig, targetLanguageIsCpp(), hasModalReactors);

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -647,7 +647,7 @@ public class PythonGenerator extends CGenerator {
             add_subdirectory(core)
             set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
             set(LF_MAIN_TARGET <pyModuleName>)
-            find_package(Python 3.10.0...<3.11.0 REQUIRED COMPONENTS Interpreter Development)
+            find_package(Python 3.12.7...<3.13.0 REQUIRED COMPONENTS Interpreter Development)
             Python_add_library(
                 ${LF_MAIN_TARGET}
                 MODULE

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -647,7 +647,8 @@ public class PythonGenerator extends CGenerator {
     //            set(Python_FIND_FRAMEWORK LAST)
     //            find_package(Python 3.10.0...<3.13.0 REQUIRED COMPONENTS Interpreter Development)
     // However, this does not work for me (macOS Sequoia 15.0.1).
-    // Hence, we use the command line here to find the Python version in the PATH and specify that version.
+    // Hence, we use the command line here to find the Python version in the PATH and specify that
+    // version.
     return ("""
             set(CMAKE_POSITION_INDEPENDENT_CODE ON)
             add_compile_definitions(_PYTHON_TARGET_ENABLED)

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -654,7 +654,7 @@ public class PythonGenerator extends CGenerator {
             add_subdirectory(core)
             set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
             set(LF_MAIN_TARGET <pyModuleName>)
-            find_package(Python 3.12.7 EXACT REQUIRED COMPONENTS Interpreter Development)
+            find_package(Python 3.10.0...<3.11.0 REQUIRED COMPONENTS Interpreter Development)
             Python_add_library(
                 ${LF_MAIN_TARGET}
                 MODULE

--- a/core/src/main/java/org/lflang/generator/python/PythonPortGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonPortGenerator.java
@@ -177,7 +177,6 @@ public class PythonPortGenerator {
         "    }",
         "    /* Release the thread. No Python API allowed beyond this point. */",
         "    PyGILState_Release(gstate);",
-        "    Py_FinalizeEx();",
         "    exit(1);",
         "}",
         "for (int i = 0; i < " + generateWidthVariable(reactorName) + "; i++) {",

--- a/core/src/main/java/org/lflang/generator/python/PythonPortGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonPortGenerator.java
@@ -192,7 +192,6 @@ public class PythonPortGenerator {
         "        }",
         "        /* Release the thread. No Python API allowed beyond this point. */",
         "        PyGILState_Release(gstate);",
-        "        Py_FinalizeEx();",
         "        exit(1);",
         "    }",
         "}");

--- a/core/src/main/java/org/lflang/generator/python/PythonPreambleGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonPreambleGenerator.java
@@ -44,8 +44,8 @@ public class PythonPreambleGenerator {
   public static String generateCIncludeStatements(
       TargetConfig targetConfig, boolean CCppMode, boolean hasModalReactors) {
     CodeBuilder code = new CodeBuilder();
-    code.pr(CPreambleGenerator.generateIncludeStatements(targetConfig, CCppMode));
     code.pr("#include \"pythontarget.h\"");
+    code.pr(CPreambleGenerator.generateIncludeStatements(targetConfig, CCppMode));
     if (hasModalReactors) {
       code.pr("#include \"include/modal_models/definitions.h\"");
     }

--- a/core/src/main/java/org/lflang/generator/python/PythonReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonReactionGenerator.java
@@ -102,10 +102,12 @@ public class PythonReactionGenerator {
                 + "."
                 + pythonFunctionName
                 + "\");",
+            "PyObject *arglist = Py_BuildValue(\"(" + "O".repeat(pyObjects.size()) + ")\"" + pyObjectsJoined + ");",
             "PyObject *rValue = PyObject_CallObject(",
             "    self->" + cpythonFunctionName + ", ",
-            "    Py_BuildValue(\"(" + "O".repeat(pyObjects.size()) + ")\"" + pyObjectsJoined + ")",
+            "    arglist",
             ");",
+            "Py_DECREF(arglist);",
             "if (rValue == NULL) {",
             "    lf_print_error(\"FATAL: Calling reaction "
                 + reactorDeclName

--- a/core/src/main/java/org/lflang/generator/python/PythonReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonReactionGenerator.java
@@ -102,7 +102,11 @@ public class PythonReactionGenerator {
                 + "."
                 + pythonFunctionName
                 + "\");",
-            "PyObject *arglist = Py_BuildValue(\"(" + "O".repeat(pyObjects.size()) + ")\"" + pyObjectsJoined + ");",
+            "PyObject *arglist = Py_BuildValue(\"("
+                + "O".repeat(pyObjects.size())
+                + ")\""
+                + pyObjectsJoined
+                + ");",
             "PyObject *rValue = PyObject_CallObject(",
             "    self->" + cpythonFunctionName + ", ",
             "    arglist",

--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -26,39 +26,7 @@ import java.util.Optional;
 import java.util.Set;
 import net.jcip.annotations.Immutable;
 import org.lflang.lf.TargetDecl;
-import org.lflang.target.property.AuthProperty;
-import org.lflang.target.property.BuildCommandsProperty;
-import org.lflang.target.property.BuildTypeProperty;
-import org.lflang.target.property.CargoDependenciesProperty;
-import org.lflang.target.property.CargoFeaturesProperty;
-import org.lflang.target.property.ClockSyncModeProperty;
-import org.lflang.target.property.ClockSyncOptionsProperty;
-import org.lflang.target.property.CmakeIncludeProperty;
-import org.lflang.target.property.CompileDefinitionsProperty;
-import org.lflang.target.property.CompilerProperty;
-import org.lflang.target.property.CoordinationOptionsProperty;
-import org.lflang.target.property.CoordinationProperty;
-import org.lflang.target.property.DockerProperty;
-import org.lflang.target.property.ExportDependencyGraphProperty;
-import org.lflang.target.property.ExternalRuntimePathProperty;
-import org.lflang.target.property.FilesProperty;
-import org.lflang.target.property.KeepaliveProperty;
-import org.lflang.target.property.NoRuntimeValidationProperty;
-import org.lflang.target.property.NoSourceMappingProperty;
-import org.lflang.target.property.PlatformProperty;
-import org.lflang.target.property.PrintStatisticsProperty;
-import org.lflang.target.property.ProtobufsProperty;
-import org.lflang.target.property.Ros2DependenciesProperty;
-import org.lflang.target.property.Ros2Property;
-import org.lflang.target.property.RuntimeVersionProperty;
-import org.lflang.target.property.RustIncludeProperty;
-import org.lflang.target.property.SchedulerProperty;
-import org.lflang.target.property.SingleFileProjectProperty;
-import org.lflang.target.property.SingleThreadedProperty;
-import org.lflang.target.property.TracePluginProperty;
-import org.lflang.target.property.TracingProperty;
-import org.lflang.target.property.VerifyProperty;
-import org.lflang.target.property.WorkersProperty;
+import org.lflang.target.property.*;
 
 /**
  * Enumeration of targets and their associated properties.
@@ -634,6 +602,7 @@ public enum Target {
               KeepaliveProperty.INSTANCE,
               NoSourceMappingProperty.INSTANCE,
               ProtobufsProperty.INSTANCE,
+              PythonVersionProperty.INSTANCE,
               SchedulerProperty.INSTANCE,
               SingleThreadedProperty.INSTANCE,
               TracingProperty.INSTANCE,

--- a/core/src/main/java/org/lflang/target/property/PythonVersionProperty.java
+++ b/core/src/main/java/org/lflang/target/property/PythonVersionProperty.java
@@ -1,0 +1,17 @@
+package org.lflang.target.property;
+
+/** A specific Python version to use. */
+public final class PythonVersionProperty extends StringProperty {
+
+  /** Singleton target property instance. */
+  public static final PythonVersionProperty INSTANCE = new PythonVersionProperty();
+
+  private PythonVersionProperty() {
+    super();
+  }
+
+  @Override
+  public String name() {
+    return "python-version";
+  }
+}

--- a/test/Python/src/serialization/CustomSerializer.lf
+++ b/test/Python/src/serialization/CustomSerializer.lf
@@ -5,7 +5,10 @@ target Python {
 }
 
 preamble {=
+  # Note that both federates will try to install the pickle_serializer package. One will likely fail,
+  # but the other will succeed.
   os.system("pip install ./src/serialization/pickle_serializer/ --user")
+  import pickle_serializer
 =}
 
 reactor Client {
@@ -66,5 +69,5 @@ federated reactor {
   client = new Client()
   server = new Server()
   server.server_message -> client.server_message after 100 ms serializer "pickle_serializer"
-  client.client_message -> server.client_message serializer "pickle_serializer"
+  client.client_message -> server.client_message after 100 ms serializer "pickle_serializer"
 }


### PR DESCRIPTION
This PR makes Python versions 3.11, 3.12, and 3.13, at least, work with the Python target.
By default, the Python version is found by CMake with the constraint that it be at least 3.10.0.
This is specified by the following directive:

```
            find_package(Python 3.10.0 REQUIRED COMPONENTS Interpreter Development)
```

Because CMake does not work as advertised (see below), this PR adds a target parameter `python-version` to specify a precise version to use. For example, to use 3.13.0, you would specify:

```
target Python {
  python-version: "3.13.0"
}
```

This will change the above directive in the generated CMakeLists.txt file to read like this:

```
            find_package(Python 3.13.0 EXACT REQUIRED COMPONENTS Interpreter Development)
```

This PR fixes some memory issues, particularly with modal models, that were previously causing crashes with Python versions greater than 3.10.

---------
The rest of this text documents the issue with CMake.

There is a problem I need help with, however.  In this PR, the Python version is hardwired to 3.12.7 in the PythonGenerator.java file, which generates the CMake directives, and has this line:

```
            find_package(Python 3.12.7...<3.13.0 REQUIRED COMPONENTS Interpreter Development)
```
The problem is that if this line allows 3.10.0 up to 3.13.0, which is what we want, then lfc inevitably picks a different Python from one identified by CMake, and you get an error message like:

```
SystemError: initialization of LinguaFrancaActionDelay did not return an extension module
```

How can we force CMake to pick the Python version that is in the PATH?  Sadly, it does not do that.
This supersedes #1902, which I will close.
