### PR TITLE
Fix federated ZDC detection algorithm

### DIFF
--- a/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
+++ b/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
@@ -609,8 +609,9 @@ public class FederateInstance {
               || visited.contains(destination)) return;
           if (setOfDelays.contains(null)) {
             // Only if we have a zero-delay connection to destination do we add it to visited.
-            // If we have a delayed connection to destination, we should not skip a future zero-delay
-            // connection there. 
+            // If we have a delayed connection to destination, we should not skip a future
+            // zero-delay
+            // connection there.
             visited.add(destination);
             // There is a zero-delay connection to destination.
             if (destination == end) {

--- a/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
+++ b/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
@@ -607,8 +607,11 @@ public class FederateInstance {
           if (end._isInZeroDelayCycle
               || (end == next && destination == next)
               || visited.contains(destination)) return;
-          visited.add(destination);
           if (setOfDelays.contains(null)) {
+            // Only if we have a zero-delay connection to destination do we add it to visited.
+            // If we have a delayed connection to destination, we should not skip a future zero-delay
+            // connection there. 
+            visited.add(destination);
             // There is a zero-delay connection to destination.
             if (destination == end) {
               // Found a zero delay cycle.


### PR DESCRIPTION
Thanks to @byeonggiljun for debugging this. There was a bug in the ZDC detection algorithm where a node is added to the set of visited when we have a delayed connection to it. This made us skip this node later when we had an actual zero-delay connection. The fix is to only add nodes that you actually visit to the visited set.

Fixes https://github.com/lf-lang/lingua-franca/issues/2475