### PR TITLE
Add support for reactor-uc attributes to the validator (for the VS Code plugin).

### DIFF
--- a/core/src/main/java/org/lflang/AttributeUtils.java
+++ b/core/src/main/java/org/lflang/AttributeUtils.java
@@ -209,40 +209,40 @@ public class AttributeUtils {
   }
 
   /**
-   * Return the declared label of the node, as given by the `@label` annotation.
+   * Return the declared label of the node, as given by the `@label` attribute.
    *
    * @param node The node to get the label from.
-   * @return The label of the node or null if there is no such annotation.
+   * @return The label of the node or null if there is no such attribute.
    */
   public static String getLabel(EObject node) {
     return getAttributeValue(node, "label");
   }
 
   /**
-   * Return the declared icon of the node, as given by the `@icon` annotation, or null if there is no
-   * such annotation.
+   * Return the declared icon of the node, as given by the `@icon` attribute, or null if there is no
+   * such attribute.
    *
    * @param node The node to get the icon path from.
-   * @return The icon path of the node or null if there is no such annotation.
+   * @return The icon path of the node or null if there is no such attribute.
    */
   public static String getIconPath(EObject node) {
     return getAttributeValue(node, "icon");
   }
 
   /**
-   * Return the `@side` annotation for the given node (presumably a port) or null if there is
-   * no such annotation.
+   * Return the `@side` attribute for the given node (presumably a port) or null if there is
+   * no such attribute.
    *
    * @param node The node to get the port side from.
-   * @return The port side of the node or null if there is no such annotation.
+   * @return The port side of the node or null if there is no such attribute.
    */
   public static String getPortSide(EObject node) {
     return getAttributeValue(node, "side");
   }
 
   /**
-   * Return the layout annotations for the given element or null if there is no such annotation.
-   * Layout annotations have the form:
+   * Return the layout attributes for the given element or null if there is no such attribute.
+   * Layout attributes have the form:
    *
    * <pre>{@code
    * @layout(option="string", value="any")
@@ -254,7 +254,7 @@ public class AttributeUtils {
    * @layout(option="port.side", value="WEST")
    * }</pre>
    *
-   * This will return all such annotations for the specified node in the form of a map from the option
+   * This will return all such attributes for the specified node in the form of a map from the option
    * name to the value.
    */
   public static Map<String, String> getLayoutOption(EObject node) {

--- a/core/src/main/java/org/lflang/validation/AttributeSpec.java
+++ b/core/src/main/java/org/lflang/validation/AttributeSpec.java
@@ -275,6 +275,44 @@ public class AttributeSpec {
                 new AttrParamSpec("expect", AttrParamType.BOOLEAN, true))));
     ATTRIBUTE_SPECS_BY_NAME.put("_c_body", new AttributeSpec(null));
 
+    // @build_type("value") - e.g. @build_type("DEBUG") or @build_type("RELEASE")
+    ATTRIBUTE_SPECS_BY_NAME.put(
+        "build_type",
+        new AttributeSpec(List.of(new AttrParamSpec(VALUE_ATTR, AttrParamType.STRING, false))));
+    // @logging("value") - e.g. @logging("WARN")
+    ATTRIBUTE_SPECS_BY_NAME.put(
+        "logging",
+        new AttributeSpec(List.of(new AttrParamSpec(VALUE_ATTR, AttrParamType.STRING, false))));
+    // @timeout(value) - e.g. @timeout(10 sec)
+    ATTRIBUTE_SPECS_BY_NAME.put(
+        "timeout",
+        new AttributeSpec(List.of(new AttrParamSpec(VALUE_ATTR, AttrParamType.TIME, false))));
+    // @fast(value) - e.g. @fast(true)
+    ATTRIBUTE_SPECS_BY_NAME.put(
+        "fast",
+        new AttributeSpec(List.of(new AttrParamSpec(VALUE_ATTR, AttrParamType.BOOLEAN, false))));
+    // @keepalive(value) - e.g. @keepalive(true)
+    ATTRIBUTE_SPECS_BY_NAME.put(
+        "keepalive",
+        new AttributeSpec(List.of(new AttrParamSpec(VALUE_ATTR, AttrParamType.BOOLEAN, false))));
+    // @clock_sync("value") - simple form: @clock_sync("on") or @clock_sync("off")
+    // detailed form: @clock_sync(grandmaster=true, period=3500000000, max_adj=512000, kp=0.5,
+    // ki=0.1)
+    ATTRIBUTE_SPECS_BY_NAME.put(
+        "clock_sync",
+        new AttributeSpec(
+            List.of(
+                new AttrParamSpec(VALUE_ATTR, AttrParamType.STRING, true),
+                new AttrParamSpec("grandmaster", AttrParamType.BOOLEAN, true),
+                new AttrParamSpec("period", AttrParamType.BIGINT, true),
+                new AttrParamSpec("max_adj", AttrParamType.BIGINT, true),
+                new AttrParamSpec("kp", AttrParamType.FLOAT, true),
+                new AttrParamSpec("ki", AttrParamType.FLOAT, true))));
+    // @platform("value") - e.g. @platform("NATIVE")
+    ATTRIBUTE_SPECS_BY_NAME.put(
+        "platform",
+        new AttributeSpec(List.of(new AttrParamSpec(VALUE_ATTR, AttrParamType.STRING, false))));
+
     // Attributes used internally only by the federated code generation
     ATTRIBUTE_SPECS_BY_NAME.put("_fed_config", new AttributeSpec(List.of()));
     // Marker for total port order (TPO) levels.

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -1354,6 +1354,9 @@ public class LFValidator extends BaseLFValidator {
     } else if (name.equals("absent_after")) {
       checkAbsentAfterAttribute(attr);
     }
+    if (GLOBAL_ANNOTATION_NAMES.contains(name)) {
+      checkGlobalAnnotation(attr);
+    }
   }
 
   private void checkMaxWaitAttribute(Attribute attr) {
@@ -1372,6 +1375,26 @@ public class LFValidator extends BaseLFValidator {
           attr,
           Literals.ATTRIBUTE__ATTR_NAME);
       return;
+    }
+  }
+
+  private void checkGlobalAnnotation(Attribute attr) {
+    var container = attr.eContainer();
+    if (!(container instanceof Reactor)) {
+      error(
+          "The @"
+              + attr.getAttrName()
+              + " annotation is only allowed on a main or federated reactor.",
+          Literals.ATTRIBUTE__ATTR_NAME);
+      return;
+    }
+    Reactor reactor = (Reactor) container;
+    if (!reactor.isMain() && !reactor.isFederated()) {
+      error(
+          "The @"
+              + attr.getAttrName()
+              + " annotation is only allowed on a main or federated reactor.",
+          Literals.ATTRIBUTE__ATTR_NAME);
     }
   }
 
@@ -2073,6 +2096,9 @@ public class LFValidator extends BaseLFValidator {
   private static String RESERVED_MESSAGE =
       "Reserved words in the target language are not allowed for objects (inputs, outputs, actions,"
           + " timers, parameters, state, reactor definitions, and reactor instantiation): ";
+
+  private static final Set<String> GLOBAL_ANNOTATION_NAMES =
+      Set.of("build_type", "logging", "timeout", "fast", "keepalive", "clock_sync", "platform");
 
   private static List<String> SPACING_VIOLATION_POLICIES =
       List.of("defer", "drop", "replace", "update");

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -1354,8 +1354,8 @@ public class LFValidator extends BaseLFValidator {
     } else if (name.equals("absent_after")) {
       checkAbsentAfterAttribute(attr);
     }
-    if (GLOBAL_ANNOTATION_NAMES.contains(name)) {
-      checkGlobalAnnotation(attr);
+    if (GLOBAL_ATTRIBUTE_NAMES.contains(name)) {
+      checkGlobalAttribute(attr);
     }
   }
 
@@ -1378,13 +1378,13 @@ public class LFValidator extends BaseLFValidator {
     }
   }
 
-  private void checkGlobalAnnotation(Attribute attr) {
+  private void checkGlobalAttribute(Attribute attr) {
     var container = attr.eContainer();
     if (!(container instanceof Reactor)) {
       error(
           "The @"
               + attr.getAttrName()
-              + " annotation is only allowed on a main or federated reactor.",
+              + " attribute is only allowed on a main or federated reactor.",
           Literals.ATTRIBUTE__ATTR_NAME);
       return;
     }
@@ -1393,7 +1393,7 @@ public class LFValidator extends BaseLFValidator {
       error(
           "The @"
               + attr.getAttrName()
-              + " annotation is only allowed on a main or federated reactor.",
+              + " attribute is only allowed on a main or federated reactor.",
           Literals.ATTRIBUTE__ATTR_NAME);
     }
   }
@@ -2097,7 +2097,7 @@ public class LFValidator extends BaseLFValidator {
       "Reserved words in the target language are not allowed for objects (inputs, outputs, actions,"
           + " timers, parameters, state, reactor definitions, and reactor instantiation): ";
 
-  private static final Set<String> GLOBAL_ANNOTATION_NAMES =
+  private static final Set<String> GLOBAL_ATTRIBUTE_NAMES =
       Set.of("build_type", "logging", "timeout", "fast", "keepalive", "clock_sync", "platform");
 
   private static List<String> SPACING_VIOLATION_POLICIES =


### PR DESCRIPTION
To ensure that the 0.12.0 VSCode plugin works with reactor-uc, this PR adds reactor-uc-specific annotation checks to the validator. Here's a summary of the changes:

### `AttributeSpec.java` — New attribute specs added

Seven new annotations registered in `ATTRIBUTE_SPECS_BY_NAME`:

| Annotation | Parameter Type | Example |
|---|---|---|
| `@build_type` | STRING (required) | `@build_type("DEBUG")` |
| `@logging` | STRING (required) | `@logging("WARN")` |
| `@timeout` | TIME (required) | `@timeout(10 sec)` |
| `@fast` | BOOLEAN (required) | `@fast(true)` |
| `@keepalive` | BOOLEAN (required) | `@keepalive(true)` |
| `@clock_sync` | STRING (optional `value`) + optional detailed params (`grandmaster`, `period`, `max_adj`, `kp`, `ki`) | `@clock_sync("on")` or `@clock_sync(grandmaster=true, period=3500000000)` |
| `@platform` | STRING (required) | `@platform("NATIVE")` |

For `@clock_sync`, both the simple form (`@clock_sync("on")`) and the detailed form with named parameters are supported, with all parameters optional to allow either usage.

### `LFValidator.java` — Global annotation restriction

- Added a `GLOBAL_ANNOTATION_NAMES` set containing all seven annotation names.
- Added `checkGlobalAnnotation(Attribute)` which verifies the attribute's container is a `Reactor` that is either `main` or `federated`. If not, it reports an error.
- The `checkAttributes` method now calls `checkGlobalAnnotation` for any attribute whose name is in the global set.
