### PR TITLE
Relativize trace-plugin paths for federated builds

### DIFF
--- a/core/src/main/java/org/lflang/federated/generator/FederationFileConfig.java
+++ b/core/src/main/java/org/lflang/federated/generator/FederationFileConfig.java
@@ -11,6 +11,7 @@ import org.lflang.target.property.CmakeIncludeProperty;
 import org.lflang.target.property.CmakeInitIncludeProperty;
 import org.lflang.target.property.FilesProperty;
 import org.lflang.target.property.ProtobufsProperty;
+import org.lflang.target.property.TracePluginProperty;
 import org.lflang.util.FileUtil;
 
 /**
@@ -100,6 +101,29 @@ public class FederationFileConfig extends FileConfig {
                 p.override(targetConfig, relativizePathList(targetConfig.get(p)));
               }
             });
+
+    // Handle TracePluginProperty separately since it uses TracePluginSpec, not List<String>.
+    if (targetConfig.isSet(TracePluginProperty.INSTANCE)) {
+      var spec = targetConfig.get(TracePluginProperty.INSTANCE);
+      if (spec != null && spec.paths != null && !spec.paths.isBlank()) {
+        spec.paths = relativizeSemicolonSeparatedPaths(spec.paths);
+        TracePluginProperty.INSTANCE.override(targetConfig, spec);
+      }
+    }
+  }
+
+  /**
+   * Relativize each segment of a semicolon-separated path list (CMake list syntax).
+   *
+   * @param cmakePathList Semicolon-separated paths to relativize.
+   */
+  private String relativizeSemicolonSeparatedPaths(String cmakePathList) {
+    String[] segments = cmakePathList.split(";");
+    List<String> result = new ArrayList<>();
+    for (String segment : segments) {
+      result.add(relativizePath(Paths.get(segment.trim())));
+    }
+    return String.join(";", result);
   }
 
   /**


### PR DESCRIPTION
## Summary
- `FederationFileConfig.relativizePaths()` did not handle `TracePluginProperty`, causing the trace-plugin `path` field to be resolved against the wrong base directory in federated builds.
- When `lfc` compiles a `federated reactor`, it generates per-federate `.lf` files under `fed-gen/`. The relative path from the original `.lf` file (e.g., `../../install/`) was carried through unchanged. Later, `CCmakeGenerator.absolutizeCmakePathList()` resolved it against the federate's source directory instead of the original source directory, producing an incorrect absolute path.
- This adds `TracePluginProperty` handling to `relativizePaths()`, re-relativizing semicolon-separated CMake path lists so they remain valid from the `fed-gen` source directory.

## Test plan
- [x] Compile and run a federated LF program with `trace-plugin: { path: "..." }` using `lfc-dev`
- [ ] Verify the generated `CMakeLists.txt` under `fed-gen/` contains the correct absolute path for `LF_TRACE_PLUGIN_PATHS`
- [x] CI: https://github.com/lf-lang/lf-trace-xronos (federated trace plugin tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)