### PR TITLE
Avoid copying type for Python

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CEnclavedReactorTransformation.java
+++ b/core/src/main/java/org/lflang/generator/c/CEnclavedReactorTransformation.java
@@ -250,7 +250,9 @@ public class CEnclavedReactorTransformation implements AstTransformation {
     Reactor def = createEnclaveConnectionClass();
     Instantiation inst = factory.createInstantiation();
     inst.setReactorClass(def);
-    inst.getTypeArgs().add(EcoreUtil.copy(type));
+    if (type != null) {
+      inst.getTypeArgs().add(EcoreUtil.copy(type));
+    }
 
     Assignment hasAfterDelayAssignment = factory.createAssignment();
     hasAfterDelayAssignment.setLhs(getParameter(def, hasAfterDelayParamName));


### PR DESCRIPTION
This fixes LSP test errors that were introduced by the extended support for enclaves.
Specifically, this takes into account that Python does not have types.