### PR TITLE
Tuned colors and validation for enclaves and deadlines

### DIFF
--- a/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
@@ -91,6 +91,10 @@ import org.lflang.lf.StateVar;
 @ViewSynthesisShared
 public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
 
+  public static final Colors ENCLAVE_BORDER_COLOR = Colors.CORAL_3;
+  public static final Colors DEADLINE_COLOR = Colors.WHITE; // Formerly Colors.BROWN
+  public static final Colors CODE_COLOR = Colors.BLACK;
+
   public static final float REACTION_POINTINESS = 6; // arrow point length
   // Property for marking the KContainterRendering in Reactor figures that is supposed to hold the
   // content
@@ -180,10 +184,12 @@ public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
       KNode node, ReactorInstance reactorInstance, String text) {
     int padding = getBooleanValue(LinguaFrancaSynthesis.SHOW_HYPERLINKS) ? 8 : 6;
 
+    var color = (reactorInstance.enclaveInfo == null) ? Colors.GRAY : ENCLAVE_BORDER_COLOR;
+
     Function1<KRoundedRectangle, KRendering> style =
         r -> {
           _kRenderingExtensions.setLineWidth(r, 1);
-          _kRenderingExtensions.setForeground(r, Colors.GRAY);
+          _kRenderingExtensions.setForeground(r, color);
           _kRenderingExtensions.setBackground(r, Colors.GRAY_95);
           return _linguaFrancaStyleExtensions.boldLineSelectionStyle(r);
         };
@@ -444,6 +450,7 @@ public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
               contentContainer, _utilityExtensions.trimCode(reaction.getDefinition().getCode()));
       associateWith(hasCodeText, reaction);
       _kRenderingExtensions.setFontSize(hasCodeText, 6);
+      _kRenderingExtensions.setForeground(hasCodeText, CODE_COLOR);
       _kRenderingExtensions.setFontName(hasCodeText, KlighdConstants.DEFAULT_MONOSPACE_FONT_NAME);
       _linguaFrancaStyleExtensions.noSelectionStyle(hasCodeText);
       _kRenderingExtensions.setHorizontalAlignment(hasCodeText, HorizontalAlignment.LEFT);
@@ -514,7 +521,7 @@ public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
           _kContainerRenderingExtensions.addText(
               labelContainer, reaction.declaredDeadline.maxDelay.toString());
       associateWith(stopWatchText, reaction.getDefinition().getDeadline().getDelay());
-      _kRenderingExtensions.setForeground(stopWatchText, Colors.BROWN);
+      _kRenderingExtensions.setForeground(stopWatchText, DEADLINE_COLOR);
       _kRenderingExtensions.setFontBold(stopWatchText, true);
       _kRenderingExtensions.setFontSize(stopWatchText, 7);
       _linguaFrancaStyleExtensions.underlineSelectionStyle(stopWatchText);
@@ -527,7 +534,7 @@ public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
                 contentContainer,
                 _utilityExtensions.trimCode(reaction.getDefinition().getDeadline().getCode()));
         associateWith(contentContainerText, reaction.declaredDeadline);
-        _kRenderingExtensions.setForeground(contentContainerText, Colors.BROWN);
+        _kRenderingExtensions.setForeground(contentContainerText, CODE_COLOR);
         _kRenderingExtensions.setFontSize(contentContainerText, 6);
         _kRenderingExtensions.setFontName(
             contentContainerText, KlighdConstants.DEFAULT_MONOSPACE_FONT_NAME);
@@ -581,7 +588,7 @@ public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
             List.of(
                 _kRenderingExtensions.createKPosition(LEFT, 3, 0.5f, TOP, (-2), 0),
                 _kRenderingExtensions.createKPosition(LEFT, (-3), 0.5f, TOP, (-2), 0)));
-    _kRenderingExtensions.setForeground(polyline, Colors.BROWN);
+    _kRenderingExtensions.setForeground(polyline, DEADLINE_COLOR);
 
     polyline =
         _kContainerRenderingExtensions.addPolyline(
@@ -590,11 +597,11 @@ public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
             List.of(
                 _kRenderingExtensions.createKPosition(LEFT, 0, 0.5f, TOP, (-2), 0),
                 _kRenderingExtensions.createKPosition(LEFT, 0, 0.5f, TOP, 1, 0)));
-    _kRenderingExtensions.setForeground(polyline, Colors.BROWN);
+    _kRenderingExtensions.setForeground(polyline, DEADLINE_COLOR);
 
     KEllipse body = _kContainerRenderingExtensions.addEllipse(container);
     _kRenderingExtensions.setLineWidth(body, 1);
-    _kRenderingExtensions.setForeground(body, Colors.BROWN);
+    _kRenderingExtensions.setForeground(body, DEADLINE_COLOR);
     _kRenderingExtensions.<KEllipse>setPointPlacementData(
         body,
         _kRenderingExtensions.LEFT,
@@ -616,7 +623,7 @@ public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
     arc.setArcAngle(110);
     arc.setArcType(Arc.PIE);
     _kRenderingExtensions.setLineWidth(arc, 0);
-    _kRenderingExtensions.setBackground(arc, Colors.BROWN);
+    _kRenderingExtensions.setBackground(arc, DEADLINE_COLOR);
     _kRenderingExtensions.setPointPlacementData(
         arc,
         _kRenderingExtensions.LEFT,

--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -467,7 +467,10 @@ public enum Target {
 
   /** Return true if enclaves are supported by this target. */
   public boolean supportsEnclaves() {
-    return this.equals(Target.C) || this.equals(Target.CPP) || this.equals(Target.Python);
+    return this.equals(Target.C)
+        || this.equals(Target.CCPP)
+        || this.equals(Target.CPP)
+        || this.equals(Target.Python);
   }
 
   /**

--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -458,11 +458,16 @@ public enum Target {
   }
 
   /**
-   * Return true of reaction declarations (i.e., reactions without inlined code) are supported by
+   * Return true if reaction declarations (i.e., reactions without inlined code) are supported by
    * this target.
    */
   public boolean supportsReactionDeclarations() {
     return this.equals(Target.C) || this.equals(Target.CPP);
+  }
+
+  /** Return true if enclaves are supported by this target. */
+  public boolean supportsEnclaves() {
+    return this.equals(Target.C) || this.equals(Target.CPP) || this.equals(Target.Python);
   }
 
   /**

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -706,10 +706,11 @@ public class LFValidator extends BaseLFValidator {
                 Literals.REACTION__TRIGGERS);
           } else if (AttributeUtils.getEnclaveAttribute(triggerVarRef.getContainer()) != null) {
             error(
-                    String.format(
-                            "Triggering a reaction with the output of a contained enclave is not supported: %s",
-                            triggerVarRef.getVariable().getName()),
-                    Literals.REACTION__TRIGGERS);
+                String.format(
+                    "Triggering a reaction with the output of a contained enclave is not supported:"
+                        + " %s",
+                    triggerVarRef.getVariable().getName()),
+                Literals.REACTION__TRIGGERS);
           }
         }
       }

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -698,11 +698,18 @@ public class LFValidator extends BaseLFValidator {
           }
         } else if (triggerVarRef.getVariable() instanceof Output) {
           if (triggerVarRef.getContainer() == null) {
+            // Enclaves in Cpp and C
             error(
                 String.format(
                     "Cannot have an output of this reactor as a trigger: %s",
                     triggerVarRef.getVariable().getName()),
                 Literals.REACTION__TRIGGERS);
+          } else if (AttributeUtils.getEnclaveAttribute(triggerVarRef.getContainer()) != null) {
+            error(
+                    String.format(
+                            "Triggering a reaction with the output of a contained enclave is not supported: %s",
+                            triggerVarRef.getVariable().getName()),
+                    Literals.REACTION__TRIGGERS);
           }
         }
       }

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -503,6 +503,11 @@ public class LFValidator extends BaseLFValidator {
               + instantiation.getReactorClass().getName(),
           Literals.INSTANTIATION__REACTOR_CLASS);
     }
+    if (AttributeUtils.getEnclaveAttribute(instantiation) != null && !target.supportsEnclaves()) {
+      error(
+          "This target does not support enclaves." + instantiation.getReactorClass().getName(),
+          Literals.INSTANTIATION__REACTOR_CLASS);
+    }
 
     // Report error if this instantiation is part of a cycle.
     // FIXME: improve error message.
@@ -698,13 +703,13 @@ public class LFValidator extends BaseLFValidator {
           }
         } else if (triggerVarRef.getVariable() instanceof Output) {
           if (triggerVarRef.getContainer() == null) {
-            // Enclaves in Cpp and C
             error(
                 String.format(
                     "Cannot have an output of this reactor as a trigger: %s",
                     triggerVarRef.getVariable().getName()),
                 Literals.REACTION__TRIGGERS);
           } else if (AttributeUtils.getEnclaveAttribute(triggerVarRef.getContainer()) != null) {
+            // Enclaves in Cpp, C, and Python
             error(
                 String.format(
                     "Triggering a reaction with the output of a contained enclave is not supported:"

--- a/test/C/src/enclave/EnclaveBlockingReaction.lf
+++ b/test/C/src/enclave/EnclaveBlockingReaction.lf
@@ -1,0 +1,39 @@
+/** Test that a blocking reaction in one enclave does not block the main enclave. */
+target C {
+  keepalive: true,
+  timeout: 2 sec
+}
+
+reactor BlockingReactor {
+  output out: int
+  timer t(0, 1 s)
+
+  reaction(t) -> out {=
+    lf_print("Blocking reactor invoked");
+    lf_sleep(SEC(1));
+    lf_print("Blocking reactor sending output");
+    lf_set(out, 42);
+  =}
+}
+
+reactor Print {
+  input in: int
+
+  reaction(in) {=
+    lf_print("Print reactor received enclave output at tag " PRINTF_TAG, lf_time_logical_elapsed(), lf_tag().microstep);
+  =}
+}
+
+main reactor {
+  timer t(0, 100 ms)
+  @enclave
+  blocking = new BlockingReactor()
+  print = new Print()
+  blocking.out ~> print.in
+
+  reaction(t) {=
+    lf_print("Tick at tag " PRINTF_TAG, lf_time_logical_elapsed(), lf_tag().microstep);
+  =} deadline(300 ms) {=
+    lf_print_error_and_exit("Main reactor deadline was violated!");
+  =}
+}

--- a/test/Python/src/enclave/EnclaveBlockingReaction.lf
+++ b/test/Python/src/enclave/EnclaveBlockingReaction.lf
@@ -1,0 +1,44 @@
+/** Test that a blocking reaction in one enclave does not block the main enclave. */
+target Python {
+  keepalive: true,
+  timeout: 2 sec
+}
+
+preamble {=
+  import time
+=}
+
+reactor BlockingReactor {
+  output out
+  timer t(0, 1 s)
+
+  reaction(t) -> out {=
+    print("Blocking reactor invoked")
+    time.sleep(1); # Simulate blocking
+    print("Blocking reactor sending output")
+    out.set(42)
+  =}
+}
+
+reactor Print {
+  input inp
+
+  reaction(inp) {=
+    print("Print reactor received enclave output at tag (", lf.time.logical_elapsed(), ", ", lf.tag().microstep, ")")
+  =}
+}
+
+main reactor {
+  timer t(0, 100 ms)
+  @enclave
+  blocking = new BlockingReactor()
+  print = new Print()
+  blocking.out ~> print.inp
+
+  reaction(t) {=
+    print("Tick at tag (", lf.time.logical_elapsed(), ", ", lf.tag().microstep, ")")
+  =} deadline(300 ms) {=
+    print("Main reactor deadline was violated!")
+    exit(1)
+  =}
+}


### PR DESCRIPTION
This PR makes the following changes:
* Validator ensures there are no reactions to outputs from contained enclaves.
* Validator ensures enclaves are not used outside C, Cpp, or Python.
* Enclaves are rendered with a reddish outline.
* Deadline symbol and value are changed from brown to white for better contrast.
* reactor-c is aligned to main.

When this gets merged into master, update the `vscode-lingua-franca` repo to point to this updated master to get the visual updates in the diagram server.  If you have a local copy of that repo, you can get the visual updates by doing this update manually:

```
cd vscode-lingua-franca/lingua-franca
git pull
cd ..
npm run install-extension
```
