### PR TITLE
Remove federate connections that have no effect

### DIFF
--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -397,7 +397,8 @@ public class FedASTUtils {
     // that it is connected to, which both have the same downstream reaction, have the correct
     // ordering wrt each other.
     var ub = p.getLevelUpperBound(index);
-    // Adjust the level so that input levels are even and output levels are odd, unless the level is Integer.MAX_VALUE,
+    // Adjust the level so that input levels are even and output levels are odd, unless the level is
+    // Integer.MAX_VALUE,
     // which occurs if a port has no dependent reactions.
     int level = Integer.MAX_VALUE;
     if (ub < Integer.MAX_VALUE / 2) {

--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -128,9 +128,8 @@ public class FedASTUtils {
   }
 
   /**
-   * Replace the specified connection with communication between federates.
-   * If the connection has no source reactions or no destination reactions,
-   * then return without doing anything.
+   * Replace the specified connection with communication between federates. If the connection has no
+   * source reactions or no destination reactions, then return without doing anything.
    *
    * @param connection Network connection between two federates.
    * @param resource The resource from which the ECore model was derived.

--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -129,6 +129,8 @@ public class FedASTUtils {
 
   /**
    * Replace the specified connection with communication between federates.
+   * If the connection has no source reactions or no destination reactions,
+   * then return without doing anything.
    *
    * @param connection Network connection between two federates.
    * @param resource The resource from which the ECore model was derived.
@@ -140,6 +142,11 @@ public class FedASTUtils {
       Resource resource,
       CoordinationMode coordination,
       MessageReporter messageReporter) {
+
+    if (connection.getSourcePortInstance().getDependsOnReactions().isEmpty()
+        || connection.getDestinationPortInstance().getDependentReactions().isEmpty()) {
+      return;
+    }
 
     addNetworkSenderReactor(connection, coordination, resource, messageReporter);
 
@@ -398,8 +405,7 @@ public class FedASTUtils {
     // ordering wrt each other.
     var ub = p.getLevelUpperBound(index);
     // Adjust the level so that input levels are even and output levels are odd, unless the level is
-    // Integer.MAX_VALUE,
-    // which occurs if a port has no dependent reactions.
+    // Integer.MAX_VALUE, which occurs if a port has no dependent reactions.
     int level = Integer.MAX_VALUE;
     if (ub < Integer.MAX_VALUE / 2) {
       level = p.isInput() ? 2 * ub : 2 * ub - 1;

--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -397,7 +397,13 @@ public class FedASTUtils {
     // that it is connected to, which both have the same downstream reaction, have the correct
     // ordering wrt each other.
     var ub = p.getLevelUpperBound(index);
-    e.setValue(String.valueOf(p.isInput() ? 2 * ub : 2 * ub - 1));
+    // Adjust the level so that input levels are even and output levels are odd, unless the level is Integer.MAX_VALUE,
+    // which occurs if a port has no dependent reactions.
+    int level = Integer.MAX_VALUE;
+    if (ub < Integer.MAX_VALUE / 2) {
+      level = p.isInput() ? 2 * ub : 2 * ub - 1;
+    }
+    e.setValue(String.valueOf(level));
     a.getAttrParms().add(e);
     instantiation.getAttributes().add(a);
   }

--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -689,6 +689,8 @@ public class FedGenerator {
   private void insertIndexers(ReactorInstance mainInstance, Resource resource) {
     for (ReactorInstance child : mainInstance.children) {
       for (PortInstance input : child.inputs) {
+        // If there are no dependent reactions, skip this indexer.
+        if (input.getDependentReactions().isEmpty()) continue;
         var indexer = indexer(child, input, resource);
         var count = 0;
         for (FederateInstance federate : federatesByInstantiation.get(child.getDefinition())) {

--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -690,7 +690,7 @@ public class FedGenerator {
     for (ReactorInstance child : mainInstance.children) {
       for (PortInstance input : child.inputs) {
         // If there are no dependent reactions, skip this indexer.
-        if (input.getDependentReactions().isEmpty()) continue;
+        if (!FedASTUtils.hasDestinationReaction(input)) continue;
         var indexer = indexer(child, input, resource);
         var count = 0;
         for (FederateInstance federate : federatesByInstantiation.get(child.getDefinition())) {

--- a/core/src/main/java/org/lflang/generator/PortInstance.java
+++ b/core/src/main/java/org/lflang/generator/PortInstance.java
@@ -209,15 +209,18 @@ public class PortInstance extends TriggerInstance<Port> {
    * Record that the {@code index}th sub-port of this has a dependent reaction of level {@code
    * level}.
    */
-  public void hasDependentReactionWithLevel(MixedRadixInt index, int level) {
+  public void recordIndexForPortChannel(MixedRadixInt index, int level) {
     levelUpperBounds.put(
         index, Math.min(levelUpperBounds.getOrDefault(index, Integer.MAX_VALUE), level));
   }
 
-  /** Return the minimum of the levels of the reactions that are downstream of this port. */
+  /**
+   * Return the minimum of the levels of the reactions that are downstream of this port.
+   * If there are no reactions downstream of this port, this returns Integer.MAX_VALUE.
+   */
   public int getLevelUpperBound(MixedRadixInt index) {
-    // It should be uncommon for Integer.MAX_VALUE to be used and using it can mask bugs.
-    // It makes sense when there is no downstream reaction.
+    // Normally, this function will not be used if there are no downstream reactions
+    // because the connection gets optimized away.
     return levelUpperBounds.getOrDefault(index, Integer.MAX_VALUE);
   }
 

--- a/core/src/main/java/org/lflang/generator/PortInstance.java
+++ b/core/src/main/java/org/lflang/generator/PortInstance.java
@@ -215,8 +215,8 @@ public class PortInstance extends TriggerInstance<Port> {
   }
 
   /**
-   * Return the minimum of the levels of the reactions that are downstream of this port.
-   * If there are no reactions downstream of this port, this returns Integer.MAX_VALUE.
+   * Return the minimum of the levels of the reactions that are downstream of this port. If there
+   * are no reactions downstream of this port, this returns Integer.MAX_VALUE.
    */
   public int getLevelUpperBound(MixedRadixInt index) {
     // Normally, this function will not be used if there are no downstream reactions

--- a/core/src/main/java/org/lflang/generator/ReactionInstanceGraph.java
+++ b/core/src/main/java/org/lflang/generator/ReactionInstanceGraph.java
@@ -382,7 +382,7 @@ public class ReactionInstanceGraph extends PrecedenceGraph<ReactionInstance.Runt
    */
   private void assignPortLevel(Runtime current) {
     for (var sp : current.sourcePorts) {
-      sp.port().hasDependentReactionWithLevel(sp.index(), current.level);
+      sp.port().recordIndexForPortChannel(sp.index(), current.level);
     }
   }
 

--- a/test/C/src/federated/DisconnectedInput.lf
+++ b/test/C/src/federated/DisconnectedInput.lf
@@ -1,0 +1,34 @@
+/**
+ * Verify that an unconnected input port does not cause a spurious cyclic dependency. Success is
+ * just compiling and running without error.
+ */
+target C {
+  timeout: 100 ms
+}
+
+reactor A {
+  input in: int
+  output out: int
+  timer t(0, 25 ms)
+
+  reaction(t) -> out {=
+    lf_set(out, 42);
+  =}
+}
+
+reactor B {
+  input in: int
+  output out: int
+
+  reaction(in) -> out {=
+    lf_print("B received %d", in->value);
+    lf_set(out, in->value);
+  =}
+}
+
+federated reactor {
+  a = new A()
+  b = new B()
+  a.out -> b.in
+  b.out -> a.in
+}


### PR DESCRIPTION
This PR eliminates network connections if there are either no source reactions (nothing is ever sent on the connection) or there are no destination reactions (no received message ever triggers a reaction).

This PR also fixes an overflow error, where if a federated input is unconnected, an incorrect calculation of TPO (total port order) resulted from overflow when the level was given `Integer.MAX_VALUE`. This condition, however, should now never occur because the connection will be optimized away. Nevertheless, the code now cannot exhibit this overflow error.

Closes #2478.