### PR TITLE
Update async callback tests

### DIFF
--- a/test/C/src/concurrent/AsyncCallback.lf
+++ b/test/C/src/concurrent/AsyncCallback.lf
@@ -62,6 +62,7 @@ main reactor AsyncCallback {
       printf("ERROR: Expected logical time to be larger than " PRINTF_TIME ".\n", self->expected_time);
       exit(1);
     }
+    // Use a toggle to increment expected time for every other a.
     if (self->toggle) {
       self->toggle = false;
       self->expected_time += 200000000LL;

--- a/test/C/src/concurrent/AsyncCallbackDrop.lf
+++ b/test/C/src/concurrent/AsyncCallbackDrop.lf
@@ -39,7 +39,6 @@ main reactor {
   timer t(0, 200 msec)
   state thread_id: lf_thread_t = 0
   state expected_time: time = 100 msec
-  state toggle: bool = false
 
   physical action a(100 msec, 100 msec, "drop"): int
   state i: int = 0
@@ -60,11 +59,6 @@ main reactor {
       printf("ERROR: Received: %d, expected 0 because the second event should have been dropped.\n", a->value);
       exit(2);
     }
-    if (self->toggle) {
-      self->toggle = false;
-      self->expected_time += 200000000LL;
-    } else {
-      self->toggle = true;
-    }
+    self->expected_time += 200000000LL;
   =}
 }

--- a/test/C/src/concurrent/AsyncCallbackReplace.lf
+++ b/test/C/src/concurrent/AsyncCallbackReplace.lf
@@ -57,14 +57,9 @@ main reactor {
       exit(1);
     }
     if (a->value != 1) {
-      printf("ERROR: Received: %d, expected 1 because the second event should have replaced the first.\n", a->value);
+      printf("ERROR: Received: %d, expected 1 because the second event's payload should have replaced the first event's payload.\n", a->value);
       exit(2);
     }
-    if (self->toggle) {
-      self->toggle = false;
-      self->expected_time += 200000000LL;
-    } else {
-      self->toggle = true;
-    }
+    self->expected_time += 200000000LL;
   =}
 }

--- a/test/C/src/concurrent/AsyncCallbackUpdate.lf
+++ b/test/C/src/concurrent/AsyncCallbackUpdate.lf
@@ -26,7 +26,7 @@ main reactor {
       // The minimum time between these is determined
       // by the min_spacing argument in the physical action definition.
       lf_schedule_int(a, 0, 0);
-      lf_schedule_int(a, MSEC(1), 1); // Schedule the second a 1 ms later.
+      lf_schedule_int(a, 0, 1);
     }
     // Simulate time passing before a callback occurs.
     void* take_time(void* a) {
@@ -39,13 +39,13 @@ main reactor {
   =}
   timer t(0, 200 msec)
   state thread_id: lf_thread_t = 0
-  state expected_time: time = 101 msec  // 100 ms of min delay + 1 ms additional delay
+  state expected_time: time = 100 msec  // 100 ms of min delay
 
   // To observe a scenario when "update" is not in effect,
   // change min_spacing to a value less than 1 ms (e.g., 100 nsec),
   // in this case, both physical action events will get onto the event queue,
   // triggering an error in the reaction to a.
-  logical action a(100 msec, 100 msec, "update"): int
+  physical action a(100 msec, 100 msec, "update"): int
   state i: int = 0
 
   reaction(t) -> a {=
@@ -56,8 +56,8 @@ main reactor {
   reaction(a) {=
     instant_t elapsed_time = lf_time_logical_elapsed();
     printf("Asynchronous callback %d: elapsed logical time = " PRINTF_TIME " nsec.\n", self->i++, elapsed_time);
-    if (elapsed_time != self->expected_time) {
-      printf("ERROR: Expected logical time to be " PRINTF_TIME ".\n", self->expected_time);
+    if (elapsed_time <= self->expected_time) {
+      printf("ERROR: Expected logical time to be larger than " PRINTF_TIME ".\n", self->expected_time);
       exit(1);
     }
     if (a->value != 1) {

--- a/test/C/src/concurrent/AsyncCallbackUpdate.lf
+++ b/test/C/src/concurrent/AsyncCallbackUpdate.lf
@@ -42,7 +42,7 @@ main reactor {
   state expected_time: time = 100 msec  // 100 ms of min delay
 
   // To observe a scenario when "update" is not in effect,
-  // change min_spacing to a value less than 1 ms (e.g., 100 nsec),
+  // schedule the second a with an additional delay > 100 msec,
   // in this case, both physical action events will get onto the event queue,
   // triggering an error in the reaction to a.
   physical action a(100 msec, 100 msec, "update"): int


### PR DESCRIPTION
Async callback tests only need a toggle when two back-to-back physical actions both live on the event queue. For test cases testing the min. spacing policies, using a toggle is not required. This PR removes the unnecessary toggles and fixes the misuse of logical action in `AsyncCallbackUpdate.lf`.