### PR TITLE
Support enclaves in Python target

### DIFF
--- a/core/src/integrationTest/java/org/lflang/tests/runtime/PythonTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/PythonTest.java
@@ -50,6 +50,11 @@ public class PythonTest extends RuntimeTest {
     return true;
   }
 
+  @Override
+  protected boolean supportsEnclaves() {
+    return true;
+  }
+
   @Test
   @Override
   public void runBasicTests() {

--- a/test/Python/src/enclave/EnclaveBlockingReaction.lf
+++ b/test/Python/src/enclave/EnclaveBlockingReaction.lf
@@ -1,0 +1,44 @@
+/** Test that a blocking reaction in one enclave does not block the main enclave. */
+target Python {
+  keepalive: true,
+  timeout: 2 sec
+}
+
+preamble {=
+  import time
+=}
+
+reactor BlockingReactor {
+  output out
+  timer t(0, 1 s)
+
+  reaction(t) -> out {=
+    print("Blocking reactor invoked")
+    time.sleep(1); # Simulate blocking
+    print("Blocking reactor sending output")
+    out.set(42)
+  =}
+}
+
+reactor Print {
+  input inp
+
+  reaction(inp) {=
+    print("Print reactor received enclave output at tag (", lf.time.logical_elapsed(), ", ", lf.tag().microstep, ")")
+  =}
+}
+
+main reactor {
+  timer t(0, 100 ms)
+  @enclave
+  blocking = new BlockingReactor()
+  print = new Print()
+  blocking.out ~> print.inp
+
+  reaction(t) {=
+    print("Tick at tag (", lf.time.logical_elapsed(), ", ", lf.tag().microstep, ")")
+  =} deadline(300 ms) {=
+    print("Main reactor deadline was violated!")
+    exit(1)
+  =}
+}

--- a/test/Python/src/enclave/EnclaveRequestStop.lf
+++ b/test/Python/src/enclave/EnclaveRequestStop.lf
@@ -1,0 +1,26 @@
+target Python {
+  timeout: 10 sec,
+  keepalive: true
+}
+
+reactor Stop(stop_time = 5 s) {
+  timer t(stop_time)
+
+  reaction(t) {=
+    request_stop()
+  =}
+
+  reaction(shutdown) {=
+    print("Stopped at tag ({}, {})".format(lf.time.logical_elapsed(), lf.tag().microstep))
+    if lf.time.logical_elapsed() != 50000000 or lf.tag().microstep != 1:
+        sys.stderr.write("Expected stop tag to be (50ms, 1).")
+        sys.exit(1)
+  =}
+}
+
+main reactor {
+  @enclave
+  s1 = new Stop(stop_time = 5 s)
+  @enclave
+  s2 = new Stop(stop_time = 50 ms)
+}


### PR DESCRIPTION
This is a start on supporting enclaves in the Python target.
This is not ready for review.
For now, it just adds tests that are failing because the enclave connector reactor that gets added has C code in it rather than Python code. This will need to be fixed.