### PR TITLE
Fix so that coral outline is used only for enclaves and align reactor-c

### DIFF
--- a/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
@@ -49,6 +49,7 @@ import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.Pair;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
+import org.lflang.AttributeUtils;
 import org.lflang.ast.ASTUtils;
 import org.lflang.diagram.synthesis.AbstractSynthesisExtensions;
 import org.lflang.diagram.synthesis.LinguaFrancaSynthesis;
@@ -162,7 +163,7 @@ public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
     int padding = getBooleanValue(LinguaFrancaSynthesis.SHOW_HYPERLINKS) ? 8 : 6;
 
     var color =
-        (reactorInstance.containingEnclaveReactor != reactorInstance)
+        AttributeUtils.isEnclave(reactorInstance.getDefinition())
             ? Colors.GRAY
             : ENCLAVE_BORDER_COLOR;
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
@@ -164,8 +164,8 @@ public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
 
     var color =
         AttributeUtils.isEnclave(reactorInstance.getDefinition())
-            ? Colors.GRAY
-            : ENCLAVE_BORDER_COLOR;
+            ? ENCLAVE_BORDER_COLOR
+            : Colors.GRAY;
 
     Function1<KRoundedRectangle, KRendering> style =
         r -> {


### PR DESCRIPTION
This will require updating the VS code extension after this is merged.