### PR TITLE
Address issue #2496 with space after {=

### DIFF
--- a/core/src/main/java/org/lflang/ast/ToText.java
+++ b/core/src/main/java/org/lflang/ast/ToText.java
@@ -50,13 +50,21 @@ public class ToText extends LfSwitch<String> {
       StringBuilder builder = new StringBuilder(Math.max(node.getTotalLength(), 1));
       boolean started = false;
       for (ILeafNode leaf : node.getLeafNodes()) {
-        if (!leaf.getText().equals("{=") && !leaf.getText().equals("=}")) {
-          var nothing = leaf.getText().isBlank() || ASTUtils.isSingleLineComment(leaf);
-          if (!nothing
-              || started
-              || leaf.getText().startsWith("\n")
-              || leaf.getText().startsWith("\r")) builder.append(leaf.getText());
-          if ((leaf.getText().contains("\n") || (!nothing))) {
+        var leafText = leaf.getText();
+        if (!leafText.equals("{=") && !leafText.equals("=}")) {
+          var nothing = leafText.isBlank() || ASTUtils.isSingleLineComment(leaf);
+          if (!nothing || started || leafText.startsWith("\n") || leafText.startsWith("\r")) {
+            builder.append(leafText);
+          } else if (nothing && !started) {
+            // Check for spaces after the opening {=.
+            // See https://github.com/lf-lang/lingua-franca/issues/2496
+            var trim = leafText.indexOf('\n');
+            // Preserve any indentation after the \n.
+            if (trim > 0) {
+              builder.append(leafText.substring(trim));
+            }
+          }
+          if ((leafText.contains("\n") || (!nothing))) {
             started = true;
           }
         }

--- a/test/Python/src/federated/DistributedCountDecentralizedLate.lf
+++ b/test/Python/src/federated/DistributedCountDecentralizedLate.lf
@@ -32,7 +32,7 @@ reactor Print {
       inp.intended_tag.microstep
       )
     )
-    if (lf.tag() == Tag(lf.time.start() + SEC(1), 0)):
+    if (lf.tag() == Tag(lf.time.start() + SEC(1) * self.c, 0)):
       self.success += 1 # Message was on-time
     self.c += 1
   =} STAA(0) {=


### PR DESCRIPTION
This PR closes #2496.
It also fixes an AI error in translating a test from C to Python.
This caused the test to become flaky.