### PR TITLE
Support Protobufs serialization and deserialization in the C and CCpp targets

### DIFF
--- a/core/src/main/java/org/lflang/ast/ASTUtils.java
+++ b/core/src/main/java/org/lflang/ast/ASTUtils.java
@@ -534,7 +534,7 @@ public class ASTUtils {
    *
    * @param definition The reactor definition.
    * @param feature The structural feature to collect.
-   * @param <T> The type of elements to collect (e.g., Port, Timer, etc.)
+   * @tparam <T> The type of elements to collect (e.g., Port, Timer, etc.)
    * @return A list of all elements of type T found
    */
   public static <T extends EObject> List<T> collectElements(
@@ -550,7 +550,7 @@ public class ASTUtils {
    * @param feature The structual model elements to collect.
    * @param includeSuperClasses Whether to include elements in super classes.
    * @param includeModes Whether to include elements in modes.
-   * @param <T> The type of elements to collect (e.g., Port, Timer, etc.)
+   * @tparam <T> The type of elements to collect (e.g., Port, Timer, etc.)
    * @return A list of all elements of type T found
    */
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/lflang/federated/extensions/CExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtension.java
@@ -193,7 +193,7 @@ public class CExtension implements FedTargetExtension {
       case PROTO -> {
         var portType = ASTUtils.getInferredType(((Port) receivingPort.getVariable()));
         var portTypeStr = types.getTargetType(portType);
-        if (!CUtil.isTokenType(portType)) {
+        if (!CUtil.isPointerType(portType)) {
           messageReporter
               .at(receivingPort.getVariable())
               .error(
@@ -432,7 +432,7 @@ public class CExtension implements FedTargetExtension {
       }
       case PROTO -> {
         var typeStr = types.getTargetType(type);
-        if (!CUtil.isTokenType(type)) {
+        if (!CUtil.isPointerType(type)) {
           messageReporter
               .nowhere()
               .error(

--- a/core/src/main/java/org/lflang/federated/extensions/CExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtension.java
@@ -193,9 +193,14 @@ public class CExtension implements FedTargetExtension {
       case PROTO -> {
         var portType = ASTUtils.getInferredType(((Port) receivingPort.getVariable()));
         var portTypeStr = types.getTargetType(portType);
-        if (CUtil.isTokenType(portType) || CUtil.isFixedSizeArrayType(portType)) {
-          throw new UnsupportedOperationException(
-              "Cannot handle protobuf serialization when ports are pointers or arrays.");
+        if (!CUtil.isTokenType(portType)) {
+          messageReporter
+              .at(receivingPort.getVariable())
+              .error(
+                  "Protobuf serialization requires a pointer-typed port (e.g. 'MyMessage*'). "
+                      + "Found type: "
+                      + portTypeStr);
+          return;
         }
         var protoDeserializer = new FedProtoCSerialization();
         result.pr(
@@ -427,9 +432,14 @@ public class CExtension implements FedTargetExtension {
       }
       case PROTO -> {
         var typeStr = types.getTargetType(type);
-        if (CUtil.isTokenType(type) || CUtil.isFixedSizeArrayType(type)) {
-          throw new UnsupportedOperationException(
-              "Cannot handle protobuf serialization when ports are pointers or arrays.");
+        if (!CUtil.isTokenType(type)) {
+          messageReporter
+              .nowhere()
+              .error(
+                  "Protobuf serialization requires a pointer-typed port (e.g. 'MyMessage*'). "
+                      + "Found type: "
+                      + typeStr);
+          return;
         }
         var protoSerializer = new FedProtoCSerialization();
         lengthExpression = protoSerializer.serializedBufferLength();

--- a/core/src/main/java/org/lflang/federated/extensions/CExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtension.java
@@ -17,7 +17,9 @@ import org.lflang.federated.generator.FedConnectionInstance;
 import org.lflang.federated.generator.FederateInstance;
 import org.lflang.federated.generator.FederationFileConfig;
 import org.lflang.federated.launcher.RtiConfig;
+import org.lflang.federated.serialization.FedProtoCSerialization;
 import org.lflang.federated.serialization.FedROS2CPPSerialization;
+import org.lflang.federated.serialization.FedSerialization;
 import org.lflang.generator.ActionInstance;
 import org.lflang.generator.CodeBuilder;
 import org.lflang.generator.LFGeneratorContext;
@@ -188,8 +190,19 @@ public class CExtension implements FedTargetExtension {
           }
         }
       }
-      case PROTO ->
-          throw new UnsupportedOperationException("Protobuf serialization is not supported yet.");
+      case PROTO -> {
+        var portType = ASTUtils.getInferredType(((Port) receivingPort.getVariable()));
+        var portTypeStr = types.getTargetType(portType);
+        if (CUtil.isTokenType(portType) || CUtil.isFixedSizeArrayType(portType)) {
+          throw new UnsupportedOperationException(
+              "Cannot handle protobuf serialization when ports are pointers or arrays.");
+        }
+        var protoDeserializer = new FedProtoCSerialization();
+        result.pr(
+            protoDeserializer.generateNetworkDeserializerCode(
+                "self->_lf__" + action.getName(), portTypeStr));
+        result.pr(protoDeserializer.generatePortAssignmentCode(receiveRef));
+      }
       case ROS2 -> {
         var portType = ASTUtils.getInferredType(((Port) receivingPort.getVariable()));
         var portTypeStr = types.getTargetType(portType);
@@ -412,8 +425,20 @@ public class CExtension implements FedTargetExtension {
           result.pr(sendingFunction + "(" + commonArgs + ", " + pointerExpression + ");");
         }
       }
-      case PROTO ->
-          throw new UnsupportedOperationException("Protobuf serialization is not supported yet.");
+      case PROTO -> {
+        var typeStr = types.getTargetType(type);
+        if (CUtil.isTokenType(type) || CUtil.isFixedSizeArrayType(type)) {
+          throw new UnsupportedOperationException(
+              "Cannot handle protobuf serialization when ports are pointers or arrays.");
+        }
+        var protoSerializer = new FedProtoCSerialization();
+        lengthExpression = protoSerializer.serializedBufferLength();
+        pointerExpression = protoSerializer.serializedBufferVar();
+        result.pr(protoSerializer.generateNetworkSerializerCode(sendRef, typeStr));
+        result.pr("size_t _lf_message_length = " + lengthExpression + ";");
+        result.pr(sendingFunction + "(" + commonArgs + ", " + pointerExpression + ");");
+        result.pr("free(" + FedSerialization.serializedVarName + ");");
+      }
       case ROS2 -> {
         var typeStr = types.getTargetType(type);
         if (CUtil.isTokenType(type) || CUtil.isFixedSizeArrayType(type)) {

--- a/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
@@ -13,6 +13,7 @@ import org.lflang.ast.ASTUtils;
 import org.lflang.federated.generator.FederateInstance;
 import org.lflang.federated.generator.FederationFileConfig;
 import org.lflang.federated.launcher.RtiConfig;
+import org.lflang.federated.serialization.FedProtoCSerialization;
 import org.lflang.federated.serialization.FedROS2CPPSerialization;
 import org.lflang.federated.serialization.SupportedSerializers;
 import org.lflang.generator.CodeBuilder;
@@ -535,8 +536,12 @@ public class CExtensionUtils {
     CodeBuilder code = new CodeBuilder();
     for (SupportedSerializers serializer : federate.enabledSerializers) {
       switch (serializer) {
-        case NATIVE, PROTO -> {
+        case NATIVE -> {
           // No need to do anything at this point.
+        }
+        case PROTO -> {
+          var protoSerializer = new FedProtoCSerialization();
+          code.pr(protoSerializer.generatePreambleForSupport().toString());
         }
         case ROS2 -> {
           var ROSSerializer = new FedROS2CPPSerialization();

--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -663,7 +663,7 @@ public class FedASTUtils {
   /**
    * Return a null-safe List
    *
-   * @param <E> The type of the list
+   * @tparam <E> The type of the list
    * @param list The potentially null List
    * @return Empty list or the original list
    */

--- a/core/src/main/java/org/lflang/federated/serialization/FedProtoCSerialization.java
+++ b/core/src/main/java/org/lflang/federated/serialization/FedProtoCSerialization.java
@@ -1,0 +1,331 @@
+package org.lflang.federated.serialization;
+
+import org.lflang.generator.GeneratorBase;
+import org.lflang.target.Target;
+
+/**
+ * Enables support for Protocol Buffer serialization in C code using protobuf-c.
+ *
+ * @author Edward A. Lee
+ * @ingroup Federated
+ */
+public class FedProtoCSerialization implements FedSerialization {
+
+  /**
+   * Convert a protobuf message type name to the protobuf-c function prefix. For example, {@code
+   * Person} becomes {@code person} and {@code ProtoHelloWorld} becomes {@code proto_hello_world}.
+   */
+  public static String protobufCFunctionPrefix(String messageType) {
+    StringBuilder prefix = new StringBuilder();
+    for (int i = 0; i < messageType.length(); i++) {
+      char c = messageType.charAt(i);
+      if (Character.isUpperCase(c)) {
+        if (i > 0) {
+          prefix.append('_');
+        }
+        prefix.append(Character.toLowerCase(c));
+      } else {
+        prefix.append(c);
+      }
+    }
+    return prefix.toString();
+  }
+
+  @Override
+  public boolean isCompatible(GeneratorBase generator) {
+    if (generator.getTarget() != Target.C) {
+      generator
+          .messageReporter
+          .nowhere()
+          .error("Protobuf serialization is currently only supported for the C target.");
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String serializedBufferLength() {
+    return serializedVarName + "_length";
+  }
+
+  @Override
+  public String serializedBufferVar() {
+    return serializedVarName;
+  }
+
+  @Override
+  public StringBuilder generateNetworkSerializerCode(String varName, String originalType) {
+    String prefix = protobufCFunctionPrefix(originalType);
+    String valueRef = varName + "->value";
+    StringBuilder serializerCode = new StringBuilder();
+    serializerCode.append(
+        "if (((const ProtobufCMessage *)&"
+            + valueRef
+            + ")->descriptor == NULL) {\n");
+    serializerCode.append(
+        "    ProtobufCMessage *_lf_msg_base = (ProtobufCMessage *)&" + valueRef + ";\n");
+    serializerCode.append(
+        "    _lf_msg_base->descriptor = &" + prefix + "__descriptor;\n");
+    serializerCode.append("    _lf_msg_base->n_unknown_fields = 0;\n");
+    serializerCode.append("    _lf_msg_base->unknown_fields = NULL;\n");
+    serializerCode.append("}\n");
+    serializerCode.append(
+        "size_t "
+            + serializedVarName
+            + "_length = "
+            + prefix
+            + "__get_packed_size(&"
+            + valueRef
+            + ");\n");
+    serializerCode.append(
+        "unsigned char* "
+            + serializedVarName
+            + " = (unsigned char*)malloc("
+            + serializedVarName
+            + "_length);\n");
+    serializerCode.append("if (" + serializedVarName + " == NULL) {\n");
+    serializerCode.append(
+        "    lf_print_error_and_exit(\"Failed to allocate buffer for protobuf serialization.\");\n");
+    serializerCode.append("}\n");
+    serializerCode.append(prefix + "__pack(&" + valueRef + ", " + serializedVarName + ");\n");
+    return serializerCode;
+  }
+
+  @Override
+  public StringBuilder generateNetworkDeserializerCode(String varName, String targetType) {
+    String prefix = protobufCFunctionPrefix(targetType);
+    StringBuilder deserializerCode = new StringBuilder();
+    deserializerCode.append(
+        targetType + " *" + deserializedVarName + " = " + prefix + "__unpack(NULL, ");
+    deserializerCode.append(varName + ".tmplt.token->length, ");
+    deserializerCode.append("(uint8_t*)" + varName + ".tmplt.token->value);\n");
+    deserializerCode.append("if (" + deserializedVarName + " == NULL) {\n");
+    deserializerCode.append(
+        "    lf_print_error_and_exit(\"Could not deserialize protobuf message.\");\n");
+    deserializerCode.append("}\n");
+    return deserializerCode;
+  }
+
+  /**
+   * Generate code that copies a deserialized protobuf message into a port value.
+   *
+   * @param receiveRef A target language reference to the receiving port.
+   */
+  public StringBuilder generatePortAssignmentCode(String receiveRef) {
+    StringBuilder code = new StringBuilder();
+    code.append(
+        "lf_assign_protobuf_message(&"
+            + receiveRef
+            + "->value, (ProtobufCMessage*)"
+            + deserializedVarName
+            + ");\n");
+    code.append("lf_set_present(" + receiveRef + ");\n");
+    return code;
+  }
+
+  @Override
+  public StringBuilder generatePreambleForSupport() {
+    StringBuilder preamble = new StringBuilder();
+    preamble.append("#include <protobuf-c/protobuf-c.h>\n");
+    preamble.append("#include <string.h>\n");
+    preamble.append("#include <stdlib.h>\n");
+    preamble.append(
+        """
+        // Free heap-owned fields inside a stack-allocated protobuf message.
+        // Unlike protobuf_c_message_free_unpacked(), this does not free the message struct itself.
+        static void lf_free_protobuf_message_fields(ProtobufCMessage *message) {
+          const ProtobufCMessageDescriptor *desc;
+          unsigned f;
+
+          if (message == NULL || message->descriptor == NULL) {
+            return;
+          }
+          desc = message->descriptor;
+          for (f = 0; f < desc->n_fields; f++) {
+            if (0 != (desc->fields[f].flags & PROTOBUF_C_FIELD_FLAG_ONEOF) &&
+                desc->fields[f].id !=
+                    *(uint32_t *)((char *)message + desc->fields[f].quantifier_offset)) {
+              continue;
+            }
+            if (desc->fields[f].label == PROTOBUF_C_LABEL_REPEATED) {
+              size_t n = *(size_t *)((char *)message + desc->fields[f].quantifier_offset);
+              void *arr = *(void **)((char *)message + desc->fields[f].offset);
+              if (arr != NULL) {
+                if (desc->fields[f].type == PROTOBUF_C_TYPE_STRING) {
+                  unsigned i;
+                  for (i = 0; i < n; i++) {
+                    free(((char **)arr)[i]);
+                  }
+                } else if (desc->fields[f].type == PROTOBUF_C_TYPE_BYTES) {
+                  unsigned i;
+                  for (i = 0; i < n; i++) {
+                    free(((ProtobufCBinaryData *)arr)[i].data);
+                  }
+                } else if (desc->fields[f].type == PROTOBUF_C_TYPE_MESSAGE) {
+                  unsigned i;
+                  for (i = 0; i < n; i++) {
+                    protobuf_c_message_free_unpacked(((ProtobufCMessage **)arr)[i], NULL);
+                  }
+                }
+                free(arr);
+              }
+            } else if (desc->fields[f].type == PROTOBUF_C_TYPE_STRING) {
+              char *str = *(char **)((char *)message + desc->fields[f].offset);
+              if (str && str != desc->fields[f].default_value) {
+                free(str);
+              }
+            } else if (desc->fields[f].type == PROTOBUF_C_TYPE_BYTES) {
+              ProtobufCBinaryData *bd = (ProtobufCBinaryData *)((char *)message + desc->fields[f].offset);
+              const ProtobufCBinaryData *default_bd = desc->fields[f].default_value;
+              if (bd->data != NULL && (default_bd == NULL || default_bd->data != bd->data)) {
+                free(bd->data);
+              }
+            } else if (desc->fields[f].type == PROTOBUF_C_TYPE_MESSAGE) {
+              ProtobufCMessage *sm = *(ProtobufCMessage **)((char *)message + desc->fields[f].offset);
+              if (sm && sm != desc->fields[f].default_value) {
+                protobuf_c_message_free_unpacked(sm, NULL);
+              }
+            }
+          }
+          for (f = 0; f < message->n_unknown_fields; f++) {
+            free(message->unknown_fields[f].data);
+          }
+          if (message->unknown_fields != NULL) {
+            free(message->unknown_fields);
+          }
+          protobuf_c_message_init(desc, message);
+        }
+
+        static void lf_deep_copy_protobuf_message(ProtobufCMessage *dest, const ProtobufCMessage *src) {
+          const ProtobufCMessageDescriptor *desc = src->descriptor;
+          unsigned f;
+
+          for (f = 0; f < desc->n_fields; f++) {
+            const ProtobufCFieldDescriptor *field = &desc->fields[f];
+            void *dest_field = (char *)dest + field->offset;
+            const void *src_field = (const char *)src + field->offset;
+
+            if (0 != (field->flags & PROTOBUF_C_FIELD_FLAG_ONEOF) &&
+                field->id != *(uint32_t *)((char *)src + field->quantifier_offset)) {
+              continue;
+            }
+
+            if (field->label == PROTOBUF_C_LABEL_REPEATED) {
+              size_t n = *(size_t *)((char *)src + field->quantifier_offset);
+              *(size_t *)((char *)dest + field->quantifier_offset) = n;
+              if (n == 0) {
+                *(void **)dest_field = NULL;
+                continue;
+              }
+              if (field->type == PROTOBUF_C_TYPE_STRING) {
+                char **src_arr = *(char ***)src_field;
+                char **dest_arr = (char **)malloc(n * sizeof(char *));
+                if (dest_arr == NULL) {
+                  lf_print_error_and_exit("Failed to allocate buffer for protobuf deserialization.");
+                }
+                for (size_t i = 0; i < n; i++) {
+                  dest_arr[i] = src_arr[i] ? strdup(src_arr[i]) : NULL;
+                }
+                *(char ***)dest_field = dest_arr;
+              } else if (field->type == PROTOBUF_C_TYPE_MESSAGE) {
+                lf_print_error_and_exit("Repeated protobuf sub-messages are not supported yet.");
+              } else {
+                size_t element_size = 0;
+                switch (field->type) {
+                  case PROTOBUF_C_TYPE_INT32:
+                  case PROTOBUF_C_TYPE_SINT32:
+                  case PROTOBUF_C_TYPE_SFIXED32:
+                  case PROTOBUF_C_TYPE_UINT32:
+                  case PROTOBUF_C_TYPE_FIXED32:
+                  case PROTOBUF_C_TYPE_FLOAT:
+                  case PROTOBUF_C_TYPE_ENUM:
+                    element_size = 4;
+                    break;
+                  case PROTOBUF_C_TYPE_INT64:
+                  case PROTOBUF_C_TYPE_SINT64:
+                  case PROTOBUF_C_TYPE_SFIXED64:
+                  case PROTOBUF_C_TYPE_UINT64:
+                  case PROTOBUF_C_TYPE_FIXED64:
+                  case PROTOBUF_C_TYPE_DOUBLE:
+                    element_size = 8;
+                    break;
+                  case PROTOBUF_C_TYPE_BOOL:
+                    element_size = sizeof(protobuf_c_boolean);
+                    break;
+                  default:
+                    lf_print_error_and_exit("Unsupported repeated protobuf field type.");
+                }
+                void *dest_arr = malloc(n * element_size);
+                if (dest_arr == NULL) {
+                  lf_print_error_and_exit("Failed to allocate buffer for protobuf deserialization.");
+                }
+                memcpy(dest_arr, *(void **)src_field, n * element_size);
+                *(void **)dest_field = dest_arr;
+              }
+            } else {
+              switch (field->type) {
+                case PROTOBUF_C_TYPE_STRING: {
+                  const char *src_str = *(const char **)src_field;
+                  *(char **)dest_field = src_str ? strdup(src_str) : NULL;
+                  break;
+                }
+                case PROTOBUF_C_TYPE_BYTES: {
+                  const ProtobufCBinaryData *src_bd = (const ProtobufCBinaryData *)src_field;
+                  ProtobufCBinaryData *dest_bd = (ProtobufCBinaryData *)dest_field;
+                  dest_bd->len = src_bd->len;
+                  if (src_bd->len > 0) {
+                    dest_bd->data = (uint8_t *)malloc(src_bd->len);
+                    if (dest_bd->data == NULL) {
+                      lf_print_error_and_exit("Failed to allocate buffer for protobuf deserialization.");
+                    }
+                    memcpy(dest_bd->data, src_bd->data, src_bd->len);
+                  } else {
+                    dest_bd->data = NULL;
+                  }
+                  break;
+                }
+                case PROTOBUF_C_TYPE_MESSAGE:
+                  lf_print_error_and_exit("Nested protobuf sub-messages are not supported yet.");
+                  break;
+                case PROTOBUF_C_TYPE_INT32:
+                case PROTOBUF_C_TYPE_SINT32:
+                case PROTOBUF_C_TYPE_SFIXED32:
+                case PROTOBUF_C_TYPE_UINT32:
+                case PROTOBUF_C_TYPE_FIXED32:
+                case PROTOBUF_C_TYPE_FLOAT:
+                case PROTOBUF_C_TYPE_ENUM:
+                  *(uint32_t *)dest_field = *(const uint32_t *)src_field;
+                  break;
+                case PROTOBUF_C_TYPE_INT64:
+                case PROTOBUF_C_TYPE_SINT64:
+                case PROTOBUF_C_TYPE_SFIXED64:
+                case PROTOBUF_C_TYPE_UINT64:
+                case PROTOBUF_C_TYPE_FIXED64:
+                case PROTOBUF_C_TYPE_DOUBLE:
+                  *(uint64_t *)dest_field = *(const uint64_t *)src_field;
+                  break;
+                case PROTOBUF_C_TYPE_BOOL:
+                  *(protobuf_c_boolean *)dest_field = *(const protobuf_c_boolean *)src_field;
+                  break;
+                default:
+                  lf_print_error_and_exit("Unsupported protobuf field type.");
+                  break;
+              }
+            }
+          }
+        }
+
+        static void lf_assign_protobuf_message(void *dest, ProtobufCMessage *src) {
+          lf_free_protobuf_message_fields((ProtobufCMessage *)dest);
+          lf_deep_copy_protobuf_message((ProtobufCMessage *)dest, src);
+          protobuf_c_message_free_unpacked(src, NULL);
+        }
+        """);
+    return preamble;
+  }
+
+  @Override
+  public StringBuilder generateCompilerExtensionForSupport() {
+    return new StringBuilder();
+  }
+}

--- a/core/src/main/java/org/lflang/federated/serialization/FedProtoCSerialization.java
+++ b/core/src/main/java/org/lflang/federated/serialization/FedProtoCSerialization.java
@@ -102,11 +102,7 @@ public class FedProtoCSerialization implements FedSerialization {
             + serializedVarName
             + "_length);\n");
     code.append(
-        "if ("
-            + serializedVarName
-            + " == NULL && "
-            + serializedVarName
-            + "_length > 0) {\n");
+        "if (" + serializedVarName + " == NULL && " + serializedVarName + "_length > 0) {\n");
     code.append(
         "    lf_print_error_and_exit(\"Failed to allocate buffer for protobuf"
             + " serialization.\");\n");

--- a/core/src/main/java/org/lflang/federated/serialization/FedProtoCSerialization.java
+++ b/core/src/main/java/org/lflang/federated/serialization/FedProtoCSerialization.java
@@ -6,10 +6,20 @@ import org.lflang.target.Target;
 /**
  * Enables support for Protocol Buffer serialization in C code using protobuf-c.
  *
+ * <p>For federated connections that use {@code serializer "proto"}, the port type must be a
+ * protobuf message <em>pointer</em> (e.g. {@code MyMessage*}). Sender reactions allocate and
+ * initialize messages on the heap; the runtime owns the lifetime of deserialized messages on the
+ * receiver side and frees them via {@link
+ * org.lflang.federated.serialization.FedProtoCSerialization#PROTOBUF_DESTRUCTOR_NAME} (a thin
+ * wrapper around {@code protobuf_c_message_free_unpacked}).
+ *
  * @author Edward A. Lee
  * @ingroup Federated
  */
 public class FedProtoCSerialization implements FedSerialization {
+
+  /** Name of the generated destructor that frees a heap-allocated protobuf-c message. */
+  public static final String PROTOBUF_DESTRUCTOR_NAME = "_lf_protobuf_destructor";
 
   /**
    * Convert a protobuf message type name to the protobuf-c function prefix. For example, {@code
@@ -29,6 +39,15 @@ public class FedProtoCSerialization implements FedSerialization {
       }
     }
     return prefix.toString();
+  }
+
+  /** Strip trailing {@code *} characters from a C pointer type string. */
+  public static String stripPointer(String type) {
+    String result = type;
+    while (result.endsWith("*")) {
+      result = result.substring(0, result.length() - 1).trim();
+    }
+    return result;
   }
 
   @Override
@@ -53,73 +72,86 @@ public class FedProtoCSerialization implements FedSerialization {
     return serializedVarName;
   }
 
+  /**
+   * Generate code that serializes the value of a pointer-typed port using {@code __pack}.
+   *
+   * @param varName Reference to the port (e.g. {@code msg[0]}). The port's {@code value} field is
+   *     expected to be a pointer to a protobuf message of type {@code originalType}.
+   * @param originalType The protobuf message type name (without the trailing {@code *}).
+   */
   @Override
   public StringBuilder generateNetworkSerializerCode(String varName, String originalType) {
-    String prefix = protobufCFunctionPrefix(originalType);
+    String prefix = protobufCFunctionPrefix(stripPointer(originalType));
     String valueRef = varName + "->value";
-    StringBuilder serializerCode = new StringBuilder();
-    serializerCode.append(
-        "if (((const ProtobufCMessage *)&"
-            + valueRef
-            + ")->descriptor == NULL) {\n");
-    serializerCode.append(
-        "    ProtobufCMessage *_lf_msg_base = (ProtobufCMessage *)&" + valueRef + ";\n");
-    serializerCode.append(
-        "    _lf_msg_base->descriptor = &" + prefix + "__descriptor;\n");
-    serializerCode.append("    _lf_msg_base->n_unknown_fields = 0;\n");
-    serializerCode.append("    _lf_msg_base->unknown_fields = NULL;\n");
-    serializerCode.append("}\n");
-    serializerCode.append(
+    StringBuilder code = new StringBuilder();
+    code.append(
         "size_t "
             + serializedVarName
             + "_length = "
             + prefix
-            + "__get_packed_size(&"
+            + "__get_packed_size("
             + valueRef
             + ");\n");
-    serializerCode.append(
+    code.append(
         "unsigned char* "
             + serializedVarName
             + " = (unsigned char*)malloc("
             + serializedVarName
             + "_length);\n");
-    serializerCode.append("if (" + serializedVarName + " == NULL) {\n");
-    serializerCode.append(
+    code.append("if (" + serializedVarName + " == NULL) {\n");
+    code.append(
         "    lf_print_error_and_exit(\"Failed to allocate buffer for protobuf serialization.\");\n");
-    serializerCode.append("}\n");
-    serializerCode.append(prefix + "__pack(&" + valueRef + ", " + serializedVarName + ");\n");
-    return serializerCode;
-  }
-
-  @Override
-  public StringBuilder generateNetworkDeserializerCode(String varName, String targetType) {
-    String prefix = protobufCFunctionPrefix(targetType);
-    StringBuilder deserializerCode = new StringBuilder();
-    deserializerCode.append(
-        targetType + " *" + deserializedVarName + " = " + prefix + "__unpack(NULL, ");
-    deserializerCode.append(varName + ".tmplt.token->length, ");
-    deserializerCode.append("(uint8_t*)" + varName + ".tmplt.token->value);\n");
-    deserializerCode.append("if (" + deserializedVarName + " == NULL) {\n");
-    deserializerCode.append(
-        "    lf_print_error_and_exit(\"Could not deserialize protobuf message.\");\n");
-    deserializerCode.append("}\n");
-    return deserializerCode;
+    code.append("}\n");
+    code.append(prefix + "__pack(" + valueRef + ", " + serializedVarName + ");\n");
+    return code;
   }
 
   /**
-   * Generate code that copies a deserialized protobuf message into a port value.
+   * Generate code that deserializes a network message into a freshly heap-allocated protobuf
+   * message via {@code __unpack}.
    *
-   * @param receiveRef A target language reference to the receiving port.
+   * @param varName Reference to the receiving action.
+   * @param targetType The protobuf message type name (without the trailing {@code *}).
+   */
+  @Override
+  public StringBuilder generateNetworkDeserializerCode(String varName, String targetType) {
+    String base = stripPointer(targetType);
+    String prefix = protobufCFunctionPrefix(base);
+    StringBuilder code = new StringBuilder();
+    code.append(
+        base
+            + " *"
+            + deserializedVarName
+            + " = "
+            + prefix
+            + "__unpack(NULL, "
+            + varName
+            + ".tmplt.token->length, (uint8_t*)"
+            + varName
+            + ".tmplt.token->value);\n");
+    code.append("if (" + deserializedVarName + " == NULL) {\n");
+    code.append(
+        "    lf_print_error_and_exit(\"Could not deserialize protobuf message.\");\n");
+    code.append("}\n");
+    return code;
+  }
+
+  /**
+   * Generate code that hands ownership of the deserialized message to the LF runtime via a token,
+   * so that {@code protobuf_c_message_free_unpacked} is invoked when the token's reference count
+   * drops to zero.
    */
   public StringBuilder generatePortAssignmentCode(String receiveRef) {
     StringBuilder code = new StringBuilder();
     code.append(
-        "lf_assign_protobuf_message(&"
+        "lf_token_t* _lf_proto_token = lf_new_token((void*)"
             + receiveRef
-            + "->value, (ProtobufCMessage*)"
+            + ", "
             + deserializedVarName
-            + ");\n");
-    code.append("lf_set_present(" + receiveRef + ");\n");
+            + ", 1);\n");
+    code.append(
+        "lf_set_destructor(" + receiveRef + ", " + PROTOBUF_DESTRUCTOR_NAME + ");\n");
+    code.append("lf_set_token(" + receiveRef + ", _lf_proto_token);\n");
     return code;
   }
 
@@ -127,200 +159,15 @@ public class FedProtoCSerialization implements FedSerialization {
   public StringBuilder generatePreambleForSupport() {
     StringBuilder preamble = new StringBuilder();
     preamble.append("#include <protobuf-c/protobuf-c.h>\n");
-    preamble.append("#include <string.h>\n");
-    preamble.append("#include <stdlib.h>\n");
     preamble.append(
         """
-        // Free heap-owned fields inside a stack-allocated protobuf message.
-        // Unlike protobuf_c_message_free_unpacked(), this does not free the message struct itself.
-        static void lf_free_protobuf_message_fields(ProtobufCMessage *message) {
-          const ProtobufCMessageDescriptor *desc;
-          unsigned f;
-
-          if (message == NULL || message->descriptor == NULL) {
-            return;
-          }
-          desc = message->descriptor;
-          for (f = 0; f < desc->n_fields; f++) {
-            if (0 != (desc->fields[f].flags & PROTOBUF_C_FIELD_FLAG_ONEOF) &&
-                desc->fields[f].id !=
-                    *(uint32_t *)((char *)message + desc->fields[f].quantifier_offset)) {
-              continue;
-            }
-            if (desc->fields[f].label == PROTOBUF_C_LABEL_REPEATED) {
-              size_t n = *(size_t *)((char *)message + desc->fields[f].quantifier_offset);
-              void *arr = *(void **)((char *)message + desc->fields[f].offset);
-              if (arr != NULL) {
-                if (desc->fields[f].type == PROTOBUF_C_TYPE_STRING) {
-                  unsigned i;
-                  for (i = 0; i < n; i++) {
-                    free(((char **)arr)[i]);
-                  }
-                } else if (desc->fields[f].type == PROTOBUF_C_TYPE_BYTES) {
-                  unsigned i;
-                  for (i = 0; i < n; i++) {
-                    free(((ProtobufCBinaryData *)arr)[i].data);
-                  }
-                } else if (desc->fields[f].type == PROTOBUF_C_TYPE_MESSAGE) {
-                  unsigned i;
-                  for (i = 0; i < n; i++) {
-                    protobuf_c_message_free_unpacked(((ProtobufCMessage **)arr)[i], NULL);
-                  }
-                }
-                free(arr);
-              }
-            } else if (desc->fields[f].type == PROTOBUF_C_TYPE_STRING) {
-              char *str = *(char **)((char *)message + desc->fields[f].offset);
-              if (str && str != desc->fields[f].default_value) {
-                free(str);
-              }
-            } else if (desc->fields[f].type == PROTOBUF_C_TYPE_BYTES) {
-              ProtobufCBinaryData *bd = (ProtobufCBinaryData *)((char *)message + desc->fields[f].offset);
-              const ProtobufCBinaryData *default_bd = desc->fields[f].default_value;
-              if (bd->data != NULL && (default_bd == NULL || default_bd->data != bd->data)) {
-                free(bd->data);
-              }
-            } else if (desc->fields[f].type == PROTOBUF_C_TYPE_MESSAGE) {
-              ProtobufCMessage *sm = *(ProtobufCMessage **)((char *)message + desc->fields[f].offset);
-              if (sm && sm != desc->fields[f].default_value) {
-                protobuf_c_message_free_unpacked(sm, NULL);
-              }
-            }
-          }
-          for (f = 0; f < message->n_unknown_fields; f++) {
-            free(message->unknown_fields[f].data);
-          }
-          if (message->unknown_fields != NULL) {
-            free(message->unknown_fields);
-          }
-          protobuf_c_message_init(desc, message);
-        }
-
-        static void lf_deep_copy_protobuf_message(ProtobufCMessage *dest, const ProtobufCMessage *src) {
-          const ProtobufCMessageDescriptor *desc = src->descriptor;
-          unsigned f;
-
-          for (f = 0; f < desc->n_fields; f++) {
-            const ProtobufCFieldDescriptor *field = &desc->fields[f];
-            void *dest_field = (char *)dest + field->offset;
-            const void *src_field = (const char *)src + field->offset;
-
-            if (0 != (field->flags & PROTOBUF_C_FIELD_FLAG_ONEOF) &&
-                field->id != *(uint32_t *)((char *)src + field->quantifier_offset)) {
-              continue;
-            }
-
-            if (field->label == PROTOBUF_C_LABEL_REPEATED) {
-              size_t n = *(size_t *)((char *)src + field->quantifier_offset);
-              *(size_t *)((char *)dest + field->quantifier_offset) = n;
-              if (n == 0) {
-                *(void **)dest_field = NULL;
-                continue;
-              }
-              if (field->type == PROTOBUF_C_TYPE_STRING) {
-                char **src_arr = *(char ***)src_field;
-                char **dest_arr = (char **)malloc(n * sizeof(char *));
-                if (dest_arr == NULL) {
-                  lf_print_error_and_exit("Failed to allocate buffer for protobuf deserialization.");
-                }
-                for (size_t i = 0; i < n; i++) {
-                  dest_arr[i] = src_arr[i] ? strdup(src_arr[i]) : NULL;
-                }
-                *(char ***)dest_field = dest_arr;
-              } else if (field->type == PROTOBUF_C_TYPE_MESSAGE) {
-                lf_print_error_and_exit("Repeated protobuf sub-messages are not supported yet.");
-              } else {
-                size_t element_size = 0;
-                switch (field->type) {
-                  case PROTOBUF_C_TYPE_INT32:
-                  case PROTOBUF_C_TYPE_SINT32:
-                  case PROTOBUF_C_TYPE_SFIXED32:
-                  case PROTOBUF_C_TYPE_UINT32:
-                  case PROTOBUF_C_TYPE_FIXED32:
-                  case PROTOBUF_C_TYPE_FLOAT:
-                  case PROTOBUF_C_TYPE_ENUM:
-                    element_size = 4;
-                    break;
-                  case PROTOBUF_C_TYPE_INT64:
-                  case PROTOBUF_C_TYPE_SINT64:
-                  case PROTOBUF_C_TYPE_SFIXED64:
-                  case PROTOBUF_C_TYPE_UINT64:
-                  case PROTOBUF_C_TYPE_FIXED64:
-                  case PROTOBUF_C_TYPE_DOUBLE:
-                    element_size = 8;
-                    break;
-                  case PROTOBUF_C_TYPE_BOOL:
-                    element_size = sizeof(protobuf_c_boolean);
-                    break;
-                  default:
-                    lf_print_error_and_exit("Unsupported repeated protobuf field type.");
-                }
-                void *dest_arr = malloc(n * element_size);
-                if (dest_arr == NULL) {
-                  lf_print_error_and_exit("Failed to allocate buffer for protobuf deserialization.");
-                }
-                memcpy(dest_arr, *(void **)src_field, n * element_size);
-                *(void **)dest_field = dest_arr;
-              }
-            } else {
-              switch (field->type) {
-                case PROTOBUF_C_TYPE_STRING: {
-                  const char *src_str = *(const char **)src_field;
-                  *(char **)dest_field = src_str ? strdup(src_str) : NULL;
-                  break;
-                }
-                case PROTOBUF_C_TYPE_BYTES: {
-                  const ProtobufCBinaryData *src_bd = (const ProtobufCBinaryData *)src_field;
-                  ProtobufCBinaryData *dest_bd = (ProtobufCBinaryData *)dest_field;
-                  dest_bd->len = src_bd->len;
-                  if (src_bd->len > 0) {
-                    dest_bd->data = (uint8_t *)malloc(src_bd->len);
-                    if (dest_bd->data == NULL) {
-                      lf_print_error_and_exit("Failed to allocate buffer for protobuf deserialization.");
-                    }
-                    memcpy(dest_bd->data, src_bd->data, src_bd->len);
-                  } else {
-                    dest_bd->data = NULL;
-                  }
-                  break;
-                }
-                case PROTOBUF_C_TYPE_MESSAGE:
-                  lf_print_error_and_exit("Nested protobuf sub-messages are not supported yet.");
-                  break;
-                case PROTOBUF_C_TYPE_INT32:
-                case PROTOBUF_C_TYPE_SINT32:
-                case PROTOBUF_C_TYPE_SFIXED32:
-                case PROTOBUF_C_TYPE_UINT32:
-                case PROTOBUF_C_TYPE_FIXED32:
-                case PROTOBUF_C_TYPE_FLOAT:
-                case PROTOBUF_C_TYPE_ENUM:
-                  *(uint32_t *)dest_field = *(const uint32_t *)src_field;
-                  break;
-                case PROTOBUF_C_TYPE_INT64:
-                case PROTOBUF_C_TYPE_SINT64:
-                case PROTOBUF_C_TYPE_SFIXED64:
-                case PROTOBUF_C_TYPE_UINT64:
-                case PROTOBUF_C_TYPE_FIXED64:
-                case PROTOBUF_C_TYPE_DOUBLE:
-                  *(uint64_t *)dest_field = *(const uint64_t *)src_field;
-                  break;
-                case PROTOBUF_C_TYPE_BOOL:
-                  *(protobuf_c_boolean *)dest_field = *(const protobuf_c_boolean *)src_field;
-                  break;
-                default:
-                  lf_print_error_and_exit("Unsupported protobuf field type.");
-                  break;
-              }
-            }
+        static void %s(void* value) {
+          if (value != NULL) {
+            protobuf_c_message_free_unpacked((ProtobufCMessage*)value, NULL);
           }
         }
-
-        static void lf_assign_protobuf_message(void *dest, ProtobufCMessage *src) {
-          lf_free_protobuf_message_fields((ProtobufCMessage *)dest);
-          lf_deep_copy_protobuf_message((ProtobufCMessage *)dest, src);
-          protobuf_c_message_free_unpacked(src, NULL);
-        }
-        """);
+        """
+            .formatted(PROTOBUF_DESTRUCTOR_NAME));
     return preamble;
   }
 

--- a/core/src/main/java/org/lflang/federated/serialization/FedProtoCSerialization.java
+++ b/core/src/main/java/org/lflang/federated/serialization/FedProtoCSerialization.java
@@ -92,13 +92,21 @@ public class FedProtoCSerialization implements FedSerialization {
             + "__get_packed_size("
             + valueRef
             + ");\n");
+    // Note: malloc(0) is permitted to return NULL without indicating failure, so we only treat
+    // NULL as an allocation error when a non-zero buffer was requested. Empty protobuf messages
+    // (where __get_packed_size returns 0) thus serialize to a zero-byte payload as expected.
     code.append(
         "unsigned char* "
             + serializedVarName
             + " = (unsigned char*)malloc("
             + serializedVarName
             + "_length);\n");
-    code.append("if (" + serializedVarName + " == NULL) {\n");
+    code.append(
+        "if ("
+            + serializedVarName
+            + " == NULL && "
+            + serializedVarName
+            + "_length > 0) {\n");
     code.append(
         "    lf_print_error_and_exit(\"Failed to allocate buffer for protobuf"
             + " serialization.\");\n");

--- a/core/src/main/java/org/lflang/federated/serialization/FedProtoCSerialization.java
+++ b/core/src/main/java/org/lflang/federated/serialization/FedProtoCSerialization.java
@@ -100,7 +100,8 @@ public class FedProtoCSerialization implements FedSerialization {
             + "_length);\n");
     code.append("if (" + serializedVarName + " == NULL) {\n");
     code.append(
-        "    lf_print_error_and_exit(\"Failed to allocate buffer for protobuf serialization.\");\n");
+        "    lf_print_error_and_exit(\"Failed to allocate buffer for protobuf"
+            + " serialization.\");\n");
     code.append("}\n");
     code.append(prefix + "__pack(" + valueRef + ", " + serializedVarName + ");\n");
     return code;
@@ -130,8 +131,7 @@ public class FedProtoCSerialization implements FedSerialization {
             + varName
             + ".tmplt.token->value);\n");
     code.append("if (" + deserializedVarName + " == NULL) {\n");
-    code.append(
-        "    lf_print_error_and_exit(\"Could not deserialize protobuf message.\");\n");
+    code.append("    lf_print_error_and_exit(\"Could not deserialize protobuf message.\");\n");
     code.append("}\n");
     return code;
   }
@@ -149,8 +149,7 @@ public class FedProtoCSerialization implements FedSerialization {
             + ", "
             + deserializedVarName
             + ", 1);\n");
-    code.append(
-        "lf_set_destructor(" + receiveRef + ", " + PROTOBUF_DESTRUCTOR_NAME + ");\n");
+    code.append("lf_set_destructor(" + receiveRef + ", " + PROTOBUF_DESTRUCTOR_NAME + ");\n");
     code.append("lf_set_token(" + receiveRef + ", _lf_proto_token);\n");
     return code;
   }

--- a/core/src/main/java/org/lflang/generator/GeneratorUtils.java
+++ b/core/src/main/java/org/lflang/generator/GeneratorUtils.java
@@ -74,7 +74,7 @@ public class GeneratorUtils {
    *
    * @param resource A resource to be searched.
    * @param nodeType The type of the desired parse tree nodes.
-   * @param <T> The type of the desired parse tree nodes.
+   * @tparam <T> The type of the desired parse tree nodes.
    * @return all instances of `eObjectType` in `resource`
    */
   public static <T> Iterable<T> findAll(Resource resource, Class<T> nodeType) {

--- a/core/src/main/java/org/lflang/generator/LfExpressionVisitor.java
+++ b/core/src/main/java/org/lflang/generator/LfExpressionVisitor.java
@@ -36,8 +36,8 @@ public interface LfExpressionVisitor<P, R> {
    * @param e An expression that will be visited
    * @param arg Argument for the visitor
    * @param visitor Visitor
-   * @param <P> Type of parameter expected by the visitor
-   * @param <R> Return type of the visitor
+   * @tparam <P> Type of parameter expected by the visitor
+   * @tparam <R> Return type of the visitor
    * @return The return value of the visitor
    */
   static <P, R> R dispatch(

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1687,23 +1687,38 @@ public class CGenerator extends GeneratorBase {
    * @param filename Name of the file to process.
    */
   public void processProtoFile(String filename) {
+    var protoPath = Paths.get(filename);
+    var protoDir = protoPath.getParent();
+    var protocArgs = new ArrayList<String>();
+    protocArgs.add("--c_out=" + this.fileConfig.getSrcGenPath());
+    if (protoDir != null && !protoDir.toString().isEmpty()) {
+      protocArgs.add("-I" + protoDir);
+    } else {
+      protocArgs.add("-I" + fileConfig.srcPath);
+    }
+    protocArgs.add(filename);
     var protoc =
-        commandFactory.createCommand(
-            "protoc-c",
-            List.of("--c_out=" + this.fileConfig.getSrcGenPath(), filename),
-            fileConfig.srcPath);
+        commandFactory.createCommand("protoc-c", protocArgs, fileConfig.srcPath);
     if (protoc == null) {
       messageReporter.nowhere().error("Processing .proto files requires protoc-c >= 1.3.3.");
       return;
     }
     var returnCode = protoc.run();
     if (returnCode == 0) {
-      var nameSansProto = filename.substring(0, filename.length() - 6);
       targetConfig.compileAdditionalSources.add(
-          fileConfig.getSrcGenPath().resolve(nameSansProto + ".pb-c.c").toString());
+          fileConfig.getSrcGenPath().resolve(protoBaseName(filename) + ".pb-c.c").toString());
     } else {
       messageReporter.nowhere().error("protoc-c returns error code " + returnCode);
     }
+  }
+
+  /** Return the base name of a .proto file without its extension. */
+  private static String protoBaseName(String filename) {
+    var name = Paths.get(filename).getFileName().toString();
+    if (name.endsWith(".proto")) {
+      return name.substring(0, name.length() - 6);
+    }
+    return name;
   }
 
   /**
@@ -2251,12 +2266,7 @@ public class CGenerator extends GeneratorBase {
 
     // Also generate includes for all the .proto files that are used.
     for (String file : targetConfig.get(ProtobufsProperty.INSTANCE)) {
-      var dotIndex = file.lastIndexOf(".");
-      var rootFilename = file;
-      if (dotIndex > 0) {
-        rootFilename = file.substring(0, dotIndex);
-      }
-      builder.pr("#include " + addDoubleQuotes(rootFilename + ".pb-c.h"));
+      builder.pr("#include " + addDoubleQuotes(protoBaseName(file) + ".pb-c.h"));
     }
 
     builder.pr("#endif // " + guard);

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -1697,8 +1697,7 @@ public class CGenerator extends GeneratorBase {
       protocArgs.add("-I" + fileConfig.srcPath);
     }
     protocArgs.add(filename);
-    var protoc =
-        commandFactory.createCommand("protoc-c", protocArgs, fileConfig.srcPath);
+    var protoc = commandFactory.createCommand("protoc-c", protocArgs, fileConfig.srcPath);
     if (protoc == null) {
       messageReporter.nowhere().error("Processing .proto files requires protoc-c >= 1.3.3.");
       return;

--- a/core/src/main/java/org/lflang/generator/c/CGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CGenerator.java
@@ -14,6 +14,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -1684,19 +1685,31 @@ public class CGenerator extends GeneratorBase {
    * <p>Run, if possible, the proto-c protocol buffer code generator to produce the required .h and
    * .c files.
    *
+   * <p>The path of a .proto file relative to its include root is preserved in the names of the
+   * generated .pb-c.c and .pb-c.h files (mirroring protoc-c's own output convention). This
+   * prevents two .proto files with the same basename in different subdirectories from clobbering
+   * each other and keeps the {@code #include} directives in sync with the actual file locations.
+   *
    * @param filename Name of the file to process.
    */
   public void processProtoFile(String filename) {
-    var protoPath = Paths.get(filename);
-    var protoDir = protoPath.getParent();
+    var info = resolveProtoFile(filename);
+    var generatedCAbs = fileConfig.getSrcGenPath().resolve(info.generatedBase() + ".pb-c.c");
+    var parent = generatedCAbs.getParent();
+    if (parent != null) {
+      try {
+        Files.createDirectories(parent);
+      } catch (IOException e) {
+        messageReporter
+            .nowhere()
+            .error("Could not create output directory for protobuf generation: " + e.getMessage());
+        return;
+      }
+    }
     var protocArgs = new ArrayList<String>();
     protocArgs.add("--c_out=" + this.fileConfig.getSrcGenPath());
-    if (protoDir != null && !protoDir.toString().isEmpty()) {
-      protocArgs.add("-I" + protoDir);
-    } else {
-      protocArgs.add("-I" + fileConfig.srcPath);
-    }
-    protocArgs.add(filename);
+    protocArgs.add("-I" + info.includeRoot());
+    protocArgs.add(info.includeRoot().resolve(info.relativeProto()).toString());
     var protoc = commandFactory.createCommand("protoc-c", protocArgs, fileConfig.srcPath);
     if (protoc == null) {
       messageReporter.nowhere().error("Processing .proto files requires protoc-c >= 1.3.3.");
@@ -1704,20 +1717,70 @@ public class CGenerator extends GeneratorBase {
     }
     var returnCode = protoc.run();
     if (returnCode == 0) {
-      targetConfig.compileAdditionalSources.add(
-          fileConfig.getSrcGenPath().resolve(protoBaseName(filename) + ".pb-c.c").toString());
+      targetConfig.compileAdditionalSources.add(generatedCAbs.toString());
     } else {
       messageReporter.nowhere().error("protoc-c returns error code " + returnCode);
     }
   }
 
-  /** Return the base name of a .proto file without its extension. */
-  private static String protoBaseName(String filename) {
-    var name = Paths.get(filename).getFileName().toString();
-    if (name.endsWith(".proto")) {
-      return name.substring(0, name.length() - 6);
+  /**
+   * Information about a .proto file resolved against a stable include root.
+   *
+   * @param includeRoot Directory passed to {@code protoc-c} via {@code -I}.
+   * @param relativeProto Path of the .proto file relative to {@code includeRoot} (including the
+   *     {@code .proto} extension).
+   * @param generatedBase Path of the generated files relative to {@code srcGenPath}, without any
+   *     extension (e.g. {@code "sub/Foo"} for {@code "sub/Foo.proto"}). Always uses {@code /} as
+   *     the separator so it can be embedded directly in {@code #include} directives.
+   */
+  private record ProtoFileInfo(Path includeRoot, Path relativeProto, String generatedBase) {}
+
+  /**
+   * Resolve a .proto filename (as listed in the {@code protobufs} target property) into an include
+   * root and a relative path.
+   *
+   * <p>If the .proto file is located under the LF source directory, that directory is used as the
+   * include root and the subdirectory structure is preserved in the generated files. Otherwise
+   * (e.g. an absolute path, or a relative path with {@code ..} components pointing outside
+   * {@code srcPath} as happens in federated builds), the file's own parent directory is used as
+   * the include root and only the basename is preserved. This keeps {@code protoc-c}'s output
+   * path in sync with the {@code #include} directives we generate.
+   */
+  private ProtoFileInfo resolveProtoFile(String filename) {
+    var protoPath = Paths.get(filename);
+    var absProto =
+        (protoPath.isAbsolute() ? protoPath : fileConfig.srcPath.resolve(protoPath))
+            .toAbsolutePath()
+            .normalize();
+    var absSrc = fileConfig.srcPath.toAbsolutePath().normalize();
+
+    Path includeRoot;
+    Path relativeProto;
+    if (absProto.startsWith(absSrc)) {
+      includeRoot = absSrc;
+      relativeProto = absSrc.relativize(absProto);
+    } else {
+      includeRoot = absProto.getParent();
+      relativeProto = Paths.get(absProto.getFileName().toString());
     }
-    return name;
+
+    var leaf = relativeProto.getFileName().toString();
+    if (leaf.endsWith(".proto")) {
+      leaf = leaf.substring(0, leaf.length() - ".proto".length());
+    }
+    var parent = relativeProto.getParent();
+    var generatedBase =
+        (parent == null ? leaf : parent.resolve(leaf).toString()).replace(File.separatorChar, '/');
+    return new ProtoFileInfo(includeRoot, relativeProto, generatedBase);
+  }
+
+  /**
+   * Return the path (without extension) of the generated protobuf-c files for a given .proto
+   * filename, relative to {@code srcGenPath}. Uses forward slashes so the result can be embedded
+   * directly in {@code #include} directives.
+   */
+  private String protoIncludeBase(String filename) {
+    return resolveProtoFile(filename).generatedBase();
   }
 
   /**
@@ -2265,7 +2328,7 @@ public class CGenerator extends GeneratorBase {
 
     // Also generate includes for all the .proto files that are used.
     for (String file : targetConfig.get(ProtobufsProperty.INSTANCE)) {
-      builder.pr("#include " + addDoubleQuotes(protoBaseName(file) + ".pb-c.h"));
+      builder.pr("#include " + addDoubleQuotes(protoIncludeBase(file) + ".pb-c.h"));
     }
 
     builder.pr("#endif // " + guard);

--- a/core/src/main/java/org/lflang/generator/c/CUtil.java
+++ b/core/src/main/java/org/lflang/generator/c/CUtil.java
@@ -760,6 +760,21 @@ public class CUtil {
   }
 
   /**
+   * Given a type for an input or output, return true if it is a pointer type (i.e. ends with one
+   * or more {@code *} characters). Unlike {@link #isTokenType(InferredType)}, this returns false
+   * for variable-length array types such as {@code int[]}.
+   *
+   * @param type The type specification.
+   */
+  public static boolean isPointerType(InferredType type) {
+    if (type.isUndefined()) return false;
+    return type.astType != null
+        && (!type.astType.getStars().isEmpty()
+            || type.astType.getCode() != null
+                && type.astType.getCode().getBody().stripTrailing().endsWith("*"));
+  }
+
+  /**
    * Given a type for an input or output, return true if it is a fixed-size array (declared with
    * `type[int]`). For such types, the memory is allocated in the output struct.
    *

--- a/core/src/main/java/org/lflang/target/TargetConfig.java
+++ b/core/src/main/java/org/lflang/target/TargetConfig.java
@@ -321,8 +321,8 @@ public class TargetConfig {
    *
    * @param property The property to get the value of
    * @return The current value, or the initial value of none was assigned.
-   * @param <T> The Java type of the returned value.
-   * @param <S> The LF type of the returned value.
+   * @tparam <T> The Java type of the returned value.
+   * @tparam <S> The LF type of the returned value.
    */
   public <T, S extends TargetPropertyType> T getOrDefault(TargetProperty<T, S> property) {
     try {
@@ -390,8 +390,8 @@ public class TargetConfig {
    *
    * @param property The target property to assign the value to.
    * @param value The value to assign to the target property.
-   * @param <T> The Java type of the value.
-   * @param <S> The LF type of the value.
+   * @tparam <T> The Java type of the value.
+   * @tparam <S> The LF type of the value.
    */
   public <T, S extends TargetPropertyType> void set(TargetProperty<T, S> property, T value) {
     if (value != null) {
@@ -415,8 +415,8 @@ public class TargetConfig {
    * Return the AST node that was used to assign a value for the given target property.
    *
    * @param targetProperty The target property to find a matching AST node for.
-   * @param <T> The Java type of values assigned to the given target property.
-   * @param <S> The LF type of values assigned to the given target property.
+   * @tparam <T> The Java type of values assigned to the given target property.
+   * @tparam <S> The LF type of values assigned to the given target property.
    */
   public <T, S extends TargetPropertyType> KeyValuePair lookup(
       TargetProperty<T, S> targetProperty) {

--- a/core/src/main/java/org/lflang/util/CollectionUtil.java
+++ b/core/src/main/java/org/lflang/util/CollectionUtil.java
@@ -31,7 +31,7 @@ public class CollectionUtil {
    *
    * @param set initial set, nullable
    * @param t new element
-   * @param <T> Type of elements
+   * @tparam <T> Type of elements
    * @return A new set, or the same
    */
   public static <T> Set<T> plus(Set<T> set, T t) {
@@ -146,7 +146,7 @@ public class CollectionUtil {
    * Returns a copy of the set. The returned set should be considered unmodifiable.
    *
    * @param set initial set, nullable
-   * @param <T> Type of elements
+   * @tparam <T> Type of elements
    * @return A new set, or the same
    */
   public static <T> Set<T> copy(Set<T> set) {

--- a/core/src/main/java/org/lflang/util/IteratorUtil.java
+++ b/core/src/main/java/org/lflang/util/IteratorUtil.java
@@ -31,8 +31,8 @@ public final class IteratorUtil {
    * Given an iterator of type T, turn it into a stream containing only the instances of the given
    * class of type S.
    *
-   * @param <T> The type of elements the iterator iterates over.
-   * @param <S> The type of class to filter out instance of.
+   * @tparam <T> The type of elements the iterator iterates over.
+   * @tparam <S> The type of class to filter out instance of.
    * @param iterator An iterator of type T.
    * @param cls A given class of type S.
    * @return A filtered stream that only has in it instances of the given class.

--- a/core/src/test/java/org/lflang/federated/serialization/FedProtoCSerializationTest.java
+++ b/core/src/test/java/org/lflang/federated/serialization/FedProtoCSerializationTest.java
@@ -13,4 +13,11 @@ public class FedProtoCSerializationTest {
     assertEquals(
         "proto_hello_world", FedProtoCSerialization.protobufCFunctionPrefix("ProtoHelloWorld"));
   }
+
+  @Test
+  public void stripPointer() {
+    assertEquals("Person", FedProtoCSerialization.stripPointer("Person"));
+    assertEquals("Person", FedProtoCSerialization.stripPointer("Person*"));
+    assertEquals("Person", FedProtoCSerialization.stripPointer("Person **"));
+  }
 }

--- a/core/src/test/java/org/lflang/federated/serialization/FedProtoCSerializationTest.java
+++ b/core/src/test/java/org/lflang/federated/serialization/FedProtoCSerializationTest.java
@@ -1,0 +1,16 @@
+package org.lflang.federated.serialization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link FedProtoCSerialization}. */
+public class FedProtoCSerializationTest {
+
+  @Test
+  public void protobufCFunctionPrefix() {
+    assertEquals("person", FedProtoCSerialization.protobufCFunctionPrefix("Person"));
+    assertEquals(
+        "proto_hello_world", FedProtoCSerialization.protobufCFunctionPrefix("ProtoHelloWorld"));
+  }
+}

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -260,7 +260,6 @@ PLANTUML_CFG_FILE      =
 PLANTUML_INCLUDE_PATH  =
 DOT_GRAPH_MAX_NODES    = 50
 MAX_DOT_GRAPH_DEPTH    = 0
-DOT_MULTI_TARGETS      = NO
 GENERATE_LEGEND        = YES
 DOT_CLEANUP            = YES
 # Generated files are not included in the GitHub action that generates the docs.

--- a/test/C/src/serialization/ProtoBuiltInSerialization.lf
+++ b/test/C/src/serialization/ProtoBuiltInSerialization.lf
@@ -1,11 +1,11 @@
 /**
- * This test showcases automatic protobuf serialization and deserialization in federated C
- * programs. The sender federate sends a ProtoHelloWorld message to the receiver federate using
- * serializer "proto".
+ * This test showcases automatic protobuf serialization and deserialization in federated C programs.
+ * The sender federate sends a ProtoHelloWorld message to the receiver federate using serializer
+ * "proto".
  *
- * The port type is a pointer (ProtoHelloWorld*); the sender allocates and initializes the
- * message and uses lf_set to transfer ownership. On the receiver, the runtime manages the
- * lifetime of the deserialized message via the standard LF token mechanism and frees it with
+ * The port type is a pointer (ProtoHelloWorld*); the sender allocates and initializes the message
+ * and uses lf_set to transfer ownership. On the receiver, the runtime manages the lifetime of the
+ * deserialized message via the standard LF token mechanism and frees it with
  * protobuf_c_message_free_unpacked when the token reference count drops to zero.
  *
  * To run this test, install protoc, protoc-c, and libprotobuf-c. See PersonProtocolBuffers.lf for

--- a/test/C/src/serialization/ProtoBuiltInSerialization.lf
+++ b/test/C/src/serialization/ProtoBuiltInSerialization.lf
@@ -1,0 +1,53 @@
+/**
+ * This test showcases automatic protobuf serialization and deserialization in federated C
+ * programs. The sender federate sends a ProtoHelloWorld message to the receiver federate using
+ * serializer "proto".
+ *
+ * To run this test, install protoc, protoc-c, and libprotobuf-c. See PersonProtocolBuffers.lf for
+ * details.
+ */
+target C {
+  protobufs: [ProtoHelloWorld.proto],
+  timeout: 2 sec,
+  build-type: debug
+}
+
+reactor Sender {
+  output out: ProtoHelloWorld
+
+  state count: int = 0
+
+  timer t(0, 1 sec)
+
+  reaction(t) -> out {=
+    self->count++;
+    out->value.name = "Hello World";
+    out->value.number = self->count;
+    lf_set_present(out);
+  =}
+}
+
+reactor Receiver {
+  input in: ProtoHelloWorld
+
+  state count: int = 0
+
+  reaction(in) {=
+    lf_print(
+      "Received: name=\"%s\", number=%d.",
+      in->value.name,
+      in->value.number
+    );
+    if (in->value.number != self->count + 1) {
+      lf_print_error_and_exit("Expected number %d.", self->count + 1);
+    }
+    self->count++;
+  =}
+}
+
+federated reactor {
+  sender = new Sender()
+  receiver = new Receiver()
+
+  sender.out -> receiver.in after 100 msec serializer "proto"
+}

--- a/test/C/src/serialization/ProtoBuiltInSerialization.lf
+++ b/test/C/src/serialization/ProtoBuiltInSerialization.lf
@@ -3,17 +3,21 @@
  * programs. The sender federate sends a ProtoHelloWorld message to the receiver federate using
  * serializer "proto".
  *
+ * The port type is a pointer (ProtoHelloWorld*); the sender allocates and initializes the
+ * message and uses lf_set to transfer ownership. On the receiver, the runtime manages the
+ * lifetime of the deserialized message via the standard LF token mechanism and frees it with
+ * protobuf_c_message_free_unpacked when the token reference count drops to zero.
+ *
  * To run this test, install protoc, protoc-c, and libprotobuf-c. See PersonProtocolBuffers.lf for
  * details.
  */
 target C {
   protobufs: [ProtoHelloWorld.proto],
-  timeout: 2 sec,
-  build-type: debug
+  timeout: 2 sec
 }
 
 reactor Sender {
-  output out: ProtoHelloWorld
+  output out: ProtoHelloWorld*
 
   state count: int = 0
 
@@ -21,24 +25,26 @@ reactor Sender {
 
   reaction(t) -> out {=
     self->count++;
-    out->value.name = "Hello World";
-    out->value.number = self->count;
-    lf_set_present(out);
+    ProtoHelloWorld* msg = (ProtoHelloWorld*)malloc(sizeof(ProtoHelloWorld));
+    proto_hello_world__init(msg);
+    msg->name = "Hello World";
+    msg->number = self->count;
+    lf_set(out, msg);
   =}
 }
 
 reactor Receiver {
-  input in: ProtoHelloWorld
+  input in: ProtoHelloWorld*
 
   state count: int = 0
 
   reaction(in) {=
     lf_print(
       "Received: name=\"%s\", number=%d.",
-      in->value.name,
-      in->value.number
+      in->value->name,
+      in->value->number
     );
-    if (in->value.number != self->count + 1) {
+    if (in->value->number != self->count + 1) {
       lf_print_error_and_exit("Expected number %d.", self->count + 1);
     }
     self->count++;


### PR DESCRIPTION
This PR adds support for Protobufs serialization and deserialization in the C target. The input and output data types are required to be *pointers* to Protobuf structs for proper memory management using the token infrastructure.

This PR also fixes some Doxygen warnings by changing `@param` to `@tparam` for type parameters.