### PR TITLE
Upgrade spotless and fix spotless hang

### DIFF
--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,6 +1,6 @@
 [versions]
-spotlessVersion=6.21.0
-spotlessLibVersion=2.30.0
+spotlessVersion=6.25.0
+spotlessLibVersion=2.45.0
 kotlinVersion=1.9.0
 shadowJarVersion=8.1.1
 spotbugsPluginVersion=5.1.3

--- a/buildSrc/src/main/java/lfformat/LfFormatStep.java
+++ b/buildSrc/src/main/java/lfformat/LfFormatStep.java
@@ -39,7 +39,7 @@ public final class LfFormatStep {
     }
 
     @Override
-    public String format(@SuppressWarnings("NullableProblems") String rawUnix, File file)
+    public synchronized String format(@SuppressWarnings("NullableProblems") String rawUnix, File file)
         throws IOException, InterruptedException {
       initializeFormatter();
       StringBuilder output = new StringBuilder();


### PR DESCRIPTION
This PR upgrades spotless to 6.25 and fixes a hang issue (observed on Apple M4) by disabling concurrent `lff` calls by spotless.

During the hang, the CPU throttles to 100% with a lot of `rg` processes, which seem to be [ripgrep](https://github.com/BurntSushi/ripgrep). The only fix is to restart the computer.

![Screenshot 2025-05-12 at 11 29 27 AM](https://github.com/user-attachments/assets/b250e905-9d47-4bd5-ad34-df61508543fa)
