### PR TITLE
Time syntax

### DIFF
--- a/bin/lfc-dev
+++ b/bin/lfc-dev
@@ -4,7 +4,7 @@
 # Description:      Build and run the Lingua Franca compiler (lfc).
 # Authors:          Marten Lohstroh
 #                   Christian Menard
-# Usage:            Usage: lfc-dev [options] files...
+# Usage:            Usage: lfc-dev --help
 #============================================================================
 
 #============================================================================
@@ -54,6 +54,35 @@ fi
 
 gradlew="${base}/gradlew"
 
+# Parse arguments for script-specific options
+gradle_args=""
+lfc_args=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --offline)
+            gradle_args="--offline"
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: lfc-dev [options] files..."
+            echo ""
+            echo "Build and run the Lingua Franca compiler (lfc)."
+            echo ""
+            echo "Options:"
+            echo "  --offline    Run Gradle in offline mode"
+            echo "  -h, --help   Show this help message"
+            echo ""
+            echo "All other arguments are passed to the lfc compiler."
+            exit 0
+            ;;
+        *)
+            lfc_args+=("$1")
+            shift
+            ;;
+    esac
+done
+
 # Launch the tool.
-"${gradlew}" --quiet -p "${base}" assemble ":cli:lfc:assemble"
-"${base}/build/install/lf-cli/bin/lfc" "$@"
+"${gradlew}" --quiet ${gradle_args} -p "${base}" assemble ":cli:lfc:assemble"
+"${base}/build/install/lf-cli/bin/lfc" "${lfc_args[@]}"

--- a/cli/lff/src/main/java/org/lflang/cli/Lff.java
+++ b/cli/lff/src/main/java/org/lflang/cli/Lff.java
@@ -182,11 +182,13 @@ public class Lff extends CliBase {
         .doSwitch(
             new LfParsingHelper()
                 .parseSourceAsIfInDirectory(path.getParent(), formattedFileContents))) {
-      reporter.printFatalErrorAndExit(
-          "The formatter failed to produce output that is semantically equivalent to its input when"
-              + " executed on the file "
-              + path
-              + ". Please file a bug report with Lingua Franca.");
+      if (!ignoreErrors) {
+        reporter.printFatalErrorAndExit(
+            "The formatter failed to produce output that is semantically equivalent to its input"
+                + " when executed on the file "
+                + path
+                + ". Please file a bug report with Lingua Franca.");
+      }
     }
 
     try {

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -178,7 +178,7 @@ Reaction:
     ('(' (triggers+=TriggerRef (',' triggers+=TriggerRef)*)? ')')
     ( => sources+=VarRef (',' sources+=VarRef)*)?
     ('->' effects+=VarRefOrModeTransition (',' effects+=VarRefOrModeTransition)*)?
-    (code=Code)? (stp=STP)? (deadline=Deadline)? (delimited?=';')?
+    (code=Code)? (maxWait=MaxWait)? (deadline=Deadline)? (delimited?=';')?
     ;
 
 TriggerRef:
@@ -196,7 +196,7 @@ Watchdog:
     ('->' effects+=VarRefOrModeTransition (',' effects+=VarRefOrModeTransition)*)?
     code=Code;
 
-STP:
+MaxWait:
     ('STP' | 'STAA' | 'maxwait') ('(' value=Expression ')')? code=Code;
 
 Preamble:
@@ -210,6 +210,7 @@ Instantiation:
     ')' (('at' host=Host ';') | ';'?);
 
 Connection:
+    (attributes+=Attribute)*
     ((leftPorts += VarRef (',' leftPorts += VarRef)*)
     | ( '(' leftPorts += VarRef (',' leftPorts += VarRef)* ')' iterated ?= '+'?))
     ('->' | physical?='~>')

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -197,7 +197,7 @@ Watchdog:
     code=Code;
 
 MaxWait:
-    ('STP' | 'STAA' | 'maxwait') ('(' value=Expression ')')? code=Code;
+    ('STP' | 'STAA' | 'maxwait') ('(' value=Expression ')')? (code=Code)?;
 
 Preamble:
     (visibility=Visibility)? 'preamble' code=Code;

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -247,7 +247,7 @@ Element:
     keyvalue=KeyValuePairs
     | array=Array
     | literal=Literal
-    | (time=INT unit=TimeUnit)
+    | time=Time
     | id=Path;
 
 ///////// Pieces
@@ -312,7 +312,7 @@ ParameterReference:
 ;
 
 Time:
-    (interval=INT unit=TimeUnit)
+    (interval=INT unit=TimeUnit) | forever=Forever | never=Never
 ;
 
 Port:
@@ -374,7 +374,7 @@ Never:
 ;
 
 Literal:
-    STRING | CHAR_LIT | SignedFloat | SignedInt | Boolean | Forever | Never
+    STRING | CHAR_LIT | SignedFloat | SignedInt | Boolean
 ;
 
 Boolean:

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -197,7 +197,7 @@ Watchdog:
     code=Code;
 
 STP:
-    ('STP' | 'STAA' | 'maxwait') '(' value=Expression ')' code=Code;
+    ('STP' | 'STAA' | 'maxwait') ('(' value=Expression ')')? code=Code;
 
 Preamble:
     (visibility=Visibility)? 'preamble' code=Code;

--- a/core/src/main/java/org/lflang/TimeUnit.java
+++ b/core/src/main/java/org/lflang/TimeUnit.java
@@ -81,6 +81,14 @@ public enum TimeUnit {
     return canonicalName;
   }
 
+  /** Returns the name that is preferred when displaying this unit. */
+  public static String staticGetCanonicalName(TimeUnit unit) {
+    if (unit == null) {
+      return null;
+    }
+    return unit.getCanonicalName();
+  }
+
   /** Returns true if the given name is one of the aliases of this unit. */
   public boolean hasAlias(String name) {
     return allNames.contains(name);

--- a/core/src/main/java/org/lflang/TimeValue.java
+++ b/core/src/main/java/org/lflang/TimeValue.java
@@ -1,35 +1,13 @@
-/*************
- * Copyright (c) 2019, The University of California at Berkeley.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang;
+
+import org.lflang.lf.Time;
 
 /**
  * Represents an amount of time (a duration).
  *
  * @author Marten Lohstroh
  * @author Clément Fournier - TU Dresden, INSA Rennes
+ * @ingroup Utilities
  */
 public final class TimeValue implements Comparable<TimeValue> {
 
@@ -66,7 +44,9 @@ public final class TimeValue implements Comparable<TimeValue> {
   /**
    * Create a new time value.
    *
-   * @throws IllegalArgumentException If time is non-zero and the unit is null
+   * @param time The time value.
+   * @param unit The unit of the time value.
+   * @throws IllegalArgumentException If time is non-zero and the unit is null.
    */
   public TimeValue(long time, TimeUnit unit) {
     if (unit == null && time != 0) {
@@ -74,6 +54,25 @@ public final class TimeValue implements Comparable<TimeValue> {
     }
     this.time = time;
     this.unit = unit;
+  }
+
+  /**
+   * Create a new time value.
+   *
+   * @param time The time AST node..
+   * @throws IllegalArgumentException If time is non-zero and the unit is null.
+   */
+  public TimeValue(Time time) {
+    if (time == null || time.getNever() != null) {
+      this.time = Long.MIN_VALUE;
+      this.unit = TimeUnit.NANO;
+    } else if (time.getForever() != null) {
+      this.time = Long.MAX_VALUE;
+      this.unit = TimeUnit.NANO;
+    } else {
+      this.time = time.getInterval();
+      this.unit = TimeUnit.fromName(time.getUnit());
+    }
   }
 
   @Override

--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -925,16 +925,6 @@ public class ASTUtils {
   }
 
   /**
-   * Report whether the given literal is never or not.
-   *
-   * @param literal AST node to inspect.
-   * @return True if the given literal denotes the constant `never`, false otherwise.
-   */
-  public static boolean isNever(String literal) {
-    return literal != null && literal.equals("never");
-  }
-
-  /**
    * Report whether the given expression is zero or not.
    *
    * @param expr AST node to inspect.
@@ -948,19 +938,6 @@ public class ASTUtils {
   }
 
   /**
-   * Report whether the given expression is never or not.
-   *
-   * @param expr AST node to inspect.
-   * @return True if the given value denotes the constant `never`, false otherwise.
-   */
-  public static boolean isNever(Expression expr) {
-    if (expr instanceof Literal) {
-      return isNever(((Literal) expr).getLiteral());
-    }
-    return false;
-  }
-
-  /**
    * Report whether the given string literal is an integer number or not.
    *
    * @param literal AST node to inspect.
@@ -969,7 +946,7 @@ public class ASTUtils {
   public static boolean isInteger(String literal) {
     try {
       //noinspection ResultOfMethodCallIgnored
-      Integer.decode(literal);
+      Long.decode(literal);
     } catch (NumberFormatException e) {
       return false;
     }

--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -720,7 +720,7 @@ public class ASTUtils {
    * @param e The element to be rendered as a time value.
    */
   public static TimeValue toTimeValue(Element e) {
-    return new TimeValue(e.getTime(), TimeUnit.fromName(e.getUnit()));
+    return new TimeValue(e.getTime());
   }
 
   /** Returns the time value represented by the given AST node. */
@@ -863,10 +863,12 @@ public class ASTUtils {
    */
   public static Element toElement(TimeValue tv) {
     Element e = LfFactory.eINSTANCE.createElement();
-    e.setTime((int) tv.time);
+    Time time = LfFactory.eINSTANCE.createTime();
+    time.setInterval((int) tv.time);
     if (tv.unit != null) {
-      e.setUnit(tv.unit.toString());
+      time.setUnit(tv.unit.toString());
     }
+    e.setTime(time);
     return e;
   }
 

--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -729,7 +729,7 @@ public class ASTUtils {
       // invalid unit, will have been reported by validator
       throw new IllegalArgumentException();
     }
-    return new TimeValue(e.getInterval(), TimeUnit.fromName(e.getUnit()));
+    return new TimeValue(e);
   }
 
   /**
@@ -925,16 +925,6 @@ public class ASTUtils {
   }
 
   /**
-   * Report whether the given literal is forever or not.
-   *
-   * @param literal AST node to inspect.
-   * @return True if the given literal denotes the constant `forever`, false otherwise.
-   */
-  public static boolean isForever(String literal) {
-    return literal != null && literal.equals("forever");
-  }
-
-  /**
    * Report whether the given literal is never or not.
    *
    * @param literal AST node to inspect.
@@ -953,19 +943,6 @@ public class ASTUtils {
   public static boolean isZero(Expression expr) {
     if (expr instanceof Literal) {
       return isZero(((Literal) expr).getLiteral());
-    }
-    return false;
-  }
-
-  /**
-   * Report whether the given expression is forever or not.
-   *
-   * @param expr AST node to inspect.
-   * @return True if the given value denotes the constant `forever`, false otherwise.
-   */
-  public static boolean isForever(Expression expr) {
-    if (expr instanceof Literal) {
-      return isForever(((Literal) expr).getLiteral());
     }
     return false;
   }
@@ -1163,10 +1140,6 @@ public class ASTUtils {
       return toTimeValue((Time) expr);
     } else if (expr instanceof Literal && isZero(((Literal) expr).getLiteral())) {
       return TimeValue.ZERO;
-    } else if (expr instanceof Literal && isForever(((Literal) expr).getLiteral())) {
-      return TimeValue.MAX_VALUE;
-    } else if (expr instanceof Literal && isNever(((Literal) expr).getLiteral())) {
-      return TimeValue.MIN_VALUE;
     } else {
       return null;
     }

--- a/core/src/main/java/org/lflang/ast/IsEqual.java
+++ b/core/src/main/java/org/lflang/ast/IsEqual.java
@@ -387,7 +387,7 @@ public class IsEqual extends LfSwitch<Boolean> {
         .equivalent(Element::getArray)
         .equalAsObjects(Element::getLiteral)
         .equalAsObjects(Element::getId)
-        .equalAsObjects(Element::getUnit)
+        .equivalent(Element::getTime)
         .conclusion;
   }
 
@@ -475,11 +475,16 @@ public class IsEqual extends LfSwitch<Boolean> {
 
   @Override
   public Boolean caseTime(Time object) {
+    if (object == null) return false;
+    // (interval=INT unit=TimeUnit) | forever=Forever | never=Never
     return new ComparisonMachine<>(object, Time.class)
+        .equalAsObjects(Time::getForever)
+        .equalAsObjects(Time::getNever)
         .equalAsObjects(Time::getInterval)
         .equalAsObjectsModulo(
             Time::getUnit,
-            ((Function<TimeUnit, String>) TimeUnit::getCanonicalName).compose(TimeUnit::fromName))
+            ((Function<TimeUnit, String>) TimeUnit::staticGetCanonicalName)
+                .compose(TimeUnit::fromName))
         .conclusion;
   }
 
@@ -652,7 +657,7 @@ public class IsEqual extends LfSwitch<Boolean> {
 
     /**
      * Conclude false if the two properties are not equal as objects, given that
-     * `projectionToClassRepresentatives` maps each object to some semantically equivalent object.
+     * `projectionToClassRepresentatives` maps each object to some semantically equivalent object. If either or both of the objects are null, also conclude false.
      */
     <T> ComparisonMachine<E> equalAsObjectsModulo(
         Function<E, T> propertyGetter, Function<T, T> projectionToClassRepresentatives) {

--- a/core/src/main/java/org/lflang/ast/IsEqual.java
+++ b/core/src/main/java/org/lflang/ast/IsEqual.java
@@ -34,6 +34,7 @@ import org.lflang.lf.Instantiation;
 import org.lflang.lf.KeyValuePair;
 import org.lflang.lf.KeyValuePairs;
 import org.lflang.lf.Literal;
+import org.lflang.lf.MaxWait;
 import org.lflang.lf.Method;
 import org.lflang.lf.MethodArgument;
 import org.lflang.lf.Mode;
@@ -48,7 +49,6 @@ import org.lflang.lf.Preamble;
 import org.lflang.lf.Reaction;
 import org.lflang.lf.Reactor;
 import org.lflang.lf.ReactorDecl;
-import org.lflang.lf.STP;
 import org.lflang.lf.Serializer;
 import org.lflang.lf.StateVar;
 import org.lflang.lf.TargetDecl;
@@ -286,7 +286,7 @@ public class IsEqual extends LfSwitch<Boolean> {
         .equalAsObjects(Reaction::isMutation)
         .equalAsObjects(Reaction::getName)
         .equivalent(Reaction::getCode)
-        .equivalent(Reaction::getStp)
+        .equivalent(Reaction::getMaxWait)
         .equivalent(Reaction::getDeadline)
         .conclusion;
   }
@@ -312,10 +312,10 @@ public class IsEqual extends LfSwitch<Boolean> {
   }
 
   @Override
-  public Boolean caseSTP(STP object) {
-    return new ComparisonMachine<>(object, STP.class)
-        .equivalent(STP::getValue)
-        .equivalent(STP::getCode)
+  public Boolean caseMaxWait(MaxWait object) {
+    return new ComparisonMachine<>(object, MaxWait.class)
+        .equivalent(MaxWait::getValue)
+        .equivalent(MaxWait::getCode)
         .conclusion;
   }
 

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -48,6 +48,7 @@ import org.lflang.lf.Instantiation;
 import org.lflang.lf.KeyValuePair;
 import org.lflang.lf.KeyValuePairs;
 import org.lflang.lf.Literal;
+import org.lflang.lf.MaxWait;
 import org.lflang.lf.Method;
 import org.lflang.lf.MethodArgument;
 import org.lflang.lf.Mode;
@@ -62,7 +63,6 @@ import org.lflang.lf.Preamble;
 import org.lflang.lf.Reaction;
 import org.lflang.lf.Reactor;
 import org.lflang.lf.ReactorDecl;
-import org.lflang.lf.STP;
 import org.lflang.lf.Serializer;
 import org.lflang.lf.StateVar;
 import org.lflang.lf.TargetDecl;
@@ -654,7 +654,7 @@ public class ToLf extends LfSwitch<MalleableString> {
     // ('(' (triggers+=TriggerRef (',' triggers+=TriggerRef)*)? ')')
     // (sources+=VarRef (',' sources+=VarRef)*)?
     // ('->' effects+=VarRefOrModeTransition (',' effects+=VarRefOrModeTransition)*)?
-    // ((('named' name=ID)? code=Code) | 'named' name=ID)(stp=STP)?(deadline=Deadline)?
+    // ((('named' name=ID)? code=Code) | 'named' name=ID)(maxwait=MaxWait)?(deadline=Deadline)?
     Builder msb = new Builder();
     addAttributes(msb, object::getAttributes);
     if (object.isMutation()) {
@@ -685,7 +685,7 @@ public class ToLf extends LfSwitch<MalleableString> {
                   .collect(new Joiner(", ")));
     }
     if (object.getCode() != null) msb.append(" ").append(doSwitch(object.getCode()));
-    if (object.getStp() != null) msb.append(" ").append(doSwitch(object.getStp()));
+    if (object.getMaxWait() != null) msb.append(" ").append(doSwitch(object.getMaxWait()));
     if (object.getDeadline() != null) msb.append(" ").append(doSwitch(object.getDeadline()));
     return msb.get();
   }
@@ -745,9 +745,9 @@ public class ToLf extends LfSwitch<MalleableString> {
   }
 
   @Override
-  public MalleableString caseSTP(STP object) {
-    // 'STP' '(' value=Expression ')' code=Code
-    return handler(object, "STAA", STP::getValue, STP::getCode);
+  public MalleableString caseMaxWait(MaxWait object) {
+    // 'maxwait' '(' value=Expression ')' code=Code
+    return handler(object, "STAA", MaxWait::getValue, MaxWait::getCode);
   }
 
   private <T extends EObject> MalleableString handler(

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -322,12 +322,17 @@ public class ToLf extends LfSwitch<MalleableString> {
 
   @Override
   public MalleableString caseTime(Time t) {
-    // (interval=INT unit=TimeUnit)
+    // (interval=INT unit=TimeUnit) | forever=Forever | never=Never
+    if (t.getForever() != null || t.getInterval() == Long.MAX_VALUE) {
+      return MalleableString.anyOf("forever");
+    }
+    if (t.getNever() != null || t.getInterval() == Long.MIN_VALUE) {
+      return MalleableString.anyOf("never");
+    }
     final var interval = Integer.toString(t.getInterval());
-    if (t.getUnit() == null) {
+    if (t.getUnit() == null || t.getUnit().equals("")) {
       return MalleableString.anyOf(interval);
     }
-
     return MalleableString.anyOf(interval + " " + t.getUnit());
   }
 
@@ -908,15 +913,23 @@ public class ToLf extends LfSwitch<MalleableString> {
     // keyvalue=KeyValuePairs
     // | array=Array
     // | literal=Literal
-    // | (time=INT unit=TimeUnit)
+    // | Time
     // | id=Path
     if (object.getKeyvalue() != null) return doSwitch(object.getKeyvalue());
     if (object.getArray() != null) return doSwitch(object.getArray());
     if (object.getLiteral() != null) return MalleableString.anyOf(object.getLiteral());
     if (object.getId() != null) return MalleableString.anyOf(object.getId());
-    if (object.getUnit() != null)
-      return MalleableString.anyOf(String.format("%d %s", object.getTime(), object.getUnit()));
-    return MalleableString.anyOf(String.valueOf(object.getTime()));
+    if (object.getTime() != null) {
+      var time = object.getTime();
+      if (time.getForever() != null || time.getInterval() == Long.MAX_VALUE) {
+        return MalleableString.anyOf("forever");
+      }
+      if (time.getNever() != null || time.getInterval() == Long.MIN_VALUE) {
+        return MalleableString.anyOf("never");
+      }
+      return MalleableString.anyOf(String.format("%d %s", time.getInterval(), time.getUnit()));
+    }
+    return MalleableString.anyOf("ERROR");
   }
 
   @Override

--- a/core/src/main/java/org/lflang/ast/ToSExpr.java
+++ b/core/src/main/java/org/lflang/ast/ToSExpr.java
@@ -45,6 +45,7 @@ import org.lflang.lf.Instantiation;
 import org.lflang.lf.KeyValuePair;
 import org.lflang.lf.KeyValuePairs;
 import org.lflang.lf.Literal;
+import org.lflang.lf.MaxWait;
 import org.lflang.lf.Method;
 import org.lflang.lf.MethodArgument;
 import org.lflang.lf.Mode;
@@ -58,7 +59,6 @@ import org.lflang.lf.Preamble;
 import org.lflang.lf.Reaction;
 import org.lflang.lf.Reactor;
 import org.lflang.lf.ReactorDecl;
-import org.lflang.lf.STP;
 import org.lflang.lf.Serializer;
 import org.lflang.lf.StateVar;
 import org.lflang.lf.TargetDecl;
@@ -474,7 +474,7 @@ public class ToSExpr extends LfSwitch<SExpr> {
     //            ('(' (triggers+=TriggerRef (',' triggers+=TriggerRef)*)? ')')
     //        ( => sources+=VarRef (',' sources+=VarRef)*)?
     //        ('->' effects+=VarRefOrModeTransition (',' effects+=VarRefOrModeTransition)*)?
-    //        (code=Code)? (stp=STP)? (deadline=Deadline)? (delimited?=';')?
+    //        (code=Code)? (maxwait=MaxWait)? (deadline=Deadline)? (delimited?=';')?
     //        ;
     return sList(
         "reaction",
@@ -485,7 +485,7 @@ public class ToSExpr extends LfSwitch<SExpr> {
         sList("sources", object.getSources()),
         sList("effects", object.getEffects()),
         object.getCode(),
-        object.getStp(),
+        object.getMaxWait(),
         object.getDeadline(),
         sList("is-delimited", object.isDelimited()));
   }
@@ -530,10 +530,10 @@ public class ToSExpr extends LfSwitch<SExpr> {
   }
 
   @Override
-  public SExpr caseSTP(STP object) {
-    //        STP:
-    //        'STP' '(' value=Expression ')' code=Code;
-    return sList("stp", object.getValue(), object.getCode());
+  public SExpr caseMaxWait(MaxWait object) {
+    //        maxwait:
+    //        'maxwait' ()'(' value=Expression ')')? code=Code;
+    return sList("maxwait", object.getValue(), object.getCode());
   }
 
   @Override

--- a/core/src/main/java/org/lflang/ast/ToSExpr.java
+++ b/core/src/main/java/org/lflang/ast/ToSExpr.java
@@ -632,20 +632,20 @@ public class ToSExpr extends LfSwitch<SExpr> {
     //        keyvalue=KeyValuePairs
     //            | array=Array
     //            | literal=Literal
-    //            | (time=INT unit=TimeUnit)
-    //    | id=Path;
+    //            | time=Time
+    //            | id=Path;
     return sList(
         "element",
         object.getKeyvalue(),
         object.getArray(),
         object.getLiteral(),
-        object.getTime() == 0
-                && (object.getKeyvalue() != null
-                    || object.getArray() != null
-                    || object.getLiteral() != null
-                    || object.getId() != null)
+        object.getTime() == null
             ? null
-            : sList("time", object.getTime(), object.getUnit()),
+            : object.getTime().getForever() != null
+                ? "forever"
+                : object.getTime().getNever() != null
+                    ? "never"
+                    : sList("time", object.getTime().getInterval(), object.getTime().getUnit()),
         object.getId());
   }
 

--- a/core/src/main/java/org/lflang/federated/extensions/CExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtension.java
@@ -687,7 +687,7 @@ public class CExtension implements FedTargetExtension {
             "init_shutdown_mutex();",
             "lf_cond_init(&lf_port_status_changed, &env->mutex);"));
 
-    // Find the STA (A.K.A. the global STP offset) for this federate.
+    // Find the maxwait (A.K.A. STA, the global STP offset) for this federate.
     if (federate.targetConfig.get(CoordinationProperty.INSTANCE)
         == CoordinationMode.DECENTRALIZED) {
       var reactor = ASTUtils.toDefinition(federate.instantiation.getReactorClass());

--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -525,12 +525,11 @@ public class FedASTUtils {
   }
 
   /**
-   * @brief Find the maximum STP offset (STAA) for the given 'port'.
-   *     <p>An STP offset (STAA) may be nested in contained reactors in the federate. This returns
-   *     TimeValue.ZERO if there are no STAA offsets for the port.
-   * @param connection The connection to find the max STP offset for.
+   * Find the maximum maxwait (STP offset, STAA) for the destination port of the given
+   * connection. This maximum may be nested in contained reactors in the federate.
+   * This method returns TimeValue.ZERO if there are no maxwait offsets for the port.
+   * @param connection The connection to find the maxwait offset for.
    * @param coordination The coordination scheme.
-   * @return The maximum STP (STAA) as a TimeValue
    */
   private static TimeValue findMaxSTAA(
       FedConnectionInstance connection, CoordinationMode coordination) {

--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -576,14 +576,14 @@ public class FedASTUtils {
       for (Reaction r : safe(reactionsWithPort)) {
         // If STP offset is determined, add it
         // If not, assume it is zero
-        if (r.getStp() != null) {
-          if (r.getStp().getValue() instanceof ParameterReference) {
+        if (r.getMaxWait() != null) {
+          if (r.getMaxWait().getValue() instanceof ParameterReference) {
             List<Instantiation> instantList = new ArrayList<>();
             instantList.add(instance.instantiation);
-            final var param = ((ParameterReference) r.getStp().getValue()).getParameter();
+            final var param = ((ParameterReference) r.getMaxWait().getValue()).getParameter();
             STPList.add(ASTUtils.initialValue(param, instantList));
           } else {
-            STPList.add(r.getStp().getValue());
+            STPList.add(r.getMaxWait().getValue());
           }
         }
       }
@@ -616,14 +616,14 @@ public class FedASTUtils {
         for (Reaction r : safe(childReactionsWithPort)) {
           // If STP offset is determined, add it
           // If not, assume it is zero
-          if (r.getStp() != null) {
-            if (r.getStp().getValue() instanceof ParameterReference) {
+          if (r.getMaxWait() != null) {
+            if (r.getMaxWait().getValue() instanceof ParameterReference) {
               List<Instantiation> instantList = new ArrayList<>();
               instantList.add(childPort.getContainer());
-              final var param = ((ParameterReference) r.getStp().getValue()).getParameter();
+              final var param = ((ParameterReference) r.getMaxWait().getValue()).getParameter();
               STPList.add(ASTUtils.initialValue(param, instantList));
             } else {
-              STPList.add(r.getStp().getValue());
+              STPList.add(r.getMaxWait().getValue());
             }
           }
         }

--- a/core/src/main/java/org/lflang/generator/TargetTypes.java
+++ b/core/src/main/java/org/lflang/generator/TargetTypes.java
@@ -177,10 +177,6 @@ public interface TargetTypes {
   default String getTargetExpr(Expression expr, InferredType type) {
     if (ASTUtils.isZero(expr) && type != null && type.isTime) {
       return getTargetTimeExpr(TimeValue.ZERO);
-    } else if (ASTUtils.isForever(expr) && type != null) {
-      return getTargetTimeExpr(TimeValue.MAX_VALUE);
-    } else if (ASTUtils.isNever(expr) && type != null) {
-      return getTargetTimeExpr(TimeValue.MIN_VALUE);
     } else if (expr instanceof ParameterReference) {
       return getTargetParamRef((ParameterReference) expr, type);
     } else if (expr instanceof Time) {

--- a/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
@@ -898,7 +898,7 @@ public class CReactionGenerator {
 
       // Assign the STP handler
       var STPFunctionPointer = "NULL";
-      if (reaction.getStp() != null) {
+      if (reaction.getMaxWait() != null) {
         // The following has to match the name chosen in generateReactions
         var STPFunctionName = generateStpFunctionName(tpr, reactionCount);
         STPFunctionPointer = "&" + STPFunctionName;
@@ -1154,12 +1154,12 @@ public class CReactionGenerator {
     // Now generate code for the late function, if there is one
     // Note that this function can only be defined on reactions
     // in federates that have inputs from a logical connection.
-    if (reaction.getStp() != null) {
+    if (reaction.getMaxWait() != null) {
       code.pr(
           generateFunction(
               generateStpFunctionHeader(tpr, reactionIndex),
               init,
-              reaction.getStp().getCode(),
+              reaction.getMaxWait().getCode(),
               suppressLineDirectives));
     }
 

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -527,7 +527,7 @@ public class PythonGenerator extends CGenerator implements CCmakeGenerator.SetUp
           "PyObject* "
               + PythonReactionGenerator.generateCPythonReactionFunctionName(reactionIndex)
               + ";");
-      if (reaction.getStp() != null) {
+      if (reaction.getMaxWait() != null) {
         selfStructBody.pr(
             "PyObject* "
                 + PythonReactionGenerator.generateCPythonSTPFunctionName(reactionIndex)

--- a/core/src/main/java/org/lflang/generator/python/PythonReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonReactionGenerator.java
@@ -180,12 +180,12 @@ public class PythonReactionGenerator {
             generateCPythonReactionCaller(tpr, reactionIndex, pyObjects, cPyInit)));
 
     // Generate code for the STP violation handler, if there is one.
-    if (reaction.getStp() != null) {
+    if (reaction.getMaxWait() != null) {
       code.pr(
           generateFunction(
               CReactionGenerator.generateStpFunctionHeader(tpr, reactionIndex),
               cInit,
-              reaction.getStp().getCode(),
+              reaction.getMaxWait().getCode(),
               generateCPythonSTPCaller(tpr, reactionIndex, pyObjects)));
     }
     // Generate code for the deadline violation function, if there is one.
@@ -457,7 +457,7 @@ public class PythonReactionGenerator {
         generateCPythonFunctionLinker(
             nameOfSelfStruct, generateCPythonReactionFunctionName(reaction.index),
             instance, generatePythonReactionFunctionName(reaction.index)));
-    if (reaction.getDefinition().getStp() != null) {
+    if (reaction.getDefinition().getMaxWait() != null) {
       code.pr(
           generateCPythonFunctionLinker(
               nameOfSelfStruct, generateCPythonSTPFunctionName(reaction.index),
@@ -564,12 +564,12 @@ public class PythonReactionGenerator {
             ASTUtils.toText(reaction.getCode()),
             reactionParameters));
     // Generate code for the STP violation handler function, if there is one.
-    if (reaction.getStp() != null) {
+    if (reaction.getMaxWait() != null) {
       code.pr(
           generatePythonFunction(
               generatePythonSTPFunctionName(reactionIndex),
               "",
-              ASTUtils.toText(reaction.getStp().getCode()),
+              ASTUtils.toText(reaction.getMaxWait().getCode()),
               reactionParameters));
     }
     // Generate code for the deadline violation function, if there is one.

--- a/core/src/main/java/org/lflang/target/property/type/PrimitiveType.java
+++ b/core/src/main/java/org/lflang/target/property/type/PrimitiveType.java
@@ -45,7 +45,7 @@ public enum PrimitiveType implements TargetPropertyType {
               && v.getArray() == null
               && v.getLiteral() == null
               && v.getId() == null
-              && (v.getTime() == 0 || v.getUnit() != null)),
+              && v.getTime() != null),
   STRING(
       "a string",
       v -> v.getLiteral() != null && !isCharLiteral(v.getLiteral()) || v.getId() != null),

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -1772,15 +1772,6 @@ public class LFValidator extends BaseLFValidator {
       if (ASTUtils.isZero(((Literal) value).getLiteral())) {
         return;
       }
-
-      if (ASTUtils.isForever(((Literal) value).getLiteral())) {
-        return;
-      }
-
-      if (ASTUtils.isNever(((Literal) value).getLiteral())) {
-        return;
-      }
-
       if (ASTUtils.isInteger(((Literal) value).getLiteral())) {
         error("Missing time unit.", feature);
         return;

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -831,7 +831,7 @@ public class LFValidator extends BaseLFValidator {
             Literals.REACTION__CODE);
         return;
       }
-      if (reaction.getDeadline() == null && reaction.getStp() == null) {
+      if (reaction.getDeadline() == null && reaction.getMaxWait() == null) {
         var text = NodeModelUtils.findActualNodeFor(reaction).getText();
         var matcher = Pattern.compile("\\)\\s*[\\n\\r]+(.*[\\n\\r])*.*->").matcher(text);
         if (matcher.find()) {


### PR DESCRIPTION
This PR:
* changes the grammar so that `forever` and `never` are `Time` objects rather than `Literal`.
* Modifies the ldc-dev script so that it accepts `--offline` and `--help` options.
* Renames the `STP` object in the syntax to `MaxWait` for compatibility with reactor-uc.
* Makes the code body optional in the syntax for maxwait for compatibility with reactor-uc.