### PR TITLE
Free disk space for Zephyr tests

### DIFF
--- a/.github/workflows/c-zephyr-tests.yml
+++ b/.github/workflows/c-zephyr-tests.yml
@@ -21,6 +21,16 @@ jobs:
   zephyr-tests:
     runs-on: ubuntu-24.04
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - name: Check out lingua-franca repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The Zephyr tests are running out of disk space. This PR modifies the workflow to free disk space, removing a bunch of unnecessary junk before running the tests.