### PR TITLE
Minimal changes to allow lff and lfd to run with reactor-uc

### DIFF
--- a/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
+++ b/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
@@ -590,7 +590,7 @@ public class FedLauncherGenerator {
       case C, CCPP -> new CBuildConfig(federate, fileConfig, messageReporter);
       case Python -> new PyBuildConfig(federate, fileConfig, messageReporter);
       case TS -> new TsBuildConfig(federate, fileConfig, messageReporter);
-      case CPP, Rust -> throw new UnsupportedOperationException();
+      case CPP, Rust, UC-> throw new UnsupportedOperationException();
     };
   }
 }

--- a/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
+++ b/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
@@ -590,7 +590,7 @@ public class FedLauncherGenerator {
       case C, CCPP -> new CBuildConfig(federate, fileConfig, messageReporter);
       case Python -> new PyBuildConfig(federate, fileConfig, messageReporter);
       case TS -> new TsBuildConfig(federate, fileConfig, messageReporter);
-      case CPP, Rust, UC-> throw new UnsupportedOperationException();
+      case CPP, Rust, UC -> throw new UnsupportedOperationException();
     };
   }
 }

--- a/core/src/main/java/org/lflang/generator/LFGenerator.java
+++ b/core/src/main/java/org/lflang/generator/LFGenerator.java
@@ -61,7 +61,7 @@ public class LFGenerator extends AbstractGenerator {
         case CPP -> new CppFileConfig(resource, srcGenBasePath, useHierarchicalBin);
         case Rust -> new RustFileConfig(resource, srcGenBasePath, useHierarchicalBin);
         case TS -> new TSFileConfig(resource, srcGenBasePath, useHierarchicalBin);
-        case UC -> throw new RuntimeException("Code-generation is not supported for the UC target yet");
+        case UC -> throw new RuntimeException("Please refer to www.github.com/lf-lang/reactor-uc for code-generation for the uC target.");
       };
     } catch (IOException e) {
       throw new RuntimeException(
@@ -83,7 +83,7 @@ public class LFGenerator extends AbstractGenerator {
       case CPP -> new CppGenerator(context, scopeProvider);
       case TS -> new TSGenerator(context);
       case Rust -> new RustGenerator(context, scopeProvider);
-      case UC -> throw new RuntimeException("Code-generation is not supported for the UC target yet");
+      case UC -> throw new RuntimeException("Please refer to www.github.com/lf-lang/reactor-uc for code-generation for the uC target.");
     };
   }
 

--- a/core/src/main/java/org/lflang/generator/LFGenerator.java
+++ b/core/src/main/java/org/lflang/generator/LFGenerator.java
@@ -61,7 +61,10 @@ public class LFGenerator extends AbstractGenerator {
         case CPP -> new CppFileConfig(resource, srcGenBasePath, useHierarchicalBin);
         case Rust -> new RustFileConfig(resource, srcGenBasePath, useHierarchicalBin);
         case TS -> new TSFileConfig(resource, srcGenBasePath, useHierarchicalBin);
-        case UC -> throw new RuntimeException("Please refer to www.github.com/lf-lang/reactor-uc for code-generation for the uC target.");
+        case UC ->
+            throw new RuntimeException(
+                "Please refer to www.github.com/lf-lang/reactor-uc for code-generation for the uC"
+                    + " target.");
       };
     } catch (IOException e) {
       throw new RuntimeException(
@@ -83,7 +86,10 @@ public class LFGenerator extends AbstractGenerator {
       case CPP -> new CppGenerator(context, scopeProvider);
       case TS -> new TSGenerator(context);
       case Rust -> new RustGenerator(context, scopeProvider);
-      case UC -> throw new RuntimeException("Please refer to www.github.com/lf-lang/reactor-uc for code-generation for the uC target.");
+      case UC ->
+          throw new RuntimeException(
+              "Please refer to www.github.com/lf-lang/reactor-uc for code-generation for the uC"
+                  + " target.");
     };
   }
 

--- a/core/src/main/java/org/lflang/generator/LFGenerator.java
+++ b/core/src/main/java/org/lflang/generator/LFGenerator.java
@@ -61,6 +61,7 @@ public class LFGenerator extends AbstractGenerator {
         case CPP -> new CppFileConfig(resource, srcGenBasePath, useHierarchicalBin);
         case Rust -> new RustFileConfig(resource, srcGenBasePath, useHierarchicalBin);
         case TS -> new TSFileConfig(resource, srcGenBasePath, useHierarchicalBin);
+        case UC -> throw new RuntimeException("Code-generation is not supported for the UC target yet");
       };
     } catch (IOException e) {
       throw new RuntimeException(
@@ -82,6 +83,7 @@ public class LFGenerator extends AbstractGenerator {
       case CPP -> new CppGenerator(context, scopeProvider);
       case TS -> new TSGenerator(context);
       case Rust -> new RustGenerator(context, scopeProvider);
+      case UC -> throw new RuntimeException("Code-generation is not supported for the UC target yet");
     };
   }
 

--- a/core/src/main/java/org/lflang/generator/docker/DockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerGenerator.java
@@ -260,7 +260,7 @@ public abstract class DockerGenerator {
       case C, CCPP -> new CDockerGenerator(context);
       case TS -> new TSDockerGenerator(context);
       case Python -> new PythonDockerGenerator(context);
-      case CPP, Rust ->
+      case CPP, Rust, UC ->
           throw new IllegalArgumentException("No Docker support for " + target + " yet.");
     };
   }

--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -350,7 +350,8 @@ public enum Target {
       // In our Rust implementation, the only reserved keywords
       // are those that are a valid expression. Others may be escaped
       // with the syntax r#keyword.
-      Arrays.asList("self", "true", "false"));
+      Arrays.asList("self", "true", "false")),
+  UC("uC", false, Arrays.asList());
 
   /** String representation of this target. */
   private final String displayName;


### PR DESCRIPTION
This PR introduces the possibility of running `lff` and `lfd` on LF programs with `target uC`. When recompiling the vscode extension with this version of `lingua-franca` this removes the squiggly lines under `target uC`.

If we try to run `lfc` on a file with `target uC` a runtime exception is thrown:

```
> bin/lfc-dev test/UC.lf
lfc: warning: File 'UC.lf' is not located in an 'src' directory.
lfc: warning: Adopting the current working directory as the package root.
lfc: fatal error: An unexpected error occurred:
java.lang.RuntimeException: Code-generation is not supported for the UC target yet
        at org.lflang.generator.LFGenerator.createFileConfig(LFGenerator.java:64)
        at org.lflang.generator.MainContext.<init>(MainContext.java:98)
        at org.lflang.cli.Lfc.invokeGenerator(Lfc.java:228)
        at org.lflang.cli.Lfc.doRun(Lfc.java:201)
        at org.lflang.cli.CliBase.run(CliBase.java:124)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2026)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
        at picocli.CommandLine.execute(CommandLine.java:2170)
        at org.lflang.cli.CliBase.doExecute(CliBase.java:115)
        at org.lflang.cli.CliBase.cliMain(CliBase.java:107)
        at org.lflang.cli.Lfc.main(Lfc.java:189)
        at org.lflang.cli.Lfc.main(Lfc.java:179)
``` 