### PR TITLE
Import top-level preamble of all imported files

### DIFF
--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -2199,18 +2199,39 @@ public class CGenerator extends GeneratorBase {
   /**
    * Generate guarded preamble code for the given file (Model container) if not already visited.
    *
+   * <p>In addition to emitting the preambles declared in the file itself, this also recursively
+   * emits the preambles of every file imported (directly or transitively) by this file. This
+   * ensures that type and macro definitions from a preamble in an imported file are visible to all
+   * reactors defined in the importing file, not just reactors that happen to instantiate something
+   * from the imported file.
+   *
    * @param fileContainer The eContainer of a reactor (the Model/file containing it).
    * @param visited Set of already-visited containers to avoid duplicates.
    * @param builder The CodeBuilder to append the preamble to.
    */
   private void generatePreambleForFile(
       EObject fileContainer, Set<EObject> visited, CodeBuilder builder) {
-    if (visited.contains(fileContainer)) {
+    if (visited.contains(fileContainer) || !(fileContainer instanceof Model model)) {
       return;
     }
     visited.add(fileContainer);
 
-    var preambles = ((Model) fileContainer).getPreambles();
+    // First, recursively emit preambles of files imported by this file. A preamble declared
+    // at the top level of an imported file should be visible to every reactor defined in this
+    // file, mirroring the way imported type names are resolved by the scope provider.
+    for (var imp : model.getImports()) {
+      for (var importedReactor : imp.getReactorClasses()) {
+        var resolved = importedReactor.getReactorClass();
+        if (resolved != null) {
+          var importedFile = resolved.eContainer();
+          if (importedFile != null) {
+            generatePreambleForFile(importedFile, visited, builder);
+          }
+        }
+      }
+    }
+
+    var preambles = model.getPreambles();
     var hasPreamble =
         !preambles.isEmpty() || targetConfig.get(ProtobufsProperty.INSTANCE).size() > 0;
     if (!hasPreamble) {

--- a/test/C/src/ImportedType.lf
+++ b/test/C/src/ImportedType.lf
@@ -1,0 +1,24 @@
+target C
+
+import Imported from "lib/Imported.lf"
+
+reactor Test {
+  state s: foo_t
+
+  reaction(startup) {=
+    self->s.foo = 42;
+    lf_print("s.foo is %f", self->s.foo);
+  =}
+}
+
+main reactor {
+  state s: foo_t
+
+  a = new Imported()
+  b = new Test()
+
+  reaction(startup) {=
+    self->s.foo = 42;
+    lf_print("s.foo is %f", self->s.foo);
+  =}
+}

--- a/test/C/src/lib/ImportedAgain.lf
+++ b/test/C/src/lib/ImportedAgain.lf
@@ -2,6 +2,13 @@
 // reactor definition.
 target C
 
+preamble {=
+  // Test that type definitions are visible when this is imported.
+  typedef struct {
+    double foo;
+  } foo_t;
+=}
+
 reactor ImportedAgain {
   input x: int
 


### PR DESCRIPTION
This PR ensures that if a file X imports another file that has a top-level preamble, then that top-level preamble's definitions are available in all reactors defined in file X.  It adds a test.