### PR TITLE
Use same list for length and access

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/TypeParameterizedReactor.java
+++ b/core/src/main/java/org/lflang/generator/c/TypeParameterizedReactor.java
@@ -95,7 +95,7 @@ public class TypeParameterizedReactor {
       Instantiation instantiation, TypeParameterizedReactor parent, List<String> typeParams) {
     HashMap<String, Type> ret = new HashMap<>();
     if (instantiation.getTypeArgs() != null) {
-      for (int i = 0; i < instantiation.getTypeArgs().size(); i++) {
+      for (int i = 0; i < instantiation.getTypeArgs().size() && i < typeParams.size(); i++) {
         var arg = instantiation.getTypeArgs().get(i);
         ret.put(typeParams.get(i), parent == null ? arg : parent.resolveType(arg));
       }


### PR DESCRIPTION
This PR checked array boundaries before accessing them. In an untyped language (Python), these array sizes may not match.