### PR TITLE
Patmos can compile LF codes with its prev compiler

### DIFF
--- a/.github/actions/setup-patmos/action.yml
+++ b/.github/actions/setup-patmos/action.yml
@@ -28,7 +28,7 @@ runs:
         mkdir ~/t-crest
         cd ~/t-crest
         git clone https://github.com/t-crest/patmos-misc.git misc
-        ./misc/build.sh
+        ./misc/build.sh toolchain1
         patmos-clang --version
         which patmos-clang
       shell: bash

--- a/.github/workflows/c-embedded.yml
+++ b/.github/workflows/c-embedded.yml
@@ -25,5 +25,5 @@ jobs:
 #     uses: ./.github/workflows/c-flexpret-tests.yml
 
       # Run the C Patmos integration tests.
-#  patmos:
-#    uses: ./.github/workflows/c-patmos-tests.yml
+  patmos:
+    uses: ./.github/workflows/c-patmos-tests.yml


### PR DESCRIPTION
Patmos can compile LF-generated c codes with its previous compiler version. We will change it again when the issue with the new compile is resolved.