### PR TITLE
Docs cleanup 1

### DIFF
--- a/core/src/integrationTest/java/org/lflang/tests/RunSingleTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/RunSingleTest.java
@@ -1,27 +1,3 @@
-/*
- * Copyright (c) 2021, TU Dresden.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 package org.lflang.tests;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -43,9 +19,10 @@ import org.lflang.tests.runtime.TypeScriptTest;
 /**
  * Execute a single test case.
  *
- * <p>Use it with the gradle task {@code ./gradlew singleTest -DsingleTest=test/C/src/Minimal.lf}
+ * <p>Use it with the gradle task `./gradlew singleTest -DsingleTest=test/C/src/Minimal.lf`
  *
  * @author Clément Fournier
+ * @ingroup Tests
  */
 public class RunSingleTest {
 

--- a/core/src/integrationTest/java/org/lflang/tests/RuntimeTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/RuntimeTest.java
@@ -12,6 +12,7 @@ import org.lflang.tests.TestRegistry.TestCategory;
  * A collection of JUnit tests to perform on a given set of targets.
  *
  * @author Marten Lohstroh
+ * @ingroup Tests
  */
 public abstract class RuntimeTest extends TestBase {
 

--- a/core/src/integrationTest/java/org/lflang/tests/lsp/ErrorInserter.java
+++ b/core/src/integrationTest/java/org/lflang/tests/lsp/ErrorInserter.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
  * Insert problems into integration tests.
  *
  * @author Peter Donovan
+ * @ingroup Tests
  */
 @SuppressWarnings("ClassCanBeRecord")
 class ErrorInserter {

--- a/core/src/integrationTest/java/org/lflang/tests/lsp/LspTests.java
+++ b/core/src/integrationTest/java/org/lflang/tests/lsp/LspTests.java
@@ -28,6 +28,7 @@ import org.lflang.tests.lsp.ErrorInserter.AlteredTest;
  * Test the code generator features that are required by the language server.
  *
  * @author Peter Donovan
+ * @ingroup Tests
  */
 class LspTests extends LfInjectedTestBase {
 

--- a/core/src/integrationTest/java/org/lflang/tests/lsp/MockCancelIndicator.java
+++ b/core/src/integrationTest/java/org/lflang/tests/lsp/MockCancelIndicator.java
@@ -6,6 +6,7 @@ import org.eclipse.xtext.util.CancelIndicator;
  * Mock the CancelIndicator interface for testing.
  *
  * @author Erling Jellum
+ * @ingroup Tests
  */
 public class MockCancelIndicator implements CancelIndicator {
   @Override

--- a/core/src/integrationTest/java/org/lflang/tests/lsp/MockLanguageClient.java
+++ b/core/src/integrationTest/java/org/lflang/tests/lsp/MockLanguageClient.java
@@ -16,6 +16,7 @@ import org.eclipse.lsp4j.services.LanguageClient;
  * A {@code MockLanguageClient} is a language client that should be used in language server tests.
  *
  * @author Peter Donovan
+ * @ingroup Tests
  */
 public class MockLanguageClient implements LanguageClient {
 

--- a/core/src/integrationTest/java/org/lflang/tests/lsp/MockReportProgress.java
+++ b/core/src/integrationTest/java/org/lflang/tests/lsp/MockReportProgress.java
@@ -6,6 +6,7 @@ import org.lflang.generator.IntegratedBuilder;
  * Collect progress reports and check that they have the expected properties.
  *
  * @author Peter Donovan
+ * @ingroup Tests
  */
 public class MockReportProgress implements IntegratedBuilder.ReportProgress {
   private int previousPercentProgress;

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CArduinoTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CArduinoTest.java
@@ -13,6 +13,7 @@ import org.lflang.tests.Transformers;
  * Collection of Arduino tests for the C target.
  *
  * @author Anirudh Rengarajan <arengarajan@berkeley.edu>
+ * @ingroup Tests
  */
 public class CArduinoTest extends TestBase {
 

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CCppTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CCppTest.java
@@ -14,6 +14,7 @@ import org.lflang.tests.TestRegistry.TestCategory;
  * <p>NOTE: This test does not inherit any tests because it directly extends TestBase.
  *
  * @author Marten Lohstroh
+ * @ingroup Tests
  */
 public class CCppTest extends TestBase {
 

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CFlexPRETTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CFlexPRETTest.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2023, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.tests.runtime;
 
 import java.util.List;
@@ -33,6 +9,11 @@ import org.lflang.tests.TestBase;
 import org.lflang.tests.TestRegistry.TestCategory;
 import org.lflang.tests.Transformers;
 
+/**
+ * Collection of tests for the FlexPRET target.
+ *
+ * @ingroup Tests
+ */
 public class CFlexPRETTest extends TestBase {
 
   public CFlexPRETTest() {

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CPatmosTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CPatmosTest.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2023, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.tests.runtime;
 
 import java.util.ArrayList;
@@ -38,6 +14,11 @@ import org.lflang.tests.TestRegistry.TestCategory;
 import org.lflang.tests.Transformers;
 import org.lflang.util.LFCommand;
 
+/**
+ * Collection of tests for the Patmos target.
+ *
+ * @ingroup Tests
+ */
 public class CPatmosTest extends TestBase {
 
   public CPatmosTest() {

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CSchedulerTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CSchedulerTest.java
@@ -9,7 +9,11 @@ import org.lflang.tests.TestBase;
 import org.lflang.tests.TestRegistry.TestCategory;
 import org.lflang.tests.Transformers;
 
-/** */
+/**
+ * Collection of tests for the C schedulers.
+ *
+ * @ingroup Tests
+ */
 public class CSchedulerTest extends TestBase {
 
   public CSchedulerTest() {

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CTest.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2019, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.tests.runtime;
 
 import org.junit.jupiter.api.Assumptions;
@@ -38,6 +14,7 @@ import org.lflang.tests.RuntimeTest;
  * typically done by right-clicking on the name of the test method and then clicking "Run".*
  *
  * @author Marten Lohstroh
+ * @ingroup Tests
  */
 public class CTest extends RuntimeTest {
 

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CVerifierTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CVerifierTest.java
@@ -9,6 +9,11 @@ import org.lflang.tests.TestBase;
 import org.lflang.tests.TestRegistry;
 import org.lflang.tests.Transformers;
 
+/**
+ * Collection of tests for the C verifier.
+ *
+ * @ingroup Tests
+ */
 public class CVerifierTest extends TestBase {
   protected CVerifierTest() {
     super(Target.C);

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CZephyrTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CZephyrTest.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2023, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.tests.runtime;
 
 import java.util.List;
@@ -36,7 +12,8 @@ import org.lflang.tests.Transformers;
 /**
  * Collection of Zephyr tests for the C target.
  *
- * @author Erling Rennemo Jellum <erling.r.jellum@ntnu.no>
+ * @author Erling Rennemo Jellum
+ * @ingroup Tests
  */
 public class CZephyrTest extends TestBase {
 

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CppRos2Test.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CppRos2Test.java
@@ -15,6 +15,7 @@ import org.lflang.tests.Transformers;
  * <p>NOTE: This test does not inherit any tests because it directly extends TestBase.
  *
  * @author Christian Menard
+ * @ingroup Tests
  */
 public class CppRos2Test extends TestBase {
 

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CppTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CppTest.java
@@ -1,29 +1,3 @@
-/* Integration tests for the C++ target. */
-
-/*************
- * Copyright (c) 2021, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.tests.runtime;
 
 import org.junit.jupiter.api.Test;
@@ -37,6 +11,7 @@ import org.lflang.tests.RuntimeTest;
  * test method and then clicking "Run".
  *
  * @author Marten Lohstroh
+ * @ingroup Tests
  */
 public class CppTest extends RuntimeTest {
 

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/PythonTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/PythonTest.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2019, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.tests.runtime;
 
 import org.junit.jupiter.api.Assumptions;
@@ -41,6 +17,7 @@ import org.lflang.tests.RuntimeTest;
  * This is typically done by right-clicking on the name of the test method and then clicking "Run".
  *
  * @author Marten Lohstroh
+ * @ingroup Tests
  */
 public class PythonTest extends RuntimeTest {
 

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/RustTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/RustTest.java
@@ -1,34 +1,14 @@
-/*
- * Copyright (c) 2021, TU Dresden.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 package org.lflang.tests.runtime;
 
 import org.junit.jupiter.api.Test;
 import org.lflang.target.Target;
 import org.lflang.tests.RuntimeTest;
 
-/** */
+/**
+ * Collection of tests for the Rust target.
+ *
+ * @ingroup Tests
+ */
 public class RustTest extends RuntimeTest {
 
   public RustTest() {

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/TypeScriptTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/TypeScriptTest.java
@@ -13,6 +13,7 @@ import org.lflang.tests.RuntimeTest;
  * This is typically done by right-clicking on the name of the test method and then clicking "Run".
  *
  * @author Marten Lohstroh
+ * @ingroup Tests
  */
 public class TypeScriptTest extends RuntimeTest {
   public TypeScriptTest() {

--- a/core/src/integrationTest/java/org/lflang/tests/serialization/SerializationTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/serialization/SerializationTest.java
@@ -11,6 +11,11 @@ import org.lflang.tests.TestBase;
 import org.lflang.tests.TestRegistry.TestCategory;
 import org.lflang.tests.Transformers;
 
+/**
+ * Collection of tests for the serialization.
+ *
+ * @ingroup Tests
+ */
 public class SerializationTest extends TestBase {
 
   protected SerializationTest() {

--- a/core/src/main/java/org/lflang/AttributeUtils.java
+++ b/core/src/main/java/org/lflang/AttributeUtils.java
@@ -1,28 +1,3 @@
-/*
-Copyright (c) 2022, The University of California at Berkeley.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
 package org.lflang;
 
 import java.util.HashMap;
@@ -39,16 +14,21 @@ import org.lflang.util.StringUtil;
 import org.lflang.validation.AttributeSpec;
 
 /**
- * @brief A helper class for processing attributes in the AST.
+ * A helper class for processing attributes in the AST.
+ *
+ * <p>An attribute is an annotation using the `@` syntax. For example, `@label("My Label")` is an
+ * attribute. It is associated with whatever node comes immediately after it.
+ *
  * @author Shaokai Lin
  * @author Clément Fournier
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Utilities
  */
 public class AttributeUtils {
 
   /**
-   * @brief Return the attributes declared on the given node or null if the node does not support
-   *     declaring attributes.
+   * Return the attributes declared on the given node or null if the node does not support declaring
+   * attributes.
    */
   public static List<Attribute> getAttributes(EObject node) {
     if (node instanceof Reactor) {
@@ -76,8 +56,10 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return the attribute with the given name if present, otherwise return null.
-   *     <p>If there are multiple attributes with the same name, this returns the first one.
+   * Return the attribute with the given name if present, otherwise return null.
+   *
+   * <p>If there are multiple attributes with the same name, this returns the first one.
+   *
    * @param node The node to search for the attribute.
    * @param name The name of the attribute to search for.
    * @return The attribute with the given name or null if it is not found.
@@ -98,8 +80,9 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return all attributes with the given name or null if the node does not support declaring
-   *     attributes.
+   * Return all attributes with the given name or null if the node does not support declaring
+   * attributes.
+   *
    * @see findAttributeByName
    */
   public static List<Attribute> findAttributesByName(EObject node, String name) {
@@ -116,9 +99,10 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return the first argument specified for the attribute or null if the attribute is not
-   *     found or if it does not have any arguments.
-   *     <p>This should be used only if the attribute is expected to have a single argument.
+   * Return the first argument specified for the attribute or null if the attribute is not found or
+   * if it does not have any arguments. This should be used only if the attribute is expected to
+   * have a single argument.
+   *
    * @param attr The attribute to get the first argument from.
    * @return The first argument of the attribute or null if the attribute is not found or if it does
    *     not have any arguments.
@@ -131,10 +115,10 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Search for an attribute with the given name on the given AST node and return its first
-   *     argument as a String or null if the attribute is not found or if it does not have any
-   *     arguments.
-   *     <p>This should only be used on attributes that are expected to have a single argument.
+   * Search for an attribute with the given name on the given AST node and return its first argument
+   * as a String or null if the attribute is not found or if it does not have any arguments. This
+   * should only be used on attributes that are expected to have a single argument.
+   *
    * @param node The node to search for the attribute.
    * @param attrName The name of the attribute to search for.
    * @return The first argument of the attribute or null if the attribute is not found or if it does
@@ -152,11 +136,11 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief For an attribute with the given name on the given AST node, return a map of the
-   *     attribute parameters to their values.
-   *     <p>This should only be used on attributes that are expected to have a single argument. This
-   *     returns null if the given node does not support declaring attributes, and returns an empty
-   *     map if the attribute is not found or if it does not have any arguments.
+   * For an attribute with the given name on the given AST node, return a map of the attribute
+   * parameters to their values. This should only be used on attributes that are expected to have a
+   * single argument. This returns null if the given node does not support declaring attributes, and
+   * returns an empty map if the attribute is not found or if it does not have any arguments.
+   *
    * @param node The node to search for the attribute.
    * @param attrName The name of the attribute to search for.
    * @return A map of the attribute parameters to their values or null if the attribute is not found
@@ -177,12 +161,11 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Retrieve a specific annotation in a comment associated with the given model element in
-   *     the AST.
-   *     <p>This will look for a comment. If one is found, it searches for the given annotation
-   *     {@code key} and extracts any string that follows the annotation marker. Note that
-   *     annotations in comments are deprecated, but we still check for them for backwards
-   *     compatibility.
+   * Retrieve a specific annotation in a comment associated with the given model element in the AST.
+   * This will look for a comment. If one is found, it searches for the given annotation {@code key}
+   * and extracts any string that follows the annotation marker. Note that annotations in comments
+   * are deprecated, but we still check for them for backwards compatibility.
+   *
    * @param object The AST model element to search a comment for.
    * @param key The specific annotation key to be extracted.
    * @return {@code null} if no JavaDoc style comment was found or if it does not contain the given
@@ -202,8 +185,9 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return the parameter of the given attribute with the given name.
-   *     <p>Return null if no such parameter is found.
+   * Return the parameter of the given attribute with the given name. Return null if no such
+   * parameter is found.
+   *
    * @param attribute The attribute to get the parameter from.
    * @param parameterName The name of the parameter to get.
    * @return The parameter value or null if no such parameter is found.
@@ -220,9 +204,9 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return the parameter of the given attribute with the given name and interpret it as a
-   *     boolean.
-   *     <p>Returns null if no such parameter is found.
+   * Return the parameter of the given attribute with the given name and interpret it as a boolean.
+   * Returns null if no such parameter is found.
+   *
    * @param attribute The attribute to get the parameter from.
    * @param parameterName The name of the parameter to get.
    * @return The parameter value or null if no such parameter is found.
@@ -239,7 +223,8 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return true if the specified node is an Input and has an {@code @sparse} attribute.
+   * Return true if the specified node is an Input and has an {@code @sparse} attribute.
+   *
    * @param node An AST node.
    * @return True if the specified node is an Input and has an {@code @sparse} attribute.
    */
@@ -248,7 +233,8 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return true if the reactor is marked to be a federate.
+   * Return true if the reactor is marked to be a federate.
+   *
    * @param reactor The reactor to check.
    * @return True if the reactor is marked to be a federate.
    */
@@ -257,9 +243,9 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return true if the reaction is marked to have a C code body.
-   *     <p>Currently, this is only used for synthesized reactions in the context of federated
-   *     execution in Python.
+   * Return true if the reaction is marked to have a C code body. Currently, this is only used for
+   * synthesized reactions in the context of federated execution in Python.
+   *
    * @param reaction The reaction to check.
    * @return True if the reaction is marked to have a C code body.
    */
@@ -268,7 +254,8 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return the declared label of the node, as given by the @label annotation.
+   * Return the declared label of the node, as given by the @label annotation.
+   *
    * @param node The node to get the label from.
    * @return The label of the node or null if there is no such annotation.
    */
@@ -277,8 +264,9 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return the declared icon of the node, as given by the @icon annotation, or null if there
-   *     is no such annotation.
+   * Return the declared icon of the node, as given by the @icon annotation, or null if there is no
+   * such annotation.
+   *
    * @param node The node to get the icon path from.
    * @return The icon path of the node or null if there is no such annotation.
    */
@@ -287,8 +275,9 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return the {@code @side} annotation for the given node (presumably a port) or null if
-   *     there is no such annotation.
+   * Return the {@code @side} annotation for the given node (presumably a port) or null if there is
+   * no such annotation.
+   *
    * @param node The node to get the port side from.
    * @return The port side of the node or null if there is no such annotation.
    */
@@ -297,8 +286,9 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return the {@code layout} annotation for the given element or null if there is no such
-   *     annotation.
+   * Return the {@code layout} annotation for the given element or null if there is no such
+   * annotation.
+   *
    * @param node The node to get the layout option from.
    * @return The layout option of the node or null if there is no such annotation.
    */
@@ -307,8 +297,9 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return the {@code @enclave} attribute annotated on the given node.
-   *     <p>Return null if there is no such attribute.
+   * Return the {@code @enclave} attribute annotated on the given node. Return null if there is no
+   * such attribute.
+   *
    * @param node The node to get the enclave attribute from.
    * @return The enclave attribute of the node or null if there is no such attribute.
    */
@@ -317,7 +308,8 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return true if the specified instance has an {@code @enclave} attribute.
+   * Return true if the specified instance has an {@code @enclave} attribute.
+   *
    * @param node The node to check.
    * @return True if the specified instance has an {@code @enclave} attribute.
    */
@@ -326,7 +318,8 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Return true if the specified instantiation is of an EnclaveConnection reactor.
+   * Return true if the specified instantiation is of an EnclaveConnection reactor.
+   *
    * @param node The node to check.
    * @return True if the specified instantiation is of an EnclaveConnection reactor.
    */
@@ -335,8 +328,9 @@ public class AttributeUtils {
   }
 
   /**
-   * @brief Retrieve the number of worker parameter from an enclave attribute.
-   *     <p>Return 1 if not specified or has illegal value
+   * Retrieve the number of worker parameter from an enclave attribute. Return 1 if not specified or
+   * has illegal value
+   *
    * @param node The node to get the number of workers from.
    * @return The number of workers or 1 if not specified or has illegal value.
    */

--- a/core/src/main/java/org/lflang/DefaultMessageReporter.java
+++ b/core/src/main/java/org/lflang/DefaultMessageReporter.java
@@ -6,7 +6,11 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.lflang.generator.Range;
 
-/** Simple implementation of the ErrorReport interface that simply prints to standard out. */
+/**
+ * Simple implementation of the ErrorReport interface that simply prints to standard out.
+ *
+ * @ingroup Validation
+ */
 public class DefaultMessageReporter extends MessageReporterBase implements MessageReporter {
 
   private void println(String s) {

--- a/core/src/main/java/org/lflang/InferredType.java
+++ b/core/src/main/java/org/lflang/InferredType.java
@@ -1,28 +1,3 @@
-/*************
- * Copyright (c) 2020, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang;
 
 import java.util.function.Function;
@@ -44,6 +19,7 @@ import org.lflang.lf.Type;
  * generators or be converted to a general textual representation using toText().
  *
  * @author Christian Menard
+ * @ingroup Utilities
  */
 public class InferredType {
 

--- a/core/src/main/java/org/lflang/LFResourceDescriptionStrategy.java
+++ b/core/src/main/java/org/lflang/LFResourceDescriptionStrategy.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2019, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang;
 
 import com.google.inject.Inject;
@@ -45,6 +21,7 @@ import org.lflang.util.ImportUtil;
  *
  * @author Marten Lohstroh
  * @see "https://blogs.itemis.com/en/in-five-minutes-to-transitive-imports-within-a-dsl-with-xtext"
+ * @ingroup Infrastructure
  */
 public class LFResourceDescriptionStrategy extends DefaultResourceDescriptionStrategy {
 

--- a/core/src/main/java/org/lflang/LFResourceProvider.java
+++ b/core/src/main/java/org/lflang/LFResourceProvider.java
@@ -8,6 +8,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
  * Class that provides access to a resource set.
  *
  * @author Marten Lohstroh
+ * @ingroup Infrastructure
  */
 public class LFResourceProvider {
   /** Injected resource set provider. */

--- a/core/src/main/java/org/lflang/LFRuntimeModule.java
+++ b/core/src/main/java/org/lflang/LFRuntimeModule.java
@@ -16,11 +16,10 @@ import org.lflang.validation.LFNamesAreUniqueValidationHelper;
  * Binds services that are available both when running LFC standalone, and when running within the
  * IDE.
  *
- * <ul>
- *   <li>LfIdeModule overrides this module with additional bindings when running in the IDE.
- *   <li>{@code org.lflang.lfc.LFStandaloneModule} overrides this module when running LFC
- *       standalone.
- * </ul>
+ * <p>* LfIdeModule overrides this module with additional bindings when running in the IDE. * {@code
+ * org.lflang.lfc.LFStandaloneModule} overrides this module when running LFC standalone.
+ *
+ * @ingroup Infrastructure
  */
 public class LFRuntimeModule extends AbstractLFRuntimeModule {
 

--- a/core/src/main/java/org/lflang/LFStandaloneSetup.java
+++ b/core/src/main/java/org/lflang/LFStandaloneSetup.java
@@ -7,6 +7,8 @@ import com.google.inject.Injector;
  * Initialization support for running Xtext languages without Equinox extension registry.
  *
  * <p>See {@link LFRuntimeModule}, the base Guice module for LF services.
+ *
+ * @ingroup Infrastructure
  */
 public class LFStandaloneSetup extends LFStandaloneSetupGenerated {
 

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -1,30 +1,3 @@
-/* The Lingua Franca grammar. */
-
-/*************
-Copyright (c) 2020, The University of California at Berkeley.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-***************/
-
 /**
  * Grammar for Lingua Franca.
  * A note of caution: extending this grammar with productions that introduce

--- a/core/src/main/java/org/lflang/diagram/synthesis/AbstractSynthesisExtensions.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/AbstractSynthesisExtensions.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis;
 
 import com.google.inject.Inject;
@@ -34,6 +10,7 @@ import org.eclipse.emf.ecore.EObject;
  * convince methods.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 public abstract class AbstractSynthesisExtensions {
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis;
 
 import com.google.common.collect.HashBasedTable;
@@ -141,6 +117,7 @@ import org.lflang.util.FileUtil;
  * Diagram synthesis for Lingua Franca programs.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 @ViewSynthesisShared
 public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {

--- a/core/src/main/java/org/lflang/diagram/synthesis/ReactorParameterDisplayModes.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/ReactorParameterDisplayModes.java
@@ -1,34 +1,10 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang.diagram.synthesis;
 
 /**
  * Enumeration of different display options for reactor parameters.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 public enum ReactorParameterDisplayModes {
   NONE,

--- a/core/src/main/java/org/lflang/diagram/synthesis/SynthesisRegistration.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/SynthesisRegistration.java
@@ -17,6 +17,7 @@ import org.lflang.diagram.synthesis.util.NamedInstanceUtil;
  * Registration of all diagram synthesis related classes in Klighd.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 public class SynthesisRegistration implements IKlighdStartupHook {
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/action/AbstractAction.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/action/AbstractAction.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.action;
 
 import de.cau.cs.kieler.klighd.IAction;
@@ -34,6 +10,7 @@ import org.lflang.lf.Reactor;
  * Abstract super class for diagram actions that provides some convince methods.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 public abstract class AbstractAction implements IAction {
   public Object sourceElement(final KGraphElement elem) {

--- a/core/src/main/java/org/lflang/diagram/synthesis/action/CollapseAllReactorsAction.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/action/CollapseAllReactorsAction.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.action;
 
 import de.cau.cs.kieler.klighd.IAction;
@@ -36,6 +12,7 @@ import org.lflang.lf.Mode;
  * Action that expands (shows details) of all reactor nodes.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 public class CollapseAllReactorsAction extends AbstractAction {
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/action/ExpandAllReactorsAction.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/action/ExpandAllReactorsAction.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.action;
 
 import de.cau.cs.kieler.klighd.IAction;
@@ -36,6 +12,7 @@ import org.lflang.lf.Mode;
  * Action that collapses (hides details) of all reactor nodes.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 public class ExpandAllReactorsAction extends AbstractAction {
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/action/FilterCycleAction.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/action/FilterCycleAction.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.action;
 
 import com.google.common.collect.Iterables;
@@ -47,6 +23,7 @@ import org.lflang.diagram.synthesis.util.CycleVisualization;
  * Action that filters the diagram for only those elements included in a cycle.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 public class FilterCycleAction extends AbstractAction {
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/action/MemorizingExpandCollapseAction.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/action/MemorizingExpandCollapseAction.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.action;
 
 import com.google.common.base.Preconditions;
@@ -42,6 +18,7 @@ import org.lflang.generator.ReactorInstance;
  * expanded nodes.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 public class MemorizingExpandCollapseAction extends AbstractAction {
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/action/ShowCycleAction.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/action/ShowCycleAction.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.action;
 
 import de.cau.cs.kieler.klighd.IAction;
@@ -39,6 +15,7 @@ import org.lflang.diagram.synthesis.util.NamedInstanceUtil;
  * Action that expands all reactor nodes that are included in a cycle.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 public class ShowCycleAction extends AbstractAction {
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/postprocessor/ReactionPortAdjustment.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/postprocessor/ReactionPortAdjustment.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.postprocessor;
 
 import de.cau.cs.kieler.klighd.IStyleModifier;
@@ -49,6 +25,7 @@ import org.lflang.diagram.synthesis.styles.LinguaFrancaShapeExtensions;
  * (snuggle) to pointy shape of reaction node.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 public class ReactionPortAdjustment implements IStyleModifier {
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/postprocessor/ReactorPortAdjustment.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/postprocessor/ReactorPortAdjustment.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2023, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.postprocessor;
 
 import com.google.inject.Binder;
@@ -51,6 +27,7 @@ import org.lflang.diagram.synthesis.styles.LinguaFrancaShapeExtensions;
  * correct.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 public class ReactorPortAdjustment implements IStyleModifier {
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.styles;
 
 import static de.cau.cs.kieler.klighd.krendering.extensions.PositionReferenceX.LEFT;
@@ -87,6 +63,7 @@ import org.lflang.lf.StateVar;
  * Extension class that provides shapes and figures for the Lingua Franca diagram synthesis.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 @ViewSynthesisShared
 public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {

--- a/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaStyleExtensions.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaStyleExtensions.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.styles;
 
 import static de.cau.cs.kieler.klighd.krendering.extensions.PositionReferenceX.*;
@@ -64,6 +40,7 @@ import org.lflang.diagram.synthesis.LinguaFrancaSynthesis;
  * Extension class that provides styles and coloring for the Lingua Franca diagram synthesis.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 @ViewSynthesisShared
 public class LinguaFrancaStyleExtensions extends AbstractSynthesisExtensions {

--- a/core/src/main/java/org/lflang/diagram/synthesis/styles/ReactorFigureComponents.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/styles/ReactorFigureComponents.java
@@ -1,25 +1,3 @@
-/**
- * Copyright (c) 2020, Kiel University.
- *
- * <p>Redistribution and use in source and binary forms, with or without modification, are permitted
- * provided that the following conditions are met:
- *
- * <p>1. Redistributions of source code must retain the above copyright notice, this list of
- * conditions and the following disclaimer.
- *
- * <p>2. Redistributions in binary form must reproduce the above copyright notice, this list of
- * conditions and the following disclaimer in the documentation and/or other materials provided with
- * the distribution.
- *
- * <p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
- * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
- * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package org.lflang.diagram.synthesis.styles;
 
 import de.cau.cs.kieler.klighd.krendering.KContainerRendering;
@@ -28,6 +6,11 @@ import java.util.List;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
+/**
+ * Components of a reactor figure.
+ *
+ * @ingroup Diagram
+ */
 public class ReactorFigureComponents {
   private final KContainerRendering outer;
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/util/CycleVisualization.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/util/CycleVisualization.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.util;
 
 import com.google.common.collect.HashMultimap;
@@ -45,6 +21,7 @@ import org.lflang.lf.Connection;
  * Dependency cycle detection for Lingua Franca diagrams.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 @ViewSynthesisShared
 public class CycleVisualization extends AbstractSynthesisExtensions {

--- a/core/src/main/java/org/lflang/diagram/synthesis/util/InterfaceDependenciesVisualization.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/util/InterfaceDependenciesVisualization.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.util;
 
 import com.google.common.collect.ImmutableList;
@@ -66,6 +42,7 @@ import org.lflang.diagram.synthesis.styles.LinguaFrancaStyleExtensions;
  * Utility class to handle dependency edges for collapsed reactors in Lingua Franca diagrams.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 @ViewSynthesisShared
 public class InterfaceDependenciesVisualization extends AbstractSynthesisExtensions {

--- a/core/src/main/java/org/lflang/diagram/synthesis/util/LayoutPostProcessing.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/util/LayoutPostProcessing.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2022, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.util;
 
 import de.cau.cs.kieler.klighd.SynthesisOption;
@@ -48,6 +24,7 @@ import org.lflang.generator.TriggerInstance.BuiltinTriggerVariable;
  * Set layout configuration options for the Lingua Franca diagram synthesis.
  *
  * @author Sören Domrös
+ * @ingroup Diagram
  */
 @ViewSynthesisShared
 public class LayoutPostProcessing extends AbstractSynthesisExtensions {

--- a/core/src/main/java/org/lflang/diagram/synthesis/util/ModeDiagrams.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/util/ModeDiagrams.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2021, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.util;
 
 import com.google.common.collect.LinkedHashMultimap;
@@ -101,6 +77,7 @@ import org.lflang.lf.Timer;
  * Transformations to support modes in the Lingua Franca diagram synthesis.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 @ViewSynthesisShared
 public class ModeDiagrams extends AbstractSynthesisExtensions {

--- a/core/src/main/java/org/lflang/diagram/synthesis/util/NamedInstanceUtil.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/util/NamedInstanceUtil.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.util;
 
 import de.cau.cs.kieler.klighd.kgraph.KGraphElement;
@@ -33,6 +9,7 @@ import org.lflang.generator.NamedInstance;
  * Utility class to link KGraphElements to NamedInstances.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 public class NamedInstanceUtil {
   public static final Property<NamedInstance<?>> LINKED_INSTANCE =

--- a/core/src/main/java/org/lflang/diagram/synthesis/util/ReactorIcons.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/util/ReactorIcons.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.util;
 
 // import org.eclipse.swt.graphics.ImageData;
@@ -41,6 +17,7 @@ import org.lflang.util.FileUtil;
  * Utility class to handle icons for reactors in Lingua Franca diagrams.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 @ViewSynthesisShared
 public class ReactorIcons extends AbstractSynthesisExtensions {

--- a/core/src/main/java/org/lflang/diagram/synthesis/util/SynthesisMessageReporter.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/util/SynthesisMessageReporter.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.util;
 
 import de.cau.cs.kieler.klighd.Klighd;
@@ -35,7 +11,10 @@ import org.lflang.MessageReporterBase;
 import org.lflang.generator.Range;
 
 /**
+ * Message reporter for the Lingua Franca diagram synthesis.
+ *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 public class SynthesisMessageReporter extends MessageReporterBase {
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/util/UtilityExtensions.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/util/UtilityExtensions.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2020, Kiel University.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.diagram.synthesis.util;
 
 import de.cau.cs.kieler.klighd.internal.util.KlighdInternalProperties;
@@ -50,6 +26,7 @@ import org.lflang.lf.Reactor;
  * Extension class that provides various utility methods for the synthesis.
  *
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Diagram
  */
 @ViewSynthesisShared
 public class UtilityExtensions extends AbstractSynthesisExtensions {

--- a/core/src/main/resources/lib/c/EnclaveConnection.lf
+++ b/core/src/main/resources/lib/c/EnclaveConnection.lf
@@ -1,5 +1,5 @@
 /**
- * This is a library reactor implementing an Enclaved connection. It is used by
+ * Library reactor implementing an Enclaved connection. It is used by
  * the code-generator when it finds a connection between two enclaves. Any event
  * written to the input port of this reactor is first scheduled on to an action
  * and then later written to the output port. This reactor is situated between


### PR DESCRIPTION
This PR cleans up the javadocs in several files. This project is split into multiple PRs because GitHub's web interface freezes if there are too many files in a PR.  The cleanups include:

* Adding `@ingroup` tags for the benefit of the [topics](https://www.lf-lang.org/lingua-franca/topics.html) web page.
* Removing redundant copyright notices.
* Miscellaneous formatting improvements.