### PR TITLE
Revert "Set annotated layout options for modes."

### DIFF
--- a/core/src/main/java/org/lflang/diagram/synthesis/util/ModeDiagrams.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/util/ModeDiagrams.java
@@ -129,7 +129,6 @@ public class ModeDiagrams extends AbstractSynthesisExtensions {
   @Inject @Extension private LinguaFrancaStyleExtensions _linguaFrancaStyleExtensions;
   @Inject @Extension private UtilityExtensions _utilityExtensions;
   @Inject @Extension private LayoutPostProcessing _layoutPostProcessing;
-  @Inject @Extension private LinguaFrancaSynthesis synthesis;
 
   @Extension private KRenderingFactory _kRenderingFactory = KRenderingFactory.eINSTANCE;
 
@@ -341,7 +340,6 @@ public class ModeDiagrams extends AbstractSynthesisExtensions {
             modeContainer.getProperty(LayeredOptions.SPACING_NODE_NODE_BETWEEN_LAYERS)
                 + (getBooleanValue(SHOW_TRANSITION_LABELS) ? 6.0 : 10.0));
       }
-      synthesis.setAnnotatedLayoutOptions(reactor.reactorDefinition, modeContainer);
 
       var modeContainerPorts = new HashMap<KPort, KPort>();
       for (var mode : reactor.modes) {


### PR DESCRIPTION
This reverts commit 02f965ae6e23db79807cb58528e3a0d46ad4969e.

Thanks @soerendomroes for identifying this. This PR simply reverts this commit. Do we lose any functionality by reverting this? I am gonna look into why this wasn't caught by the CI earlier. See #2465 