### PR TITLE
Fix bug with overridden parameters and enable the `cmake-args` target property in Python.

### DIFF
--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -42,6 +42,8 @@ import org.lflang.lf.Reactor;
 import org.lflang.lf.VarRef;
 import org.lflang.lf.WidthSpec;
 import org.lflang.target.Target;
+import org.lflang.target.TargetConfig;
+import org.lflang.target.property.CmakeArgsProperty;
 import org.lflang.target.property.DockerProperty;
 import org.lflang.target.property.ProtobufsProperty;
 import org.lflang.target.property.PythonVersionProperty;
@@ -89,7 +91,7 @@ public class PythonGenerator extends CGenerator implements CCmakeGenerator.SetUp
                 "lib/python_time.c",
                 "lib/pythontarget.c"),
             null, // Temporarily, because can't pass this.
-            generateCmakeInstall(context.getFileConfig())));
+            generateCmakeInstall(context.getFileConfig(), context.getTargetConfig())));
     cmakeGenerator.setCmakeGenerator(this);
   }
 
@@ -681,19 +683,29 @@ public class PythonGenerator extends CGenerator implements CCmakeGenerator.SetUp
       pythonVersion = targetConfig.get(PythonVersionProperty.INSTANCE) + " EXACT";
     }
     return ("""
-            set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-            add_compile_definitions(_PYTHON_TARGET_ENABLED)
-            add_subdirectory(core)
-            set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
-            set(LF_MAIN_TARGET <pyModuleName>)
-            set(Python_FIND_VIRTUALENV FIRST)
-            set(Python_FIND_STRATEGY LOCATION)
-            set(Python_FIND_FRAMEWORK LAST)
-            find_package(Python <pyVersion> REQUIRED COMPONENTS Interpreter Development)
-            Python_add_library(
-                ${LF_MAIN_TARGET}
-                MODULE
-            """
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+add_compile_definitions(_PYTHON_TARGET_ENABLED)
+add_subdirectory(core)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
+set(LF_MAIN_TARGET <pyModuleName>)
+set(Python_FIND_VIRTUALENV FIRST)
+set(Python_FIND_STRATEGY LOCATION)
+set(Python_FIND_FRAMEWORK LAST)
+# If Python_EXECUTABLE is a bare command name (e.g. mjpython), resolve it before
+# FindPython runs; otherwise FindPython may search PATH and pick another interpreter.
+if(Python_EXECUTABLE)
+  get_filename_component(_lf_python_exe_parent "${Python_EXECUTABLE}" DIRECTORY)
+  if(_lf_python_exe_parent STREQUAL "")
+    find_program(_lf_python_exe_resolved NAMES "${Python_EXECUTABLE}" REQUIRED)
+    set(Python_EXECUTABLE "${_lf_python_exe_resolved}" CACHE FILEPATH "Python interpreter" FORCE)
+    unset(_lf_python_exe_resolved)
+  endif()
+endif()
+find_package(Python <pyVersion> REQUIRED COMPONENTS Interpreter Development)
+Python_add_library(
+    ${LF_MAIN_TARGET}
+    MODULE
+"""
             + cSources.collect(Collectors.joining("\n    ", "    ", "\n"))
             + """
 )
@@ -714,30 +726,60 @@ target_compile_definitions(${LF_MAIN_TARGET} PUBLIC MODULE_NAME=<pyModuleName>)
     // The use of fileConfig.name will break federated execution, but that's fine
   }
 
-  private static String generateCmakeInstall(FileConfig fileConfig) {
+  /**
+   * Escape a string for embedding in a CMake double-quoted string literal.
+   */
+  private static String escapeForCmakeDoubleQuotedString(String value) {
+    return value.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
+  /**
+   * CMake {@code set(LF_USER_PYTHON_LAUNCHER ...)} line: non-empty when the user set {@code
+   * Python_EXECUTABLE} in {@code cmake-args}, so install scripts keep that exact command (e.g.
+   * {@code mjpython}) instead of whatever path FindPython canonicalizes to.
+   */
+  private static String cmakeUserPythonLauncherLine(TargetConfig targetConfig) {
+    String userPy = targetConfig.getOrDefault(CmakeArgsProperty.INSTANCE).get("Python_EXECUTABLE");
+    if (userPy != null && !userPy.isBlank()) {
+      return "set(LF_USER_PYTHON_LAUNCHER \""
+          + escapeForCmakeDoubleQuotedString(userPy.strip())
+          + "\")";
+    }
+    return "set(LF_USER_PYTHON_LAUNCHER \"\")";
+  }
+
+  private static String generateCmakeInstall(FileConfig fileConfig, TargetConfig targetConfig) {
     final var pyMainPath =
         fileConfig.getSrcGenPath().resolve(fileConfig.name + ".py").toAbsolutePath();
     // need to replace '\' with '\\' on Windwos for proper escaping in cmake
     final var pyMainName = pyMainPath.toString().replace("\\", "\\\\");
+    final var userLauncherLine = cmakeUserPythonLauncherLine(targetConfig);
     return """
   if (NOT DEFINED CMAKE_INSTALL_BINDIR)
     set(CMAKE_INSTALL_BINDIR "bin")
+  endif()
+  <userLauncherLine>
+  if(LF_USER_PYTHON_LAUNCHER STREQUAL "")
+    set(LF_PY_FOR_LAUNCHER "${Python_EXECUTABLE}")
+  else()
+    set(LF_PY_FOR_LAUNCHER "${LF_USER_PYTHON_LAUNCHER}")
   endif()
   if(WIN32)
     file(GENERATE OUTPUT <fileName>.bat CONTENT
       "@echo off
 \
-      ${Python_EXECUTABLE} <pyMainName> %*"
+      ${LF_PY_FOR_LAUNCHER} <pyMainName> %*"
     )
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/<fileName>.bat DESTINATION ${CMAKE_INSTALL_BINDIR})
   else()
     file(GENERATE OUTPUT <fileName> CONTENT
         "#!/bin/sh\\n\\
-        ${Python_EXECUTABLE} <pyMainName> \\"$@\\""
+        ${LF_PY_FOR_LAUNCHER} <pyMainName> \\"$@\\""
     )
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/<fileName> DESTINATION ${CMAKE_INSTALL_BINDIR})
   endif()
 """
+        .replace("<userLauncherLine>", userLauncherLine)
         .replace("<fileName>", fileConfig.name)
         .replace("<pyMainName>", pyMainName);
   }

--- a/core/src/main/java/org/lflang/generator/python/PythonParameterGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonParameterGenerator.java
@@ -1,6 +1,7 @@
 package org.lflang.generator.python;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import org.lflang.ast.ASTUtils;
 import org.lflang.generator.ParameterInstance;
@@ -82,7 +83,14 @@ public class PythonParameterGenerator {
    * @return The list of all parameters of 'decl'
    */
   private static List<Parameter> getAllParameters(ReactorDecl decl) {
-    return ASTUtils.allParameters(ASTUtils.toDefinition(decl));
+    // Deduplicate parameters by name, keeping the most-derived class's override.
+    // ASTUtils.allParameters() returns base class parameters first, so later puts
+    // (from derived classes) overwrite earlier ones.
+    var unique = new LinkedHashMap<String, Parameter>();
+    for (Parameter p : ASTUtils.allParameters(ASTUtils.toDefinition(decl))) {
+      unique.put(p.getName(), p);
+    }
+    return new ArrayList<>(unique.values());
   }
 
   /**

--- a/core/src/main/java/org/lflang/generator/python/PythonReactorGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonReactorGenerator.java
@@ -1,6 +1,7 @@
 package org.lflang.generator.python;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import org.lflang.ast.ASTUtils;
 import org.lflang.generator.CodeBuilder;
@@ -178,8 +179,13 @@ public class PythonReactorGenerator {
     CodeBuilder code = new CodeBuilder();
     code.pr(PyUtil.reactorRef(instance) + " = _" + className + "(");
     code.indent();
-    boolean hasBankIndexParameter = false;
+    // Deduplicate parameters by name, keeping the most-derived class's override.
+    var deduped = new LinkedHashMap<String, ParameterInstance>();
     for (ParameterInstance param : instance.parameters) {
+      deduped.put(param.getName(), param);
+    }
+    boolean hasBankIndexParameter = false;
+    for (ParameterInstance param : deduped.values()) {
       if (param.getName().equals("bank_index")) {
         if (param.getOverride() != null) hasBankIndexParameter = true;
         else continue; // Skip bank_index if it is not explicitly set

--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -592,6 +592,7 @@ public enum Target {
               BuildTypeProperty.INSTANCE,
               ClockSyncModeProperty.INSTANCE,
               ClockSyncOptionsProperty.INSTANCE,
+              CmakeArgsProperty.INSTANCE,
               CmakeIncludeProperty.INSTANCE,
               CompileDefinitionsProperty.INSTANCE,
               CoordinationOptionsProperty.INSTANCE,

--- a/core/src/main/java/org/lflang/target/property/CmakeArgsProperty.java
+++ b/core/src/main/java/org/lflang/target/property/CmakeArgsProperty.java
@@ -64,4 +64,9 @@ public final class CmakeArgsProperty
   public String name() {
     return "cmake-args";
   }
+
+  @Override
+  public boolean loadFromImport() {
+    return true;
+  }
 }

--- a/core/src/main/java/org/lflang/target/property/CompileDefinitionsProperty.java
+++ b/core/src/main/java/org/lflang/target/property/CompileDefinitionsProperty.java
@@ -63,4 +63,9 @@ public final class CompileDefinitionsProperty
   public String name() {
     return "compile-definitions";
   }
+
+  @Override
+  public boolean loadFromImport() {
+    return true;
+  }
 }

--- a/test/Python/src/ParameterOverride.lf
+++ b/test/Python/src/ParameterOverride.lf
@@ -1,0 +1,16 @@
+target Python
+
+reactor A(x=0) {
+  reaction(startup) {=
+    if self.x != 1:
+      print(f"x is {self.x}. Should be 1.")
+      exit(1)
+  =}
+}
+
+reactor B(x=1) extends A {
+}
+
+main reactor {
+  b = new B()
+}


### PR DESCRIPTION
This PR fixes a bug where when a subclass definition overrides a parameter value, the parameter shows up twice, as if it were two parameters with the same name. This apparently caused no difficulty in the C target, but created errors in the Python target. This PR adds a test and a fix.

This PR also enables the `cmake-args` target parameter for the Python target and ensures that if you import a file that defines this target parameter, then cmake will get the parameter without having to give the target parameter again in the main file.