### PR TITLE
Removed invocation of benchmark tests

### DIFF
--- a/.github/workflows/only-c.yml
+++ b/.github/workflows/only-c.yml
@@ -19,12 +19,6 @@ jobs:
     with:
       all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
-  # Run the C benchmark tests.
-  benchmarking:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
-    with:
-      target: "C"
-
   # Run the CCpp integration tests.
   ccpp:
     uses: ./.github/workflows/c-tests.yml

--- a/.github/workflows/only-cpp.yml
+++ b/.github/workflows/only-cpp.yml
@@ -13,12 +13,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
-  # Run the C++ benchmark tests.
-  cpp-benchmark-tests:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
-    with:
-      target: "Cpp"
-
   # Run the C++ integration tests.
   cpp-tests:
     uses: ./.github/workflows/cpp-tests.yml

--- a/.github/workflows/only-rs.yml
+++ b/.github/workflows/only-rs.yml
@@ -18,9 +18,3 @@ jobs:
     uses: ./.github/workflows/rs-tests.yml
     with:
       all-platforms: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-
-  # Run the Rust benchmark tests.
-  rs-benchmark-tests:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
-    with:
-      target: "Rust"

--- a/.github/workflows/only-ts.yml
+++ b/.github/workflows/only-ts.yml
@@ -13,12 +13,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
-  # Run the TypeScript benchmark tests.
-  benchmarking:
-    uses: lf-lang/benchmarks-lingua-franca/.github/workflows/benchmark-tests.yml@main
-    with:
-      target: "TS"
-
   # Run the TypeScript integration tests.
   ts-tests:
     uses: ./.github/workflows/ts-tests.yml


### PR DESCRIPTION
This PR simplifies testing by removing automatic invocation of the tests in benchmarks-lingua-franca.
Tests that you want to include in CI for lingua-franca should be put in this repo.