### PR TITLE
Bumping up reactor-ts package version.

### DIFF
--- a/core/src/main/resources/lib/ts/package.json
+++ b/core/src/main/resources/lib/ts/package.json
@@ -2,7 +2,7 @@
     "name": "LinguaFrancaDefault",
     "type": "commonjs",
     "dependencies": {
-        "@lf-lang/reactor-ts": "^0.6.1",
+        "@lf-lang/reactor-ts": "^0.6.2",
         "command-line-args": "^5.1.1",
         "command-line-usage": "^6.1.3"
     },


### PR DESCRIPTION
This should fix the issue with the unrecognized RTI message error in reactor-ts tests like this:
https://github.com/lf-lang/lingua-franca/actions/runs/14114135784/job/39540256256?pr=2482

New reactor-ts package has just been released: https://github.com/lf-lang/reactor-ts/releases/tag/v0.6.2