### PR TITLE
Replace javadoc @code with backticks

### DIFF
--- a/cli/lfc/src/main/java/org/lflang/cli/Lfc.java
+++ b/cli/lfc/src/main/java/org/lflang/cli/Lfc.java
@@ -294,7 +294,8 @@ public class Lfc extends CliBase {
   }
 
   /**
-   * Return a URI that points to the RTI if one has been specified via the CLI arguments, or `* null` otherwise.
+   * Return a URI that points to the RTI if one has been specified via the CLI arguments,
+   * or `null` otherwise.
    */
   private URI getRtiUri() {
     URI uri = null;

--- a/core/src/integrationTest/java/org/lflang/tests/lsp/ErrorInserter.java
+++ b/core/src/integrationTest/java/org/lflang/tests/lsp/ErrorInserter.java
@@ -303,7 +303,7 @@ class ErrorInserter {
     }
 
     /**
-     * Record that the resulting `ErrorInserter` may replace `phrase` with `* alternativePhrase`.
+     * Record that the resulting `ErrorInserter` may replace `phrase` with `alternativePhrase`.
      *
      * @param phrase A phrase in target language code.
      * @param alternativePhrase A phrase that `phrase` may be replaced with in order to

--- a/core/src/integrationTest/java/org/lflang/tests/lsp/LspTests.java
+++ b/core/src/integrationTest/java/org/lflang/tests/lsp/LspTests.java
@@ -135,7 +135,7 @@ class LspTests extends LfInjectedTestBase {
 
   /**
    * Verify that the diagnostics that result from fully validating tests associated with
-   * `* target` satisfy `requirementGetter`.
+   * `target` satisfy `requirementGetter`.
    *
    * @param target Any target language.
    * @param requirementGetter A map from altered tests to the requirements that diagnostics

--- a/core/src/integrationTest/java/org/lflang/tests/lsp/MockLanguageClient.java
+++ b/core/src/integrationTest/java/org/lflang/tests/lsp/MockLanguageClient.java
@@ -13,7 +13,7 @@ import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 
 /**
- * A {@code MockLanguageClient} is a language client that should be used in language server tests.
+ * A `MockLanguageClient` is a language client that should be used in language server tests.
  *
  * @author Peter Donovan
  * @ingroup Tests
@@ -60,12 +60,12 @@ public class MockLanguageClient implements LanguageClient {
     showMessage(message);
   }
 
-  /** Return the diagnostics that {@code this} has received. */
+  /** Return the diagnostics that `this` has received. */
   public List<Diagnostic> getReceivedDiagnostics() {
     return Collections.unmodifiableList(receivedDiagnostics);
   }
 
-  /** Clear the diagnostics recorded by {@code this}. */
+  /** Clear the diagnostics recorded by `this`. */
   public void clearDiagnostics() {
     receivedDiagnostics.clear();
   }

--- a/core/src/main/java/org/lflang/AttributeUtils.java
+++ b/core/src/main/java/org/lflang/AttributeUtils.java
@@ -162,13 +162,13 @@ public class AttributeUtils {
 
   /**
    * Retrieve a specific annotation in a comment associated with the given model element in the AST.
-   * This will look for a comment. If one is found, it searches for the given annotation {@code key}
+   * This will look for a comment. If one is found, it searches for the given annotation `key`
    * and extracts any string that follows the annotation marker. Note that annotations in comments
    * are deprecated, but we still check for them for backwards compatibility.
    *
    * @param object The AST model element to search a comment for.
    * @param key The specific annotation key to be extracted.
-   * @return {@code null} if no JavaDoc style comment was found or if it does not contain the given
+   * @return `null` if no JavaDoc style comment was found or if it does not contain the given
    *     key. The string immediately following the annotation marker otherwise.
    */
   public static String findAnnotationInComments(EObject object, String key) {
@@ -223,10 +223,10 @@ public class AttributeUtils {
   }
 
   /**
-   * Return true if the specified node is an Input and has an {@code @sparse} attribute.
+   * Return true if the specified node is an Input and has an `@sparse` attribute.
    *
    * @param node An AST node.
-   * @return True if the specified node is an Input and has an {@code @sparse} attribute.
+   * @return True if the specified node is an Input and has an `@sparse` attribute.
    */
   public static boolean isSparse(EObject node) {
     return findAttributeByName(node, "sparse") != null;
@@ -275,7 +275,7 @@ public class AttributeUtils {
   }
 
   /**
-   * Return the {@code @side} annotation for the given node (presumably a port) or null if there is
+   * Return the `@side` annotation for the given node (presumably a port) or null if there is
    * no such annotation.
    *
    * @param node The node to get the port side from.
@@ -286,7 +286,7 @@ public class AttributeUtils {
   }
 
   /**
-   * Return the {@code layout} annotation for the given element or null if there is no such
+   * Return the `layout` annotation for the given element or null if there is no such
    * annotation.
    *
    * @param node The node to get the layout option from.
@@ -297,7 +297,7 @@ public class AttributeUtils {
   }
 
   /**
-   * Return the {@code @enclave} attribute annotated on the given node. Return null if there is no
+   * Return the `@enclave` attribute annotated on the given node. Return null if there is no
    * such attribute.
    *
    * @param node The node to get the enclave attribute from.
@@ -308,10 +308,10 @@ public class AttributeUtils {
   }
 
   /**
-   * Return true if the specified instance has an {@code @enclave} attribute.
+   * Return true if the specified instance has an `@enclave` attribute.
    *
    * @param node The node to check.
-   * @return True if the specified instance has an {@code @enclave} attribute.
+   * @return True if the specified instance has an `@enclave` attribute.
    */
   public static boolean isEnclave(Instantiation node) {
     return getEnclaveAttribute(node) != null;

--- a/core/src/main/java/org/lflang/FileConfig.java
+++ b/core/src/main/java/org/lflang/FileConfig.java
@@ -56,9 +56,9 @@ public abstract class FileConfig {
    * The directory that is the root of the package in which the .lf source file resides. This path
    * is determined differently depending on whether the compiler is invoked through the IDE or from
    * the command line. In the former case, the package is the project root that the source resides
-   * in. In the latter case, it is the parent directory of the nearest {@code src} directory up the
-   * hierarchy, if there is one, or just the {@code outPath} if there is none. It is recommended to
-   * always keep the sources in a {@code src} directory regardless of the workflow, in which case
+   * in. In the latter case, it is the parent directory of the nearest `src` directory up the
+   * hierarchy, if there is one, or just the `outPath` if there is none. It is recommended to
+   * always keep the sources in a `src` directory regardless of the workflow, in which case
    * the output behavior will be identical irrespective of the way the compiler is invoked.
    */
   public final Path srcPkgPath;
@@ -112,14 +112,14 @@ public abstract class FileConfig {
   // private fields
 
   /**
-   * The parent of the directory designated for placing generated sources into ({@code ./src-gen} by
-   * default). Additional directories (such as {@code bin} or {@code build}) should be created as
+   * The parent of the directory designated for placing generated sources into (`./src-gen` by
+   * default). Additional directories (such as `bin` or `build`) should be created as
    * siblings of the directory for generated sources, which means that such directories should be
    * created relative to the path assigned to this class variable.
    *
    * <p>The generated source directory is specified in the IDE (Project
    * Properties->LF->Compiler->Output Folder). When invoking the standalone compiler, the output
-   * path is specified directly using the {@code -o} or {@code --output-path} option.
+   * path is specified directly using the `-o` or `--output-path` option.
    */
   private final Path outPath;
 
@@ -161,14 +161,14 @@ public abstract class FileConfig {
   }
 
   /**
-   * The parent of the directory designated for placing generated sources into ({@code ./src-gen} by
-   * default). Additional directories (such as {@code bin} or {@code build}) should be created as
+   * The parent of the directory designated for placing generated sources into (`./src-gen` by
+   * default). Additional directories (such as `bin` or `build`) should be created as
    * siblings of the directory for generated sources, which means that such directories should be
    * created relative to the path assigned to this class variable.
    *
    * <p>The generated source directory is specified in the IDE (Project
    * Properties->LF->Compiler->Output Folder). When invoking the standalone compiler, the output
-   * path is specified directly using the {@code -o} or {@code --output-path} option.
+   * path is specified directly using the `-o` or `--output-path` option.
    */
   public Path getOutPath() {
     return outPath;

--- a/core/src/main/java/org/lflang/LFRuntimeModule.java
+++ b/core/src/main/java/org/lflang/LFRuntimeModule.java
@@ -16,8 +16,8 @@ import org.lflang.validation.LFNamesAreUniqueValidationHelper;
  * Binds services that are available both when running LFC standalone, and when running within the
  * IDE.
  *
- * <p>* LfIdeModule overrides this module with additional bindings when running in the IDE. * {@code
- * org.lflang.lfc.LFStandaloneModule} overrides this module when running LFC standalone.
+ * `LfIdeModule` overrides this module with additional bindings when running in the IDE.
+ * `org.lflang.lfc.LFStandaloneModule` overrides this module when running LFC standalone.
  *
  * @ingroup Infrastructure
  */
@@ -44,7 +44,7 @@ public class LFRuntimeModule extends AbstractLFRuntimeModule {
     return LFSyntaxErrorMessageProvider.class;
   }
 
-  /** The error reporter. {@code org.lflang.lfc.LFStandaloneModule} overrides this binding. */
+  /** The error reporter. `org.lflang.lfc.LFStandaloneModule` overrides this binding. */
   public Class<? extends MessageReporter> bindErrorReporter() {
     return DefaultMessageReporter.class;
   }

--- a/core/src/main/java/org/lflang/MessageReporter.java
+++ b/core/src/main/java/org/lflang/MessageReporter.java
@@ -9,16 +9,16 @@ import org.lflang.generator.Range;
 
 /**
  * Interface for reporting messages like errors or info. This interface is a staged builder: first
- * call one of the {@code at} methods to specify the position of the message, then use one of the
+ * call one of the `at` methods to specify the position of the message, then use one of the
  * report methods on the returned {@link Stage2} instance.
  *
- * <p>Examples:
+ * Examples:
  *
- * <pre>{@code
+ * ```
  * errorReporter.at(file, line).error("an error")
  * errorReporter.at(node).warning("a warning reported on a node")
  * errorReporter.nowhere().error("Some error that has no specific position")
- * }</pre>
+ * ```
  *
  * @see MessageReporterBase
  * @author Edward A. Lee

--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -133,7 +133,7 @@ public class ASTUtils {
    * Get the main reactor defined in the given resource, if there is one.
    *
    * @param resource the resource to extract reactors from
-   * @return An {@code Optional} reactor that may be present or absent.
+   * @return An `Optional` reactor that may be present or absent.
    */
   public static Optional<Reactor> getMainReactor(Resource resource) {
     return StreamSupport.stream(
@@ -148,7 +148,7 @@ public class ASTUtils {
    * Get the federated reactor defined in the given resource, if there is one.
    *
    * @param resource the resource to extract reactors from
-   * @return An {@code Optional} reactor that may be present or absent.
+   * @return An `Optional` reactor that may be present or absent.
    */
   public static Optional<Reactor> getFederatedReactor(Resource resource) {
     return StreamSupport.stream(
@@ -372,7 +372,7 @@ public class ASTUtils {
     return ASTUtils.collectElements(definition, featurePackage.getReactor_Inputs());
   }
 
-  /** A list of all ports of {@code definition}, in an unspecified order. */
+  /** A list of all ports of `definition`, in an unspecified order. */
   public static List<Port> allPorts(Reactor definition) {
     return Stream.concat(
             ASTUtils.allInputs(definition).stream(), ASTUtils.allOutputs(definition).stream())
@@ -677,8 +677,8 @@ public class ASTUtils {
   //// Utility functions for translating AST nodes into text
 
   /**
-   * Translate the given code into its textual representation with {@code CodeMap.Correspondence}
-   * tags inserted, or return the empty string if {@code node} is {@code null}. This method should
+   * Translate the given code into its textual representation with `CodeMap.Correspondence`
+   * tags inserted, or return the empty string if `node` is `null`. This method should
    * be used to generate code.
    *
    * @param node AST node to render as string.
@@ -690,8 +690,8 @@ public class ASTUtils {
   }
 
   /**
-   * Translate the given code into its textual representation without {@code CodeMap.Correspondence}
-   * tags, or return the empty string if {@code node} is {@code null}. This method should be used
+   * Translate the given code into its textual representation without `CodeMap.Correspondence`
+   * tags, or return the empty string if `node` is `null`. This method should be used
    * for analyzing AST nodes in cases where they are easiest to analyze as strings.
    *
    * @param node AST node to render as string.
@@ -821,7 +821,7 @@ public class ASTUtils {
   }
 
   /**
-   * Given a single string, convert it into its AST representation. {@code addQuotes} controls if
+   * Given a single string, convert it into its AST representation. `addQuotes` controls if
    * the generated representation should be accompanied by double quotes ("") or not.
    */
   private static Element toElement(String str, boolean addQuotes) {
@@ -909,7 +909,7 @@ public class ASTUtils {
    * Report whether the given literal is zero or not.
    *
    * @param literal AST node to inspect.
-   * @return True if the given literal denotes the constant {@code 0}, false otherwise.
+   * @return True if the given literal denotes the constant `0`, false otherwise.
    */
   public static boolean isZero(String literal) {
     try {
@@ -926,7 +926,7 @@ public class ASTUtils {
    * Report whether the given literal is forever or not.
    *
    * @param literal AST node to inspect.
-   * @return True if the given literal denotes the constant {@code forever}, false otherwise.
+   * @return True if the given literal denotes the constant `forever`, false otherwise.
    */
   public static boolean isForever(String literal) {
     return literal != null && literal.equals("forever");
@@ -936,7 +936,7 @@ public class ASTUtils {
    * Report whether the given literal is never or not.
    *
    * @param literal AST node to inspect.
-   * @return True if the given literal denotes the constant {@code never}, false otherwise.
+   * @return True if the given literal denotes the constant `never`, false otherwise.
    */
   public static boolean isNever(String literal) {
     return literal != null && literal.equals("never");
@@ -946,7 +946,7 @@ public class ASTUtils {
    * Report whether the given expression is zero or not.
    *
    * @param expr AST node to inspect.
-   * @return True if the given value denotes the constant {@code 0}, false otherwise.
+   * @return True if the given value denotes the constant `0`, false otherwise.
    */
   public static boolean isZero(Expression expr) {
     if (expr instanceof Literal) {
@@ -959,7 +959,7 @@ public class ASTUtils {
    * Report whether the given expression is forever or not.
    *
    * @param expr AST node to inspect.
-   * @return True if the given value denotes the constant {@code forever}, false otherwise.
+   * @return True if the given value denotes the constant `forever`, false otherwise.
    */
   public static boolean isForever(Expression expr) {
     if (expr instanceof Literal) {
@@ -972,7 +972,7 @@ public class ASTUtils {
    * Report whether the given expression is never or not.
    *
    * @param expr AST node to inspect.
-   * @return True if the given value denotes the constant {@code never}, false otherwise.
+   * @return True if the given value denotes the constant `never`, false otherwise.
    */
   public static boolean isNever(Expression expr) {
     if (expr instanceof Literal) {
@@ -1372,7 +1372,7 @@ public class ASTUtils {
   }
 
   /**
-   * @brief Return the delay denoted by {@code delay} or {@code null} if the delay cannot be
+   * @brief Return the delay denoted by `delay` or `null` if the delay cannot be
    *     determined.
    * @param delay The delay to get the time value from.
    * @return The delay time value or null if the delay cannot be determined.
@@ -1392,7 +1392,7 @@ public class ASTUtils {
   }
 
   /**
-   * @brief Return the delay (in nanoseconds) denoted by {@code delay}, or {@code null} if the delay
+   * @brief Return the delay (in nanoseconds) denoted by `delay`, or `null` if the delay
    *     cannot be determined.
    * @param delay The delay to get the time value from.
    * @return The delay time value or null if the delay cannot be determined.
@@ -1672,19 +1672,19 @@ public class ASTUtils {
     return ret.stream();
   }
 
-  /** Return whether {@code node} is a comment. */
+  /** Return whether `node` is a comment. */
   public static boolean isComment(INode node) {
     return isMultilineComment(node) || isSingleLineComment(node);
   }
 
-  /** Return whether {@code node} is a multiline comment. */
+  /** Return whether `node` is a multiline comment. */
   public static boolean isMultilineComment(INode node) {
     return node instanceof HiddenLeafNode hlNode
         && hlNode.getGrammarElement() instanceof TerminalRule tRule
         && tRule.getName().equals("ML_COMMENT");
   }
 
-  /** Return whether {@code node} is a multiline comment. */
+  /** Return whether `node` is a multiline comment. */
   public static boolean isSingleLineComment(INode node) {
     return node instanceof HiddenLeafNode hlNode
         && hlNode.getGrammarElement() instanceof TerminalRule tRule
@@ -1698,7 +1698,7 @@ public class ASTUtils {
   }
 
   /**
-   * Return {@code true} if the given instance is top-level, i.e., its parent is {@code null}.
+   * Return `true` if the given instance is top-level, i.e., its parent is `null`.
    *
    * @param instance The instance to check.
    */

--- a/core/src/main/java/org/lflang/ast/DelayedConnectionTransformation.java
+++ b/core/src/main/java/org/lflang/ast/DelayedConnectionTransformation.java
@@ -38,7 +38,7 @@ import org.lflang.util.Pair;
 
 /**
  * This class implements AST transformations for delayed connections. There are two types of delayed
- * connections: 1) Connections with {@code after}-delays 2) Physical connections.
+ * connections: 1) Connections with `after`-delays 2) Physical connections.
  *
  * @ingroup Utilities
  */
@@ -332,7 +332,7 @@ public class DelayedConnectionTransformation implements AstTransformation {
 
   /**
    * Return the generated delay reactor that corresponds to the given class name if it had been
-   * created already, {@code null} otherwise.
+   * created already, `null` otherwise.
    */
   private Reactor findDelayClass(String className) {
     return IterableExtensions.findFirst(delayClasses, it -> it.getName().equals(className));

--- a/core/src/main/java/org/lflang/ast/FormattingUtil.java
+++ b/core/src/main/java/org/lflang/ast/FormattingUtil.java
@@ -42,7 +42,7 @@ public class FormattingUtil {
 
   static final long BADNESS_PER_NEWLINE = 1;
 
-  /** Return a String representation of {@code object}, with lines wrapped at {@code lineLength}. */
+  /** Return a String representation of `object`, with lines wrapped at `lineLength`. */
   public static String render(Model object, int lineLength) {
     return render(object, lineLength, inferTarget(object), false);
   }
@@ -53,8 +53,8 @@ public class FormattingUtil {
   }
 
   /**
-   * Return a String representation of {@code object}, with lines wrapped at {@code lineLength},
-   * with the assumption that the target language is {@code target}.
+   * Return a String representation of `object`, with lines wrapped at `lineLength`,
+   * with the assumption that the target language is `target`.
    */
   public static String render(EObject object, int lineLength, Target target, boolean codeMapTags) {
     var toLf = new ToLf();
@@ -90,12 +90,12 @@ public class FormattingUtil {
     throw new IllegalArgumentException("Unable to determine target based on given EObject.");
   }
 
-  /** Return a String representation of {@code object} using a reasonable default line length. */
+  /** Return a String representation of `object` using a reasonable default line length. */
   public static String render(Model object) {
     return render(object, DEFAULT_LINE_LENGTH);
   }
 
-  /** Return the number of characters appearing in columns exceeding {@code lineLength}. */
+  /** Return the number of characters appearing in columns exceeding `lineLength`. */
   private static ToLongFunction<String> countCharactersViolatingLineLength(int lineLength) {
     return s -> s.lines().mapToInt(it -> Math.max(0, it.length() - lineLength)).sum();
   }
@@ -105,7 +105,7 @@ public class FormattingUtil {
   }
 
   /**
-   * Break lines at spaces so that each line is no more than {@code width} columns long, if
+   * Break lines at spaces so that each line is no more than `width` columns long, if
    * possible. Normalize whitespace. Merge consecutive single-line comments.
    */
   static String lineWrapComments(List<String> comments, int width, String singleLineCommentPrefix) {
@@ -214,13 +214,13 @@ public class FormattingUtil {
   }
 
   /**
-   * Merge {@code comment} into the given list of strings without changing the length of the list,
-   * preferably in a place that indicates that {@code comment} is associated with the {@code i}th
+   * Merge `comment` into the given list of strings without changing the length of the list,
+   * preferably in a place that indicates that `comment` is associated with the `i`th
    * string.
    *
-   * @param comment A comment associated with an element of {@code components}.
+   * @param comment A comment associated with an element of `components`.
    * @param components A list of strings that will be rendered in sequence.
-   * @param i The position of the component associated with {@code comment}.
+   * @param i The position of the component associated with `comment`.
    * @param width The ideal number of columns available for comments that appear on their own line.
    * @param keepCommentsOnSameLine Whether to make a best-effort attempt to keep the comment on the
    *     same line as the associated string.

--- a/core/src/main/java/org/lflang/ast/IsEqual.java
+++ b/core/src/main/java/org/lflang/ast/IsEqual.java
@@ -67,8 +67,8 @@ import org.lflang.lf.util.LfSwitch;
 
 /**
  * Switch class that checks if subtrees of the AST are semantically equivalent to each other. Return
- * {@code false} if they are not equivalent; return {@code true} or {@code false} (but preferably
- * {@code true}) if they are equivalent.
+ * `false` if they are not equivalent; return `true` or `false` (but preferably
+ * `true`) if they are equivalent.
  *
  * @ingroup Utilities
  */
@@ -651,8 +651,8 @@ public class IsEqual extends LfSwitch<Boolean> {
     }
 
     /**
-     * Conclude false if the two properties are not equal as objects, given that {@code
-     * projectionToClassRepresentatives} maps each object to some semantically equivalent object.
+     * Conclude false if the two properties are not equal as objects, given that
+     * `projectionToClassRepresentatives` maps each object to some semantically equivalent object.
      */
     <T> ComparisonMachine<E> equalAsObjectsModulo(
         Function<E, T> propertyGetter, Function<T, T> projectionToClassRepresentatives) {
@@ -673,7 +673,7 @@ public class IsEqual extends LfSwitch<Boolean> {
 
     /**
      * Conclude false if the two properties are not semantically equivalent parse nodes, given that
-     * {@code projectionToClassRepresentatives} maps each parse node to some semantically equivalent
+     * `projectionToClassRepresentatives` maps each parse node to some semantically equivalent
      * node.
      */
     <T extends EObject> ComparisonMachine<E> equivalentModulo(

--- a/core/src/main/java/org/lflang/ast/MalleableString.java
+++ b/core/src/main/java/org/lflang/ast/MalleableString.java
@@ -21,7 +21,7 @@ import org.lflang.lf.Code;
 import org.lflang.util.StringUtil;
 
 /**
- * A {@code MalleableString} is an object with multiple valid textual representations. These textual
+ * A `MalleableString` is an object with multiple valid textual representations. These textual
  * representations are code that may have associated comments.
  *
  * @ingroup Utilities
@@ -70,8 +70,8 @@ public abstract class MalleableString {
   }
 
   /**
-   * Render this using {@code indentation} spaces per indentation level and {@code
-   * singleLineCommentMarker} to mark the beginnings of single-line comments.
+   * Render this using `indentation` spaces per indentation level and `singleLineCommentMarker`
+   * to mark the beginnings of single-line comments.
    */
   public abstract RenderResult render(
       int indentation,
@@ -119,7 +119,7 @@ public abstract class MalleableString {
     return ret;
   }
 
-  /** Build a {@code MalleableString} in a manner analogous to the way we build {@code String}s. */
+  /** Build a `MalleableString` in a manner analogous to the way we build `String`s. */
   public static final class Builder {
 
     private final List<MalleableString> components = new ArrayList<>();
@@ -165,25 +165,24 @@ public abstract class MalleableString {
     }
   }
 
-  /** Join {@code MalleableString}s together using the given separator. */
+  /** Join `MalleableString`s together using the given separator. */
   public static final class Joiner implements Collector<MalleableString, Builder, MalleableString> {
     private final Function<Builder, Builder> appendSeparator;
     private final Function<Builder, Builder> prependPrefix;
     private final Function<Builder, Builder> appendSuffix;
 
-    /** Join strings using {@code separator}. */
+    /** Join strings using `separator`. */
     public Joiner(String separator) {
       this(MalleableString.anyOf(separator));
     }
 
-    /** Join strings using {@code separator}. */
+    /** Join strings using `separator`. */
     public Joiner(MalleableString separator) {
       this(separator, MalleableString.anyOf(""), MalleableString.anyOf(""));
     }
 
     /**
-     * Join strings using {@code separator} and delimit the result with {@code prefix} and {@code
-     * suffix}.
+     * Join strings using `separator` and delimit the result with `prefix` and `suffix`.
      */
     public Joiner(MalleableString separator, MalleableString prefix, MalleableString suffix) {
       this.appendSeparator =
@@ -193,8 +192,7 @@ public abstract class MalleableString {
     }
 
     /**
-     * Join strings using {@code separator} and delimit the result with {@code prefix} and {@code
-     * suffix}.
+     * Join strings using `separator` and delimit the result with `prefix` and `suffix`.
      */
     public Joiner(String separator, String prefix, String suffix) {
       this(
@@ -234,7 +232,7 @@ public abstract class MalleableString {
     }
   }
 
-  /** The result of rendering a {@code MalleableString}. */
+  /** The result of rendering a `MalleableString`. */
   public record RenderResult(
       Stream<String> unplacedComments, String rendering, int levelsOfCommentDisplacement) {
     private RenderResult with(Stream<String> moreUnplacedComments) {
@@ -432,7 +430,7 @@ public abstract class MalleableString {
     }
   }
 
-  /** Represent an indented version of another {@code MalleableString}. */
+  /** Represent an indented version of another `MalleableString`. */
   private static final class Indented extends MalleableString {
 
     private final MalleableString nested;
@@ -495,7 +493,7 @@ public abstract class MalleableString {
     }
   }
 
-  /** Represent a {@code MalleableString} that admits multiple possible representations. */
+  /** Represent a `MalleableString` that admits multiple possible representations. */
   private abstract static class MalleableStringWithAlternatives<T> extends MalleableString {
     protected abstract List<T> getPossibilities();
 
@@ -542,7 +540,7 @@ public abstract class MalleableString {
     }
   }
 
-  /** A {@code Fork} can be represented by multiple possible {@code MalleableString}s. */
+  /** A `Fork` can be represented by multiple possible `MalleableString`s. */
   private static final class Fork extends MalleableStringWithAlternatives<MalleableString> {
     private final ImmutableList<MalleableString> possibilities;
 
@@ -584,7 +582,7 @@ public abstract class MalleableString {
     }
   }
 
-  /** A {@code Leaf} can be represented by multiple possible {@code String}s. */
+  /** A `Leaf` can be represented by multiple possible `String`s. */
   private static final class Leaf extends MalleableStringWithAlternatives<String> {
     private List<String> possibilities;
 

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -151,7 +151,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     return super.doSwitch(eObject).addComments(allComments.stream()).setSourceEObject(eObject);
   }
 
-  /** Return all comments contained by ancestors of {@code node} that belong to said ancestors. */
+  /** Return all comments contained by ancestors of `node` that belong to said ancestors. */
   static Set<INode> getAncestorComments(INode node) {
     Set<INode> ancestorComments = new HashSet<>();
     for (ICompositeNode ancestor = node.getParent();
@@ -165,8 +165,8 @@ public class ToLf extends LfSwitch<MalleableString> {
   }
 
   /**
-   * Return the next composite sibling of {@code node}, as given by sequential application of {@code
-   * getNextSibling}.
+   * Return the next composite sibling of `node`, as given by sequential application of
+   * `getNextSibling`.
    */
   static ICompositeNode getNextCompositeSibling(INode node, Function<INode, INode> getNextSibling) {
     INode sibling = node;
@@ -178,7 +178,7 @@ public class ToLf extends LfSwitch<MalleableString> {
   }
 
   /**
-   * Return the siblings following {@code node} up to (and not including) the next non-leaf sibling.
+   * Return the siblings following `node` up to (and not including) the next non-leaf sibling.
    */
   private static Stream<INode> getFollowingNonCompositeSiblings(ICompositeNode node) {
     INode sibling = node;
@@ -190,8 +190,8 @@ public class ToLf extends LfSwitch<MalleableString> {
   }
 
   /**
-   * Return comments that follow {@code node} in the source code and that either satisfy {@code
-   * filter} or that cannot belong to any following sibling of {@code node}.
+   * Return comments that follow `node` in the source code and that either satisfy `filter`
+   * or that cannot belong to any following sibling of `node`.
    */
   private static Stream<String> getFollowingComments(
       ICompositeNode node, Predicate<INode> precedingFilter, Predicate<INode> followingFilter) {
@@ -207,7 +207,7 @@ public class ToLf extends LfSwitch<MalleableString> {
   }
 
   /**
-   * Return comments contained by {@code node} that logically belong to this node (and not to any of
+   * Return comments contained by `node` that logically belong to this node (and not to any of
    * its children).
    */
   private static List<INode> getContainedCodeComments(INode node) {
@@ -231,7 +231,7 @@ public class ToLf extends LfSwitch<MalleableString> {
   }
 
   /**
-   * Return all comments that are part of {@code node}, regardless of where they appear relative to
+   * Return all comments that are part of `node`, regardless of where they appear relative to
    * the main content of the node.
    */
   private static List<INode> getContainedComments(INode node) {
@@ -1149,7 +1149,7 @@ public class ToLf extends LfSwitch<MalleableString> {
    * @param statementListList A list of groups of statements.
    * @param forceWhitespace Whether to force a line of vertical whitespace regardless of textual
    *     input
-   * @return A string representation of {@code statementListList}.
+   * @return A string representation of `statementListList`.
    */
   private MalleableString indentedStatements(
       List<EList<? extends EObject>> statementListList, boolean forceWhitespace) {

--- a/core/src/main/java/org/lflang/federated/extensions/CExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtension.java
@@ -77,7 +77,7 @@ public class CExtension implements FedTargetExtension {
     FedSetupProperty.INSTANCE.override(federate.targetConfig, getPreamblePath(federate));
   }
 
-  /** Generate a cmake-include file for {@code federate} if needed. */
+  /** Generate a cmake-include file for `federate` if needed. */
   protected void generateCMakeInclude(FederateInstance federate, FederationFileConfig fileConfig)
       throws IOException {
     CExtensionUtils.generateCMakeInclude(federate, fileConfig);
@@ -125,7 +125,7 @@ public class CExtension implements FedTargetExtension {
   /**
    * Generate code to deserialize a message received over the network.
    *
-   * @param action The network action that is mapped to the {@code receivingPort}
+   * @param action The network action that is mapped to the `receivingPort`
    * @param receivingPort The receiving port
    * @param connection The connection used to receive the message
    * @param type Type for the port
@@ -353,7 +353,7 @@ public class CExtension implements FedTargetExtension {
    * @param sendRef C code representing a reference to the data to be sent.
    * @param result An accumulator of the generated code.
    * @param sendingFunction The name of the function that sends the serialized data.
-   * @param commonArgs Arguments passed to {@code sendingFunction} regardless of serialization
+   * @param commonArgs Arguments passed to `sendingFunction` regardless of serialization
    *     method.
    */
   protected void serializeAndSend(
@@ -482,7 +482,7 @@ public class CExtension implements FedTargetExtension {
     return "uint8_t*";
   }
 
-  /** Put the C preamble in a {@code include/_federate.name + _preamble.h} file. */
+  /** Put the C preamble in a `include/_federate.name + _preamble.h` file. */
   protected final void writePreambleFile(
       FederateInstance federate,
       FederationFileConfig fileConfig,
@@ -670,7 +670,7 @@ public class CExtension implements FedTargetExtension {
   }
 
   /**
-   * Generate code to initialize the {@code federate}.
+   * Generate code to initialize the `federate`.
    *
    * @param rtiConfig Information about the RTI's deployment.
    * @return The generated code
@@ -802,7 +802,7 @@ public class CExtension implements FedTargetExtension {
   }
 
   /**
-   * Generate code to handle physical actions in the {@code federate}.
+   * Generate code to handle physical actions in the `federate`.
    *
    * @param messageReporter Used to report errors.
    * @return Generated code.

--- a/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
@@ -324,8 +324,8 @@ public class CExtensionUtils {
   }
 
   /**
-   * Generate code that sends the neighbor structure message to the RTI. See {@code
-   * MSG_TYPE_NEIGHBOR_STRUCTURE} in {@code federated/net_common.h}.
+   * Generate code that sends the neighbor structure message to the RTI. See
+   * `MSG_TYPE_NEIGHBOR_STRUCTURE` in `federated/net_common.h`.
    *
    * @param federate The federate that is sending its neighbor structure
    */
@@ -472,7 +472,7 @@ public class CExtensionUtils {
   }
 
   /**
-   * Surround {@code code} with blocks to ensure that code only executes if the program is
+   * Surround `code` with blocks to ensure that code only executes if the program is
    * federated.
    */
   public static String surroundWithIfFederated(String code) {
@@ -500,7 +500,7 @@ public class CExtensionUtils {
   }
 
   /**
-   * Surround {@code code} with blocks to ensure that code only executes if the program is federated
+   * Surround `code` with blocks to ensure that code only executes if the program is federated
    * and has a centralized coordination.
    */
   public static String surroundWithIfFederatedCentralized(String code) {
@@ -513,7 +513,7 @@ public class CExtensionUtils {
   }
 
   /**
-   * Surround {@code code} with blocks to ensure that code only executes if the program is federated
+   * Surround `code` with blocks to ensure that code only executes if the program is federated
    * and has a decentralized coordination.
    */
   public static String surroundWithIfFederatedDecentralized(String code) {

--- a/core/src/main/java/org/lflang/federated/extensions/FedTargetExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/FedTargetExtension.java
@@ -30,7 +30,7 @@ public interface FedTargetExtension {
    * @param context The context of the original code generation process.
    * @param federateNames The names of all the federates in the program.
    * @param federate The federate instance.
-   * @param fileConfig An instance of {@code FedFileConfig}.
+   * @param fileConfig An instance of `FedFileConfig`.
    * @param messageReporter Used to report errors.
    */
   void initializeTargetConfig(
@@ -68,7 +68,7 @@ public interface FedTargetExtension {
   /** Generate code for the parameter that specifies the sender index. */
   void addSenderIndexParameter(Reactor sender);
 
-  /** Generate code for the sender index argument of {@code instantiation}. */
+  /** Generate code for the sender index argument of `instantiation`. */
   void supplySenderIndexParameter(Instantiation inst, int idx);
 
   /**
@@ -102,7 +102,7 @@ public interface FedTargetExtension {
   default void annotateReaction(Reaction reaction) {}
 
   /**
-   * Return the type for the raw network buffer in the target language (e.g., {@code uint_8} in C).
+   * Return the type for the raw network buffer in the target language (e.g., `uint_8` in C).
    * This would be the type of the network messages after serialization and before deserialization.
    * It is primarily used to determine the type for the network action at the receiver.
    */

--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -434,7 +434,7 @@ public class FedASTUtils {
   }
 
   /**
-   * Go upstream from input port {@code port} until we reach one or more output ports that belong to
+   * Go upstream from input port `port` until we reach one or more output ports that belong to
    * the same federate.
    *
    * <p>Along the path, we follow direct connections, as well as reactions, as long as there is no
@@ -769,7 +769,7 @@ public class FedASTUtils {
   }
 
   /**
-   * Return the reaction that initializes the containing network sender reactor on {@code startup}.
+   * Return the reaction that initializes the containing network sender reactor on `startup`.
    */
   private static Reaction getInitializationReaction(FedTargetExtension extension, String body) {
     var initializationReaction = LfFactory.eINSTANCE.createReaction();

--- a/core/src/main/java/org/lflang/federated/generator/FedEmitter.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedEmitter.java
@@ -35,7 +35,7 @@ public class FedEmitter {
     this.rtiConfig = rtiConfig;
   }
 
-  /** Generate a .lf file for federate {@code federate}. */
+  /** Generate a .lf file for federate `federate`. */
   Map<Path, CodeMap> generateFederate(
       LFGeneratorContext context, FederateInstance federate, List<String> federateNames)
       throws IOException {

--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -384,7 +384,7 @@ public class FedGenerator {
     }
   }
 
-  /** Return whether federated execution is supported for {@code resource}. */
+  /** Return whether federated execution is supported for `resource`. */
   private boolean federatedExecutionIsSupported(Resource resource, LFGeneratorContext context) {
     TargetDecl targetDecl = GeneratorUtils.findTargetDecl(resource);
     var target = Target.fromDecl(targetDecl);
@@ -695,7 +695,7 @@ public class FedGenerator {
   }
 
   /**
-   * Get federate instances for a given {@code instantiation}. A bank will result in the creation of
+   * Get federate instances for a given `instantiation`. A bank will result in the creation of
    * multiple federate instances (one for each member of the bank).
    *
    * @param instantiation An instantiation that corresponds to a federate.
@@ -799,7 +799,7 @@ public class FedGenerator {
   }
 
   /**
-   * Add an {@code indexer} to the model and return it. An indexer is a reactor that is an adapter
+   * Add an `indexer` to the model and return it. An indexer is a reactor that is an adapter
    * from many ports to just one port
    */
   private Reactor indexer(ReactorInstance reactorInstance, PortInstance input, Resource resource) {
@@ -831,7 +831,7 @@ public class FedGenerator {
     return indexer;
   }
 
-  /** Return a {@code VarRef} with the given name. */
+  /** Return a `VarRef` with the given name. */
   private static VarRef varRefOf(Instantiation container, String name) {
     var varRef = LfFactory.eINSTANCE.createVarRef();
     var variable = LfFactory.eINSTANCE.createVariable();

--- a/core/src/main/java/org/lflang/federated/generator/FedImportEmitter.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedImportEmitter.java
@@ -22,7 +22,7 @@ public class FedImportEmitter {
 
   private static final Set<Import> visitedImports = new HashSet<>();
 
-  /** Generate import statements for {@code federate}. */
+  /** Generate import statements for `federate`. */
   String generateImports(FederateInstance federate, FederationFileConfig fileConfig) {
     var imports =
         ((Model) federate.instantiation.eContainer().eContainer())

--- a/core/src/main/java/org/lflang/federated/generator/FedMainEmitter.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedMainEmitter.java
@@ -18,7 +18,7 @@ import org.lflang.lf.Reactor;
 public class FedMainEmitter {
 
   /**
-   * Generate a main reactor for {@code federate}.
+   * Generate a main reactor for `federate`.
    *
    * @param originalMainReactor The original main reactor.
    * @param messageReporter Used to report errors.

--- a/core/src/main/java/org/lflang/federated/generator/FedReactorEmitter.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedReactorEmitter.java
@@ -13,7 +13,7 @@ public class FedReactorEmitter {
 
   public FedReactorEmitter() {}
 
-  /** Return textual representations of all reactor classes belonging to {@code federate}. */
+  /** Return textual representations of all reactor classes belonging to `federate`. */
   String generateReactorDefinitions(FederateInstance federate) {
     return ((Model) federate.instantiation.eContainer().eContainer())
         .getReactors().stream()

--- a/core/src/main/java/org/lflang/federated/generator/FedUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedUtils.java
@@ -10,8 +10,7 @@ import org.lflang.lf.Connection;
  */
 public class FedUtils {
   /**
-   * Get the serializer for the {@code connection} between {@code srcFederate} and {@code
-   * dstFederate}.
+   * Get the serializer for the `connection` between `srcFederate` and `dstFederate`.
    */
   public static SupportedSerializers getSerializer(
       Connection connection, FederateInstance srcFederate, FederateInstance dstFederate) {

--- a/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
+++ b/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
@@ -55,7 +55,7 @@ public class FederateInstance {
    *
    * @param instantiation The AST node of the instantiation.
    * @param id An identifier.
-   * @param bankIndex If {@code instantiation.widthSpec !== null}, this gives the bank position.
+   * @param bankIndex If `instantiation.widthSpec !== null`, this gives the bank position.
    * @param messageReporter An object for reporting messages to the user.
    */
   public FederateInstance(
@@ -150,8 +150,8 @@ public class FederateInstance {
   public List<FederateInstance> networkMessageSourceFederate = new ArrayList<>();
 
   /**
-   * List of after delay values of the corresponding entries of {@code networkMessageActions}. These
-   * will be {@code null} in the case of zero-delay connections and {@code 0} in the case of
+   * List of after delay values of the corresponding entries of `networkMessageActions`. These
+   * will be `null` in the case of zero-delay connections and `0` in the case of
    * microstep-delay connections.
    */
   public List<Expression> networkMessageActionDelays = new ArrayList<>();
@@ -257,8 +257,8 @@ public class FederateInstance {
   private final MessageReporter messageReporter;
 
   /**
-   * Return {@code true} if the class declaration of the given {@code instantiation} references the
-   * {@code declaration} of a reactor class, either directly or indirectly (i.e, via a superclass or
+   * Return `true` if the class declaration of the given `instantiation` references the
+   * `declaration` of a reactor class, either directly or indirectly (i.e, via a superclass or
    * a contained instantiation of the reactor class).
    *
    * @param declaration The reactor declaration to check whether it is referenced.
@@ -268,8 +268,8 @@ public class FederateInstance {
   }
 
   /**
-   * Return {@code true} if the class declaration of the given {@code instantiation} references the
-   * {@code declaration} of a reactor class, either directly or indirectly (i.e, via a superclass or
+   * Return `true` if the class declaration of the given `instantiation` references the
+   * `declaration` of a reactor class, either directly or indirectly (i.e, via a superclass or
    * a contained instantiation of the reactor class).
    *
    * <p>An instantiation references the declaration of a reactor class if it is an instance of that
@@ -330,7 +330,7 @@ public class FederateInstance {
   }
 
   /**
-   * Return {@code true} if this federate references the given import.
+   * Return `true` if this federate references the given import.
    *
    * @param imp The import to check whether it is referenced.
    */
@@ -344,7 +344,7 @@ public class FederateInstance {
   }
 
   /**
-   * Return {@code true} if this federate references the given parameter.
+   * Return `true` if this federate references the given parameter.
    *
    * @param param The parameter to check whether it is referenced.
    */
@@ -377,7 +377,7 @@ public class FederateInstance {
   }
 
   /**
-   * Return {@code true} if this federate includes a top-level reaction that references the given
+   * Return `true` if this federate includes a top-level reaction that references the given
    * action as a trigger, a source, or an effect.
    *
    * @param action The action to check whether it is to be included.
@@ -415,7 +415,7 @@ public class FederateInstance {
   }
 
   /**
-   * Return {@code true} if the specified reaction should be included in the code generated for this
+   * Return `true` if the specified reaction should be included in the code generated for this
    * federate at the top-level. This means that if the reaction is triggered by or sends data to a
    * port of a contained reactor, then that reaction is in the federate. Otherwise, return false.
    *
@@ -453,7 +453,7 @@ public class FederateInstance {
   }
 
   /**
-   * Return {@code true} if this federate includes a top-level reaction that references the given
+   * Return `true` if this federate includes a top-level reaction that references the given
    * timer as a trigger, a source, or an effect.
    *
    * @param timer The action to check whether it is to be included.
@@ -477,9 +477,9 @@ public class FederateInstance {
   }
 
   /**
-   * Return {@code true} if this federate instance includes the given instance.
+   * Return `true` if this federate instance includes the given instance.
    *
-   * <p>NOTE: If the instance is a bank within the top level, then this returns {@code true} even
+   * <p>NOTE: If the instance is a bank within the top level, then this returns `true` even
    * though only one of the bank members is included in the federate.
    *
    * @param instance The reactor instance to check whether it is to be included.

--- a/core/src/main/java/org/lflang/federated/validation/FedValidator.java
+++ b/core/src/main/java/org/lflang/federated/validation/FedValidator.java
@@ -54,8 +54,7 @@ public class FedValidator {
   }
 
   /**
-   * Check if this federate contains all the {@code varRefs}. If not, report an error using {@code
-   * errorReporter}.
+   * Check if this federate contains all the `varRefs`. If not, report an error using `errorReporter`.
    */
   private static void containsAllVarRefs(List<VarRef> varRefs, MessageReporter messageReporter) {
     var referencesFederate = false;

--- a/core/src/main/java/org/lflang/generator/Argument.java
+++ b/core/src/main/java/org/lflang/generator/Argument.java
@@ -16,7 +16,7 @@ import org.lflang.target.property.TargetProperty;
 public record Argument<T>(TargetProperty<T, ?> property, T value) {
 
   /**
-   * Update the target configuration if the value of this argument is not {@code null}.
+   * Update the target configuration if the value of this argument is not `null`.
    *
    * @param config The target configuration to update.
    * @param reporter An error reporter to report the use of unsupported target properties.

--- a/core/src/main/java/org/lflang/generator/CodeBuilder.java
+++ b/core/src/main/java/org/lflang/generator/CodeBuilder.java
@@ -79,7 +79,7 @@ public class CodeBuilder {
   /**
    * Append the specified text plus a final newline.
    *
-   * @param format A format string to be used by {@code String.format} or the text to append if no
+   * @param format A format string to be used by `String.format` or the text to append if no
    *     further arguments are given.
    * @param args Additional arguments to pass to the formatter.
    */

--- a/core/src/main/java/org/lflang/generator/CodeMap.java
+++ b/core/src/main/java/org/lflang/generator/CodeMap.java
@@ -47,12 +47,12 @@ public class CodeMap {
     private final boolean verbatim;
 
     /**
-     * Instantiates a Correspondence between {@code lfRange} at {@code path} and {@code
-     * generatedRange} in the generated file associated with this Correspondence.
+     * Instantiates a Correspondence between `lfRange` at `path` and `generatedRange` in the
+     * generated file associated with this Correspondence.
      *
      * @param path a path to an LF source file
      * @param lfRange a range in the given LF file
-     * @param generatedRange the range of generated code associated with {@code lfRange}
+     * @param generatedRange the range of generated code associated with `lfRange`
      */
     private Correspondence(Path path, Range lfRange, Range generatedRange, boolean verbatim) {
       this.path = path;
@@ -96,12 +96,12 @@ public class CodeMap {
     }
 
     /**
-     * Returns the Correspondence represented by {@code s}.
+     * Returns the Correspondence represented by `s`.
      *
      * @param s a String that represents a Correspondence, formatted like the output of
      *     Correspondence::toString
      * @param relativeTo the offset relative to which the offsets given are given
-     * @return the Correspondence represented by {@code s}
+     * @return the Correspondence represented by `s`
      */
     public static Correspondence fromString(String s, Position relativeTo) {
       Matcher matcher = PATTERN.matcher(s);
@@ -119,15 +119,15 @@ public class CodeMap {
     }
 
     /**
-     * Returns {@code representation}, tagged with a Correspondence to the source code associated
-     * with {@code astNode}.
+     * Returns `representation`, tagged with a Correspondence to the source code associated
+     * with `astNode`.
      *
      * @param astNode an arbitrary AST node
      * @param representation the code generated from that AST node
-     * @param verbatim whether {@code representation} is copied verbatim from the part of the source
-     *     code associated with {@code astNode}
-     * @return {@code representation}, tagged with a Correspondence to the source code associated
-     *     with {@code astNode}
+     * @param verbatim whether `representation` is copied verbatim from the part of the source
+     *     code associated with `astNode`
+     * @return `representation`, tagged with a Correspondence to the source code associated
+     *     with `astNode`
      */
     public static String tag(EObject astNode, String representation, boolean verbatim) {
       final INode node = NodeModelUtils.getNode(astNode);
@@ -157,7 +157,7 @@ public class CodeMap {
     }
 
     /**
-     * Return the {@code eResource} associated with the given AST node. This is a dangerous
+     * Return the `eResource` associated with the given AST node. This is a dangerous
      * operation which can cause an unrecoverable error.
      */
     private static Resource bestEffortGetEResource(EObject astNode) {
@@ -169,11 +169,11 @@ public class CodeMap {
 
     /**
      * Make a best-effort attempt to find the index of a near substring whose first line is expected
-     * to be an exact substring of {@code s}. Return 0 upon failure.
+     * to be an exact substring of `s`. Return 0 upon failure.
      *
      * @param s an arbitrary string
-     * @param imperfectSubstring an approximate substring of {@code s}
-     * @return the index of {@code imperfectSubstring} within {@code s}
+     * @param imperfectSubstring an approximate substring of `s`
+     * @return the index of `imperfectSubstring` within `s`
      */
     private static int indexOf(String s, String imperfectSubstring) {
       String firstLine = imperfectSubstring.lines().findFirst().orElse("");
@@ -199,9 +199,9 @@ public class CodeMap {
   /* ------------------------- PUBLIC METHODS -------------------------- */
 
   /**
-   * Instantiates a {@code CodeMap} from {@code internalGeneratedCode}. {@code
-   * internalGeneratedCode} may be invalid code that is different from the final generated code
-   * because it should contain deserializable representations of {@code Correspondences}.
+   * Instantiate a `CodeMap` from `internalGeneratedCode`. `internalGeneratedCode` may be
+   * invalid code that is different from the final generated code because it should contain
+   * deserializable representations of `Correspondences`.
    *
    * @param internalGeneratedCode code from a code generator that contains serialized
    *     Correspondences
@@ -240,12 +240,12 @@ public class CodeMap {
   }
 
   /**
-   * Returns the position in {@code lfFile} corresponding to {@code generatedFilePosition} if such a
+   * Returns the position in `lfFile` corresponding to `generatedFilePosition` if such a
    * position is known, or the zero Position otherwise.
    *
    * @param lfFile the path to an arbitrary Lingua Franca source file
    * @param generatedFilePosition a position in a generated file
-   * @return the position in {@code lfFile} corresponding to {@code generatedFilePosition}
+   * @return the position in `lfFile` corresponding to `generatedFilePosition`
    */
   public Position adjusted(Path lfFile, Position generatedFilePosition) {
     NavigableMap<Range, Range> mapOfInterest = map.get(lfFile);
@@ -266,12 +266,12 @@ public class CodeMap {
   }
 
   /**
-   * Returns the range in {@code lfFile} corresponding to {@code generatedFileRange} if such a range
+   * Returns the range in `lfFile` corresponding to `generatedFileRange` if such a range
    * is known, or a degenerate Range otherwise.
    *
    * @param lfFile the path to an arbitrary Lingua Franca source file
    * @param generatedFileRange a position in a generated file
-   * @return the range in {@code lfFile} corresponding to {@code generatedFileRange}
+   * @return the range in `lfFile` corresponding to `generatedFileRange`
    */
   public Range adjusted(Path lfFile, Range generatedFileRange) {
     final Position start = adjusted(lfFile, generatedFileRange.getStartInclusive());
@@ -295,7 +295,7 @@ public class CodeMap {
   }
 
   /**
-   * Removes serialized Correspondences from {@code line} and updates {@code map} according to those
+   * Removes serialized Correspondences from `line` and updates `map` according to those
    * Correspondences.
    *
    * @param line a line of generated code

--- a/core/src/main/java/org/lflang/generator/DiagnosticReporting.java
+++ b/core/src/main/java/org/lflang/generator/DiagnosticReporting.java
@@ -48,11 +48,11 @@ public class DiagnosticReporting {
   }
 
   /**
-   * Convert {@code severity} into a {@code DiagnosticSeverity} using a heuristic that should be
+   * Convert `severity` into a `DiagnosticSeverity` using a heuristic that should be
    * compatible with many tools.
    *
    * @param severity The string representation of a diagnostic severity.
-   * @return The {@code DiagnosticSeverity} representation of {@code severity}.
+   * @return The `DiagnosticSeverity` representation of `severity`.
    */
   public static DiagnosticSeverity severityOf(String severity) {
     severity = severity.toLowerCase();

--- a/core/src/main/java/org/lflang/generator/GeneratorBase.java
+++ b/core/src/main/java/org/lflang/generator/GeneratorBase.java
@@ -92,16 +92,16 @@ public abstract class GeneratorBase extends AbstractLFValidator {
   /**
    * A list of Reactor definitions in the main resource, including non-main reactors defined in
    * imported resources. These are ordered in the list in such a way that each reactor is preceded
-   * by any reactor that it instantiates using a command like {@code foo = new Foo();}
+   * by any reactor that it instantiates using a command like `foo = new Foo();`
    */
   protected List<Reactor> reactors = new ArrayList<>();
 
   /**
    * Graph that tracks dependencies between instantiations. This is a graph where each node is a
    * Reactor (not a ReactorInstance) and an arc from Reactor A to Reactor B means that B contains an
-   * instance of A, constructed with a statement like {@code a = new A();} After creating the graph,
+   * instance of A, constructed with a statement like `a = new A();` After creating the graph,
    * sort the reactors in topological order and assign them to the reactors class variable. Hence,
-   * after this method returns, {@code this.reactors} will be a list of Reactors such that any
+   * after this method returns, `this.reactors` will be a list of Reactors such that any
    * reactor is preceded in the list by reactors that it instantiates.
    */
   protected InstantiationGraph instantiationGraph;
@@ -262,9 +262,9 @@ public abstract class GeneratorBase extends AbstractLFValidator {
   /**
    * Create a new instantiation graph. This is a graph where each node is a Reactor (not a
    * ReactorInstance) and an arc from Reactor A to Reactor B means that B contains an instance of A,
-   * constructed with a statement like {@code a = new A();} After creating the graph, sort the
+   * constructed with a statement like `a = new A();` After creating the graph, sort the
    * reactors in topological order and assign them to the reactors class variable. Hence, after this
-   * method returns, {@code this.reactors} will be a list of Reactors such that any reactor is
+   * method returns, `this.reactors` will be a list of Reactors such that any reactor is
    * preceded in the list by reactors that it instantiates.
    */
   protected void setReactorsAndInstantiationGraph(LFGeneratorContext.Mode mode) {
@@ -274,9 +274,9 @@ public abstract class GeneratorBase extends AbstractLFValidator {
     // Topologically sort the reactors such that all of a reactor's instantiation dependencies occur
     // earlier in
     // the sorted list of reactors. This helps the code generator output code in the correct order.
-    // For example if {@code reactor Foo {bar = new Bar()}} then the definition of {@code Bar} has
+    // For example if `reactor Foo {bar = new Bar()`} then the definition of `Bar` has
     // to be generated before
-    // the definition of {@code Foo}.
+    // the definition of `Foo`.
     reactors = instantiationGraph.nodesInTopologicalOrder();
 
     // If there is no main reactor or if all reactors in the file need to be validated, then make
@@ -298,7 +298,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
    *
    * <p>This should be overridden by the target generators.
    *
-   * @param targetConfig The targetConfig to read the {@code files} from.
+   * @param targetConfig The targetConfig to read the `files` from.
    * @param fileConfig The fileConfig used to make the copy and resolve paths.
    */
   protected void copyUserFiles(TargetConfig targetConfig, FileConfig fileConfig) {
@@ -589,7 +589,7 @@ public abstract class GeneratorBase extends AbstractLFValidator {
     }
   }
 
-  /** Return a {@code DockerGenerator} instance suitable for the target. */
+  /** Return a `DockerGenerator` instance suitable for the target. */
   protected abstract DockerGenerator getDockerGenerator(LFGeneratorContext context);
 
   /** Create Dockerfiles and docker-compose.yml, build, and create a launcher. */

--- a/core/src/main/java/org/lflang/generator/GeneratorResult.java
+++ b/core/src/main/java/org/lflang/generator/GeneratorResult.java
@@ -19,7 +19,7 @@ public class GeneratorResult {
       GENERATED_NO_EXECUTABLE =
           (context, codeMaps) -> new GeneratorResult(Status.GENERATED, context, codeMaps);
 
-  /** A {@code Status} is a level of completion of a code generation task. */
+  /** A `Status` is a level of completion of a code generation task. */
   public enum Status {
     NOTHING(result -> ""), // Code generation was not performed.
     CANCELLED(result -> "Code generation was cancelled."),
@@ -32,7 +32,7 @@ public class GeneratorResult {
     COMPILED(GetUserMessage.COMPLETED);
 
     /**
-     * A {@code GetUserMessage} is a function that translates a {@code GeneratorResult} into a
+     * A `GetUserMessage` is a function that translates a `GeneratorResult` into a
      * human-readable report for the end user.
      */
     public interface GetUserMessage {
@@ -46,10 +46,10 @@ public class GeneratorResult {
       String apply(GeneratorResult result);
     }
 
-    /** The {@code GetUserMessage} associated with this {@code Status}. */
+    /** The `GetUserMessage` associated with this `Status`. */
     private final GetUserMessage gum;
 
-    /** Initializes a {@code Status} whose {@code GetUserMessage} is {@code gum}. */
+    /** Initializes a `Status` whose `GetUserMessage` is `gum`. */
     Status(GetUserMessage gum) {
       this.gum = gum;
     }
@@ -75,20 +75,20 @@ public class GeneratorResult {
   }
 
   /**
-   * Return the result of an incomplete generation task that terminated with status {@code status}.
+   * Return the result of an incomplete generation task that terminated with status `status`.
    *
-   * @return the result of an incomplete generation task that terminated with status {@code status}
+   * @return the result of an incomplete generation task that terminated with status `status`
    */
   private static GeneratorResult incompleteGeneratorResult(Status status) {
     return new GeneratorResult(status, null, Collections.emptyMap());
   }
 
-  /** Return the status of {@code this}. */
+  /** Return the status of `this`. */
   public Status getStatus() {
     return status;
   }
 
-  /** Return a message that can be relayed to the end user about this {@code GeneratorResult}. */
+  /** Return a message that can be relayed to the end user about this `GeneratorResult`. */
   public String getUserMessage() {
     return status.gum.apply(this);
   }

--- a/core/src/main/java/org/lflang/generator/GeneratorUtils.java
+++ b/core/src/main/java/org/lflang/generator/GeneratorUtils.java
@@ -38,8 +38,8 @@ public class GeneratorUtils {
   }
 
   /**
-   * Look for physical actions in 'resource'. If appropriate, set keepalive to true in {@code
-   * targetConfig}. This is a helper function for setTargetConfig. It should not be used elsewhere.
+   * Look for physical actions in 'resource'. If appropriate, set keepalive to true in
+   * `targetConfig`. This is a helper function for setTargetConfig. It should not be used elsewhere.
    */
   public static void accommodatePhysicalActionsIfPresent(
       Set<Resource> resources,
@@ -69,12 +69,12 @@ public class GeneratorUtils {
   }
 
   /**
-   * Return all instances of {@code eObjectType} in {@code resource}.
+   * Return all instances of `eObjectType` in `resource`.
    *
    * @param resource A resource to be searched.
    * @param nodeType The type of the desired parse tree nodes.
    * @param <T> The type of the desired parse tree nodes.
-   * @return all instances of {@code eObjectType} in {@code resource}
+   * @return all instances of `eObjectType` in `resource`
    */
   public static <T> Iterable<T> findAll(Resource resource, Class<T> nodeType) {
     return () -> IteratorExtensions.filter(resource.getAllContents(), nodeType);

--- a/core/src/main/java/org/lflang/generator/HumanReadableReportingStrategy.java
+++ b/core/src/main/java/org/lflang/generator/HumanReadableReportingStrategy.java
@@ -26,12 +26,12 @@ public class HumanReadableReportingStrategy implements DiagnosticReporting.Strat
   /** The path against which any paths should be resolved. */
   private final Path relativeTo;
 
-  /** The next line to be processed, or {@code null}. */
+  /** The next line to be processed, or `null`. */
   private String bufferedLine;
 
   /**
-   * Instantiate a reporting strategy for lines of validator output that match {@code
-   * diagnosticMessagePattern}.
+   * Instantiate a reporting strategy for lines of validator output that match
+   * `diagnosticMessagePattern`.
    *
    * @param diagnosticMessagePattern A pattern that matches lines that should be reported via this
    *     strategy. This pattern must contain named capturing groups called "path", "line", "column",
@@ -45,8 +45,8 @@ public class HumanReadableReportingStrategy implements DiagnosticReporting.Strat
   }
 
   /**
-   * Instantiate a reporting strategy for lines of validator output that match {@code
-   * diagnosticMessagePattern}.
+   * Instantiate a reporting strategy for lines of validator output that match
+   * `diagnosticMessagePattern`.
    *
    * @param diagnosticMessagePattern a pattern that matches lines that should be reported via this
    *     strategy. This pattern must contain named capturing groups called "path", "line", "column",
@@ -125,7 +125,7 @@ public class HumanReadableReportingStrategy implements DiagnosticReporting.Strat
   }
 
   /**
-   * Find the appropriate range to {@code report}.
+   * Find the appropriate range to `report`.
    *
    * @param lfFilePosition The point about which the relevant range is anchored.
    * @param it An iterator over the lines immediately following a diagnostic message.
@@ -151,10 +151,10 @@ public class HumanReadableReportingStrategy implements DiagnosticReporting.Strat
   }
 
   /**
-   * Strip the ANSI escape sequences from {@code s}.
+   * Strip the ANSI escape sequences from `s`.
    *
    * @param s Any string.
-   * @return {@code s}, with any escape sequences removed.
+   * @return `s`, with any escape sequences removed.
    */
   private static String stripEscaped(String s) {
     return s.replaceAll("\u001B\\[[;\\d]*[ -/]*[@-~]", "");

--- a/core/src/main/java/org/lflang/generator/IntegratedBuilder.java
+++ b/core/src/main/java/org/lflang/generator/IntegratedBuilder.java
@@ -33,7 +33,7 @@ public class IntegratedBuilder {
   public static final int GENERATED_PERCENT_PROGRESS = 67;
   public static final int COMPILED_PERCENT_PROGRESS = 100;
 
-  /** A {@code ProgressReporter} reports the progress of a build. */
+  /** A `ProgressReporter` reports the progress of a build. */
   public interface ReportProgress {
     void apply(String message, Integer percentage);
   }
@@ -48,7 +48,7 @@ public class IntegratedBuilder {
   /* ------------------------- PUBLIC METHODS -------------------------- */
 
   /**
-   * Generates code from the Lingua Franca file {@code f}.
+   * Generates code from the Lingua Franca file `f`.
    *
    * @param uri The URI of a Lingua Franca file.
    * @param mustComplete Whether the build must be taken to completion.
@@ -79,7 +79,7 @@ public class IntegratedBuilder {
   /* ------------------------- PRIVATE METHODS ------------------------- */
 
   /**
-   * Validates the Lingua Franca file {@code f}.
+   * Validates the Lingua Franca file `f`.
    *
    * @param uri The URI of a Lingua Franca file.
    * @param messageReporter The error reporter.
@@ -94,7 +94,7 @@ public class IntegratedBuilder {
   }
 
   /**
-   * Generates code from the contents of {@code f}.
+   * Generates code from the contents of `f`.
    *
    * @param uri The URI of a Lingua Franca file.
    * @param mustComplete Whether the build must be taken to completion.
@@ -122,10 +122,10 @@ public class IntegratedBuilder {
   }
 
   /**
-   * Returns the resource corresponding to {@code uri}.
+   * Returns the resource corresponding to `uri`.
    *
    * @param uri The URI of a Lingua Franca file.
-   * @return The resource corresponding to {@code uri}.
+   * @return The resource corresponding to `uri`.
    */
   public Resource getResource(URI uri) {
     return resourceSetProvider.get().getResource(uri, true);

--- a/core/src/main/java/org/lflang/generator/LFGeneratorContext.java
+++ b/core/src/main/java/org/lflang/generator/LFGeneratorContext.java
@@ -45,8 +45,7 @@ public interface LFGeneratorContext extends IGeneratorContext {
   }
 
   /**
-   * Mark the code generation process performed in this context as finished with the result {@code
-   * result}.
+   * Mark the code generation process performed in this context as finished with the result `result`.
    *
    * @param result The result of the code generation process that was performed in this context.
    */
@@ -90,14 +89,14 @@ public interface LFGeneratorContext extends IGeneratorContext {
   }
 
   /**
-   * Return the {@code LFGeneratorContext} that best describes the given {@code context} when
-   * building {@code Resource}.
+   * Return the `LFGeneratorContext` that best describes the given `context` when
+   * building `Resource`.
    *
    * @param resource
    * @param fsa
    * @param context The context of a Lingua Franca build process.
-   * @return The {@code LFGeneratorContext} that best describes the given {@code context} when
-   *     building {@code Resource}.
+   * @return The `LFGeneratorContext` that best describes the given `context` when
+   *     building `Resource`.
    */
   static LFGeneratorContext lfGeneratorContextOf(
       Resource resource, IFileSystemAccess2 fsa, IGeneratorContext context) {

--- a/core/src/main/java/org/lflang/generator/LanguageServerMessageReporter.java
+++ b/core/src/main/java/org/lflang/generator/LanguageServerMessageReporter.java
@@ -39,8 +39,7 @@ public class LanguageServerMessageReporter extends MessageReporterBase {
   private final Map<Path, List<Diagnostic>> diagnostics;
 
   /**
-   * Initialize a {@code DiagnosticAcceptor} for the document whose parse tree root node is {@code
-   * parseRoot}.
+   * Initialize a `DiagnosticAcceptor` for the document whose parse tree root node is `parseRoot`.
    *
    * @param parseRoot the root of the AST of the document for which this is an error reporter
    */
@@ -142,7 +141,7 @@ public class LanguageServerMessageReporter extends MessageReporterBase {
   }
 
   /**
-   * Return the line at index {@code line} in the document for which this is an error reporter.
+   * Return the line at index `line` in the document for which this is an error reporter.
    *
    * @param line the zero-based line index
    * @return the line located at the given index
@@ -152,11 +151,11 @@ public class LanguageServerMessageReporter extends MessageReporterBase {
   }
 
   /**
-   * Return the Range that starts at {@code p0} and ends at {@code p1}.
+   * Return the Range that starts at `p0` and ends at `p1`.
    *
    * @param p0 an arbitrary Position
-   * @param p1 a Position that is greater than {@code p0}
-   * @return the Range that starts at {@code p0} and ends at {@code p1}
+   * @param p1 a Position that is greater than `p0`
+   * @return the Range that starts at `p0` and ends at `p1`
    */
   private Range toRange(Position p0, Position p1) {
     return new Range(

--- a/core/src/main/java/org/lflang/generator/MainContext.java
+++ b/core/src/main/java/org/lflang/generator/MainContext.java
@@ -14,8 +14,8 @@ import org.lflang.generator.IntegratedBuilder.ReportProgress;
 import org.lflang.target.TargetConfig;
 
 /**
- * An {@code LFGeneratorContext} that is not nested in any other generator context. There is one
- * {@code MainContext} for every build process.
+ * An `LFGeneratorContext` that is not nested in any other generator context. There is one
+ * `MainContext` for every build process.
  *
  * @author Peter Donovan
  * @ingroup Infrastructure
@@ -28,7 +28,7 @@ public class MainContext implements LFGeneratorContext {
   /** The indicator that shows whether this build process is canceled. */
   private final CancelIndicator cancelIndicator;
 
-  /** The {@code ReportProgress} function of {@code this}. */
+  /** The `ReportProgress` function of `this`. */
   private final ReportProgress reportProgress;
 
   private final FileConfig fileConfig;
@@ -45,8 +45,7 @@ public class MainContext implements LFGeneratorContext {
   private final MessageReporter messageReporter;
 
   /**
-   * Initialize the context of a build process whose cancellation is indicated by {@code
-   * cancelIndicator}
+   * Initialize the context of a build process whose cancellation is indicated by `cancelIndicator`
    *
    * @param mode The mode of this build process.
    * @param cancelIndicator The cancel indicator of the code generation process to which this
@@ -67,13 +66,12 @@ public class MainContext implements LFGeneratorContext {
   }
 
   /**
-   * Initialize the context of a build process whose cancellation is indicated by {@code
-   * cancelIndicator}
+   * Initialize the context of a build process whose cancellation is indicated by `cancelIndicator`
    *
    * @param mode The mode of this build process.
    * @param cancelIndicator The cancel indicator of the code generation process to which this
    *     corresponds.
-   * @param reportProgress The {@code ReportProgress} function of {@code this}.
+   * @param reportProgress The `ReportProgress` function of `this`.
    * @param args Any arguments that may be used to affect the product of the build.
    * @param resource ...
    * @param fsa ...

--- a/core/src/main/java/org/lflang/generator/PortInstance.java
+++ b/core/src/main/java/org/lflang/generator/PortInstance.java
@@ -107,10 +107,10 @@ public class PortInstance extends TriggerInstance<Port> {
    * <p>Each item in the returned list has the following fields:
    *
    * <ul>
-   *   <li>{@code startRange}: The starting channel index of this port.
-   *   <li>{@code rangeWidth}: The number of channels sent to the destinations.
-   *   <li>{@code destinations}: A list of port ranges for destination ports, each of which has the
-   *       same width as {@code rangeWidth}.
+   *   <li>`startRange`: The starting channel index of this port.
+   *   <li>`rangeWidth`: The number of channels sent to the destinations.
+   *   <li>`destinations`: A list of port ranges for destination ports, each of which has the
+   *       same width as `rangeWidth`.
    * </ul>
    *
    * Each item also has a method, {@link SendRange#getNumberOfDestinationReactors()}, that returns
@@ -239,8 +239,7 @@ public class PortInstance extends TriggerInstance<Port> {
   }
 
   /**
-   * Record that the {@code index}th sub-port of this has a dependent reaction of level {@code
-   * level}.
+   * Record that the `index`th sub-port of this has a dependent reaction of level `level`.
    */
   public void recordIndexForPortChannel(MixedRadixInt index, int level) {
     levelUpperBounds.put(

--- a/core/src/main/java/org/lflang/generator/Position.java
+++ b/core/src/main/java/org/lflang/generator/Position.java
@@ -27,7 +27,7 @@ public class Position implements Comparable<Position> {
    *
    * @param line the zero-based line number
    * @param column the zero-based column number
-   * @return a Position describing the position described by {@code line} and {@code column}.
+   * @return a Position describing the position described by `line` and `column`.
    */
   public static Position fromZeroBased(int line, int column) {
     return new Position(line, column);
@@ -38,18 +38,18 @@ public class Position implements Comparable<Position> {
    *
    * @param line the one-based line number
    * @param column the one-based column number
-   * @return a Position describing the position described by {@code line} and {@code column}.
+   * @return a Position describing the position described by `line` and `column`.
    */
   public static Position fromOneBased(int line, int column) {
     return new Position(line - 1, column - 1);
   }
 
   /**
-   * Return the Position that equals the displacement caused by {@code text}, assuming that {@code
-   * text} starts in column 0.
+   * Return the Position that equals the displacement caused by `text`, assuming that
+   * `text` starts in column 0.
    *
    * @param text an arbitrary string
-   * @return the Position that equals the displacement caused by {@code text}
+   * @return the Position that equals the displacement caused by `text`
    */
   public static Position displacementOf(String text) {
     String[] lines = text.lines().toArray(String[]::new);
@@ -58,11 +58,11 @@ public class Position implements Comparable<Position> {
   }
 
   /**
-   * Return the Position that describes the same location in {@code content} as {@code offset}.
+   * Return the Position that describes the same location in `content` as `offset`.
    *
-   * @param offset a location, expressed as an offset from the beginning of {@code content}
+   * @param offset a location, expressed as an offset from the beginning of `content`
    * @param content the content of a document
-   * @return the Position that describes the same location in {@code content} as {@code offset}
+   * @return the Position that describes the same location in `content` as `offset`
    */
   public static Position fromOffset(int offset, String content) {
     int lineNumber = 0;
@@ -93,48 +93,48 @@ public class Position implements Comparable<Position> {
   /* -----------------------  PUBLIC METHODS  ------------------------- */
 
   /**
-   * Return the one-based line number described by this {@code Position}.
+   * Return the one-based line number described by this `Position`.
    *
-   * @return the one-based line number described by this {@code Position}
+   * @return the one-based line number described by this `Position`
    */
   public int getOneBasedLine() {
     return line + 1;
   }
 
   /**
-   * Return the one-based column number described by this {@code Position}.
+   * Return the one-based column number described by this `Position`.
    *
-   * @return the one-based column number described by this {@code Position}
+   * @return the one-based column number described by this `Position`
    */
   public int getOneBasedColumn() {
     return column + 1;
   }
 
   /**
-   * Return the zero-based line number described by this {@code Position}.
+   * Return the zero-based line number described by this `Position`.
    *
-   * @return the zero-based line number described by this {@code Position}
+   * @return the zero-based line number described by this `Position`
    */
   public int getZeroBasedLine() {
     return line;
   }
 
   /**
-   * Return the zero-based column number described by this {@code Position}.
+   * Return the zero-based column number described by this `Position`.
    *
-   * @return the zero-based column number described by this {@code Position}
+   * @return the zero-based column number described by this `Position`
    */
   public int getZeroBasedColumn() {
     return column;
   }
 
   /**
-   * Return the Position that equals the displacement of ((text whose displacement equals {@code
-   * this}) concatenated with {@code text}). Note that this is not necessarily equal to ({@code
-   * this} + displacementOf(text)).
+   * Return the Position that equals the displacement of ((text whose displacement equals `this`)
+   * concatenated with `text`). Note that this is not necessarily equal to
+   * (`this` + displacementOf(text)).
    *
    * @param text an arbitrary string
-   * @return the Position that equals the displacement caused by {@code text}
+   * @return the Position that equals the displacement caused by `text`
    */
   public Position plus(String text) {
     text += "\n"; // Turn line separators into line terminators.
@@ -146,22 +146,22 @@ public class Position implements Comparable<Position> {
   }
 
   /**
-   * Return the sum of this and another {@code Position}. The result has meaning because Positions
+   * Return the sum of this and another `Position`. The result has meaning because Positions
    * are relative.
    *
-   * @param other another {@code Position}
-   * @return the sum of this and {@code other}
+   * @param other another `Position`
+   * @return the sum of this and `other`
    */
   public Position plus(Position other) {
     return new Position(line + other.line, column + other.column);
   }
 
   /**
-   * Return the difference of this and another {@code Position}. The result has meaning because
+   * Return the difference of this and another `Position`. The result has meaning because
    * Positions are relative.
    *
-   * @param other another {@code Position}
-   * @return the difference of this and {@code other}
+   * @param other another `Position`
+   * @return the difference of this and `other`
    */
   public Position minus(Position other) {
     return new Position(line - other.line, column - other.column);
@@ -190,11 +190,10 @@ public class Position implements Comparable<Position> {
   }
 
   /**
-   * Return the Position represented by {@code s}.
+   * Return the Position represented by `s`.
    *
-   * @param s a String that represents a Position, formatted like the output of {@code
-   *     Position::toString}.
-   * @return the Position represented by {@code s}
+   * @param s a String that represents a Position, formatted like the output of `Position::toString`.
+   * @return the Position represented by `s`
    */
   public static Position fromString(String s) {
     Matcher matcher = PATTERN.matcher(s);
@@ -211,10 +210,10 @@ public class Position implements Comparable<Position> {
   }
 
   /**
-   * Remove the names from the named capturing groups that appear in {@code regex}.
+   * Remove the names from the named capturing groups that appear in `regex`.
    *
    * @param regex an arbitrary regular expression
-   * @return a string representation of {@code regex} with the names removed from the named
+   * @return a string representation of `regex` with the names removed from the named
    *     capturing groups
    */
   public static String removeNamedCapturingGroups(Pattern regex) { // FIXME: Does this belong here?

--- a/core/src/main/java/org/lflang/generator/Range.java
+++ b/core/src/main/java/org/lflang/generator/Range.java
@@ -26,8 +26,8 @@ public class Range implements Comparable<Range> {
   /* ------------------------- PUBLIC METHODS -------------------------- */
 
   /**
-   * Initializes a Range that starts at {@code startInclusive} and ends at, but does not include,
-   * {@code endExclusive}.
+   * Initializes a Range that starts at `startInclusive` and ends at, but does not include,
+   * `endExclusive`.
    *
    * @param startInclusive the start of the range (inclusive)
    * @param endExclusive the end of the range (exclusive)
@@ -69,10 +69,10 @@ public class Range implements Comparable<Range> {
   }
 
   /**
-   * Compares this to {@code o}.
+   * Compares this to `o`.
    *
    * @param o another Range
-   * @return an integer indicating how this compares to {@code o}
+   * @return an integer indicating how this compares to `o`
    */
   @Override
   public int compareTo(Range o) {
@@ -80,10 +80,10 @@ public class Range implements Comparable<Range> {
   }
 
   /**
-   * Returns whether this contains {@code p}.
+   * Returns whether this contains `p`.
    *
    * @param p an arbitrary Position
-   * @return whether this contains {@code p}
+   * @return whether this contains `p`
    */
   public boolean contains(Position p) {
     return start.compareTo(p) <= 0 && p.compareTo(end) < 0;
@@ -95,23 +95,23 @@ public class Range implements Comparable<Range> {
   }
 
   /**
-   * Converts {@code s} to a Range.
+   * Converts `s` to a Range.
    *
-   * @param s a String that represents a Range, formatted like the output of {@code Range::toString}
-   * @return the Range r such that {@code r.toString()} equals {@code s}
+   * @param s a String that represents a Range, formatted like the output of `Range::toString`
+   * @return the Range r such that `r.toString()` equals `s`
    */
   public static Range fromString(String s) {
     return fromString(s, Position.fromZeroBased(0, 0));
   }
 
   /**
-   * Converts {@code s} to a Range, with the assumption that the positions expressed in {@code s}
-   * are given relative to {@code relativeTo}.
+   * Converts `s` to a Range, with the assumption that the positions expressed in `s`
+   * are given relative to `relativeTo`.
    *
-   * @param s a String that represents a Range, formatted like the output of {@code Range::toString}
-   * @param relativeTo the position relative to which the positions in {@code s} are represented
-   * @return the Range represented by {@code s}, expressed relative to the Position relative to
-   *     which the Position {@code relativeTo} is expressed
+   * @param s a String that represents a Range, formatted like the output of `Range::toString`
+   * @param relativeTo the position relative to which the positions in `s` are represented
+   * @return the Range represented by `s`, expressed relative to the Position relative to
+   *     which the Position `relativeTo` is expressed
    */
   public static Range fromString(String s, Position relativeTo) {
     Matcher matcher = PATTERN.matcher(s);
@@ -124,10 +124,10 @@ public class Range implements Comparable<Range> {
   }
 
   /**
-   * Returns the degenerate range that simply describes the exact location specified by {@code p}.
+   * Returns the degenerate range that simply describes the exact location specified by `p`.
    *
    * @param p an arbitrary Position
-   * @return a Range that starts and ends immediately before {@code p}
+   * @return a Range that starts and ends immediately before `p`
    */
   public static Range degenerateRange(Position p) {
     return new Range(p, p);

--- a/core/src/main/java/org/lflang/generator/ReactionInstance.java
+++ b/core/src/main/java/org/lflang/generator/ReactionInstance.java
@@ -375,13 +375,13 @@ public class ReactionInstance extends NamedInstance<Reaction> {
    * Return an array of runtime instances of this reaction in a <i>natural order</i>, defined as
    * follows. The position within the returned list of the runtime instance is given by a
    * mixed-radix number where the low-order digit is the bank index within the container reactor (or
-   * {@code 0} if it is not a bank), the second low order digit is the bank index of the container's
-   * container (or {@code 0} if it is not a bank), etc., until the container that is directly
+   * `0` if it is not a bank), the second low order digit is the bank index of the container's
+   * container (or `0` if it is not a bank), etc., until the container that is directly
    * contained by the top level (the top-level reactor need not be included because its index is
-   * always {@code 0}).
+   * always `0`).
    *
    * <p>The size of the returned array is the product of the widths of all the container {@link
-   * ReactorInstance} objects. If none of these is a bank, then the size will be {@code 1}.
+   * ReactorInstance} objects. If none of these is a bank, then the size will be `1`.
    *
    * <p>This method creates this array the first time it is called, but then holds on to it. The
    * array is used by {@link ReactionInstanceGraph} to determine and record levels and deadline for

--- a/core/src/main/java/org/lflang/generator/ReactionInstanceGraph.java
+++ b/core/src/main/java/org/lflang/generator/ReactionInstanceGraph.java
@@ -250,7 +250,7 @@ public class ReactionInstanceGraph extends PrecedenceGraph<ReactionInstance.Runt
   }
 
   /**
-   * Get those reactions contained directly or transitively by the children of {@code main} whose
+   * Get those reactions contained directly or transitively by the children of `main` whose
    * TPO levels are specified.
    *
    * @return A map from TPO levels to reactions that are constrained to have the TPO levels.
@@ -268,7 +268,7 @@ public class ReactionInstanceGraph extends PrecedenceGraph<ReactionInstance.Runt
     return constrainedReactions;
   }
 
-  /** Add all reactions contained directly or transitively by {@code r}. */
+  /** Add all reactions contained directly or transitively by `r`. */
   private void getAllContainedReactions(List<Runtime> runtimeReactions, ReactorInstance r) {
     for (var reaction : r.reactions) {
       runtimeReactions.addAll(reaction.getRuntimeInstances());
@@ -293,8 +293,8 @@ public class ReactionInstanceGraph extends PrecedenceGraph<ReactionInstance.Runt
   public record MriPortPair(MixedRadixInt index, PortInstance port) {}
 
   /**
-   * For each port in {@code reactor}, add that port to its downstream reactions, together with the
-   * {@code MixedRadixInt} that is the index of the downstream reaction relative to the port and the
+   * For each port in `reactor`, add that port to its downstream reactions, together with the
+   * `MixedRadixInt` that is the index of the downstream reaction relative to the port and the
    * intervening ports.
    */
   private void registerPortInstances(ReactorInstance reactor) {
@@ -392,7 +392,7 @@ public class ReactionInstanceGraph extends PrecedenceGraph<ReactionInstance.Runt
   }
 
   /**
-   * Update the level of the source ports of {@code current} to be at most that of {@code current}.
+   * Update the level of the source ports of `current` to be at most that of `current`.
    */
   private void assignPortLevel(Runtime current) {
     for (var sp : current.sourcePorts) {
@@ -402,7 +402,7 @@ public class ReactionInstanceGraph extends PrecedenceGraph<ReactionInstance.Runt
 
   /**
    * This function assigns inferred deadlines to all the reactions in the graph. It is modeled after
-   * {@code assignLevels} but it starts at the leaf nodes, but it does not destroy the graph.
+   * `assignLevels` but it starts at the leaf nodes, but it does not destroy the graph.
    */
   private void assignInferredDeadlines() {
     List<Runtime> start = new ArrayList<>(leafNodes());

--- a/core/src/main/java/org/lflang/generator/ReactorInstance.java
+++ b/core/src/main/java/org/lflang/generator/ReactorInstance.java
@@ -165,7 +165,7 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
   public TypeParameterizedReactor tpr;
 
   /**
-   * The Total Port Order level with which {@code this} was annotated, or {@code null} if there is
+   * The Total Port Order level with which `this` was annotated, or `null` if there is
    * no TPO annotation. TPO is total port order. See
    * https://github.com/icyphy/lf-pubs/blob/54af48a97cc95058dbfb3333b427efb70294f66c/federated/TOMACS/paper.tex#L1353
    */
@@ -307,7 +307,7 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
 
   /**
    * @see NamedInstance#uniqueID()
-   *     <p>Append {@code _main} to the name of the main reactor to allow instantiations within that
+   *     <p>Append `_main` to the name of the main reactor to allow instantiations within that
    *     reactor to have the same name.
    */
   @Override
@@ -1069,14 +1069,14 @@ public class ReactorInstance extends NamedInstance<Instantiation> {
    * (a port representing ports of the bank members) so the returned list includes ranges of banks
    * and channels.
    *
-   * <p>If a given port reference has the form {@code interleaved(b.m)}, where {@code b} is a bank
-   * and {@code m} is a multiport, then the corresponding range in the returned list is marked
+   * <p>If a given port reference has the form `interleaved(b.m)`, where `b` is a bank
+   * and `m` is a multiport, then the corresponding range in the returned list is marked
    * interleaved.
    *
-   * <p>For example, if {@code b} and {@code m} have width 2, without the interleaved keyword, the
-   * returned range represents the sequence {@code [b0.m0, b0.m1, b1.m0, b1.m1]}. With the
-   * interleaved marking, the returned range represents the sequence {@code [b0.m0, b1.m0, b0.m1,
-   * b1.m1]}. Both ranges will have width 4.
+   * <p>For example, if `b` and `m` have width 2, without the interleaved keyword, the
+   * returned range represents the sequence `[b0.m0, b0.m1, b1.m0, b1.m1]`. With the
+   * interleaved marking, the returned range represents the sequence `[b0.m0, b1.m0, b0.m1,
+   * b1.m1]`. Both ranges will have width 4.
    *
    * @param references The variable references on one side of the connection.
    * @param connection The connection.

--- a/core/src/main/java/org/lflang/generator/RuntimeRange.java
+++ b/core/src/main/java/org/lflang/generator/RuntimeRange.java
@@ -273,27 +273,27 @@ public class RuntimeRange<T extends NamedInstance<?>> implements Comparable<Runt
 
   /**
    * Return a set of identifiers for runtime instances of a parent of this {@link RuntimeRange}'s
-   * instance {@code n} levels above this {@link RuntimeRange}'s instance. If {@code n == 1}, for
+   * instance `n` levels above this {@link RuntimeRange}'s instance. If `n == 1`, for
    * example, then this return the identifiers for the parent ReactorInstance.
    *
    * This returns a list of <i>natural identifiers</i>, as defined below, for the instances
    * within the range.
    *
    * The resulting list can be used to count the number of distinct runtime instances of this
-   * RuntimeRange's instance (using {@code n == 0}) or any of its parents that lie within the range
+   * RuntimeRange's instance (using `n == 0`) or any of its parents that lie within the range
    * and to provide an index into an array of runtime instances.
    *
    * Each <i>natural identifier</i> is the integer value of a mixed-radix number defined as
    * follows:
    *
-   * * The low-order digit is the index of the runtime instance of {@code i} within its
-   *       container. If the {@link NamedInstance} is a {@code PortInstance}, this will be the
-   *       multiport channel or {@code 0} if it is not a multiport. If the NamedInstance is a
-   *       ReactorInstance, then it will be the bank index or {@code 0} if the reactor is not a
+   * * The low-order digit is the index of the runtime instance of `i` within its
+   *       container. If the {@link NamedInstance} is a `PortInstance`, this will be the
+   *       multiport channel or `0` if it is not a multiport. If the NamedInstance is a
+   *       ReactorInstance, then it will be the bank index or `0` if the reactor is not a
    *       bank. The radix for this digit will be the multiport width or bank width or 1 if the
    *       NamedInstance is neither a multiport nor a bank.
    * * The next digit will be the bank index of the container of the specified {@link
-   *       NamedInstance} or {@code 0} if it is not a bank.
+   *       NamedInstance} or `0` if it is not a bank.
    * * The remaining digits will be bank indices of containers up to but not including the
    *       top-level reactor (there is no point in including the top-level reactor because it is
    *       never a bank).

--- a/core/src/main/java/org/lflang/generator/SubContext.java
+++ b/core/src/main/java/org/lflang/generator/SubContext.java
@@ -6,8 +6,8 @@ import org.lflang.MessageReporter;
 import org.lflang.target.TargetConfig;
 
 /**
- * A {@code SubContext} is the context of a process within a build process. For example, compilation
- * of generated code may optionally be given a {@code SubContext} because compilation is part of a
+ * A `SubContext` is the context of a process within a build process. For example, compilation
+ * of generated code may optionally be given a `SubContext` because compilation is part of a
  * complete build.
  *
  * @author Peter Donovan
@@ -23,8 +23,8 @@ public class SubContext implements LFGeneratorContext {
   protected MessageReporter messageReporter;
 
   /**
-   * Initializes the context within {@code containingContext} of the process that extends from
-   * {@code startPercentProgress} to {@code endPercentProgress}.
+   * Initializes the context within `containingContext` of the process that extends from
+   * `startPercentProgress` to `endPercentProgress`.
    *
    * @param containingContext The context of the containing build process.
    * @param startPercentProgress The percent progress of the containing build process when this

--- a/core/src/main/java/org/lflang/generator/ValidationStrategy.java
+++ b/core/src/main/java/org/lflang/generator/ValidationStrategy.java
@@ -12,8 +12,8 @@ import org.lflang.util.LFCommand;
 public interface ValidationStrategy {
 
   /**
-   * Return the command that produces validation output in association with {@code generatedFile},
-   * or {@code null} if this strategy has no command that will successfully produce validation
+   * Return the command that produces validation output in association with `generatedFile`,
+   * or `null` if this strategy has no command that will successfully produce validation
    * output.
    */
   LFCommand getCommand(Path generatedFile);

--- a/core/src/main/java/org/lflang/generator/Validator.java
+++ b/core/src/main/java/org/lflang/generator/Validator.java
@@ -27,7 +27,7 @@ import org.lflang.util.LFCommand;
 public abstract class Validator {
 
   /**
-   * Files older than {@code FILE_AGE_THRESHOLD_MILLIS} may be skipped in validation on the grounds
+   * Files older than `FILE_AGE_THRESHOLD_MILLIS` may be skipped in validation on the grounds
    * that they probably have not been updated since the last validator pass.
    */
   // This will cause silent validation failures if it takes too long to write all generated code to
@@ -48,8 +48,8 @@ public abstract class Validator {
   protected final ImmutableMap<Path, CodeMap> codeMaps;
 
   /**
-   * Initialize a {@code Validator} that reports errors to {@code errorReporter} and adjusts
-   * document positions using {@code codeMaps}.
+   * Initialize a `Validator` that reports errors to `errorReporter` and adjusts
+   * document positions using `codeMaps`.
    */
   protected Validator(MessageReporter messageReporter, Map<Path, CodeMap> codeMaps) {
     this.messageReporter = messageReporter;
@@ -138,7 +138,7 @@ public abstract class Validator {
 
   /**
    * Run the given command, report any messages produced using the reporting strategies given by
-   * {@code getBuildReportingStrategies}, and return its return code.
+   * `getBuildReportingStrategies`, and return its return code.
    */
   public final int run(LFCommand command, CancelIndicator cancelIndicator) {
     final int returnCode = command.run(cancelIndicator);

--- a/core/src/main/java/org/lflang/generator/c/CCompiler.java
+++ b/core/src/main/java/org/lflang/generator/c/CCompiler.java
@@ -283,7 +283,7 @@ public class CCompiler {
   /**
    * Return a flash/emulate command using west. If board is null (defaults to qemu_cortex_m3) or
    * qemu_* Return a flash command which runs the target as an emulation If ordinary target, return
-   * {@code west flash}
+   * `west flash`
    */
   public LFCommand buildWestFlashCommand(PlatformOptions options) {
     // Set the build directory to be "build"

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -733,8 +733,8 @@ public class CGenerator extends GeneratorBase {
   }
 
   /**
-   * Copy all files or directories listed in the target property {@code files}, {@code
-   * cmake-include}, and {@code _fed_setup} into the src-gen folder of the main .lf file
+   * Copy all files or directories listed in the target property `files`, `cmake-include`,
+   * and `_fed_setup` into the src-gen folder of the main .lf file
    *
    * @param targetConfig The targetConfig to read the target properties from.
    * @param fileConfig The fileConfig used to make the copy and resolve paths.
@@ -1022,7 +1022,7 @@ public class CGenerator extends GeneratorBase {
     generateConstructor(src, header, tpr, constructorCode);
   }
 
-  /** Generate methods for {@code reactor}. */
+  /** Generate methods for `reactor`. */
   protected void generateMethods(CodeBuilder src, TypeParameterizedReactor tpr) {
     CMethodGenerator.generateMethods(
         tpr, src, types, this.targetConfig.get(NoSourceMappingProperty.INSTANCE));

--- a/core/src/main/java/org/lflang/generator/c/CMainFunctionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CMainFunctionGenerator.java
@@ -31,7 +31,7 @@ public class CMainFunctionGenerator {
   /**
    * Generate the code that is the entry point of the program.
    *
-   * <p>Ideally, this code would belong to its own {@code main.c} file, but it currently lives in
+   * <p>Ideally, this code would belong to its own `main.c` file, but it currently lives in
    * the same file as all the code generated for reactors.
    */
   public String generateCode() {
@@ -41,7 +41,7 @@ public class CMainFunctionGenerator {
     return code.toString();
   }
 
-  /** Generate the {@code main} function. */
+  /** Generate the `main` function. */
   private String generateMainFunction() {
     var platform = Platform.AUTO;
     if (targetConfig.isSet(PlatformProperty.INSTANCE)) {
@@ -73,7 +73,7 @@ public class CMainFunctionGenerator {
       }
       case ZEPHYR -> {
         // The Zephyr "runtime" does not terminate when main returns.
-        //  Rather, {@code exit} should be called explicitly.
+        //  Rather, `exit` should be called explicitly.
         return String.join(
             "\n",
             "int main(void) {",
@@ -96,7 +96,7 @@ public class CMainFunctionGenerator {
   }
 
   /**
-   * Generate code that is used to override the command line options to the {@code main} function
+   * Generate code that is used to override the command line options to the `main` function
    */
   private String generateSetDefaultCliOption() {
     // Generate function to set default command-line options.

--- a/core/src/main/java/org/lflang/generator/c/CPortGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CPortGenerator.java
@@ -209,7 +209,7 @@ public class CPortGenerator {
 
   /**
    * For the specified port, return a declaration for port struct to contain the value of the port.
-   * A multiport output with width 4 and type {@code int[10]}, for example, will result in this:
+   * A multiport output with width 4 and type `int[10]`, for example, will result in this:
    *
    * <pre><code>
    *     int value[10];

--- a/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
@@ -1270,7 +1270,7 @@ public class CReactionGenerator {
   }
 
   /**
-   * Return the start of a function declaration for a function that takes a {@code void*} argument
+   * Return the start of a function declaration for a function that takes a `void*` argument
    * and returns void.
    *
    * @param functionName

--- a/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactorHeaderFileGenerator.java
@@ -31,7 +31,7 @@ public class CReactorHeaderFileGenerator {
     void generate(CodeBuilder b, TypeParameterizedReactor r, boolean userFacing);
   }
 
-  /** Return the path to the user-visible header file that would be generated for {@code r}. */
+  /** Return the path to the user-visible header file that would be generated for `r`. */
   public static Path outputPath(TypeParameterizedReactor tpr) {
     return Path.of(
             FileUtil.toPath(tpr.reactor().eResource().getURI())
@@ -103,8 +103,8 @@ public class CReactorHeaderFileGenerator {
   }
 
   /**
-   * Return a String with the user facing type of TypeParameterized Reactor. `*` is replaced with
-   * `Ptr`.
+   * Return a String with the user facing type of TypeParameterized Reactor.
+   * `*` is replaced with `Ptr`.
    */
   private static String userFacingSelfType(TypeParameterizedReactor tpr) {
     return tpr.getName().toLowerCase().replace("*", "Ptr") + "_self_t";
@@ -143,7 +143,7 @@ public class CReactorHeaderFileGenerator {
     return "(" + userFacingSelfType(tpr) + "*) self";
   }
 
-  /** Generate initialization code that is needed if {@code r} is not inlined. */
+  /** Generate initialization code that is needed if `r` is not inlined. */
   public static String nonInlineInitialization(Reaction r, TypeParameterizedReactor reactor) {
     var mainDef = LfFactory.eINSTANCE.createInstantiation();
     mainDef.setName(reactor.getName());
@@ -185,7 +185,7 @@ public class CReactorHeaderFileGenerator {
         .collect(Collectors.joining("\n"));
   }
 
-  /** Return a string representation of the arguments passed to the function for {@code r}. */
+  /** Return a string representation of the arguments passed to the function for `r`. */
   public static String reactionArguments(Reaction r, TypeParameterizedReactor reactor) {
     return Stream.concat(
             Stream.of(getApiSelfStruct(reactor)),
@@ -194,7 +194,7 @@ public class CReactorHeaderFileGenerator {
         .collect(Collectors.joining(", "));
   }
 
-  /** Return a stream of all ports referenced by the signature of {@code r}. */
+  /** Return a stream of all ports referenced by the signature of `r`. */
   private static Stream<PortVariable> portVariableStream(
       Reaction r, TypeParameterizedReactor reactorOfReaction) {
     return varRefStream(r)
@@ -216,8 +216,8 @@ public class CReactorHeaderFileGenerator {
    *
    * @param tv The variable of the variable reference.
    * @param r The reactor in which the port is being used.
-   * @param container The {@code Instantiation} referenced in the obtaining of {@code tv}, if
-   *     applicable; {@code null} otherwise.
+   * @param container The `Instantiation` referenced in the obtaining of `tv`, if
+   *     applicable; `null` otherwise.
    */
   private record PortVariable(
       TypedVariable tv, TypeParameterizedReactor r, Instantiation container) {

--- a/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CTriggerObjectsGenerator.java
@@ -1088,7 +1088,7 @@ public class CTriggerObjectsGenerator {
   /**
    * If any reaction of the specified reactor provides input to a contained reactor, then generate
    * code to allocate memory to store the data produced by those reactions. The allocated memory is
-   * pointed to by a field called {@code _lf_containername.portname} on the self struct of the
+   * pointed to by a field called `_lf_containername.portname` on the self struct of the
    * reactor.
    *
    * @param reactor The reactor.

--- a/core/src/main/java/org/lflang/generator/c/CTypes.java
+++ b/core/src/main/java/org/lflang/generator/c/CTypes.java
@@ -47,9 +47,9 @@ public class CTypes implements TargetTypes {
 
   /**
    * Given a type, return a C representation of the type. Note that C types are very idiosyncratic.
-   * For example, {@code int[]} is not always accepted as a type, and {@code int*} must be used
-   * instead, except when initializing a variable using a static initializer, as in {@code int[] foo
-   * = {1, 2, 3};}. When initializing a variable using a static initializer, use {@link
+   * For example, `int[]` is not always accepted as a type, and `int*` must be used
+   * instead, except when initializing a variable using a static initializer, as in `int[] foo
+   * = {1, 2, 3`;}. When initializing a variable using a static initializer, use {@link
    * #getVariableDeclaration(TypeParameterizedReactor, InferredType, String, boolean)} instead.
    *
    * @param type The type.
@@ -79,15 +79,15 @@ public class CTypes implements TargetTypes {
   }
 
   /**
-   * Return a variable declaration of the form "{@code type name}". The type is as returned by
-   * {@link #getTargetType(InferredType)}, except with the array syntax {@code [size]} preferred
-   * over the pointer syntax {@code *} (if applicable). This also includes the variable name because
+   * Return a variable declaration of the form "`type name`". The type is as returned by
+   * {@link #getTargetType(InferredType)}, except with the array syntax `[size]` preferred
+   * over the pointer syntax `*` (if applicable). This also includes the variable name because
    * C requires the array type specification to be placed after the variable name rather than with
-   * the type. The result is of the form {@code type variable_name[size]} or {@code type
-   * variable_name} depending on whether the given type is an array type, unless the array type has
-   * no size (it is given as {@code []}. In that case, the returned form depends on the third
-   * argument, initializer. If true, the then the returned declaration will have the form {@code
-   * type variable_name[]}, and otherwise it will have the form {@code type* variable_name}.
+   * the type. The result is of the form `type variable_name[size]` or `type
+   * variable_name` depending on whether the given type is an array type, unless the array type has
+   * no size (it is given as `[]`. In that case, the returned form depends on the third
+   * argument, initializer. If true, the then the returned declaration will have the form
+   * `type variable_name[]`, and otherwise it will have the form `type* variable_name`.
    *
    * @param type The type.
    * @param variableName The name of the variable.

--- a/core/src/main/java/org/lflang/generator/c/CUtil.java
+++ b/core/src/main/java/org/lflang/generator/c/CUtil.java
@@ -291,7 +291,8 @@ public class CUtil {
    * Return a reference to the port on the self struct of the parent of the port's parent, but
    * without the channel indexing, even if it is a multiport. This is used when an input port is
    * written to by a reaction in the parent of the port's parent, or when an output port triggers a
-   * reaction in the parent of the port's parent. This is equivalent to calling `* portRefNested(port, true, false, runtimeIndex, bankIndex, channelIndex)`.
+   * reaction in the parent of the port's parent. This is equivalent to calling
+   * `portRefNested(port, true, false, runtimeIndex, bankIndex, channelIndex)`.
    *
    * @param port The port.
    * @param runtimeIndex A variable name to use to index the runtime instance or null to use the

--- a/core/src/main/java/org/lflang/generator/c/TypeParameterizedReactor.java
+++ b/core/src/main/java/org/lflang/generator/c/TypeParameterizedReactor.java
@@ -29,10 +29,10 @@ public class TypeParameterizedReactor {
 
   /**
    * Construct the TPR corresponding to the given instantiation which syntactically appears within
-   * the definition corresponding to {@code parent}.
+   * the definition corresponding to `parent`.
    *
    * @param i An instantiation of the TPR to be constructed.
-   * @param parent The reactor in which {@code i} appears, or {@code null} if type variables are
+   * @param parent The reactor in which `i` appears, or `null` if type variables are
    *     permitted instead of types in this TPR.
    */
   public TypeParameterizedReactor(Instantiation i, TypeParameterizedReactor parent) {
@@ -69,7 +69,7 @@ public class TypeParameterizedReactor {
     return nameMap;
   }
 
-  /** Return a name that is unique to the given {@code Reactor}. */
+  /** Return a name that is unique to the given `Reactor`. */
   private String uniqueName(Reactor def) {
     var name = def.getName().toLowerCase();
     var number = Objects.requireNonNull(nameMap.get(name)).get(def.eResource().getURI());
@@ -77,8 +77,8 @@ public class TypeParameterizedReactor {
   }
 
   /**
-   * Construct a {@code TypeParameterizedReactor} corresponding to the reactor class of the
-   * instantiation {@code i} within the parent {@code parent} and with the given mapping of
+   * Construct a `TypeParameterizedReactor` corresponding to the reactor class of the
+   * instantiation `i` within the parent `parent` and with the given mapping of
    * definition names and URIs to integers.
    */
   private TypeParameterizedReactor(

--- a/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerComposeGenerator.java
@@ -154,7 +154,7 @@ public class DockerComposeGenerator {
   /**
    * Build using docker compose.
    *
-   * @return {@code true} if successful,{@code false} otherwise.
+   * @return `true` if successful,`false` otherwise.
    */
   public boolean build() {
     return Objects.requireNonNull(
@@ -212,7 +212,7 @@ public class DockerComposeGenerator {
   /**
    * Build, unless building was disabled.
    *
-   * @return {@code false} if building failed, {@code true} otherwise
+   * @return `false` if building failed, `true` otherwise
    */
   public boolean buildIfRequested() {
     if (!context.getTargetConfig().get(DockerProperty.INSTANCE).noBuild()) {

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -422,7 +422,7 @@ public class PythonGenerator extends CGenerator implements CCmakeGenerator.SetUp
       CodeBuilder src, Reaction reaction, TypeParameterizedReactor tpr, int reactionIndex) {
     Reactor reactor = ASTUtils.toDefinition(tpr.reactor());
 
-    // Reactions marked with a {@code @_c_body} attribute are generated in C
+    // Reactions marked with a `@_c_body` attribute are generated in C
     if (AttributeUtils.hasCBody(reaction)) {
       super.generateReaction(src, reaction, tpr, reactionIndex);
       return;
@@ -718,7 +718,7 @@ target_compile_definitions(${LF_MAIN_TARGET} PUBLIC MODULE_NAME=<pyModuleName>)
   /**
    * Generate the name of the python module.
    *
-   * <p>Ideally, this function would belong in a class like {@code PyFileConfig} that specifies all
+   * <p>Ideally, this function would belong in a class like `PyFileConfig` that specifies all
    * the paths to the generated code.
    *
    * @param lfModuleName The name of the LF module.
@@ -729,9 +729,9 @@ target_compile_definitions(${LF_MAIN_TARGET} PUBLIC MODULE_NAME=<pyModuleName>)
   }
 
   /**
-   * Generate the python file name given an {@code lfModuleName}.
+   * Generate the python file name given an `lfModuleName`.
    *
-   * <p>Ideally, this function would belong in a class like {@code PyFileConfig} that specifies all
+   * <p>Ideally, this function would belong in a class like `PyFileConfig` that specifies all
    * the paths to the generated code.
    *
    * @param lfModuleName The name of the LF module

--- a/core/src/main/java/org/lflang/generator/python/PythonMethodGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonMethodGenerator.java
@@ -14,7 +14,7 @@ import org.lflang.lf.Reactor;
  */
 public class PythonMethodGenerator {
 
-  /** Generate a Python method definition for {@code method}. */
+  /** Generate a Python method definition for `method`. */
   public static String generateMethod(Method method) {
     return String.join(
         "\n",
@@ -34,7 +34,7 @@ public class PythonMethodGenerator {
         .collect(Collectors.joining());
   }
 
-  /** Generate a list of arguments for {@code method} delimited with ', '. */
+  /** Generate a list of arguments for `method` delimited with ', '. */
   private static String generateMethodArgumentList(Method method) {
     return String.join(
         ", ",

--- a/core/src/main/java/org/lflang/generator/python/PythonReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonReactionGenerator.java
@@ -435,7 +435,7 @@ public class PythonReactionGenerator {
     code.pr(nameOfSelfStruct + "->_lf_name = \"" + instance.uniqueID() + "_lf\";");
 
     for (ReactionInstance reaction : instance.reactions) {
-      // Reactions marked with a {@code @_c_body} attribute are generated in C
+      // Reactions marked with a `@_c_body` attribute are generated in C
       if (AttributeUtils.hasCBody(reaction.getDefinition())) continue;
       // Create a PyObject for each reaction
       code.pr(generateCPythonReactionLinker(instance, reaction, nameOfSelfStruct));
@@ -548,7 +548,7 @@ public class PythonReactionGenerator {
    */
   public static String generatePythonReaction(
       Reactor reactor, Reaction reaction, int reactionIndex) {
-    // Reactions marked with a {@code @_c_body} attribute are generated in C
+    // Reactions marked with a `@_c_body` attribute are generated in C
     if (AttributeUtils.hasCBody(reaction)) return "";
 
     CodeBuilder code = new CodeBuilder();

--- a/core/src/main/java/org/lflang/generator/python/PythonValidator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonValidator.java
@@ -159,8 +159,8 @@ public class PythonValidator extends org.lflang.generator.Validator {
   private final ImmutableMap<Path, CodeMap> codeMaps;
 
   /**
-   * Initialize a {@code PythonValidator} for a build process using {@code fileConfig} and report
-   * errors to {@code errorReporter}.
+   * Initialize a `PythonValidator` for a build process using `fileConfig` and report
+   * errors to `errorReporter`.
    *
    * @param fileConfig The file configuration of this build.
    * @param messageReporter The reporter to which diagnostics should be sent.
@@ -218,7 +218,7 @@ public class PythonValidator extends org.lflang.generator.Validator {
            *
            * @param lines The lines of output from the compiler.
            * @param i The current index at which a message may start. Guaranteed to be less than
-           *     {@code lines.length - 3}.
+           *     `lines.length - 3`.
            * @return Whether an error message was reported.
            */
           private boolean tryReportTypical(String[] lines, int i) {
@@ -352,7 +352,7 @@ public class PythonValidator extends org.lflang.generator.Validator {
            * Return whether the given message should be ignored.
            *
            * @param message A Pylint message that is a candidate to be reported.
-           * @return whether {@code message} should be reported.
+           * @return whether `message` should be reported.
            */
           private boolean shouldIgnore(PylintMessage message) {
             // Code generation does not preserve whitespace, so this check is unreliable.

--- a/core/src/main/java/org/lflang/graph/InstantiationGraph.java
+++ b/core/src/main/java/org/lflang/graph/InstantiationGraph.java
@@ -43,12 +43,12 @@ import org.lflang.util.IteratorUtil;
  * between them. A "dependency" from reactor class A to reactor class B (A depends on B) means that
  * A instantiates within it at least one instance of B. Note that there a potentially confusing and
  * subtle distinction here between an "instantiation" and an "instance". They are not the same thing
- * at all. An "instantiation" is an AST node representing a statement like {@code a = new A();}.
+ * at all. An "instantiation" is an AST node representing a statement like `a = new A();`.
  * This can result in many instances of reactor class A (if the containing reactor class is
  * instantiated multiple times).
  *
  * <p>In addition to the graph, this class keeps track of the instantiations that induce the
- * dependencies. These can be retrieved using the method {@code getInstantiations(Reactor)}.
+ * dependencies. These can be retrieved using the method `getInstantiations(Reactor)`.
  *
  * @author Marten Lohstroh
  */

--- a/core/src/main/java/org/lflang/graph/PrecedenceGraph.java
+++ b/core/src/main/java/org/lflang/graph/PrecedenceGraph.java
@@ -32,7 +32,7 @@ import java.util.Stack;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 
 /**
- * Elaboration of {@code DirectedGraph} that is capable of identifying strongly connected components
+ * Elaboration of `DirectedGraph` that is capable of identifying strongly connected components
  * and topologically sorting its nodes.
  *
  * @author Marten Lohstroh
@@ -126,7 +126,7 @@ public class PrecedenceGraph<T extends Object> extends DirectedGraph<T> {
 
   /**
    * Run Tarjan's algorithm for finding strongly connected components. After invoking this method,
-   * the detected cycles with be listed in the class variable {@code cycles}.
+   * the detected cycles with be listed in the class variable `cycles`.
    */
   public void detectCycles() {
     if (!this.cycleAnalysisDone) {

--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -1,20 +1,3 @@
-/* Static information about targets. */
-/**
- * Copyright (c) 2019, The University of California at Berkeley. Redistribution and use in source
- * and binary forms, with or without modification, are permitted provided that the following
- * conditions are met: 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 2. Redistributions in binary form must
- * reproduce the above copyright notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. THIS SOFTWARE IS PROVIDED BY
- * THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
- * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
- * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package org.lflang.target;
 
 import java.util.Arrays;
@@ -32,6 +15,7 @@ import org.lflang.target.property.*;
  * Enumeration of targets and their associated properties.
  *
  * @author Marten Lohstroh
+ * @ingroup Generator
  */
 @Immutable
 public enum Target {
@@ -390,8 +374,8 @@ public enum Target {
 
   /**
    * Return the display name of the target, as it should be written in LF code. This is hence a
-   * single identifier. Eg for {@link #CPP} returns {@code "Cpp"}, for {@link #Python} returns
-   * {@code "Python"}. Avoid using either {@link #name()} or {@link #toString()}, which have
+   * single identifier. Eg for {@link #CPP} returns `"Cpp"`, for {@link #Python} returns
+   * `"Python"`. Avoid using either {@link #name()} or {@link #toString()}, which have
    * unrelated contracts.
    */
   public String getDisplayName() {
@@ -399,9 +383,9 @@ public enum Target {
   }
 
   /**
-   * Returns the conventional directory name for this target. This is used to divide e.g. the {@code
-   * test} and {@code example} directories by target language. For instance, {@code test/Cpp} is the
-   * path of {@link #CPP}'s test directory, and this method returns {@code "Cpp"}.
+   * Return the conventional directory name for this target. This is used to divide e.g. the
+   * `test` and `example` directories by target language. For instance, `test/Cpp` is the
+   * path of {@link #CPP}'s test directory, and this method returns `"Cpp"`.
    */
   public String getDirectoryName() {
     return displayName;
@@ -417,9 +401,9 @@ public enum Target {
   }
 
   /**
-   * Returns whether the given identifier is invalid as the name of an LF construct. This usually
+   * Return whether the given identifier is invalid as the name of an LF construct. This usually
    * means that the identifier is a keyword in the target language. In Rust, many keywords may be
-   * escaped with the syntax {@code r#keyword}, and they are considered valid identifiers.
+   * escaped with the syntax `r#keyword`, and they are considered valid identifiers.
    */
   public boolean isReservedIdent(String ident) {
     return this.keywords.contains(ident);
@@ -482,17 +466,17 @@ public enum Target {
     return this != CPP;
   }
 
-  /** Allow expressions of the form {@code {a, b, c}}. */
+  /** Allow expressions of the form `{a, b, c`}. */
   public boolean allowsBracedListExpressions() {
     return this == C || this == CCPP || this == CPP;
   }
 
-  /** Allow expressions of the form {@code [a, b, c]}. */
+  /** Allow expressions of the form `[a, b, c]`. */
   public boolean allowsBracketListExpressions() {
     return this == Python || this == TS || this == Rust;
   }
 
-  /** Allow expressions of the form {@code (a, b, c)}. */
+  /** Allow expressions of the form `(a, b, c)`. */
   public boolean allowsParenthesisListExpressions() {
     return this == CPP;
   }

--- a/core/src/main/java/org/lflang/target/TargetConfig.java
+++ b/core/src/main/java/org/lflang/target/TargetConfig.java
@@ -260,7 +260,7 @@ public class TargetConfig {
     }
   }
 
-  /** Return {@code true} if the given target property is supported, {@code false} otherwise. */
+  /** Return `true` if the given target property is supported, `false` otherwise. */
   public boolean isSupported(TargetProperty p) {
     return properties.containsKey(p);
   }
@@ -332,7 +332,7 @@ public class TargetConfig {
   }
 
   /**
-   * Return {@code true} if this target property has been set (past initialization), {@code false}
+   * Return `true` if this target property has been set (past initialization), `false`
    * otherwise.
    */
   public boolean isSet(TargetProperty<?, ?> property) {
@@ -454,7 +454,7 @@ public class TargetConfig {
   }
 
   /**
-   * Construct a {@code TargetDecl} by extracting the fields of the given {@code TargetConfig}.
+   * Construct a `TargetDecl` by extracting the fields of the given `TargetConfig`.
    *
    * @return A generated TargetDecl.
    */

--- a/core/src/main/java/org/lflang/target/property/CargoDependenciesProperty.java
+++ b/core/src/main/java/org/lflang/target/property/CargoDependenciesProperty.java
@@ -14,7 +14,7 @@ import org.lflang.lf.LfFactory;
 /**
  * Dependency specifications for Cargo. This property looks like this:
  *
- * <pre>{@code
+ * ```
  * cargo-dependencies: {
  *    // Name-of-the-crate: "version"
  *    rand: "0.8",
@@ -34,7 +34,7 @@ import org.lflang.lf.LfFactory;
  *      features: ["some-cargo-feature",]
  *    }
  * }
- * }</pre>
+ * ```
  */
 public final class CargoDependenciesProperty
     extends TargetProperty<Map<String, CargoDependencySpec>, CargoDependenciesPropertyType> {

--- a/core/src/main/java/org/lflang/target/property/RustIncludeProperty.java
+++ b/core/src/main/java/org/lflang/target/property/RustIncludeProperty.java
@@ -15,10 +15,10 @@ import org.lflang.util.FileUtil;
 import org.lflang.util.StringUtil;
 
 /**
- * List of module files to link into the crate as top-level. For instance, a {@code target Rust {
- * rust-modules: [ "foo.rs" ] }} will cause the file to be copied into the generated project, and
- * the generated {@code main.rs} will include it with a {@code mod foo;}. If one of the paths is a
- * directory, it must contain a {@code mod.rs} file, and all its contents are copied.
+ * List of module files to link into the crate as top-level. For instance, a `target Rust {
+ * rust-modules: [ "foo.rs" ] `} will cause the file to be copied into the generated project, and
+ * the generated `main.rs` will include it with a `mod foo;`. If one of the paths is a
+ * directory, it must contain a `mod.rs` file, and all its contents are copied.
  */
 public final class RustIncludeProperty extends TargetProperty<List<Path>, UnionType> {
 

--- a/core/src/main/java/org/lflang/target/property/StringListProperty.java
+++ b/core/src/main/java/org/lflang/target/property/StringListProperty.java
@@ -8,7 +8,7 @@ import org.lflang.lf.Element;
 import org.lflang.target.TargetConfig;
 import org.lflang.target.property.type.UnionType;
 
-/** Note: {@code set} implements an "append" semantics. */
+/** Note: `set` implements an "append" semantics. */
 public abstract class StringListProperty extends TargetProperty<List<String>, UnionType> {
 
   public StringListProperty() {

--- a/core/src/main/java/org/lflang/target/property/TargetProperty.java
+++ b/core/src/main/java/org/lflang/target/property/TargetProperty.java
@@ -71,9 +71,9 @@ public abstract class TargetProperty<T, S extends TargetPropertyType> {
    * Given an AST node, produce a corresponding value that is assignable to this target property, or
    * report an error via the given reporter in case any problems are encountered.
    *
-   * @param node The AST node to derive a value of type {@code T} from.
+   * @param node The AST node to derive a value of type `T` from.
    * @param reporter A reporter for reporting errors.
-   * @return A value of type {@code T}.
+   * @return A value of type `T`.
    */
   protected abstract T fromAst(Element node, MessageReporter reporter);
 
@@ -81,9 +81,9 @@ public abstract class TargetProperty<T, S extends TargetPropertyType> {
    * Given a string, produce a corresponding value that is assignable to this target property, or
    * report an error via the given reporter in case any problems are encountered.
    *
-   * @param string The string to derive a value of type {@code T} from.
+   * @param string The string to derive a value of type `T` from.
    * @param reporter A reporter for reporting errors.
-   * @return A value of type {@code T}.
+   * @return A value of type `T`.
    */
   protected abstract T fromString(String string, MessageReporter reporter);
 
@@ -105,7 +105,7 @@ public abstract class TargetProperty<T, S extends TargetPropertyType> {
   public abstract String name();
 
   /**
-   * Return {@code true} if this property is to be loaded from imported files, {@code false}
+   * Return `true` if this property is to be loaded from imported files, `false`
    * otherwise.
    */
   public boolean loadFromImport() {
@@ -113,15 +113,15 @@ public abstract class TargetProperty<T, S extends TargetPropertyType> {
   }
 
   /**
-   * Return {@code true} if this property is to be loaded by federates when specified at the level
-   * of the federation, {@code false} otherwise.
+   * Return `true` if this property is to be loaded by federates when specified at the level
+   * of the federation, `false` otherwise.
    */
   public boolean loadFromFederation() {
     return true;
   }
 
   /**
-   * Return {@code true} if this property is to be loaded from imported federates, {@code false}
+   * Return `true` if this property is to be loaded from imported federates, `false`
    * otherwise.
    */
   public boolean loadFromFederate() {
@@ -152,7 +152,7 @@ public abstract class TargetProperty<T, S extends TargetPropertyType> {
   /**
    * Update the given configuration based on the given corresponding AST node. If the given
    * configuration does not belong in the AST, then report an error using the error message given by
-   * {@code TargetConfig.NOT_IN_LF_SYNTAX_MESSAGE}.
+   * `TargetConfig.NOT_IN_LF_SYNTAX_MESSAGE`.
    *
    * @param config The configuration to update.
    * @param pair The pair that holds the value to perform the update with.

--- a/core/src/main/java/org/lflang/target/property/type/PlatformType.java
+++ b/core/src/main/java/org/lflang/target/property/type/PlatformType.java
@@ -47,7 +47,7 @@ public class PlatformType extends OptionsType<Platform> {
       return Platform.AUTO;
     }
 
-    /** Return {@code true} if the given platform supports federated. */
+    /** Return `true` if the given platform supports federated. */
     public static boolean supportsFederated(Platform platform) {
       return switch (platform) {
         case AUTO, LINUX, MAC -> true;

--- a/core/src/main/java/org/lflang/util/Averager.java
+++ b/core/src/main/java/org/lflang/util/Averager.java
@@ -8,14 +8,14 @@ public class Averager {
   private final int n;
   private final int[] reports;
 
-  /** Create an averager of reports from {@code n} processes. */
+  /** Create an averager of reports from `n` processes. */
   public Averager(int n) {
     this.n = n;
     reports = new int[n];
   }
 
   /**
-   * Receive {@code x} from process {@code id} and invoke {@code callback} on the mean of the
+   * Receive `x` from process `id` and invoke `callback` on the mean of the
    * numbers most recently reported by the processes.
    */
   public synchronized void report(int id, int x, Procedure1<Integer> callback) {

--- a/core/src/main/java/org/lflang/util/CollectionUtil.java
+++ b/core/src/main/java/org/lflang/util/CollectionUtil.java
@@ -117,7 +117,7 @@ public class CollectionUtil {
   }
 
   /**
-   * Returns a map that is identical to the original map, except the value for key {@code k} is
+   * Returns a map that is identical to the original map, except the value for key `k` is
    * transformed using the given function. The transformation function takes the key and current
    * value (null if the key is not present) as inputs, and returns the new value to associate to the
    * key (null if the mapping should be removed).

--- a/core/src/main/java/org/lflang/util/FileUtil.java
+++ b/core/src/main/java/org/lflang/util/FileUtil.java
@@ -54,7 +54,7 @@ public class FileUtil {
   /**
    * Return the name of the file associated with the given resource, excluding its file extension.
    *
-   * @param r Any {@code Resource}.
+   * @param r Any `Resource`.
    * @return The name of the file associated with the given resource, excluding its file extension.
    * @throws IllegalArgumentException If the resource has an invalid URI.
    */
@@ -208,8 +208,8 @@ public class FileUtil {
 
   /**
    * Copy the given source directory into the given destination directory. For example, if the
-   * source directory is {@code foo/bar} and the destination is {@code baz}, then copies of the
-   * contents of {@code foo/bar} will be located in {@code baz/bar}.
+   * source directory is `foo/bar` and the destination is `baz`, then copies of the
+   * contents of `foo/bar` will be located in `baz/bar`.
    *
    * @param srcDir The source directory path.
    * @param dstDir The destination directory path.
@@ -238,7 +238,7 @@ public class FileUtil {
   /**
    * Copy a given source file to a given destination file.
    *
-   * <p>This also creates new directories on the path to {@code dstFile} that do not yet exist.
+   * <p>This also creates new directories on the path to `dstFile` that do not yet exist.
    *
    * @param srcFile The source file path.
    * @param dstFile The destination file path.
@@ -257,7 +257,7 @@ public class FileUtil {
   /**
    * Copy a given source file to a given destination file.
    *
-   * <p>This also creates new directories for any directories on the path to {@code dstFile} that do
+   * <p>This also creates new directories for any directories on the path to `dstFile` that do
    * not yet exist.
    *
    * @param srcFile The source file path.
@@ -269,7 +269,7 @@ public class FileUtil {
   }
 
   /**
-   * Find the given {@code file} in the package and return the path to the file that was found; null
+   * Find the given `file` in the package and return the path to the file that was found; null
    * if it was not found.
    *
    * @param file The file to look for.
@@ -298,11 +298,11 @@ public class FileUtil {
    * first, relative to the source file and relative to the package root. Entries that cannot be
    * found in the file system are looked for on the class path.
    *
-   * <p>If {@code contentsOnly} is true, then for each entry that is a directory, only its contents
-   * are copied, not the directory itself. For example, if the entry is a directory {@code foo/bar}
-   * and the destination is {@code baz}, then copies of the contents of {@code foo/bar} will be
-   * located directly in {@code baz}. If {@code contentsOnly} is false, then copies of the contents
-   * of {@code foo/bar} will be located in {@code baz/bar}.
+   * <p>If `contentsOnly` is true, then for each entry that is a directory, only its contents
+   * are copied, not the directory itself. For example, if the entry is a directory `foo/bar`
+   * and the destination is `baz`, then copies of the contents of `foo/bar` will be
+   * located directly in `baz`. If `contentsOnly` is false, then copies of the contents
+   * of `foo/bar` will be located in `baz/bar`.
    *
    * @param entries The files or directories to copy from.
    * @param dstDir The location to copy the files to.
@@ -356,14 +356,14 @@ public class FileUtil {
   }
 
   /**
-   * If the given {@code entry} is a file, then copy it into the destination. If the {@code entry}
-   * is a directory and {@code contentsOnly} is true, then copy its contents to the destination
-   * directory. If the {@code entry} is a directory and {@code contentsOnly} is true, then copy it
+   * If the given `entry` is a file, then copy it into the destination. If the `entry`
+   * is a directory and `contentsOnly` is true, then copy its contents to the destination
+   * directory. If the `entry` is a directory and `contentsOnly` is true, then copy it
    * including its contents to the destination directory.
    *
    * @param entry A file or directory to copy to the destination directory.
    * @param dstDir A directory to copy the entry or its contents to.
-   * @param contentsOnly If true and {@code entry} is a directory, then copy its contents but not
+   * @param contentsOnly If true and `entry` is a directory, then copy its contents but not
    *     the directory itself.
    * @throws IOException If the operation fails.
    */
@@ -420,7 +420,7 @@ public class FileUtil {
   }
 
   /**
-   * Look up the given {@code entry} in the classpath. If it is found and is a file, copy it into
+   * Look up the given `entry` in the classpath. If it is found and is a file, copy it into
    * the destination directory. If the entry is not found or not a file, throw an exception.
    *
    * @param entry A file copy to the destination directory.
@@ -454,12 +454,12 @@ public class FileUtil {
   }
 
   /**
-   * Look up the given {@code entry} in the classpath. If it is a file, copy it into the destination
-   * directory. If the {@code entry} is a directory and {@code contentsOnly} is true, then copy its
-   * contents to the destination directory. If the {@code entry} is a directory and {@code
-   * contentsOnly} is true, then copy it including its contents to the destination directory.
+   * Look up the given `entry` in the classpath. If it is a file, copy it into the destination
+   * directory. If the `entry` is a directory and `contentsOnly` is true, then copy its
+   * contents to the destination directory. If the `entry` is a directory and `contentsOnly`
+   * is true, then copy it including its contents to the destination directory.
    *
-   * <p>This also creates new directories for any directories on the destination path that do not
+   * This also creates new directories for any directories on the destination path that do not
    * yet exist.
    *
    * @param entry The entry to be found on the class path and copied to the given destination.
@@ -521,10 +521,10 @@ public class FileUtil {
   }
 
   /**
-   * Given a JAR file and a {@code srcFile} entry, copy it into the given destination directory.
+   * Given a JAR file and a `srcFile` entry, copy it into the given destination directory.
    *
-   * @param jar The JAR file from which to copy {@code srcFile}.
-   * @param srcFile The source file to copy from the given {@code jar}.
+   * @param jar The JAR file from which to copy `srcFile`.
+   * @param srcFile The source file to copy from the given `jar`.
    * @param dstDir The directory to top the source file into.
    * @param skipIfUnchanged If true, don't overwrite the destination file if its content would * not
    *     be changed.
@@ -543,9 +543,9 @@ public class FileUtil {
   /**
    * Copy the contents from an entry in a JAR to destination directory in the filesystem. The entry
    * may be a file, in which case it will be copied under the same name into the destination
-   * directory. If the entry is a directory, then if {@code contentsOnly} is true, only the contents
+   * directory. If the entry is a directory, then if `contentsOnly` is true, only the contents
    * of the directory will be copied into the destination directory (not the directory itself). A
-   * directory will be copied as a whole, including its contents, if {@code contentsOnly} is false.
+   * directory will be copied as a whole, including its contents, if `contentsOnly` is false.
    *
    * <p>This method should only be used in standalone mode (lfc).
    *
@@ -575,11 +575,11 @@ public class FileUtil {
 
   /**
    * Given a connection to a JAR file that points to an entry that is a directory, recursively copy
-   * all entries located in that directory into the given {@code dstDir}.
+   * all entries located in that directory into the given `dstDir`.
    *
-   * <p>If {@code contentsOnly} is true, only the contents of the directory will be copied into the
+   * <p>If `contentsOnly` is true, only the contents of the directory will be copied into the
    * destination directory (not the directory itself). The directory will be copied as a whole,
-   * including its contents, if {@code contentsOnly} is false.
+   * including its contents, if `contentsOnly` is false.
    *
    * @param connection A connection to a JAR file that points to a directory entry.
    * @param dstDir The destination directory to copy the matching entries to.
@@ -624,13 +624,13 @@ public class FileUtil {
 
   /**
    * Given a connection to a JAR file that points to an entry that is a file, copy the file into the
-   * given {@code dstDir}.
+   * given `dstDir`.
    *
    * @param connection A connection to a JAR file that points to a directory entry.
    * @param dstDir The destination directory to copy the file to.
    * @param skipIfUnchanged
-   * @return {@code true} the connection entry is a file, and it was copied successfully; {@code
-   *     false} if the connection entry is not a file and the copy operation was aborted.
+   * @return `true` the connection entry is a file, and it was copied successfully or
+   *  `false` if the connection entry is not a file and the copy operation was aborted.
    * @throws IOException If the operation failed.
    */
   private static boolean copyFileFromJar(
@@ -776,7 +776,7 @@ public class FileUtil {
   }
 
   /**
-   * Delete the given file or directory if it exists. If {@code fileOrDirectory} is a directory,
+   * Delete the given file or directory if it exists. If `fileOrDirectory` is a directory,
    * deletion is recursive.
    *
    * @param fileOrDirectory The file or directory to delete.

--- a/core/src/main/java/org/lflang/util/LFCommand.java
+++ b/core/src/main/java/org/lflang/util/LFCommand.java
@@ -68,7 +68,7 @@ public class LFCommand {
   protected ByteArrayOutputStream errors = new ByteArrayOutputStream();
   protected boolean quiet;
 
-  /** Construct an LFCommand that executes the command carried by {@code pb}. */
+  /** Construct an LFCommand that executes the command carried by `pb`. */
   protected LFCommand(ProcessBuilder pb, boolean quiet) {
     this.processBuilder = pb;
     this.quiet = quiet;
@@ -100,8 +100,8 @@ public class LFCommand {
   }
 
   /**
-   * Collect as much output as possible from {@code in} without blocking, print it to {@code print}
-   * if not quiet, and store it in {@code store}.
+   * Collect as much output as possible from `in` without blocking, print it to `print`
+   * if not quiet, and store it in `store`.
    */
   private void collectOutput(InputStream in, ByteArrayOutputStream store, PrintStream print) {
     byte[] buffer = new byte[64];
@@ -130,10 +130,10 @@ public class LFCommand {
   }
 
   /**
-   * Handle user cancellation if necessary, and handle any output from {@code process} otherwise.
+   * Handle user cancellation if necessary, and handle any output from `process` otherwise.
    *
-   * @param process a {@code Process}
-   * @param cancelIndicator a flag indicating whether a cancellation of {@code process} is requested
+   * @param process a `Process`
+   * @param cancelIndicator a flag indicating whether a cancellation of `process` is requested
    *     directly to stderr and stdout).
    */
   private void poll(Process process, CancelIndicator cancelIndicator) {
@@ -149,7 +149,7 @@ public class LFCommand {
   /**
    * Execute the command.
    *
-   * <p>Executing a process directly with {@code processBuilder.start()} could lead to a deadlock as
+   * <p>Executing a process directly with `processBuilder.start()` could lead to a deadlock as
    * the subprocess blocks when output or error buffers are full. This method ensures that output
    * and error messages are continuously read and forwards them to the system output and error
    * streams as well as to the output and error streams hold in this class.
@@ -265,7 +265,7 @@ public class LFCommand {
    * not found, null is returned. In order to find the command, different methods are applied in the
    * following order:
    *
-   * <p>1. Check if the given command {@code cmd} is an executable file within {@code dir}. 2. If
+   * <p>1. Check if the given command `cmd` is an executable file within `dir`. 2. If
    * the above fails 'which <cmd>' (or 'where <cmd>' on Windows) is executed to see if the command
    * is available on the PATH. 3. If both points above fail, a third attempt is started using bash
    * to indirectly execute the command (see below for an explanation).
@@ -353,10 +353,10 @@ public class LFCommand {
    * Attempt to start the execution of this command.
    *
    * <p>First collect a list of paths where the executable might be found, then select an executable
-   * that successfully executes from the list of paths. Return the {@code Process} instance that is
-   * the result of a successful execution, or {@code null} if no successful execution happened.
+   * that successfully executes from the list of paths. Return the `Process` instance that is
+   * the result of a successful execution, or `null` if no successful execution happened.
    *
-   * @return The {@code Process} that is started by this command, or {@code null} in case of
+   * @return The `Process` that is started by this command, or `null` in case of
    *     failure.
    */
   private Process startProcess() {

--- a/core/src/main/java/org/lflang/util/Pair.java
+++ b/core/src/main/java/org/lflang/util/Pair.java
@@ -1,4 +1,4 @@
 package org.lflang.util;
 
-/** A pair whose first element has type {@code F} and whose second element has type {@code S}. */
+/** A pair whose first element has type `F` and whose second element has type `S`. */
 public record Pair<F, S>(F first, S second) {}

--- a/core/src/main/java/org/lflang/util/StringUtil.java
+++ b/core/src/main/java/org/lflang/util/StringUtil.java
@@ -45,8 +45,8 @@ public final class StringUtil {
   }
 
   /**
-   * Convert a string in Camel case to snake case. E.g. {@code MinimalReactor} will be converted to
-   * {@code minimal_reactor}. The string is assumed to be a single camel case identifier (no
+   * Convert a string in Camel case to snake case. E.g. `MinimalReactor` will be converted to
+   * `minimal_reactor`. The string is assumed to be a single camel case identifier (no
    * whitespace).
    */
   public static String camelToSnakeCase(String str) {
@@ -93,21 +93,21 @@ public final class StringUtil {
    *
    * <p>For examples, this code
    *
-   * <pre>{@code
+   * ```
    * int test = 4;
    * if (test == 42) {
    *     printf("Hello\n");
    * }
-   * }</pre>
+   * ```
    *
    * will be trimmed to this:
    *
-   * <pre>{@code
+   * ```
    * int test = 4;
    * if (test == 42) {
    *     printf("Hello\n");
    * }
-   * }</pre>
+   * ```
    *
    * @param code the code block to be trimmed
    * @param firstLineToConsider The first line not to ignore.

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -147,7 +147,7 @@ public class LFValidator extends BaseLFValidator {
     checkName(action.getName(), Literals.VARIABLE__NAME);
     if (action.getOrigin() == ActionOrigin.NONE) {
       error(
-          "Action must have modifier {@code logical} or {@code physical}.",
+          "Action must have modifier `logical` or `physical`.",
           Literals.ACTION__ORIGIN);
     }
     if (action.getPolicy() != null && !SPACING_VIOLATION_POLICIES.contains(action.getPolicy())) {
@@ -1339,7 +1339,7 @@ public class LFValidator extends BaseLFValidator {
                 Literals.WIDTH_SPEC__TERMS);
           }
         } else if (term.getPort() != null) {
-          // Widths given with {@code widthof()} are not supported (yet?).
+          // Widths given with `widthof()` are not supported (yet?).
           // This feature is currently only used for after delays.
           error("widthof is not supported.", Literals.WIDTH_SPEC__TERMS);
         } else if (term.getCode() != null) {

--- a/core/src/testFixtures/java/org/lflang/tests/TestBase.java
+++ b/core/src/testFixtures/java/org/lflang/tests/TestBase.java
@@ -407,7 +407,7 @@ public abstract class TestBase extends LfInjectedTestBase {
     }
   }
 
-  /** Return a URI pointing to an external runtime if there is one, {@code null} otherwise. */
+  /** Return a URI pointing to an external runtime if there is one, `null` otherwise. */
   private URI getExternalRuntimeUri() {
     var sysProps = System.getProperties();
     URI uri = null;

--- a/docs/replace_code_tags.py
+++ b/docs/replace_code_tags.py
@@ -1,32 +1,71 @@
 #!/usr/bin/env python3
 import re
 import sys
+import os
+import glob
 
 def replace_code_tags(file_path):
     """Replace all {@code X} patterns with `X` (backticks around the content) in the given file."""
     
-    # Read the file
-    with open(file_path, 'r', encoding='utf-8') as f:
-        content = f.read()
+    try:
+        # Read the file
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Replace {@code X} with `X` (backticks around the content)
+        # This regex matches {@code followed by any characters until }
+        pattern = r'\{@code\s*([^}]+)\}'
+        replacement = r'`\1`'
+        
+        # Perform the replacement
+        new_content = re.sub(pattern, replacement, content)
+        
+        # Only write if content actually changed
+        if new_content != content:
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write(new_content)
+            print(f"Updated: {file_path}")
+        else:
+            print(f"No changes needed: {file_path}")
+            
+    except Exception as e:
+        print(f"Error processing {file_path}: {e}")
+
+def process_directory(directory_path):
+    """Process all Java files recursively in the given directory."""
     
-    # Replace {@code X} with `X` (backticks around the content)
-    # This regex matches {@code followed by any characters until }
-    pattern = r'\{@code\s*([^}]+)\}'
-    replacement = r'`\1`'
+    # Find all Java files recursively
+    java_files = glob.glob(os.path.join(directory_path, "**/*.java"), recursive=True)
     
-    # Perform the replacement
-    new_content = re.sub(pattern, replacement, content)
+    if not java_files:
+        print(f"No Java files found in {directory_path}")
+        return
     
-    # Write back to the file
-    with open(file_path, 'w', encoding='utf-8') as f:
-        f.write(new_content)
+    print(f"Found {len(java_files)} Java files in {directory_path}")
     
-    print(f"Replaced code tags with backticks in {file_path}")
+    # Process each Java file
+    for java_file in java_files:
+        replace_code_tags(java_file)
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: python3 replace_code_tags.py <file_path>")
+        print("Usage: python3 replace_code_tags.py <file_or_directory_path>")
+        print("  If path is a file: processes that file only")
+        print("  If path is a directory: processes all .java files recursively")
         sys.exit(1)
     
-    file_path = sys.argv[1]
-    replace_code_tags(file_path)
+    path = sys.argv[1]
+    
+    if os.path.isfile(path):
+        # Process single file
+        if path.endswith('.java'):
+            replace_code_tags(path)
+        else:
+            print(f"Error: {path} is not a Java file")
+            sys.exit(1)
+    elif os.path.isdir(path):
+        # Process directory recursively
+        process_directory(path)
+    else:
+        print(f"Error: {path} is not a valid file or directory")
+        sys.exit(1)

--- a/lsp/src/main/java/org/lflang/diagram/lsp/LFLanguageServerExtension.java
+++ b/lsp/src/main/java/org/lflang/diagram/lsp/LFLanguageServerExtension.java
@@ -78,7 +78,7 @@ class LFLanguageServerExtension implements ILanguageServerExtension {
   }
 
   /**
-   * Handle a request for a complete build of the Lingua Franca file specified by {@code uri}.
+   * Handle a request for a complete build of the Lingua Franca file specified by `uri`.
    *
    * @param args the URI of the LF file of interest
    * @return A message describing the outcome of the build process.
@@ -100,12 +100,12 @@ class LFLanguageServerExtension implements ILanguageServerExtension {
 
   /**
    * Manage requests to retrieve a hierarchical structure of reactor libraries based on the provided
-   * {@code filePath}.
+   * `filePath`.
    *
    * @param filePath the URI of the LF file of interest
-   * @return A {@code CompletableFuture<LibraryFile>} representing the asynchronous computation * of
-   *     the parsed reactor structure. If an error occurs during parsing, the future will * complete
-   *     with {@code null}.
+   * @return A `CompletableFuture<LibraryFile>` representing the asynchronous computation of
+   *     the parsed reactor structure. If an error occurs during parsing, the future will complete
+   *     with `null`.
    */
   @JsonRequest("generator/getLibraryReactors")
   public CompletableFuture<LibraryFile> getLibraryReactors(String filePath) {
@@ -126,7 +126,7 @@ class LFLanguageServerExtension implements ILanguageServerExtension {
    * Retrieve the target position specified in the LF program file at the given path.
    *
    * @param path The path to the LF program file.
-   * @return A {@code CompletableFuture<NodePosition>} containing the NodePosition object
+   * @return A `CompletableFuture<NodePosition>` containing the NodePosition object
    *     representing the position of the target, or null if an error occurs during parsing or if
    *     the target position is not found.
    */
@@ -155,8 +155,8 @@ class LFLanguageServerExtension implements ILanguageServerExtension {
    * libraryFile representation.
    *
    * @param uri The URI specifying the location of the library.
-   * @return A {@code LibraryFile} object representing the hierarchical structure of the reactor
-   *     library, or {@code null} if an error occurs during parsing.
+   * @return A `LibraryFile` object representing the hierarchical structure of the reactor
+   *     library, or `null` if an error occurs during parsing.
    */
   public LibraryFile parseLibraryReactors(URI uri) {
     LibraryFile res = new LibraryFile(uri.toString());

--- a/lsp/src/main/java/org/lflang/diagram/lsp/Progress.java
+++ b/lsp/src/main/java/org/lflang/diagram/lsp/Progress.java
@@ -28,12 +28,11 @@ public class Progress {
   private final boolean cancellable;
 
   /**
-   * Initialize the {@code Progress} of a task titled {@code title} that is triggered via {@code
-   * client}.
+   * Initialize the `Progress` of a task titled `title` that is triggered via `client`.
    *
    * @param client A language client through which a task was triggered.
    * @param title The title of the task.
-   * @param cancellable Whether the task tracked by {@code this} can be cancelled.
+   * @param cancellable Whether the task tracked by `this` can be cancelled.
    */
   public Progress(LanguageClient client, String title, boolean cancellable) {
     this.client = client;
@@ -44,22 +43,22 @@ public class Progress {
     client.createProgress(new WorkDoneProgressCreateParams(Either.forRight(token)));
   }
 
-  /** Cancel the task tracked by the {@code Progress} that has token {@code token}. */
+  /** Cancel the task tracked by the `Progress` that has token `token`. */
   public static void cancel(int token) {
     if (cancellations.containsKey(token)) cancellations.put(token, true);
   }
 
   /**
-   * Returns the cancel indicator for the task tracked by this {@code Progress}.
+   * Return the cancel indicator for the task tracked by this `Progress`.
    *
-   * @return the cancel indicator for the task tracked by this {@code Progress}
+   * @return the cancel indicator for the task tracked by this `Progress`
    */
   public CancelIndicator getCancelIndicator() {
     if (cancellable) return () -> cancellations.get(token);
     return () -> false;
   }
 
-  /** Report that the task tracked by {@code this} is done. */
+  /** Report that the task tracked by `this` is done. */
   public void begin() {
     WorkDoneProgressBegin begin = new WorkDoneProgressBegin();
     begin.setTitle(title);
@@ -69,7 +68,7 @@ public class Progress {
   }
 
   /**
-   * Report the progress of the task tracked by {@code this}.
+   * Report the progress of the task tracked by `this`.
    *
    * @param message A message describing the progress of the task.
    */
@@ -82,7 +81,7 @@ public class Progress {
   }
 
   /**
-   * Marks the task tracked by {@code this} as terminated.
+   * Mark the task tracked by `this` as terminated.
    *
    * @param message A message describing the outcome of the task.
    */


### PR DESCRIPTION
Doxygen uses the syntax `{@code language}` to start and end a code block, similar to double backticks. Unfortunately, this conflicts with javadoc, which uses `{@code text}` to render text in fixed-width font.  This PR replaces all use of `@code` with standard markdown, which uses backticks.