### PR TITLE
Make reactor names available at runtime

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
@@ -1088,8 +1088,9 @@ public class CTriggerObjectsGenerator {
   }
 
   /**
-   * Set the parent pointer and reactor name. If the reactor is in a bank, the name will
-   * be the instance name with [index] appended.
+   * Set the parent pointer and reactor name. If the reactor is in a bank, the name will be the
+   * instance name with [index] appended.
+   *
    * @param reactor The reactor instance.
    */
   private static String deferredSetParentAndName(ReactorInstance reactor) {
@@ -1099,7 +1100,11 @@ public class CTriggerObjectsGenerator {
     if (parent == null) {
       code.pr(CUtil.reactorRef(reactor) + "->base.parent = (self_base_t*)NULL;");
     } else {
-      code.pr(CUtil.reactorRef(reactor) + "->base.parent = (self_base_t*)" + CUtil.reactorRef(parent) + ";");
+      code.pr(
+          CUtil.reactorRef(reactor)
+              + "->base.parent = (self_base_t*)"
+              + CUtil.reactorRef(parent)
+              + ";");
     }
     return code.toString();
   }

--- a/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
@@ -1088,6 +1088,23 @@ public class CTriggerObjectsGenerator {
   }
 
   /**
+   * Set the parent pointer and reactor name. If the reactor is in a bank, the name will
+   * be the instance name with [index] appended.
+   * @param reactor The reactor instance.
+   */
+  private static String deferredSetParentAndName(ReactorInstance reactor) {
+    var code = new CodeBuilder();
+    code.pr(CUtil.reactorRef(reactor) + "->base.name = \"" + reactor.getName() + "\";");
+    ReactorInstance parent = reactor.getParent();
+    if (parent == null) {
+      code.pr(CUtil.reactorRef(reactor) + "->base.parent = (self_base_t*)NULL;");
+    } else {
+      code.pr(CUtil.reactorRef(reactor) + "->base.parent = (self_base_t*)" + CUtil.reactorRef(parent) + ";");
+    }
+    return code.toString();
+  }
+
+  /**
    * Perform initialization functions that must be performed after all reactor runtime instances
    * have been created. This function creates nested loops over nested banks.
    *
@@ -1103,6 +1120,9 @@ public class CTriggerObjectsGenerator {
     // First batch of initializations is within a for loop iterating
     // over bank members for the reactor's parent.
     code.startScopedBlock(reactor);
+
+    // Set the parent pointer and name for the reactor.
+    code.pr(deferredSetParentAndName(reactor));
 
     // If the child has a multiport that is an effect of some reaction in its container,
     // then we have to generate code to allocate memory for arrays pointing to

--- a/test/C/src/ReactorName.lf
+++ b/test/C/src/ReactorName.lf
@@ -13,6 +13,10 @@ reactor A(parent_bank_index: size_t = 0) {
     char buffer[20];
     snprintf(buffer, 20, "ReactorName.b[%zu].a", self->parent_bank_index);
     if (strcmp(buffer, name) != 0) {
+      lf_print_error_and_exit("full name does not match");
+    }
+    name = lf_reactor_name(self);
+    if (strcmp("a", name) != 0) {
       lf_print_error_and_exit("name does not match");
     }
   =}
@@ -27,6 +31,11 @@ reactor B(bank_index: size_t = 0) {
     char buffer[20];
     snprintf(buffer, 20, "ReactorName.b[%zu]", self->bank_index);
     if (strcmp(buffer, name) != 0) {
+      lf_print_error_and_exit("full name does not match");
+    }
+    name = lf_reactor_name(self);
+    snprintf(buffer, 20, "b[%zu]", self->bank_index);
+    if (strcmp(buffer, name) != 0) {
       lf_print_error_and_exit("name does not match");
     }
   =}
@@ -38,6 +47,10 @@ main reactor {
   reaction(startup) {=
     const char* name = lf_reactor_full_name(self);
     lf_print("name: %s", name);
+    if (strcmp("ReactorName", name) != 0) {
+      lf_print_error_and_exit("full name does not match");
+    }
+    name = lf_reactor_name(self);
     if (strcmp("ReactorName", name) != 0) {
       lf_print_error_and_exit("name does not match");
     }

--- a/test/C/src/ReactorName.lf
+++ b/test/C/src/ReactorName.lf
@@ -1,0 +1,39 @@
+target C {
+  build-type: debug
+}
+
+preamble {=
+  #include <string.h>
+=}
+
+reactor A {
+  reaction(startup) {=
+    const char* name = lf_reactor_full_name(self);
+    lf_print("name: %s", name);
+    if (strcmp("ReactorName.b.a", name) != 0) {
+      lf_print_error_and_exit("name does not match");
+    }
+  =}
+}
+
+reactor B {
+  a = new A()
+  reaction(startup) {=
+    const char* name = lf_reactor_full_name(self);
+    lf_print("name: %s", name);
+    if (strcmp("ReactorName.b", name) != 0) {
+      lf_print_error_and_exit("name does not match");
+    }
+  =}
+}
+
+main reactor {
+  b = new B()
+  reaction(startup) {=
+    const char* name = lf_reactor_full_name(self);
+    lf_print("name: %s", name);
+    if (strcmp("ReactorName", name) != 0) {
+      lf_print_error_and_exit("name does not match");
+    }
+  =}
+}

--- a/test/C/src/ReactorName.lf
+++ b/test/C/src/ReactorName.lf
@@ -6,30 +6,34 @@ preamble {=
   #include <string.h>
 =}
 
-reactor A {
+reactor A(parent_bank_index: size_t = 0) {
   reaction(startup) {=
     const char* name = lf_reactor_full_name(self);
     lf_print("name: %s", name);
-    if (strcmp("ReactorName.b.a", name) != 0) {
+    char buffer[20];
+    snprintf(buffer, 20, "ReactorName.b[%zu].a", self->parent_bank_index);
+    if (strcmp(buffer, name) != 0) {
       lf_print_error_and_exit("name does not match");
     }
   =}
 }
 
-reactor B {
-  a = new A()
+reactor B(bank_index: size_t = 0) {
+  a = new A(parent_bank_index=bank_index)
 
   reaction(startup) {=
     const char* name = lf_reactor_full_name(self);
     lf_print("name: %s", name);
-    if (strcmp("ReactorName.b", name) != 0) {
+    char buffer[20];
+    snprintf(buffer, 20, "ReactorName.b[%zu]", self->bank_index);
+    if (strcmp(buffer, name) != 0) {
       lf_print_error_and_exit("name does not match");
     }
   =}
 }
 
 main reactor {
-  b = new B()
+  b = new[3] B()
 
   reaction(startup) {=
     const char* name = lf_reactor_full_name(self);

--- a/test/C/src/ReactorName.lf
+++ b/test/C/src/ReactorName.lf
@@ -18,6 +18,7 @@ reactor A {
 
 reactor B {
   a = new A()
+
   reaction(startup) {=
     const char* name = lf_reactor_full_name(self);
     lf_print("name: %s", name);
@@ -29,6 +30,7 @@ reactor B {
 
 main reactor {
   b = new B()
+
   reaction(startup) {=
     const char* name = lf_reactor_full_name(self);
     lf_print("name: %s", name);


### PR DESCRIPTION
This PR adds two functions (and macros), `lf_reactor_name` and `lf_reactor_full_name`, each of which takes a self struct as an argument.  The name is the instance name given by the `new` statement. If the reactor is in a bank, then the name will have a suffix of the form `[bank_index]`.  The full name is the name of the reactor and all its parents separated by periods. There is a [companion PR in reactor-c](https://github.com/lf-lang/reactor-c/pull/507).