### PR TITLE
CMake: Dont clear executable runtime path when installing

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -301,6 +301,10 @@ public class CCmakeGenerator {
     cMakeCode.pr("set(CMAKE_COLOR_DIAGNOSTICS ON)\n");
     cMakeCode.newLine();
 
+    cMakeCode.pr("# Do not clear runtime path of the executable when installing it\n");
+    cMakeCode.pr("SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)\n");
+    cMakeCode.newLine();
+
     if (CppMode) {
       // Suppress warnings about const char*.
       cMakeCode.pr("set(CMAKE_CXX_FLAGS \"${CMAKE_CXX_FLAGS} -Wno-write-strings\")");


### PR DESCRIPTION
While messing around with https://github.com/lf-lang/mujoco-c I was struggling with linking with an external shared object and the final LF binary not finding the shared library. It turns out that CMake by default clears the runtime path (RPATH) of an executable when it is installed (`cmake --target install`), so the binaries found in `src-gen/MyApp/build/MyApp` would run and find the shared object, but not the binary that was put in `bin`. 

This PR sets a CMake variable to disable this clearing of the RPATH. I cannot say I fully understand why this is the default behavior of CMake and if there are any pitfalls of disabling it. Maybe @tanneberger knows something?


