### PR TITLE
Do not subtract network delays from STAA and refactor code

### DIFF
--- a/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
@@ -5,10 +5,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.lflang.InferredType;
 import org.lflang.MessageReporter;
+import org.lflang.TimeValue;
 import org.lflang.ast.ASTUtils;
 import org.lflang.federated.generator.FederateInstance;
 import org.lflang.federated.generator.FederationFileConfig;
@@ -100,49 +102,43 @@ public class CExtensionUtils {
    */
   public static String stpStructs(FederateInstance federate) {
     CodeBuilder code = new CodeBuilder();
-    federate.staaOffsets.sort(
-        (d1, d2) -> {
-          if (d1.time > d2.time) return 1;
-          else if (d1.time < d2.time) return -1;
-          else return 0;
-        });
-    if (!federate.staaOffsets.isEmpty()) {
-      // Create a static array of trigger_t pointers.
-      // networkMessageActions is a list of Actions, but we
-      // need a list of trigger struct names for ActionInstances.
-      // There should be exactly one ActionInstance in the
-      // main reactor for each Action.
-      for (int i = 0; i < federate.staaOffsets.size(); ++i) {
-        // Find the corresponding ActionInstance.
-        List<Action> networkActions =
-            federate.staToNetworkActionMap.get(federate.staaOffsets.get(i));
+    // Create a static array of trigger_t pointers.
+    // networkMessageActions is a list of Actions, but we
+    // need a list of trigger struct names for ActionInstances.
+    // There should be exactly one ActionInstance in the
+    // main reactor for each Action.
+    var i = 0;
+    for (var offset : federate.staaOffsets) {
+      // Find the corresponding ActionInstance.
+      List<Action> networkActions =
+          federate.staToNetworkActionMap.get(offset);
 
-        code.pr("staa_lst[" + i + "] = (staa_t*) malloc(sizeof(staa_t));");
+      code.pr("staa_lst[" + i + "] = (staa_t*) malloc(sizeof(staa_t));");
+      code.pr(
+          "staa_lst["
+              + i
+              + "]->STAA = "
+              + CTypes.getInstance().getTargetTimeExpr(offset)
+              + ";");
+      code.pr("staa_lst[" + i + "]->num_actions = " + networkActions.size() + ";");
+      code.pr(
+          "staa_lst["
+              + i
+              + "]->actions = (lf_action_base_t**) malloc(sizeof(lf_action_base_t*) * "
+              + networkActions.size()
+              + ");");
+      var tableCount = 0;
+      for (Action action : networkActions) {
         code.pr(
             "staa_lst["
                 + i
-                + "]->STAA = "
-                + CTypes.getInstance().getTargetTimeExpr(federate.staaOffsets.get(i))
-                + ";");
-        code.pr("staa_lst[" + i + "]->num_actions = " + networkActions.size() + ";");
-        code.pr(
-            "staa_lst["
-                + i
-                + "]->actions = (lf_action_base_t**) malloc(sizeof(lf_action_base_t*) * "
-                + networkActions.size()
-                + ");");
-        var tableCount = 0;
-        for (Action action : networkActions) {
-          code.pr(
-              "staa_lst["
-                  + i
-                  + "]->actions["
-                  + tableCount++
-                  + "] = _lf_action_table["
-                  + federate.networkMessageActions.indexOf(action)
-                  + "];");
-        }
+                + "]->actions["
+                + tableCount++
+                + "] = _lf_action_table["
+                + federate.networkMessageActions.indexOf(action)
+                + "];");
       }
+      i++;
     }
     return code.getCode();
   }

--- a/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
@@ -5,12 +5,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.lflang.InferredType;
 import org.lflang.MessageReporter;
-import org.lflang.TimeValue;
 import org.lflang.ast.ASTUtils;
 import org.lflang.federated.generator.FederateInstance;
 import org.lflang.federated.generator.FederationFileConfig;
@@ -110,16 +108,11 @@ public class CExtensionUtils {
     var i = 0;
     for (var offset : federate.staaOffsets) {
       // Find the corresponding ActionInstance.
-      List<Action> networkActions =
-          federate.staToNetworkActionMap.get(offset);
+      List<Action> networkActions = federate.staToNetworkActionMap.get(offset);
 
       code.pr("staa_lst[" + i + "] = (staa_t*) malloc(sizeof(staa_t));");
       code.pr(
-          "staa_lst["
-              + i
-              + "]->STAA = "
-              + CTypes.getInstance().getTargetTimeExpr(offset)
-              + ";");
+          "staa_lst[" + i + "]->STAA = " + CTypes.getInstance().getTargetTimeExpr(offset) + ";");
       code.pr("staa_lst[" + i + "]->num_actions = " + networkActions.size() + ";");
       code.pr(
           "staa_lst["

--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -495,9 +495,8 @@ public class FedASTUtils {
 
   /**
    * @brief Find the maximum STP offset (STAA) for the given 'port'.
-   *
-   * An STP offset (STAA) may be nested in contained reactors in the federate.
-   * This returns TimeValue.ZERO if there are no STAA offsets for the port.
+   *     <p>An STP offset (STAA) may be nested in contained reactors in the federate. This returns
+   *     TimeValue.ZERO if there are no STAA offsets for the port.
    * @param connection The connection to find the max STP offset for.
    * @param coordination The coordination scheme.
    * @return The maximum STP (STAA) as a TimeValue

--- a/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
+++ b/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
@@ -34,6 +34,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.lflang.MessageReporter;
@@ -269,11 +271,8 @@ public class FederateInstance {
   /** Cached result of analysis of which reactions to exclude from main. */
   private Set<Reaction> excludeReactions = null;
 
-  /** Keep a unique list of enabled serializers */
-  public List<TimeValue> staaOffsets = new ArrayList<>();
-
-  /** The STA offsets that have been recorded thus far. */
-  public Set<Long> currentSTAOffsets = new HashSet<>();
+  /** A list of unique STAA offsets over all input ports of this federate. */
+  public SortedSet<TimeValue> staaOffsets = new TreeSet<TimeValue>();
 
   /** Keep a map of STP values to a list of network actions */
   public HashMap<TimeValue, List<Action>> staToNetworkActionMap = new HashMap<>();


### PR DESCRIPTION
This PR makes the following changes in the code generator:
1. Do not subtract network delays from STAA. It's not clear why this was done before.
2. Refactor the collection of unique STAA values using a SortedSet.

There is a companion reactor-c PR: https://github.com/lf-lang/reactor-c/pull/520
