### PR TITLE
Compile RTI for each federation

### DIFF
--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -318,8 +318,8 @@ public class FedGenerator {
               "\n",
               "cmake_minimum_required(VERSION 3.12)",
               "project(RTI VERSION 1.0.0 LANGUAGES C)",
-              "set(LOG_LEVEL " + targetConfig.get(LoggingProperty.INSTANCE).ordinal() + ")",
-              "set(AUTH " + (targetConfig.get(AuthProperty.INSTANCE) ? "ON" : "OFF") + ")",
+              "set(LOG_LEVEL " + targetConfig.getOrDefault(LoggingProperty.INSTANCE).ordinal() + ")",
+              "set(AUTH " + (targetConfig.getOrDefault(AuthProperty.INSTANCE) ? "ON" : "OFF") + ")",
               "set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})",
               "add_subdirectory(${CMAKE_SOURCE_DIR}/core/federated/RTI"
                   + " ${CMAKE_BINARY_DIR}/build_RTI)");

--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -313,13 +313,16 @@ public class FedGenerator {
       }
 
       // 3. Generate the CmakeLists.txt file
-      var rtiCMakeLists = String.join("\n",
-          "cmake_minimum_required(VERSION 3.12)",
-          "project(RTI VERSION 1.0.0 LANGUAGES C)",
-          "set(LOG_LEVEL " + targetConfig.get(LoggingProperty.INSTANCE).ordinal() + ")",
-          "set(AUTH " + (targetConfig.get(AuthProperty.INSTANCE) ? "ON" : "OFF") + ")",
-          "set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})",
-          "add_subdirectory(${CMAKE_SOURCE_DIR}/core/federated/RTI ${CMAKE_BINARY_DIR}/build_RTI)");
+      var rtiCMakeLists =
+          String.join(
+              "\n",
+              "cmake_minimum_required(VERSION 3.12)",
+              "project(RTI VERSION 1.0.0 LANGUAGES C)",
+              "set(LOG_LEVEL " + targetConfig.get(LoggingProperty.INSTANCE).ordinal() + ")",
+              "set(AUTH " + (targetConfig.get(AuthProperty.INSTANCE) ? "ON" : "OFF") + ")",
+              "set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})",
+              "add_subdirectory(${CMAKE_SOURCE_DIR}/core/federated/RTI"
+                  + " ${CMAKE_BINARY_DIR}/build_RTI)");
 
       FileUtil.writeToFile(rtiCMakeLists, dest.resolve("CMakeLists.txt"));
     } catch (IOException e) {

--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -318,7 +318,9 @@ public class FedGenerator {
               "\n",
               "cmake_minimum_required(VERSION 3.12)",
               "project(RTI VERSION 1.0.0 LANGUAGES C)",
-              "set(LOG_LEVEL " + targetConfig.getOrDefault(LoggingProperty.INSTANCE).ordinal() + ")",
+              "set(LOG_LEVEL "
+                  + targetConfig.getOrDefault(LoggingProperty.INSTANCE).ordinal()
+                  + ")",
               "set(AUTH " + (targetConfig.getOrDefault(AuthProperty.INSTANCE) ? "ON" : "OFF") + ")",
               "set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})",
               "add_subdirectory(${CMAKE_SOURCE_DIR}/core/federated/RTI"

--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -59,10 +59,12 @@ import org.lflang.lf.TargetDecl;
 import org.lflang.lf.VarRef;
 import org.lflang.target.Target;
 import org.lflang.target.TargetConfig;
+import org.lflang.target.property.AuthProperty;
 import org.lflang.target.property.CoordinationProperty;
 import org.lflang.target.property.DockerProperty;
 import org.lflang.target.property.DockerProperty.DockerOptions;
 import org.lflang.target.property.KeepaliveProperty;
+import org.lflang.target.property.LoggingProperty;
 import org.lflang.target.property.NoCompileProperty;
 import org.lflang.target.property.PlatformProperty;
 import org.lflang.target.property.type.CoordinationModeType.CoordinationMode;
@@ -240,14 +242,19 @@ public class FedGenerator {
     FederationFileConfig fileConfig = this.fileConfig;
     Path rtiSrcPath = fileConfig.getRtiSrcGenPath().resolve("core/federated/RTI");
     String cores = String.valueOf(Runtime.getRuntime().availableProcessors());
+    var t = targetConfig.get(AuthProperty.INSTANCE);
+    var st = t ? "ON" : "OFF";
 
     var clean = LFCommand.get("rm", List.of("-rf", "build"), false, rtiSrcPath);
-    // FIXME: Add LOG_LEVEL to the RTI build.
-    // FIXME: Add auth-stuff to the RTI build.
     var configure =
         LFCommand.get(
             "cmake",
-            List.of("-Bbuild", "-DCMAKE_INSTALL_PREFIX=" + fileConfig.getGenPath(), "."),
+            List.of(
+                "-Bbuild",
+                "-DCMAKE_INSTALL_PREFIX=" + fileConfig.getGenPath(),
+                "-DLOG_LEVEL=" + targetConfig.get(LoggingProperty.INSTANCE).ordinal(),
+                "-DAUTH=" + (targetConfig.get(AuthProperty.INSTANCE).booleanValue() ? "ON" : "OFF"),
+                "."),
             false,
             rtiSrcPath);
     var build =

--- a/core/src/main/java/org/lflang/federated/generator/FederationFileConfig.java
+++ b/core/src/main/java/org/lflang/federated/generator/FederationFileConfig.java
@@ -78,6 +78,16 @@ public class FederationFileConfig extends FileConfig {
     return getGenPath().resolve("src-gen");
   }
 
+  /** The directory in which to put a copy of reactor-c for compiling a RTI for this federation. */
+  public Path getRtiSrcGenPath() {
+    return getSrcGenPath().resolve("rti");
+  }
+
+  /** The path to the RTI binary that is compiled for this federation. */
+  public Path getRtiBinPath() {
+    return getFedBinPath().resolve("RTI");
+  }
+
   /**
    * Return the path to the root of a LF project generated on the basis of a federated LF program
    * currently under compilation.

--- a/core/src/main/java/org/lflang/federated/generator/FederationFileConfig.java
+++ b/core/src/main/java/org/lflang/federated/generator/FederationFileConfig.java
@@ -80,7 +80,7 @@ public class FederationFileConfig extends FileConfig {
 
   /** The directory in which to put a copy of reactor-c for compiling a RTI for this federation. */
   public Path getRtiSrcGenPath() {
-    return getSrcGenPath().resolve("rti");
+    return getSrcGenPath().resolve("RTI");
   }
 
   /** The path to the RTI binary that is compiled for this federation. */

--- a/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
+++ b/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
@@ -314,9 +314,9 @@ public class FedLauncherGenerator {
   private String getRtiCommand(List<FederateInstance> federates, boolean isRemote) {
     List<String> commands = new ArrayList<>();
     if (isRemote) {
-      commands.add("RTI -i '${FEDERATION_ID}' \\");
+      commands.add(this.fileConfig.getRtiBinPath() + " -i '${FEDERATION_ID}' \\");
     } else {
-      commands.add("RTI -i ${FEDERATION_ID} \\");
+      commands.add(this.fileConfig.getRtiBinPath() + " -i ${FEDERATION_ID} \\");
     }
     if (targetConfig.getOrDefault(AuthProperty.INSTANCE)) {
       commands.add("                        -a \\");
@@ -355,14 +355,6 @@ public class FedLauncherGenerator {
     return String.join(
         "\n",
         "echo \"#### Launching the runtime infrastructure (RTI).\"",
-        "# First, check if the RTI is on the PATH",
-        "if ! command -v RTI &> /dev/null",
-        "then",
-        "    echo \"RTI could not be found.\"",
-        "    echo \"The source code can be obtained from"
-            + " https://github.com/lf-lang/reactor-c/tree/main/core/federated/RTI\"",
-        "    exit 1",
-        "fi                ",
         "# The RTI is started first to allow proper boot-up",
         "# before federates will try to connect.",
         "# The RTI will be brought back to foreground",

--- a/core/src/main/java/org/lflang/federated/launcher/RtiConfig.java
+++ b/core/src/main/java/org/lflang/federated/launcher/RtiConfig.java
@@ -1,6 +1,10 @@
 package org.lflang.federated.launcher;
 
 import java.nio.file.Path;
+import org.lflang.FileConfig;
+import org.lflang.target.TargetConfig;
+import org.lflang.target.property.AuthProperty;
+import org.lflang.target.property.LoggingProperty;
 
 /**
  * Class for storing configuration settings pertaining to the RTI.
@@ -47,6 +51,11 @@ public class RtiConfig {
     return user;
   }
 
+  /** Return the path to the RTI binary on the remote host. */
+  public String getRtiBinPath(FileConfig fileConfig) {
+    return "~/" + directory.resolve(fileConfig.name).resolve("bin/RTI").toString();
+  }
+
   /** Set the directory to create on the remote host. */
   public void setDirectory(Path directory) {
     this.directory = directory;
@@ -65,5 +74,17 @@ public class RtiConfig {
   /** Set the username used to gain access to the host where the RTI is to be spawned. */
   public void setUser(String user) {
     this.user = user;
+  }
+
+  /** The CMakeLists.txt to be code-generated to build the RTI.  */
+  public String getRtiCmake(TargetConfig targetConfig) {
+    return String.join(
+        "\n",
+        "cmake_minimum_required(VERSION 3.12)",
+        "project(RTI VERSION 1.0.0 LANGUAGES C)",
+        "set(LOG_LEVEL " + targetConfig.get(LoggingProperty.INSTANCE).ordinal() + ")",
+        "set(AUTH " + (targetConfig.get(AuthProperty.INSTANCE) ? "ON" : "OFF") + ")",
+        "set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})",
+        "add_subdirectory(${CMAKE_SOURCE_DIR}/core/federated/RTI ${CMAKE_BINARY_DIR}/build_RTI)");
   }
 }

--- a/core/src/main/java/org/lflang/federated/launcher/RtiConfig.java
+++ b/core/src/main/java/org/lflang/federated/launcher/RtiConfig.java
@@ -2,9 +2,6 @@ package org.lflang.federated.launcher;
 
 import java.nio.file.Path;
 import org.lflang.FileConfig;
-import org.lflang.target.TargetConfig;
-import org.lflang.target.property.AuthProperty;
-import org.lflang.target.property.LoggingProperty;
 
 /**
  * Class for storing configuration settings pertaining to the RTI.

--- a/core/src/main/java/org/lflang/federated/launcher/RtiConfig.java
+++ b/core/src/main/java/org/lflang/federated/launcher/RtiConfig.java
@@ -75,16 +75,4 @@ public class RtiConfig {
   public void setUser(String user) {
     this.user = user;
   }
-
-  /** The CMakeLists.txt to be code-generated to build the RTI.  */
-  public String getRtiCmake(TargetConfig targetConfig) {
-    return String.join(
-        "\n",
-        "cmake_minimum_required(VERSION 3.12)",
-        "project(RTI VERSION 1.0.0 LANGUAGES C)",
-        "set(LOG_LEVEL " + targetConfig.get(LoggingProperty.INSTANCE).ordinal() + ")",
-        "set(AUTH " + (targetConfig.get(AuthProperty.INSTANCE) ? "ON" : "OFF") + ")",
-        "set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})",
-        "add_subdirectory(${CMAKE_SOURCE_DIR}/core/federated/RTI ${CMAKE_BINARY_DIR}/build_RTI)");
-  }
 }


### PR DESCRIPTION
This PR addresses some recent issues we have had with incompatible versions of LFC and the RTI. This PR copies the RTI into the fed-gen folder and produces a trivial `CMakeLists.txt` there. This allows the RTI to be compiled just like a federate, the executable is copied into fed-gen/bin. The existing infrastructure for distributing src-gen and compiling remotely is used for the RTI.

A small change is needed in reactor-c: https://github.com/lf-lang/reactor-c/pull/523
