### PR TITLE
Use LinkedHashSet instead of HashSet to remove non-determinism in fed-gen

### DIFF
--- a/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
+++ b/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
@@ -129,7 +129,7 @@ public class FederateInstance {
   }
 
   /** A list of individual connections between federates */
-  public Set<FedConnectionInstance> connections = new HashSet<>();
+  public Set<FedConnectionInstance> connections = new LinkedHashSet<>();
 
   /** The counter used to assign IDs to network senders. */
   public int networkIdSender = 0;


### PR DESCRIPTION
This PR solves #2740 thanks to Edward's suggestion