### PR TITLE
update jdk version in patmos setup from 8 to 11

### DIFF
--- a/.github/actions/setup-patmos/action.yml
+++ b/.github/actions/setup-patmos/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Setup
       run: |
         # install needed tools
-        sudo apt install git openjdk-8-jdk cmake make g++ texinfo flex bison \
+        sudo apt install git openjdk-11-jdk cmake make g++ texinfo flex bison \
           subversion libelf-dev graphviz libboost-dev libboost-program-options-dev ruby-full \
           liblpsolve55-dev zlib1g-dev gtkwave gtkterm scala autoconf libfl2 expect verilator curl chrpath
 


### PR DESCRIPTION
update jdk version in the Patmos setup from 8 to 11 to prevent fail-to-fetch errors