### PR TITLE
Fill in missing Python API functions

### DIFF
--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -510,6 +510,20 @@ public class PythonGenerator extends CGenerator implements CCmakeGenerator.SetUp
   protected void generateReactorInstanceExtension(ReactorInstance instance) {
     initializeTriggerObjects.pr(
         PythonReactionGenerator.generateCPythonReactionLinkers(instance, mainDef));
+    String nameOfSelfStruct = CUtil.reactorRef(instance);
+    // Create a field in the Python object for the reactor called "lf_self" that contains the
+    // C pointer to the C self struct.
+    initializeTriggerObjects.pr(
+            String.join(
+                    "\n",
+                    "if (set_python_field_to_c_pointer(\"__main__\",",
+                    "    " + nameOfSelfStruct + "->_lf_name,",
+                    "    " + CUtil.runtimeIndex(instance) + ",",
+                    "    \"lf_self\",",
+                    "    " + nameOfSelfStruct + ")) {",
+                    "  lf_print_error_and_exit(\"Could not set lf_self pointer " + instance.getName() + "\");",
+                    "}"
+            ));
   }
 
   /**


### PR DESCRIPTION
This PR is filling in missing Python API functions.

The first step was to store on the Python object for a reactor a pointer to the C self struct.

This has a [companion PR](https://github.com/lf-lang/reactor-c/pull/530).