### PR TITLE
Show forever, never, and SI units in toString()

### DIFF
--- a/core/src/main/java/org/lflang/TimeUnit.java
+++ b/core/src/main/java/org/lflang/TimeUnit.java
@@ -39,13 +39,13 @@ import java.util.stream.Collectors;
  */
 public enum TimeUnit {
   /** Nanoseconds. */
-  NANO("ns", "nsec", "nsecs"),
+  NANO("nsec", "ns", "nsecs"),
   /** Microseconds. */
-  MICRO("us", "usec", "usecs"),
+  MICRO("usec", "us", "usecs"),
   /** Milliseconds. */
-  MILLI("ms", "msec", "msecs"),
+  MILLI("msec", "ms", "msecs"),
   /** Seconds. */
-  SECOND("s", "sec", "secs", "second", "seconds"),
+  SECOND("sec", "s", "secs", "second", "seconds"),
   /** Minute. */
   // NOTE: Do not use MIN as the first entry. Common macro for minimum.
   MINUTE("minute", "min", "mins", "minutes"),
@@ -58,9 +58,11 @@ public enum TimeUnit {
 
   private final Set<String> allNames;
   private final String canonicalName;
+  private final String siName;
 
-  TimeUnit(String canonicalName, String... aliases) {
+  TimeUnit(String canonicalName, String siName, String... aliases) {
     this.canonicalName = canonicalName;
+    this.siName = siName;
     this.allNames = immutableSetOf(canonicalName, aliases);
   }
 
@@ -105,6 +107,6 @@ public enum TimeUnit {
 
   @Override
   public String toString() {
-    return this.canonicalName;
+    return this.siName;
   }
 }

--- a/core/src/main/java/org/lflang/TimeUnit.java
+++ b/core/src/main/java/org/lflang/TimeUnit.java
@@ -24,8 +24,6 @@
 
 package org.lflang;
 
-import static org.lflang.util.CollectionUtil.immutableSetOf;
-
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -54,7 +52,7 @@ public enum TimeUnit {
   HOUR("hour", "h", "hours"),
   /** Day. */
   DAY("day", "d", "days"),
-  WEEK("week", "wk","weeks"),
+  WEEK("week", "wk", "weeks"),
   ;
 
   private final Set<String> allNames;
@@ -63,6 +61,7 @@ public enum TimeUnit {
 
   /**
    * Construct a time unit.
+   *
    * @param canonicalName The name used in the generated code for the unit.
    * @param siName The SI unit name, if there is one, and otherwise a short name.
    * @param aliases Any number of alternative names for the unit.

--- a/core/src/main/java/org/lflang/TimeUnit.java
+++ b/core/src/main/java/org/lflang/TimeUnit.java
@@ -27,6 +27,7 @@ package org.lflang;
 import static org.lflang.util.CollectionUtil.immutableSetOf;
 
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -63,7 +64,11 @@ public enum TimeUnit {
   TimeUnit(String canonicalName, String siName, String... aliases) {
     this.canonicalName = canonicalName;
     this.siName = siName;
-    this.allNames = immutableSetOf(canonicalName, aliases);
+    var all = new LinkedHashSet<String>();
+    all.add(canonicalName);
+    all.add(siName);
+    all.addAll(Arrays.asList(aliases));
+    this.allNames = all;
   }
 
   /** Returns the name that is preferred when displaying this unit. */

--- a/core/src/main/java/org/lflang/TimeUnit.java
+++ b/core/src/main/java/org/lflang/TimeUnit.java
@@ -54,13 +54,19 @@ public enum TimeUnit {
   HOUR("hour", "h", "hours"),
   /** Day. */
   DAY("day", "d", "days"),
-  WEEK("week", "weeks"),
+  WEEK("week", "wk","weeks"),
   ;
 
   private final Set<String> allNames;
   private final String canonicalName;
   private final String siName;
 
+  /**
+   * Construct a time unit.
+   * @param canonicalName The name used in the generated code for the unit.
+   * @param siName The SI unit name, if there is one, and otherwise a short name.
+   * @param aliases Any number of alternative names for the unit.
+   */
   TimeUnit(String canonicalName, String siName, String... aliases) {
     this.canonicalName = canonicalName;
     this.siName = siName;

--- a/core/src/main/java/org/lflang/TimeUnit.java
+++ b/core/src/main/java/org/lflang/TimeUnit.java
@@ -39,13 +39,13 @@ import java.util.stream.Collectors;
  */
 public enum TimeUnit {
   /** Nanoseconds. */
-  NANO("nsec", "ns", "nsecs"),
+  NANO("ns", "nsec", "nsecs"),
   /** Microseconds. */
-  MICRO("usec", "us", "usecs"),
+  MICRO("us", "usec", "usecs"),
   /** Milliseconds. */
-  MILLI("msec", "ms", "msecs"),
+  MILLI("ms", "msec", "msecs"),
   /** Seconds. */
-  SECOND("sec", "s", "secs", "second", "seconds"),
+  SECOND("s", "sec", "secs", "second", "seconds"),
   /** Minute. */
   // NOTE: Do not use MIN as the first entry. Common macro for minimum.
   MINUTE("minute", "min", "mins", "minutes"),

--- a/core/src/main/java/org/lflang/TimeValue.java
+++ b/core/src/main/java/org/lflang/TimeValue.java
@@ -176,6 +176,8 @@ public final class TimeValue implements Comparable<TimeValue> {
 
   /** Return a string representation of this time value. */
   public String toString() {
+    if (this.equals(MAX_VALUE)) return "forever";
+    if (this.equals(MIN_VALUE)) return "never";
     return unit != null ? time + " " + unit.getCanonicalName() : Long.toString(time);
   }
 

--- a/core/src/main/java/org/lflang/TimeValue.java
+++ b/core/src/main/java/org/lflang/TimeValue.java
@@ -178,7 +178,7 @@ public final class TimeValue implements Comparable<TimeValue> {
   public String toString() {
     if (this.equals(MAX_VALUE)) return "forever";
     if (this.equals(MIN_VALUE)) return "never";
-    return unit != null ? time + " " + unit.getCanonicalName() : Long.toString(time);
+    return unit != null ? time + " " + unit.toString() : Long.toString(time);
   }
 
   /** Return the latest of both values. */


### PR DESCRIPTION
This PR changes the toString() method of TimeValue to return "forever" and "never" when appropriate.
It also changes the default string representation in TimeUnit to use SI units, like "ms" instead of "msec".