### PR TITLE
Make local build of the RTI the default

### DIFF
--- a/.github/workflows/rti-docker.yml
+++ b/.github/workflows/rti-docker.yml
@@ -19,24 +19,25 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: Look up the current version and export as environment variable
+        id: version
         run: |
           export LF_VERSION=$(cat core/src/main/resources/org/lflang/StringsBundle.properties | sed -n 's/.*VERSION = \(.*\)/\1/p' | tr '[:upper:]' '[:lower:]')
           echo "lf_version=$LF_VERSION"
           echo "lf_version=$LF_VERSION" >> $GITHUB_ENV
+          echo "version=$LF_VERSION" >> $GITHUB_OUTPUT
       - name: Build and push RTI to Docker Hub
         uses: ./.github/actions/push-rti-docker
         with:
-          tag: ${{ env.lf_version }}
+          tag: ${{ steps.version.outputs.version }}
           latest: false
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: ${{ endsWith(env.lf_version, '-snapshot') && github.repository_owner == 'lf-lang' }}
-
+        if: ${{ endsWith(steps.version.outputs.version, '-snapshot') && github.repository_owner == 'lf-lang' }}
       - name: Update latest (released versions only)
         uses: ./.github/actions/push-rti-docker
         with:
-          tag: ${{ env.lf_version }}
+          tag: ${{ steps.version.outputs.version }}
           latest: true
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: ${{ !endsWith(env.lf_version, '-snapshot') && github.repository_owner == 'lf-lang' }}
+        if: ${{ !endsWith(steps.version.outputs.version, '-snapshot') && github.repository_owner == 'lf-lang' }}

--- a/core/src/main/java/org/lflang/target/property/DockerProperty.java
+++ b/core/src/main/java/org/lflang/target/property/DockerProperty.java
@@ -1,6 +1,5 @@
 package org.lflang.target.property;
 
-import org.lflang.LocalStrings;
 import org.lflang.MessageReporter;
 import org.lflang.ast.ASTUtils;
 import org.lflang.lf.Element;

--- a/core/src/main/java/org/lflang/target/property/DockerProperty.java
+++ b/core/src/main/java/org/lflang/target/property/DockerProperty.java
@@ -149,17 +149,13 @@ public final class DockerProperty extends TargetProperty<DockerOptions, UnionTyp
       String envFile,
       String dockerConfigFile) {
 
-    /** Default location to pull the rti from. */
-    public static final String DOCKERHUB_RTI_IMAGE =
-        "lflang/rti:" + LocalStrings.VERSION.toLowerCase();
-
     public static final String DEFAULT_SHELL = "/bin/sh";
 
     /** String to indicate a local build of the rti. */
     public static final String LOCAL_RTI_IMAGE = "rti:local";
 
     public DockerOptions(boolean enabled) {
-      this(enabled, false, "", "", DOCKERHUB_RTI_IMAGE, DEFAULT_SHELL, "", "", "", "", "");
+      this(enabled, false, "", "", LOCAL_RTI_IMAGE, DEFAULT_SHELL, "", "", "", "", "");
     }
   }
 

--- a/core/src/main/java/org/lflang/target/property/DockerProperty.java
+++ b/core/src/main/java/org/lflang/target/property/DockerProperty.java
@@ -38,7 +38,7 @@ public final class DockerProperty extends TargetProperty<DockerOptions, UnionTyp
     var noBuild = false;
     var builderBase = "";
     var runnerBase = "";
-    var rti = DockerOptions.DOCKERHUB_RTI_IMAGE;
+    var rti = DockerOptions.LOCAL_RTI_IMAGE;
     var shell = DockerOptions.DEFAULT_SHELL;
     var preBuildScript = "";
     var postBuildScript = "";


### PR DESCRIPTION
This PR makes local building the RTI the default, rather than pulling a pre-built image from docker hub.