### PR TITLE
Allow derived classes to override parameter default values

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CParameterGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CParameterGenerator.java
@@ -6,6 +6,8 @@ import org.lflang.generator.ParameterInstance;
 import org.lflang.lf.Initializer;
 import org.lflang.lf.Parameter;
 
+import java.util.HashSet;
+
 /**
  * Generates C code to declare and initialize parameters.
  *
@@ -41,7 +43,14 @@ public class CParameterGenerator {
   public static String generateDeclarations(
       TypeParameterizedReactor reactor, CTypes types, boolean suppressLineDirectives) {
     CodeBuilder code = new CodeBuilder();
+    // Allow derived classes to override base class parameter definitions.
+    // Assume that the validator has checked that types match.
+    var declared = new HashSet<String>();
     for (Parameter parameter : ASTUtils.allParameters(reactor.reactor())) {
+      // If the parameter name has been seen already, assume it is an override of the default value
+      // in a derived class.  The validator should check.
+      if (declared.contains(parameter.getName())) continue;
+      declared.add(parameter.getName());
       code.prSourceLineNumber(parameter, suppressLineDirectives);
       code.pr(
           types.getTargetType(reactor.resolveType(ASTUtils.getInferredType(parameter)))

--- a/core/src/main/java/org/lflang/generator/c/CParameterGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CParameterGenerator.java
@@ -1,12 +1,11 @@
 package org.lflang.generator.c;
 
+import java.util.HashSet;
 import org.lflang.ast.ASTUtils;
 import org.lflang.generator.CodeBuilder;
 import org.lflang.generator.ParameterInstance;
 import org.lflang.lf.Initializer;
 import org.lflang.lf.Parameter;
-
-import java.util.HashSet;
 
 /**
  * Generates C code to declare and initialize parameters.

--- a/test/C/src/ParameterOverride.lf
+++ b/test/C/src/ParameterOverride.lf
@@ -1,0 +1,15 @@
+target C
+
+reactor A(x:int = 0) {
+  reaction(startup) {=
+    if (self->x != 1) {
+      lf_print_error_and_exit("x is %d. Should be 1.", self->x);
+    }
+  =}
+}
+
+reactor B(x:int = 1) extends A { }
+
+main reactor {
+  b = new B()
+}

--- a/test/C/src/ParameterOverride.lf
+++ b/test/C/src/ParameterOverride.lf
@@ -1,6 +1,6 @@
 target C
 
-reactor A(x:int = 0) {
+reactor A(x: int = 0) {
   reaction(startup) {=
     if (self->x != 1) {
       lf_print_error_and_exit("x is %d. Should be 1.", self->x);
@@ -8,7 +8,8 @@ reactor A(x:int = 0) {
   =}
 }
 
-reactor B(x:int = 1) extends A { }
+reactor B(x: int = 1) extends A {
+}
 
 main reactor {
   b = new B()


### PR DESCRIPTION
This fixes #2451. The validator does not currently check for some possible errors (like changing the type of a parameter), but the compiler should give reasonable error messages, so this is not a high priority.