### PR TITLE
Docs cleanup 2

### DIFF
--- a/core/src/main/java/org/lflang/generator/GeneratorArguments.java
+++ b/core/src/main/java/org/lflang/generator/GeneratorArguments.java
@@ -7,8 +7,6 @@ import java.util.List;
 /**
  * Arguments to be passed to a code generator.
  *
- * <p>
- *
  * @param clean Whether to clean before building.
  * @param externalRuntimeUri FIXME: change type of
  *     org.lflang.target.property.ExternalRuntimePathProperty to URI
@@ -19,6 +17,7 @@ import java.util.List;
  * @param rti The location of the rti.
  * @param overrides List of arguments that are meant to override target properties
  * @author Marten Lohstroh
+ * @ingroup Generator
  */
 public record GeneratorArguments(
     boolean clean,

--- a/core/src/main/java/org/lflang/generator/LFGeneratorContext.java
+++ b/core/src/main/java/org/lflang/generator/LFGeneratorContext.java
@@ -10,10 +10,11 @@ import org.lflang.MessageReporter;
 import org.lflang.target.TargetConfig;
 
 /**
- * An {@code LFGeneratorContext} is the context of a Lingua Franca build process. It is the point of
- * communication between a build process and the environment in which it is executed.
+ * The context of a Lingua Franca build process. It is the point of communication between a build
+ * process and the environment in which it is executed.
  *
  * @author Peter Donovan
+ * @ingroup Infrastructure
  */
 public interface LFGeneratorContext extends IGeneratorContext {
 

--- a/core/src/main/java/org/lflang/generator/MainContext.java
+++ b/core/src/main/java/org/lflang/generator/MainContext.java
@@ -14,10 +14,11 @@ import org.lflang.generator.IntegratedBuilder.ReportProgress;
 import org.lflang.target.TargetConfig;
 
 /**
- * A {@code MainContext} is an {@code LFGeneratorContext} that is not nested in any other generator
- * context. There is one {@code MainContext} for every build process.
+ * An {@code LFGeneratorContext} that is not nested in any other generator context. There is one
+ * {@code MainContext} for every build process.
  *
  * @author Peter Donovan
+ * @ingroup Infrastructure
  */
 public class MainContext implements LFGeneratorContext {
 

--- a/core/src/main/java/org/lflang/generator/MixedRadixInt.java
+++ b/core/src/main/java/org/lflang/generator/MixedRadixInt.java
@@ -1,29 +1,3 @@
-/* A representation for a mixed radix number. */
-
-/*
-Copyright (c) 2019-2021, The University of California at Berkeley.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
 package org.lflang.generator;
 
 import com.google.common.collect.ImmutableList;
@@ -56,6 +30,7 @@ import java.util.Set;
  * "1%2, 2%3, 1%4" has value 11, 1 + (2*2) + (1*2*3).
  *
  * @author Edward A. Lee
+ * @ingroup Utilities
  */
 public class MixedRadixInt {
 

--- a/core/src/main/java/org/lflang/generator/NamedInstance.java
+++ b/core/src/main/java/org/lflang/generator/NamedInstance.java
@@ -1,29 +1,3 @@
-/* Base class for instances with names in Lingua Franca. */
-
-/*************
- * Copyright (c) 2019, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang.generator;
 
 import java.util.ArrayList;
@@ -39,6 +13,7 @@ import org.eclipse.emf.ecore.EObject;
  *
  * @author Marten Lohstroh
  * @author Edward A. Lee
+ * @ingroup Instances
  */
 public abstract class NamedInstance<T extends EObject> {
 

--- a/core/src/main/java/org/lflang/generator/ParameterInstance.java
+++ b/core/src/main/java/org/lflang/generator/ParameterInstance.java
@@ -1,30 +1,3 @@
-/** A data structure for a parameter instance. */
-
-/*************
- * Copyright (c) 2019, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang.generator;
 
 import java.util.List;
@@ -43,6 +16,7 @@ import org.lflang.lf.Parameter;
  *
  * @author Marten Lohstroh
  * @author Edward A. Lee
+ * @ingroup Instances
  */
 public class ParameterInstance extends NamedInstance<Parameter> {
 

--- a/core/src/main/java/org/lflang/generator/PortInstance.java
+++ b/core/src/main/java/org/lflang/generator/PortInstance.java
@@ -1,28 +1,3 @@
-/** A data structure for a port instance. */
-
-/*************
- * Copyright (c) 2019-2022, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.generator;
 
 import java.util.ArrayList;
@@ -54,6 +29,7 @@ import org.lflang.lf.WidthTerm;
  *
  * @author Marten Lohstroh
  * @author Edward A. Lee
+ * @ingroup Instances
  */
 public class PortInstance extends TriggerInstance<Port> {
 

--- a/core/src/main/java/org/lflang/generator/Position.java
+++ b/core/src/main/java/org/lflang/generator/Position.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
  * position other than the origin.
  *
  * @author Peter Donovan
+ * @ingroup Utilities
  */
 public class Position implements Comparable<Position> {
   public static final Pattern PATTERN = Pattern.compile("\\((?<line>[0-9]+), (?<column>[0-9]+)\\)");

--- a/core/src/main/java/org/lflang/generator/Range.java
+++ b/core/src/main/java/org/lflang/generator/Range.java
@@ -6,6 +6,8 @@ import java.util.regex.Pattern;
 /**
  * Represents a range in a document. Ranges have a natural ordering that respects their start
  * position(s) only.
+ *
+ * @ingroup Utilities
  */
 public class Range implements Comparable<Range> {
   public static final Pattern PATTERN =

--- a/core/src/main/java/org/lflang/generator/ReactionInstance.java
+++ b/core/src/main/java/org/lflang/generator/ReactionInstance.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2019-2022, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang.generator;
 
 import java.util.ArrayList;
@@ -52,6 +28,7 @@ import org.lflang.lf.Watchdog;
  *
  * @author Edward A. Lee
  * @author Marten Lohstroh
+ * @ingroup Instances
  */
 public class ReactionInstance extends NamedInstance<Reaction> {
 

--- a/core/src/main/java/org/lflang/generator/ReactorInstance.java
+++ b/core/src/main/java/org/lflang/generator/ReactorInstance.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2019-2022, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang.generator;
 
 import static org.lflang.AttributeUtils.isEnclave;
@@ -82,6 +58,7 @@ import org.lflang.lf.WidthSpec;
  *
  * @author Marten Lohstroh
  * @author Edward A. Lee
+ * @ingroup Instances
  */
 public class ReactorInstance extends NamedInstance<Instantiation> {
 

--- a/core/src/main/java/org/lflang/generator/RuntimeRange.java
+++ b/core/src/main/java/org/lflang/generator/RuntimeRange.java
@@ -1,28 +1,3 @@
-/* A representation of a range of runtime instances for a NamedInstance. */
-
-/*
-Copyright (c) 2019-2021, The University of California at Berkeley.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 package org.lflang.generator;
 
 import java.util.ArrayList;
@@ -32,21 +7,18 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Class representing a range of runtime instance objects (port channels, reactors, reactions,
- * etc.). This class and its derived classes have the most detailed information about the structure
- * of a Lingua Franca program. There are three levels of detail:
+ * Representation of a range of runtime instance objects (port channels, reactors, reactions, etc.).
+ * This class and its derived classes have the most detailed information about the structure of a
+ * Lingua Franca program. There are three levels of detail:
  *
- * <ul>
- *   <li>The abstract syntax tree (AST).
- *   <li>The compile-time instance graph (CIG).
- *   <li>The runtime instance graph (RIG).
- * </ul>
+ * <p>* The abstract syntax tree (AST). * The compile-time instance graph (CIG). * The runtime
+ * instance graph (RIG).
  *
- * In the AST, each reactor class is represented once. In the CIG, each reactor class is represented
- * as many times as it is instantiated, except that a bank has only one representation (as in the
- * graphical rendition). Equivalently, each CIG node has a unique full name, even though it may
- * represent many runtime instances. The CIG is represented by {@link NamedInstance} and its derived
- * classes. In the RIG, each bank is expanded so each bank member and each port channel is
+ * <p>In the AST, each reactor class is represented once. In the CIG, each reactor class is
+ * represented as many times as it is instantiated, except that a bank has only one representation
+ * (as in the graphical rendition). Equivalently, each CIG node has a unique full name, even though
+ * it may represent many runtime instances. The CIG is represented by {@link NamedInstance} and its
+ * derived classes. In the RIG, each bank is expanded so each bank member and each port channel is
  * represented.
  *
  * <p>In general, determining dependencies between reactions requires analysis at the level of the
@@ -85,26 +57,26 @@ import java.util.Set;
  * that contains a port instance P with width 2. . There are a total of 8 instances of P, which we
  * can name:
  *
- * <p>A0.B0.P0 A0.B0.P1 A0.B1.P0 A0.B1.P1 A1.B0.P0 A1.B0.P1 A1.B1.P0 A1.B1.P1
+ * <p>``` A0.B0.P0 A0.B0.P1 A0.B1.P0 A0.B1.P1 A1.B0.P0 A1.B0.P1 A1.B1.P0 A1.B1.P1 ```
  *
- * <p>If there is no interleaving, iterationOrder() returns [P, B, A], indicating that they should
+ * <p>If there is no interleaving, iterationOrder() returns `[P, B, A]`, indicating that they should
  * be iterated by incrementing the index of P first, then the index of B, then the index of A, as
  * done above.
  *
  * <p>If the connection within B to port P is interleaved, then the order of iteration order will be
- * [B, P, A], resulting in the list:
+ * `[B, P, A]`, resulting in the list:
  *
- * <p>A0.B0.P0 A0.B1.P0 A0.B0.P1 A0.B1.P1 A1.B0.P0 A1.B1.P0 A1.B0.P1 A1.B1.P1
+ * <p>``` A0.B0.P0 A0.B1.P0 A0.B0.P1 A0.B1.P1 A1.B0.P0 A1.B1.P0 A1.B0.P1 A1.B1.P1 ```
  *
- * <p>If the connection within A to B is also interleaved, then the order will be [A, B, P],
+ * <p>If the connection within A to B is also interleaved, then the order will be `[A, B, P]`,
  * resulting in the list:
  *
  * <p>A0.B0.P0 A1.B0.P0 A0.B1.P0 A1.B1.P0 A0.B0.P1 A1.B0.P1 A0.B1.P1 A1.B1.P1
  *
  * <p>Finally, if the connection within A to B is interleaved, but not the connection within B to P,
- * then the order will be [A, P, B], resulting in the list:
+ * then the order will be `[A, P, B]`, resulting in the list:
  *
- * <p>A0.B0.P0 A1.B0.P0 A0.B0.P1 A1.B0.P1 A0.B1.P0 A1.B1.P0 A0.B1.P1 A1.B1.P1
+ * <p>``` A0.B0.P0 A1.B0.P0 A0.B0.P1 A1.B0.P1 A0.B1.P0 A1.B1.P0 A0.B1.P1 A1.B1.P1 ```
  *
  * <p>A RuntimeRange is a contiguous subset of one of the above lists, given by a start offset and a
  * width that is less than or equal to maxWidth.
@@ -125,6 +97,7 @@ import java.util.Set;
  * RuntimeRange.
  *
  * @author Edward A. Lee
+ * @ingroup Instances
  */
 public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<RuntimeRange<?>> {
 

--- a/core/src/main/java/org/lflang/generator/SendRange.java
+++ b/core/src/main/java/org/lflang/generator/SendRange.java
@@ -1,28 +1,3 @@
-/* Abstract class for ranges of NamedInstance. */
-
-/*
-Copyright (c) 2019-2021, The University of California at Berkeley.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 package org.lflang.generator;
 
 import java.util.ArrayList;
@@ -44,6 +19,7 @@ import org.lflang.lf.Connection;
  * RuntimeRange.
  *
  * @author Edward A. Lee
+ * @ingroup Instances
  */
 public class SendRange extends RuntimeRange.Port {
 

--- a/core/src/main/java/org/lflang/generator/StateVariableInstance.java
+++ b/core/src/main/java/org/lflang/generator/StateVariableInstance.java
@@ -1,34 +1,13 @@
-/** A data structure for a state variable. */
-
-/*************
- * Copyright (c) 2019-2022, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.generator;
 
 import org.lflang.MessageReporter;
 import org.lflang.lf.StateVar;
 
-/** Representation of a compile-time instance of a state variable. */
+/**
+ * Representation of a compile-time instance of a state variable.
+ *
+ * @ingroup Instances
+ */
 public class StateVariableInstance extends NamedInstance<StateVar> {
 
   /**

--- a/core/src/main/java/org/lflang/generator/SubContext.java
+++ b/core/src/main/java/org/lflang/generator/SubContext.java
@@ -11,6 +11,7 @@ import org.lflang.target.TargetConfig;
  * complete build.
  *
  * @author Peter Donovan
+ * @ingroup Infrastructure
  */
 public class SubContext implements LFGeneratorContext {
 

--- a/core/src/main/java/org/lflang/generator/TargetTypes.java
+++ b/core/src/main/java/org/lflang/generator/TargetTypes.java
@@ -26,6 +26,7 @@ import org.lflang.lf.Type;
  * language-specific instance of this interface.
  *
  * @author Clément Fournier - TU Dresden, INSA Rennes
+ * @ingroup Generator
  */
 public interface TargetTypes {
 

--- a/core/src/main/java/org/lflang/generator/TimerInstance.java
+++ b/core/src/main/java/org/lflang/generator/TimerInstance.java
@@ -1,29 +1,3 @@
-/** Instance of a timer. */
-
-/*************
- * Copyright (c) 2019, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang.generator;
 
 import org.lflang.TimeValue;
@@ -34,6 +8,7 @@ import org.lflang.lf.Timer;
  *
  * @author Marten Lohstroh
  * @author Edward A. Lee
+ * @ingroup Instances
  */
 public class TimerInstance extends TriggerInstance<Timer> {
 

--- a/core/src/main/java/org/lflang/generator/TriggerInstance.java
+++ b/core/src/main/java/org/lflang/generator/TriggerInstance.java
@@ -1,29 +1,3 @@
-/** Instance of a trigger (port, action, or timer). */
-
-/*************
- * Copyright (c) 2019, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang.generator;
 
 import java.util.LinkedHashSet;
@@ -40,6 +14,7 @@ import org.lflang.lf.impl.VariableImpl;
  * @author Marten Lohstroh
  * @author Edward A. Lee
  * @author Alexander Schulz-Rosengarten
+ * @ingroup Instances
  */
 public class TriggerInstance<T extends Variable> extends NamedInstance<T> {
 

--- a/core/src/main/java/org/lflang/generator/ValidationStrategy.java
+++ b/core/src/main/java/org/lflang/generator/ValidationStrategy.java
@@ -7,6 +7,7 @@ import org.lflang.util.LFCommand;
  * A means of validating generated code.
  *
  * @author Peter Donovan
+ * @ingroup Infrastructure
  */
 public interface ValidationStrategy {
 

--- a/core/src/main/java/org/lflang/generator/Validator.java
+++ b/core/src/main/java/org/lflang/generator/Validator.java
@@ -22,6 +22,7 @@ import org.lflang.util.LFCommand;
  * Validate generated code.
  *
  * @author Peter Donovan
+ * @ingroup Validation
  */
 public abstract class Validator {
 

--- a/core/src/main/java/org/lflang/generator/WatchdogInstance.java
+++ b/core/src/main/java/org/lflang/generator/WatchdogInstance.java
@@ -1,11 +1,3 @@
-/**
- * @file
- * @author Benjamin Asch
- * @author Edward A. Lee
- * @copyright (c) 2023, The University of California at Berkeley License in <a
- *     href="https://github.com/lf-lang/lingua-franca/blob/master/LICENSE">BSD 2-clause</a>
- * @brief Instance of a watchdog
- */
 package org.lflang.generator;
 
 import java.util.LinkedHashSet;
@@ -21,6 +13,8 @@ import org.lflang.lf.Watchdog;
  * a parameter is referenced, it is looked up in the given (grand)parent reactor instance.
  *
  * @author Benjamin Asch
+ * @author Edward A. Lee
+ * @ingroup Instances
  */
 public class WatchdogInstance extends TriggerInstance<Watchdog> {
 

--- a/core/src/main/java/org/lflang/generator/c/CActionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CActionGenerator.java
@@ -22,6 +22,7 @@ import org.lflang.target.Target;
  * @author {Soroush Bateni
  * @author Alexander Schulz-Rosengarten
  * @author Hou Seng Wong
+ * @ingroup Generator
  */
 public class CActionGenerator {
   /**

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -1,28 +1,3 @@
-/*************
- * Copyright (c) 2019-2021, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang.generator.c;
 
 import java.nio.file.Files;
@@ -56,6 +31,7 @@ import org.lflang.util.FileUtil;
  *
  * @author Soroush Bateni
  * @author Peter Donovan
+ * @ingroup Generator
  */
 public class CCmakeGenerator {
   private static final String DEFAULT_INSTALL_CODE =

--- a/core/src/main/java/org/lflang/generator/c/CCompiler.java
+++ b/core/src/main/java/org/lflang/generator/c/CCompiler.java
@@ -1,28 +1,3 @@
-/*************
- * Copyright (c) 2019-2021, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang.generator.c;
 
 import java.io.File;
@@ -58,6 +33,7 @@ import org.lflang.util.LFCommand;
  * @author Christian Menard
  * @author Matt Weber
  * @author Peter Donovan
+ * @ingroup Generator
  */
 public class CCompiler {
 

--- a/core/src/main/java/org/lflang/generator/c/CConstructorGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CConstructorGenerator.java
@@ -2,7 +2,11 @@ package org.lflang.generator.c;
 
 import org.lflang.generator.CodeBuilder;
 
-/** Generates C constructor code for a reactor. */
+/**
+ * Generates C constructor code for a reactor.
+ *
+ * @ingroup Generator
+ */
 public class CConstructorGenerator {
   /**
    * Generate a constructor for the specified reactor in the specified federate.

--- a/core/src/main/java/org/lflang/generator/c/CCoreFilesUtils.java
+++ b/core/src/main/java/org/lflang/generator/c/CCoreFilesUtils.java
@@ -7,6 +7,7 @@ import java.util.List;
  * listed as arguments of each function.
  *
  * @author Hou Seng Wong
+ * @ingroup Generator
  */
 public class CCoreFilesUtils {
 

--- a/core/src/main/java/org/lflang/generator/c/CDelayBodyGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CDelayBodyGenerator.java
@@ -7,6 +7,11 @@ import org.lflang.generator.DelayBodyGenerator;
 import org.lflang.lf.Action;
 import org.lflang.lf.VarRef;
 
+/**
+ * Generate code for the bodies of the reactions involved in connections with the 'after' keyword.
+ *
+ * @ingroup Generator
+ */
 public class CDelayBodyGenerator implements DelayBodyGenerator {
 
   protected CTypes types;

--- a/core/src/main/java/org/lflang/generator/c/CEnclaveGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CEnclaveGenerator.java
@@ -18,6 +18,8 @@ import org.lflang.target.property.TracingProperty;
  * This class is in charge of code generating functions and global variables related to the enclaves
  * and environments. An environment is the context in which an enclave exists. Each enclave has its
  * own environment where queues, current tag, thread synchronization primitives etc. are stored.
+ *
+ * @ingroup Generator
  */
 public class CEnclaveGenerator {
 

--- a/core/src/main/java/org/lflang/generator/c/CEnclaveGraph.java
+++ b/core/src/main/java/org/lflang/generator/c/CEnclaveGraph.java
@@ -1,27 +1,3 @@
-/*
-Copyright (c) 2023, The Norwegian University of Science and Technology.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 package org.lflang.generator.c;
 
 import static org.lflang.AttributeUtils.isEnclave;
@@ -40,6 +16,8 @@ import org.lflang.lf.Instantiation;
  * This class contains the enclave connection graph. This graph is needed to code-generate the
  * topology information in the generated sources. To simplify things we use the AST transformation
  * object. It stores information about the topology as it is doing the AST transformation.
+ *
+ * @ingroup Generator
  */
 public class CEnclaveGraph {
   /** The graph. Public to expose its API to the code generator also. */

--- a/core/src/main/java/org/lflang/generator/c/CEnclaveInstance.java
+++ b/core/src/main/java/org/lflang/generator/c/CEnclaveInstance.java
@@ -1,27 +1,3 @@
-/*
-Copyright (c) 2023, The Norwegian University of Science and Technology.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 package org.lflang.generator.c;
 
 import org.lflang.generator.ReactorInstance;
@@ -30,6 +6,8 @@ import org.lflang.generator.ReactorInstance;
  * An CEnclaveInstance object is associated with each enclave. Here we store information about how
  * many timers, shutdown reactions etc. while code-generating. Each object is tied to a
  * ReactorInstance which is the top-level reactor within the enclave.
+ *
+ * @ingroup Generator
  */
 public class CEnclaveInstance {
   public int numIsPresentFields = 0;

--- a/core/src/main/java/org/lflang/generator/c/CEnclavedReactorTransformation.java
+++ b/core/src/main/java/org/lflang/generator/c/CEnclavedReactorTransformation.java
@@ -1,22 +1,3 @@
-/*************
- * Copyright (c) 2023, The Norwegian University of Science and Technology.
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
 package org.lflang.generator.c;
 
 import static org.lflang.AttributeUtils.isEnclave;
@@ -55,12 +36,13 @@ import org.lflang.lf.VarRef;
 import org.lflang.util.Pair;
 
 /**
- * This class implements the AST transformation enabling enclaved execution in the C target. This
- * transformation finds all connections involving an enclave and inserts a special connection
- * Reactor there. The connection Reactor is inspired by the after-delay reactors. They consist of an
- * action and two reactions. The first reaction, the `delay reaction`, schedules events received
- * onto the action. The other reaction, the `forward reaction` writes the scheduled event to its
- * output port.
+ * The AST transformation enabling enclaved execution in the C target. This transformation finds all
+ * connections involving an enclave and inserts a special connection Reactor there. The connection
+ * Reactor is inspired by the after-delay reactors. They consist of an action and two reactions. The
+ * first reaction, the `delay reaction`, schedules events received onto the action. The other
+ * reaction, the `forward reaction` writes the scheduled event to its output port.
+ *
+ * @ingroup Generator
  */
 public class CEnclavedReactorTransformation implements AstTransformation {
 

--- a/core/src/main/java/org/lflang/generator/c/CFileConfig.java
+++ b/core/src/main/java/org/lflang/generator/c/CFileConfig.java
@@ -5,6 +5,11 @@ import java.nio.file.Path;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.lflang.FileConfig;
 
+/**
+ * The file configuration for the C target.
+ *
+ * @ingroup Generator
+ */
 public class CFileConfig extends FileConfig {
   private final Path includePath;
 

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1,27 +1,3 @@
-/*************
- * Copyright (c) 2019-2021, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang.generator.c;
 
 import static org.lflang.ast.ASTUtils.allActions;
@@ -271,6 +247,7 @@ import org.lflang.util.FlexPRETUtil;
  * @author Alexander Schulz-Rosengarten
  * @author Hou Seng Wong
  * @author Anirudh Rengarajan
+ * @ingroup Generator
  */
 @SuppressWarnings("StaticPseudoFunctionalStyleMethod")
 public class CGenerator extends GeneratorBase {

--- a/core/src/main/java/org/lflang/generator/c/CMainFunctionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CMainFunctionGenerator.java
@@ -11,6 +11,11 @@ import org.lflang.target.property.TimeOutProperty;
 import org.lflang.target.property.type.PlatformType.Platform;
 import org.lflang.util.StringUtil;
 
+/**
+ * Generate the code that is the entry point of the program.
+ *
+ * @ingroup Generator
+ */
 public class CMainFunctionGenerator {
   private TargetConfig targetConfig;
 

--- a/core/src/main/java/org/lflang/generator/c/CMethodGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CMethodGenerator.java
@@ -13,6 +13,7 @@ import org.lflang.util.StringUtil;
  * Collection of functions to generate C code to declare methods.
  *
  * @author Edward A. Lee
+ * @ingroup Generator
  */
 public class CMethodGenerator {
 

--- a/core/src/main/java/org/lflang/generator/c/CMixedRadixGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CMixedRadixGenerator.java
@@ -1,5 +1,10 @@
 package org.lflang.generator.c;
 
+/**
+ * Names for the variables used to index into the mixed-radix array.
+ *
+ * @ingroup Generator
+ */
 public class CMixedRadixGenerator {
   /** Standardized name for channel index variable for a source. */
   public static String sc = "src_channel";

--- a/core/src/main/java/org/lflang/generator/c/CModesGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CModesGenerator.java
@@ -14,6 +14,7 @@ import org.lflang.lf.Reactor;
  * @author Edward A. Lee
  * @author Alexander Schulz-Rosengarten
  * @author Hou Seng Wong
+ * @ingroup Generator
  */
 public class CModesGenerator {
   /**

--- a/core/src/main/java/org/lflang/generator/c/CParameterGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CParameterGenerator.java
@@ -13,6 +13,7 @@ import org.lflang.lf.Parameter;
  * @author Edward A. Lee
  * @author Soroush Bateni
  * @author Hou Seng Wong
+ * @ingroup Generator
  */
 public class CParameterGenerator {
   /**

--- a/core/src/main/java/org/lflang/generator/c/CPortGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CPortGenerator.java
@@ -19,6 +19,7 @@ import org.lflang.target.Target;
  * @author Edward A. Lee
  * @author Soroush Bateni
  * @author Hou Seng Wong
+ * @ingroup Generator
  */
 public class CPortGenerator {
   /** Generate fields in the self struct for input and output ports */

--- a/core/src/main/java/org/lflang/generator/c/CPreambleGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CPreambleGenerator.java
@@ -27,6 +27,7 @@ import org.lflang.util.StringUtil;
  * @author Hou Seng Wong
  * @author Peter Donovan
  * @author Anirudh Rengarajan
+ * @ingroup Generator
  */
 public class CPreambleGenerator {
 

--- a/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
@@ -37,6 +37,11 @@ import org.lflang.target.TargetConfig;
 import org.lflang.target.property.NoSourceMappingProperty;
 import org.lflang.util.StringUtil;
 
+/**
+ * Generate code for reactions.
+ *
+ * @ingroup Generator
+ */
 public class CReactionGenerator {
   protected static String DISABLE_REACTION_INITIALIZATION_MARKER =
       "// **** Do not include initialization code in this reaction."; // FIXME: Such markers should

--- a/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
@@ -19,7 +19,11 @@ import org.lflang.lf.TypedVariable;
 import org.lflang.lf.VarRef;
 import org.lflang.util.FileUtil;
 
-/** Generate user-visible header files. */
+/**
+ * Generate user-visible header files.
+ *
+ * @ingroup Generator
+ */
 public class CReactorHeaderFileGenerator {
 
   /** Functional interface for generating auxiliary structs such as port structs. */

--- a/core/src/main/java/org/lflang/generator/c/CStateGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CStateGenerator.java
@@ -6,6 +6,11 @@ import org.lflang.generator.ModeInstance;
 import org.lflang.generator.ReactorInstance;
 import org.lflang.lf.StateVar;
 
+/**
+ * Generate code for state variables.
+ *
+ * @ingroup Generator
+ */
 public class CStateGenerator {
   /**
    * Generate code for state variables of a reactor in the form "stateVar.type stateVar.name;"

--- a/core/src/main/java/org/lflang/generator/c/CTimerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CTimerGenerator.java
@@ -8,6 +8,7 @@ import org.lflang.generator.TimerInstance;
  *
  * @author Edward A. Lee
  * @author {Soroush Bateni
+ * @ingroup Generator
  */
 public class CTimerGenerator {
   /**

--- a/core/src/main/java/org/lflang/generator/c/CTracingGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CTracingGenerator.java
@@ -14,6 +14,7 @@ import org.lflang.generator.TimerInstance;
  * @author Edward A. Lee
  * @author Soroush Bateni
  * @author Hou Seng Wong
+ * @ingroup Generator
  */
 public class CTracingGenerator {
   /**

--- a/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
@@ -35,6 +35,7 @@ import org.lflang.target.property.type.LoggingType.LogLevel;
  * @author Edward A. Lee
  * @author Soroush Bateni
  * @author Hou Seng Wong
+ * @ingroup Generator
  */
 public class CTriggerObjectsGenerator {
   /** Generate the _lf_initialize_trigger_objects function for 'federate'. */

--- a/core/src/main/java/org/lflang/generator/c/CTypes.java
+++ b/core/src/main/java/org/lflang/generator/c/CTypes.java
@@ -9,6 +9,11 @@ import org.lflang.generator.ReactorInstance;
 import org.lflang.generator.TargetTypes;
 import org.lflang.lf.ParameterReference;
 
+/**
+ * C-specific type information.
+ *
+ * @ingroup Generator
+ */
 public class CTypes implements TargetTypes {
 
   // Regular expression pattern for array types.

--- a/core/src/main/java/org/lflang/generator/c/CUtil.java
+++ b/core/src/main/java/org/lflang/generator/c/CUtil.java
@@ -1,29 +1,3 @@
-/* Utilities for C code generation. */
-
-/*************
- * Copyright (c) 2019-2021, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang.generator.c;
 
 import java.nio.file.Path;
@@ -60,6 +34,7 @@ import org.lflang.util.LFCommand;
  * the C target code generator. I.e., it defines how variables are named and referenced.
  *
  * @author Edward A. Lee
+ * @ingroup Generator
  */
 public class CUtil {
 

--- a/core/src/main/java/org/lflang/generator/c/CWatchdogGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CWatchdogGenerator.java
@@ -1,11 +1,3 @@
-/**
- * @file
- * @author Benjamin Asch
- * @author Edward A. Lee
- * @copyright (c) 2023, The University of California at Berkeley. License: <a
- *     href="https://github.com/lf-lang/lingua-franca/blob/master/LICENSE">BSD 2-clause</a>
- * @brief Code generation methods for watchdogs in C.
- */
 package org.lflang.generator.c;
 
 import java.util.List;
@@ -29,6 +21,7 @@ import org.lflang.util.StringUtil;
  *
  * @author Benjamin Asch
  * @author Edward A. Lee
+ * @ingroup Generator
  */
 public class CWatchdogGenerator {
 

--- a/core/src/main/java/org/lflang/generator/c/InteractingContainedReactors.java
+++ b/core/src/main/java/org/lflang/generator/c/InteractingContainedReactors.java
@@ -21,6 +21,7 @@ import org.lflang.lf.VarRef;
  * @author Edward A. Lee
  * @author Soroush Bateni
  * @author Hou Seng Wong
+ * @ingroup Generator
  */
 public class InteractingContainedReactors {
   /**

--- a/core/src/main/java/org/lflang/generator/c/TypeParameterizedReactor.java
+++ b/core/src/main/java/org/lflang/generator/c/TypeParameterizedReactor.java
@@ -12,7 +12,11 @@ import org.lflang.ast.ASTUtils;
 import org.lflang.generator.CodeBuilder;
 import org.lflang.lf.*;
 
-/** A reactor class combined with concrete type arguments bound to its type parameters. */
+/**
+ * A reactor class combined with concrete type arguments bound to its type parameters.
+ *
+ * @ingroup Generator
+ */
 public class TypeParameterizedReactor {
   /** The syntactic reactor class definition. */
   private final Reactor reactor;

--- a/core/src/main/java/org/lflang/generator/docker/CDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/CDockerGenerator.java
@@ -13,6 +13,7 @@ import org.lflang.target.Target;
  *
  * @author Hou Seng Wong
  * @author Marten Lohstroh
+ * @ingroup Docker
  */
 public class CDockerGenerator extends DockerGenerator {
 

--- a/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
@@ -19,6 +19,7 @@ import org.lflang.util.LFCommand;
  *
  * @author Marten Lohstroh
  * @author Steven Wong
+ * @ingroup Docker
  */
 public class DockerComposeGenerator {
 

--- a/core/src/main/java/org/lflang/generator/docker/DockerData.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerData.java
@@ -13,6 +13,7 @@ import org.lflang.util.FileUtil;
  * Build configuration of a docker service.
  *
  * @author Marten Lohstroh
+ * @ingroup Docker
  */
 public class DockerData {
   /** The absolute path to the docker file. */

--- a/core/src/main/java/org/lflang/generator/docker/DockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerGenerator.java
@@ -19,6 +19,7 @@ import org.lflang.util.StringUtil;
  *
  * @author Marten Lohstroh
  * @author Hou Seng Wong
+ * @ingroup Docker
  */
 public abstract class DockerGenerator {
 

--- a/core/src/main/java/org/lflang/generator/docker/FedDockerComposeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/FedDockerComposeGenerator.java
@@ -10,6 +10,7 @@ import org.lflang.target.property.TracingProperty;
  * A docker-compose configuration generator for a federated program.
  *
  * @author Marten Lohstroh
+ * @ingroup Docker
  */
 public class FedDockerComposeGenerator extends DockerComposeGenerator {
 

--- a/core/src/main/java/org/lflang/generator/docker/PythonDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/PythonDockerGenerator.java
@@ -7,6 +7,7 @@ import org.lflang.generator.LFGeneratorContext;
  * Generates the docker file related code for the Python target.
  *
  * @author Hou Seng Wong
+ * @ingroup Docker
  */
 public class PythonDockerGenerator extends CDockerGenerator {
   public static final String DEFAULT_BASE_IMAGE = "python:3.10-alpine";

--- a/core/src/main/java/org/lflang/generator/docker/TSDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/TSDockerGenerator.java
@@ -8,6 +8,7 @@ import org.lflang.generator.LFGeneratorContext;
  *
  * @author Hou Seng Wong
  * @author Marten Lohstroh
+ * @ingroup Docker
  */
 public class TSDockerGenerator extends DockerGenerator {
 


### PR DESCRIPTION
This PR cleans up the javadocs in several files. This project is split into multiple PRs because GitHub's web interface freezes if there are too many files in a PR.  The cleanups include:

* Adding `@ingroup` tags for the benefit of the [topics](https://www.lf-lang.org/lingua-franca/topics.html) web page.
* Removing redundant copyright notices.
* Miscellaneous formatting improvements.
