### PR TITLE
Make lf.source_directory() work for federated

### DIFF
--- a/.github/workflows/only-rs.yml
+++ b/.github/workflows/only-rs.yml
@@ -20,8 +20,7 @@ jobs:
       all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   # Run the Rust benchmark tests.
-  # These started failing on 2025-06-08.
-  # rs-benchmark-tests:
-  #   uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
-  #   with:
-  #     target: "Rust"
+  rs-benchmark-tests:
+    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
+    with:
+      target: "Rust"

--- a/.github/workflows/only-rs.yml
+++ b/.github/workflows/only-rs.yml
@@ -20,7 +20,8 @@ jobs:
       all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   # Run the Rust benchmark tests.
-  rs-benchmark-tests:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
-    with:
-      target: "Rust"
+  # These started failing on 2025-06-08.
+  # rs-benchmark-tests:
+  #   uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
+  #   with:
+  #     target: "Rust"

--- a/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
@@ -53,7 +53,8 @@ import org.lflang.target.property.type.CoordinationModeType.CoordinationMode;
 public class PythonExtension extends CExtension {
 
   @Override
-  protected void generateCMakeInclude(FederateInstance federate, FederationFileConfig fileConfig) throws IOException {
+  protected void generateCMakeInclude(FederateInstance federate, FederationFileConfig fileConfig)
+      throws IOException {
     // Generate the CMake include file for the federate.
     // This is needed to ensure that LF_SOURCE_DIRECTORY, etc. are defined.
     CExtensionUtils.generateCMakeInclude(federate, fileConfig);

--- a/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
@@ -53,7 +53,11 @@ import org.lflang.target.property.type.CoordinationModeType.CoordinationMode;
 public class PythonExtension extends CExtension {
 
   @Override
-  protected void generateCMakeInclude(FederateInstance federate, FederationFileConfig fileConfig) {}
+  protected void generateCMakeInclude(FederateInstance federate, FederationFileConfig fileConfig) throws IOException {
+    // Generate the CMake include file for the federate.
+    // This is needed to ensure that LF_SOURCE_DIRECTORY, etc. are defined.
+    CExtensionUtils.generateCMakeInclude(federate, fileConfig);
+  }
 
   @Override
   protected String generateSerializationIncludes(

--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -610,6 +610,7 @@ public enum Target {
               CompileDefinitionsProperty.INSTANCE,
               CoordinationOptionsProperty.INSTANCE,
               CoordinationProperty.INSTANCE,
+              DNETProperty.INSTANCE,
               DockerProperty.INSTANCE,
               FilesProperty.INSTANCE,
               KeepaliveProperty.INSTANCE,

--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -606,6 +606,7 @@ public enum Target {
               BuildTypeProperty.INSTANCE,
               ClockSyncModeProperty.INSTANCE,
               ClockSyncOptionsProperty.INSTANCE,
+              CmakeIncludeProperty.INSTANCE,
               CompileDefinitionsProperty.INSTANCE,
               CoordinationOptionsProperty.INSTANCE,
               CoordinationProperty.INSTANCE,

--- a/test/Python/src/federated/FederatedFileReader.lf
+++ b/test/Python/src/federated/FederatedFileReader.lf
@@ -1,0 +1,50 @@
+/** Test reading a file at a location relative to the source file. */
+target Python {
+  timeout: 0 s
+}
+
+reactor Source {
+  output out
+
+  reaction(startup) -> out {=
+    file_path = os.path.join(
+      lf.source_directory(),
+      "..",
+      "lib",
+      "FileReader.txt"
+    )
+
+    try:
+      with open(file_path, "r") as file:
+        buffer = file.read()
+      out.set(buffer)
+    except Exception as e:
+      sys.stderr.write(f"Error reading file at path {file_path}: {str(e)}")
+      exit(1)
+  =}
+}
+
+reactor Check {
+  input inp
+  state received = False
+
+  reaction(inp) {=
+    print(f"Received: {inp.value}")
+    self.received = True
+    if inp.value != "Hello World":
+      sys.stderr.write("Expected 'Hello World'")
+      exit(1)
+  =}
+
+  reaction(shutdown) {=
+    if not self.received:
+      sys.stderr.write("No input received.")
+      exit(1)
+  =}
+}
+
+federated reactor {
+  s = new Source()
+  c = new Check()
+  s.out -> c.inp
+}


### PR DESCRIPTION
Previously, `lf.source_directory()` would fail for federated programs.
To fix this, I added `cmake-include` to the supported target properties and used it to define `LF_SOURCE_DIRECTORY` (and related definitions) in a generated CMake file to include.

This also adds the DNET target property to Python because Python uses the same federated underlying engine as C and this property is needed to suppress warnings when physical actions are involved.

This PR also disables the Rust benchmark tests, which started spontaneously failing on June 8, 2025. See https://github.com/lf-lang/lingua-franca/actions/runs/15530831589/job/43719285633?pr=2515 for example.  The failing tests are big.rs (ref line 149:36) and banking.rs (ref line 157:36).  These reported line numbers make no sense. The error messages look like this:

```
lfc: error: implicit autoref creates a reference to the dereference of a raw pointer [big.rs:149:36]
```
