### PR TITLE
Fed decentralized improvements

### DIFF
--- a/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
@@ -100,7 +100,7 @@ public class CExtensionUtils {
    */
   public static String stpStructs(FederateInstance federate) {
     CodeBuilder code = new CodeBuilder();
-    federate.staaOffsets.sort((d1, d2) -> (int) (d1.time - d2.time));
+    federate.staaOffsets.sort((d1, d2) -> {if (d1.time > d2.time) return 1; else if (d1.time < d2.time) return -1; else return 0;});
     if (!federate.staaOffsets.isEmpty()) {
       // Create a static array of trigger_t pointers.
       // networkMessageActions is a list of Actions, but we

--- a/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
@@ -222,6 +222,7 @@ public class PythonExtension extends CExtension {
 
   @Override
   public void annotateReaction(Reaction reaction) {
+    super.annotateReaction(reaction);
     ASTUtils.addReactionAttribute(reaction, "_c_body");
   }
 

--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -245,12 +245,9 @@ public class FedASTUtils {
             .getParent()
             .reactorDefinition; // Top-level reactor.
 
-    // Add the attribute "_networkReactor" for the network receiver.
+    // Add the attribute "_network_receiver" for the network receiver.
     var a = factory.createAttribute();
-    a.setAttrName("_networkReactor");
-    var e = factory.createAttrParm();
-    e.setValue("\"receiver\"");
-    a.getAttrParms().add(e);
+    a.setAttrName("_network_receiver");
     receiver.getAttributes().add(a);
 
     receiver
@@ -324,7 +321,6 @@ public class FedASTUtils {
     // these reactions to appear only in the federate whose bank ID matches.
     setReactionBankIndex(networkReceiverReaction, connection.getDstBank());
 
-    // FIXME: do not create a new extension every time it is used
     extension.annotateReaction(networkReceiverReaction);
 
     // The connection is 'physical' if it uses the ~> notation.
@@ -670,12 +666,9 @@ public class FedASTUtils {
     // Initialize Reactor and Reaction AST Nodes
     Reactor sender = factory.createReactor();
 
-    // Add the attribute "_networkReactor" for the network sender.
+    // Add the attribute "_network_sender" for the network sender.
     var a = factory.createAttribute();
-    a.setAttrName("_networkReactor");
-    var e = factory.createAttrParm();
-    e.setValue("\"sender\"");
-    a.getAttrParms().add(e);
+    a.setAttrName("_network_sender");
     sender.getAttributes().add(a);
 
     Input in = factory.createInput();

--- a/core/src/main/java/org/lflang/validation/AttributeSpec.java
+++ b/core/src/main/java/org/lflang/validation/AttributeSpec.java
@@ -240,8 +240,7 @@ public class AttributeSpec {
     ATTRIBUTE_SPECS_BY_NAME.put(
         "_tpoLevel",
         new AttributeSpec(List.of(new AttrParamSpec(VALUE_ATTR, AttrParamType.INT, false))));
-    ATTRIBUTE_SPECS_BY_NAME.put(
-        "_networkReactor",
-        new AttributeSpec(List.of(new AttrParamSpec(VALUE_ATTR, AttrParamType.STRING, false))));
+    ATTRIBUTE_SPECS_BY_NAME.put("_network_sender", new AttributeSpec(null));
+    ATTRIBUTE_SPECS_BY_NAME.put("_network_receiver", new AttributeSpec(null));
   }
 }

--- a/core/src/main/kotlin/org/lflang/generator/ts/TSInstanceGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/ts/TSInstanceGenerator.kt
@@ -49,9 +49,10 @@ class TSInstanceGenerator(
         var portID = 0
         for (childReactor in childReactors) {
             var tpoLevel = AttributeUtils.getFirstArgumentValue(AttributeUtils.findAttributeByName(childReactor, "_tpoLevel"));
-            val networkReactorAttributeValue = AttributeUtils.getFirstArgumentValue(AttributeUtils.findAttributeByName(childReactor.reactorClass, "_networkReactor"))
-            var isNetworkReceiver = networkReactorAttributeValue == "receiver"
-            var isNetworkSender = networkReactorAttributeValue == "sender"
+
+            var isNetworkReceiver = AttributeUtils.getFirstArgumentValue(AttributeUtils.findAttributeByName(childReactor.reactorClass, "_network_receiver")) != null
+            var isNetworkSender = AttributeUtils.getFirstArgumentValue(AttributeUtils.findAttributeByName(childReactor.reactorClass, "_network_sender")) != null
+            var isNetworkReactor = isNetworkReceiver || isNetworkSender
 
             val childReactorArguments = StringJoiner(", ")
             childReactorArguments.add("this")

--- a/core/src/main/kotlin/org/lflang/generator/ts/TSReactorGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/ts/TSReactorGenerator.kt
@@ -98,10 +98,9 @@ ${"             |"..preamble.code.toText()}
         }
 
         val isFederate = AttributeUtils.isFederate(reactor)
-        val networkReactorAttributeValue = AttributeUtils.getFirstArgumentValue(AttributeUtils.findAttributeByName(reactor, "_networkReactor"))
-        var isNetworkReactor = networkReactorAttributeValue != null
-        var isNetworkReceiver = networkReactorAttributeValue == "receiver"
-        var isNetworkSender = networkReactorAttributeValue == "sender"
+        var isNetworkReceiver = AttributeUtils.getFirstArgumentValue(AttributeUtils.findAttributeByName(reactor, "_network_receiver")) != null
+        var isNetworkSender = AttributeUtils.getFirstArgumentValue(AttributeUtils.findAttributeByName(reactor, "_network_sender")) != null
+        var isNetworkReactor = isNetworkReceiver || isNetworkSender
 
         // NOTE: type parameters that are referenced in ports or actions must extend
         // Present in order for the program to type check.


### PR DESCRIPTION
This PR fixes some issues with federated code generation that make decentralized coordination harder to use:

1. Fixes an overflow error when an STA or STAA of `forever` is used.
2. Removes an unnecessary reaction to `startup` in the network receiver reactors. Such reactions are problematic for decentralized coordination because if a federate has no startup reactions of its own and no timers or logical actions, then it can safely set the `STA` to zero.  But not if it has `startup` reactions.