### PR TITLE
Implement protobuf serialization between LF federates in Python runtime and add a test

### DIFF
--- a/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
@@ -10,6 +10,7 @@ import org.lflang.federated.generator.FederationFileConfig;
 import org.lflang.federated.launcher.RtiConfig;
 import org.lflang.federated.serialization.FedCustomPythonSerialization;
 import org.lflang.federated.serialization.FedNativePythonSerialization;
+import org.lflang.federated.serialization.FedProtoPythonSerialization;
 import org.lflang.federated.serialization.FedSerialization;
 import org.lflang.federated.serialization.SupportedSerializers;
 import org.lflang.generator.CodeBuilder;
@@ -70,7 +71,7 @@ public class PythonExtension extends CExtension {
 
   @Override
   public String getNetworkBufferType() {
-    return "void*";
+    return "";
   }
 
   @Override
@@ -203,8 +204,19 @@ lf_enqueue_port_absent_reactions(self->base.environment);
         result.pr("lf_set_destructor(" + receiveRef + ", python_count_decrement);\n");
         result.pr("lf_set_token(" + receiveRef + ", token);\n");
       }
-      case PROTO ->
-          throw new UnsupportedOperationException("Protobuf serialization is not supported yet.");
+      case PROTO -> {
+        value = action.getName();
+        FedProtoPythonSerialization protoDeserializer = new FedProtoPythonSerialization();
+        result.pr(protoDeserializer.generateNetworkDeserializerCode(value, null));
+        result.pr(
+            "lf_token_t* token = lf_new_token((void*)"
+                + receiveRef
+                + ", "
+                + FedSerialization.deserializedVarName
+                + ", 1);\n");
+        result.pr("lf_set_destructor(" + receiveRef + ", python_count_decrement);\n");
+        result.pr("lf_set_token(" + receiveRef + ", token);\n");
+      }
       case ROS2 ->
           throw new UnsupportedOperationException("ROS2 serialization is not supported yet.");
     }
@@ -245,8 +257,15 @@ lf_enqueue_port_absent_reactions(self->base.environment);
         // Decrease the reference count for serialized_pyobject
         result.pr("Py_XDECREF(serialized_pyobject);\n");
       }
-      case PROTO ->
-          throw new UnsupportedOperationException("Protobuf serialization is not supported yet.");
+      case PROTO -> {
+        var variableToSerialize = sendRef + "->value";
+        FedProtoPythonSerialization protoSerializer = new FedProtoPythonSerialization();
+        lengthExpression = protoSerializer.serializedBufferLength();
+        pointerExpression = protoSerializer.serializedBufferVar();
+        result.pr(protoSerializer.generateNetworkSerializerCode(variableToSerialize, null));
+        result.pr("size_t _lf_message_length = " + lengthExpression + ";");
+        result.pr(sendingFunction + "(" + commonArgs + ", " + pointerExpression + ");\n");
+      }
       case ROS2 ->
           throw new UnsupportedOperationException("ROS2 serialization is not supported yet.");
     }

--- a/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/PythonExtension.java
@@ -265,6 +265,7 @@ lf_enqueue_port_absent_reactions(self->base.environment);
         result.pr(protoSerializer.generateNetworkSerializerCode(variableToSerialize, null));
         result.pr("size_t _lf_message_length = " + lengthExpression + ";");
         result.pr(sendingFunction + "(" + commonArgs + ", " + pointerExpression + ");\n");
+        result.pr("free(" + FedProtoPythonSerialization.BUF_VAR + ");\n");
       }
       case ROS2 ->
           throw new UnsupportedOperationException("ROS2 serialization is not supported yet.");

--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -198,19 +198,21 @@ public class FedASTUtils {
     if (connection.serializer == SupportedSerializers.NATIVE) {
       action.setType(EcoreUtil.copy(connection.getSourcePortInstance().getDefinition().getType()));
     } else {
-      Type action_type = factory.createType();
       String bufferType =
           FedTargetExtensionFactory.getExtension(connection.srcFederate.targetConfig.target)
               .getNetworkBufferType();
-      // Split trailing '*' into the stars list to match the LF grammar:
-      //   id=DottedName (stars+='*')*
-      String baseType = bufferType;
-      while (baseType.endsWith("*")) {
-        baseType = baseType.substring(0, baseType.length() - 1).trim();
-        action_type.getStars().add("*");
+      if (bufferType != null && !bufferType.isEmpty()) {
+        Type action_type = factory.createType();
+        // Split trailing '*' into the stars list to match the LF grammar:
+        //   id=DottedName (stars+='*')*
+        String baseType = bufferType;
+        while (baseType.endsWith("*")) {
+          baseType = baseType.substring(0, baseType.length() - 1).trim();
+          action_type.getStars().add("*");
+        }
+        action_type.setId(baseType);
+        action.setType(action_type);
       }
-      action_type.setId(baseType);
-      action.setType(action_type);
     }
 
     // The connection is 'physical' if it uses the ~> notation.

--- a/core/src/main/java/org/lflang/federated/serialization/FedProtoPythonSerialization.java
+++ b/core/src/main/java/org/lflang/federated/serialization/FedProtoPythonSerialization.java
@@ -87,8 +87,7 @@ public class FedProtoPythonSerialization implements FedSerialization {
         "PyObject* _lf_descriptor = PyObject_GetAttrString(" + varName + ", \"DESCRIPTOR\");\n");
     code.append("if (_lf_descriptor == NULL) {\n");
     code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
-    code.append(
-        "    lf_print_error_and_exit(\"Failed to get DESCRIPTOR from proto object.\");\n");
+    code.append("    lf_print_error_and_exit(\"Failed to get DESCRIPTOR from proto object.\");\n");
     code.append("}\n");
     code.append(
         "PyObject* _lf_full_name_obj = PyObject_GetAttrString(_lf_descriptor, \"full_name\");\n");
@@ -100,16 +99,8 @@ public class FedProtoPythonSerialization implements FedSerialization {
     code.append("const char* _lf_full_name = PyUnicode_AsUTF8(_lf_full_name_obj);\n");
     code.append("size_t _lf_name_len = strlen(_lf_full_name);\n");
     // Allocate and fill the wire buffer.
-    code.append(
-        "size_t "
-            + LEN_VAR
-            + " = 4 + _lf_name_len + (size_t)_lf_proto_raw_len;\n");
-    code.append(
-        "unsigned char* "
-            + BUF_VAR
-            + " = (unsigned char*)malloc("
-            + LEN_VAR
-            + ");\n");
+    code.append("size_t " + LEN_VAR + " = 4 + _lf_name_len + (size_t)_lf_proto_raw_len;\n");
+    code.append("unsigned char* " + BUF_VAR + " = (unsigned char*)malloc(" + LEN_VAR + ");\n");
     code.append("if (" + BUF_VAR + " == NULL) {\n");
     code.append(
         "    lf_print_error_and_exit(\"Failed to allocate buffer for proto serialization.\");\n");
@@ -120,9 +111,7 @@ public class FedProtoPythonSerialization implements FedSerialization {
     code.append(BUF_VAR + "[3] = (unsigned char)(_lf_name_len & 0xFF);\n");
     code.append("memcpy(" + BUF_VAR + " + 4, _lf_full_name, _lf_name_len);\n");
     code.append(
-        "memcpy("
-            + BUF_VAR
-            + " + 4 + _lf_name_len, _lf_proto_raw, (size_t)_lf_proto_raw_len);\n");
+        "memcpy(" + BUF_VAR + " + 4 + _lf_name_len, _lf_proto_raw, (size_t)_lf_proto_raw_len);\n");
     code.append("Py_XDECREF(_lf_full_name_obj);\n");
     code.append("Py_XDECREF(_lf_proto_bytes);\n");
     return code;
@@ -142,11 +131,8 @@ public class FedProtoPythonSerialization implements FedSerialization {
     StringBuilder code = new StringBuilder();
     // Read wire format.
     code.append(
-        "const unsigned char* _lf_wire = (const unsigned char*)"
-            + varName
-            + "->token->value;\n");
-    code.append(
-        "size_t _lf_wire_len = (size_t)" + varName + "->token->length;\n");
+        "const unsigned char* _lf_wire = (const unsigned char*)" + varName + "->token->value;\n");
+    code.append("size_t _lf_wire_len = (size_t)" + varName + "->token->length;\n");
     code.append("if (_lf_wire_len < 4) {\n");
     code.append("    lf_print_error_and_exit(\"Proto wire format too short.\");\n");
     code.append("}\n");
@@ -157,10 +143,8 @@ public class FedProtoPythonSerialization implements FedSerialization {
     code.append(
         "    lf_print_error_and_exit(\"Proto wire format: name length exceeds buffer.\");\n");
     code.append("}\n");
-    code.append(
-        "const unsigned char* _lf_proto_data = _lf_wire + 4 + _lf_full_name_len;\n");
-    code.append(
-        "size_t _lf_proto_data_len = _lf_wire_len - 4 - _lf_full_name_len;\n");
+    code.append("const unsigned char* _lf_proto_data = _lf_wire + 4 + _lf_full_name_len;\n");
+    code.append("size_t _lf_proto_data_len = _lf_wire_len - 4 - _lf_full_name_len;\n");
     // Look up the proto class using Python's symbol database.
     code.append(
         "PyObject* _lf_sym_db_mod ="
@@ -171,8 +155,7 @@ public class FedProtoPythonSerialization implements FedSerialization {
         "    lf_print_error_and_exit(\"Failed to import"
             + " google.protobuf.symbol_database.\");\n");
     code.append("}\n");
-    code.append(
-        "PyObject* _lf_sym_db = PyObject_CallMethod(_lf_sym_db_mod, \"Default\", NULL);\n");
+    code.append("PyObject* _lf_sym_db = PyObject_CallMethod(_lf_sym_db_mod, \"Default\", NULL);\n");
     code.append("Py_XDECREF(_lf_sym_db_mod);\n");
     code.append("if (_lf_sym_db == NULL) {\n");
     code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
@@ -208,8 +191,7 @@ public class FedProtoPythonSerialization implements FedSerialization {
     code.append("Py_XDECREF(_lf_proto_bytes_obj);\n");
     code.append("if (_lf_parse_result == NULL) {\n");
     code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
-    code.append(
-        "    lf_print_error_and_exit(\"Failed to parse proto message from bytes.\");\n");
+    code.append("    lf_print_error_and_exit(\"Failed to parse proto message from bytes.\");\n");
     code.append("}\n");
     code.append("Py_XDECREF(_lf_parse_result);\n");
     return code;

--- a/core/src/main/java/org/lflang/federated/serialization/FedProtoPythonSerialization.java
+++ b/core/src/main/java/org/lflang/federated/serialization/FedProtoPythonSerialization.java
@@ -6,18 +6,29 @@ import org.lflang.target.Target;
 /**
  * Enables support for Protocol Buffer serialization in Python federated programs.
  *
- * <p>In the Python target, protobuf serialization is performed by the user in Python code (e.g.,
- * using {@code SerializeToString()} and {@code ParseFromString()}). This class bridges the C level:
- * it extracts raw bytes from a Python {@code bytes} object on the sender side and reconstructs a
- * Python {@code bytes} object from raw network bytes on the receiver side.
+ * <p>User reactions work with proto objects directly (no manual SerializeToString /
+ * ParseFromString calls). The generated C code:
+ *
+ * <ul>
+ *   <li>Sender: calls {@code SerializeToString()} on the Python proto object and prepends the
+ *       message's fully-qualified type name so the receiver can reconstruct the right class.
+ *   <li>Receiver: reads the type name from the wire format, uses Python's {@code
+ *       google.protobuf.symbol_database} to obtain the class, creates an instance, and calls
+ *       {@code ParseFromString()}.
+ * </ul>
+ *
+ * <p>Wire format: {@code [4-byte big-endian name length][UTF-8 full_name][proto bytes]}
  *
  * @author Hokeun Kim
  * @ingroup Federated
  */
 public class FedProtoPythonSerialization implements FedSerialization {
 
-  private static final String BUF_VAR = serializedVarName + "_buf";
-  private static final String LEN_VAR = serializedVarName + "_len";
+  /** Name of the malloc'd wire-format buffer variable in generated C code. */
+  public static final String BUF_VAR = "_lf_proto_wire_buf";
+
+  /** Name of the wire-format buffer length variable in generated C code. */
+  public static final String LEN_VAR = "_lf_proto_wire_len";
 
   @Override
   public boolean isCompatible(GeneratorBase generator) {
@@ -30,43 +41,98 @@ public class FedProtoPythonSerialization implements FedSerialization {
 
   @Override
   public String serializedBufferLength() {
-    return "(size_t)" + LEN_VAR;
+    return LEN_VAR;
   }
 
   @Override
   public String serializedBufferVar() {
-    return "(unsigned char*)" + BUF_VAR;
+    return BUF_VAR;
   }
 
   /**
-   * Generate code that extracts raw bytes from a Python {@code bytes} object.
+   * Generate C code that serializes a Python proto object into a self-describing wire buffer.
    *
-   * @param varName The Python bytes object (e.g. {@code sendRef->value}).
+   * <p>Wire format: {@code [4-byte big-endian name_len][full_name bytes][proto bytes]}
+   *
+   * <p>The caller is responsible for calling {@code free(_lf_proto_wire_buf)} after the buffer has
+   * been sent.
+   *
+   * @param varName C expression for the Python proto object (e.g. {@code sendRef->value}).
    * @param originalType Unused.
    */
   @Override
   public StringBuilder generateNetworkSerializerCode(String varName, String originalType) {
     StringBuilder code = new StringBuilder();
-    code.append("char* " + BUF_VAR + ";\n");
-    code.append("Py_ssize_t " + LEN_VAR + ";\n");
+    // Serialize the proto object to bytes.
     code.append(
-        "if (PyBytes_AsStringAndSize("
+        "PyObject* _lf_proto_bytes = PyObject_CallMethod("
             + varName
-            + ", &"
-            + BUF_VAR
-            + ", &"
-            + LEN_VAR
-            + ") == -1) {\n");
+            + ", \"SerializeToString\", NULL);\n");
+    code.append("if (_lf_proto_bytes == NULL) {\n");
     code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
     code.append(
-        "    lf_print_error_and_exit(\"Could not extract bytes from Python proto value for"
-            + " serialization.\");\n");
+        "    lf_print_error_and_exit(\"Failed to call SerializeToString on proto object.\");\n");
     code.append("}\n");
+    code.append("char* _lf_proto_raw;\n");
+    code.append("Py_ssize_t _lf_proto_raw_len;\n");
+    code.append(
+        "if (PyBytes_AsStringAndSize(_lf_proto_bytes, &_lf_proto_raw, &_lf_proto_raw_len)"
+            + " == -1) {\n");
+    code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
+    code.append(
+        "    lf_print_error_and_exit(\"Failed to extract bytes from serialized proto.\");\n");
+    code.append("}\n");
+    // Get the fully-qualified type name from DESCRIPTOR.full_name.
+    code.append(
+        "PyObject* _lf_descriptor = PyObject_GetAttrString(" + varName + ", \"DESCRIPTOR\");\n");
+    code.append("if (_lf_descriptor == NULL) {\n");
+    code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
+    code.append(
+        "    lf_print_error_and_exit(\"Failed to get DESCRIPTOR from proto object.\");\n");
+    code.append("}\n");
+    code.append(
+        "PyObject* _lf_full_name_obj = PyObject_GetAttrString(_lf_descriptor, \"full_name\");\n");
+    code.append("Py_XDECREF(_lf_descriptor);\n");
+    code.append("if (_lf_full_name_obj == NULL) {\n");
+    code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
+    code.append("    lf_print_error_and_exit(\"Failed to get full_name from DESCRIPTOR.\");\n");
+    code.append("}\n");
+    code.append("const char* _lf_full_name = PyUnicode_AsUTF8(_lf_full_name_obj);\n");
+    code.append("size_t _lf_name_len = strlen(_lf_full_name);\n");
+    // Allocate and fill the wire buffer.
+    code.append(
+        "size_t "
+            + LEN_VAR
+            + " = 4 + _lf_name_len + (size_t)_lf_proto_raw_len;\n");
+    code.append(
+        "unsigned char* "
+            + BUF_VAR
+            + " = (unsigned char*)malloc("
+            + LEN_VAR
+            + ");\n");
+    code.append("if (" + BUF_VAR + " == NULL) {\n");
+    code.append(
+        "    lf_print_error_and_exit(\"Failed to allocate buffer for proto serialization.\");\n");
+    code.append("}\n");
+    code.append(BUF_VAR + "[0] = (unsigned char)((_lf_name_len >> 24) & 0xFF);\n");
+    code.append(BUF_VAR + "[1] = (unsigned char)((_lf_name_len >> 16) & 0xFF);\n");
+    code.append(BUF_VAR + "[2] = (unsigned char)((_lf_name_len >> 8) & 0xFF);\n");
+    code.append(BUF_VAR + "[3] = (unsigned char)(_lf_name_len & 0xFF);\n");
+    code.append("memcpy(" + BUF_VAR + " + 4, _lf_full_name, _lf_name_len);\n");
+    code.append(
+        "memcpy("
+            + BUF_VAR
+            + " + 4 + _lf_name_len, _lf_proto_raw, (size_t)_lf_proto_raw_len);\n");
+    code.append("Py_XDECREF(_lf_full_name_obj);\n");
+    code.append("Py_XDECREF(_lf_proto_bytes);\n");
     return code;
   }
 
   /**
-   * Generate code that wraps raw network bytes in a Python {@code bytes} object.
+   * Generate C code that deserializes a wire buffer into a Python proto object.
+   *
+   * <p>The type name embedded in the wire format is used to look up the proto class via Python's
+   * {@code google.protobuf.symbol_database}, so no port-type annotation is required.
    *
    * @param varName The action variable name (accessed as {@code varName->token->value}).
    * @param targetType Unused.
@@ -74,20 +140,78 @@ public class FedProtoPythonSerialization implements FedSerialization {
   @Override
   public StringBuilder generateNetworkDeserializerCode(String varName, String targetType) {
     StringBuilder code = new StringBuilder();
+    // Read wire format.
     code.append(
-        "PyObject* "
-            + deserializedVarName
-            + " = PyBytes_FromStringAndSize((char*)"
+        "const unsigned char* _lf_wire = (const unsigned char*)"
             + varName
-            + "->token->value, "
-            + varName
-            + "->token->length);\n");
-    code.append("if (" + deserializedVarName + " == NULL) {\n");
+            + "->token->value;\n");
+    code.append(
+        "size_t _lf_wire_len = (size_t)" + varName + "->token->length;\n");
+    code.append("if (_lf_wire_len < 4) {\n");
+    code.append("    lf_print_error_and_exit(\"Proto wire format too short.\");\n");
+    code.append("}\n");
+    code.append(
+        "size_t _lf_full_name_len = ((size_t)_lf_wire[0] << 24) | ((size_t)_lf_wire[1] << 16)"
+            + " | ((size_t)_lf_wire[2] << 8) | (size_t)_lf_wire[3];\n");
+    code.append("if (_lf_wire_len < 4 + _lf_full_name_len) {\n");
+    code.append(
+        "    lf_print_error_and_exit(\"Proto wire format: name length exceeds buffer.\");\n");
+    code.append("}\n");
+    code.append(
+        "const unsigned char* _lf_proto_data = _lf_wire + 4 + _lf_full_name_len;\n");
+    code.append(
+        "size_t _lf_proto_data_len = _lf_wire_len - 4 - _lf_full_name_len;\n");
+    // Look up the proto class using Python's symbol database.
+    code.append(
+        "PyObject* _lf_sym_db_mod ="
+            + " PyImport_ImportModule(\"google.protobuf.symbol_database\");\n");
+    code.append("if (_lf_sym_db_mod == NULL) {\n");
     code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
     code.append(
-        "    lf_print_error_and_exit(\"Could not create Python bytes object for proto"
-            + " deserialization.\");\n");
+        "    lf_print_error_and_exit(\"Failed to import"
+            + " google.protobuf.symbol_database.\");\n");
     code.append("}\n");
+    code.append(
+        "PyObject* _lf_sym_db = PyObject_CallMethod(_lf_sym_db_mod, \"Default\", NULL);\n");
+    code.append("Py_XDECREF(_lf_sym_db_mod);\n");
+    code.append("if (_lf_sym_db == NULL) {\n");
+    code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
+    code.append("    lf_print_error_and_exit(\"Failed to get symbol database.\");\n");
+    code.append("}\n");
+    code.append(
+        "PyObject* _lf_full_name_pystr = PyUnicode_FromStringAndSize((const char*)(_lf_wire +"
+            + " 4), _lf_full_name_len);\n");
+    code.append(
+        "PyObject* _lf_cls = PyObject_CallMethod(_lf_sym_db, \"GetSymbol\", \"O\","
+            + " _lf_full_name_pystr);\n");
+    code.append("Py_XDECREF(_lf_sym_db);\n");
+    code.append("Py_XDECREF(_lf_full_name_pystr);\n");
+    code.append("if (_lf_cls == NULL) {\n");
+    code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
+    code.append(
+        "    lf_print_error_and_exit(\"Failed to get proto class from symbol database.\");\n");
+    code.append("}\n");
+    // Create an instance and populate it from the wire bytes.
+    code.append("PyObject* " + deserializedVarName + " = PyObject_CallNoArgs(_lf_cls);\n");
+    code.append("Py_XDECREF(_lf_cls);\n");
+    code.append("if (" + deserializedVarName + " == NULL) {\n");
+    code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
+    code.append("    lf_print_error_and_exit(\"Failed to create proto instance.\");\n");
+    code.append("}\n");
+    code.append(
+        "PyObject* _lf_proto_bytes_obj = PyBytes_FromStringAndSize((const char*)_lf_proto_data,"
+            + " (Py_ssize_t)_lf_proto_data_len);\n");
+    code.append(
+        "PyObject* _lf_parse_result = PyObject_CallMethod("
+            + deserializedVarName
+            + ", \"ParseFromString\", \"O\", _lf_proto_bytes_obj);\n");
+    code.append("Py_XDECREF(_lf_proto_bytes_obj);\n");
+    code.append("if (_lf_parse_result == NULL) {\n");
+    code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
+    code.append(
+        "    lf_print_error_and_exit(\"Failed to parse proto message from bytes.\");\n");
+    code.append("}\n");
+    code.append("Py_XDECREF(_lf_parse_result);\n");
     return code;
   }
 

--- a/core/src/main/java/org/lflang/federated/serialization/FedProtoPythonSerialization.java
+++ b/core/src/main/java/org/lflang/federated/serialization/FedProtoPythonSerialization.java
@@ -1,0 +1,103 @@
+package org.lflang.federated.serialization;
+
+import org.lflang.generator.GeneratorBase;
+import org.lflang.target.Target;
+
+/**
+ * Enables support for Protocol Buffer serialization in Python federated programs.
+ *
+ * <p>In the Python target, protobuf serialization is performed by the user in Python code (e.g.,
+ * using {@code SerializeToString()} and {@code ParseFromString()}). This class bridges the C level:
+ * it extracts raw bytes from a Python {@code bytes} object on the sender side and reconstructs a
+ * Python {@code bytes} object from raw network bytes on the receiver side.
+ *
+ * @author Hokeun Kim
+ * @ingroup Federated
+ */
+public class FedProtoPythonSerialization implements FedSerialization {
+
+  private static final String BUF_VAR = serializedVarName + "_buf";
+  private static final String LEN_VAR = serializedVarName + "_len";
+
+  @Override
+  public boolean isCompatible(GeneratorBase generator) {
+    if (generator.getTarget() != Target.Python) {
+      throw new UnsupportedOperationException(
+          "FedProtoPythonSerialization only supports the Python target.");
+    }
+    return true;
+  }
+
+  @Override
+  public String serializedBufferLength() {
+    return "(size_t)" + LEN_VAR;
+  }
+
+  @Override
+  public String serializedBufferVar() {
+    return "(unsigned char*)" + BUF_VAR;
+  }
+
+  /**
+   * Generate code that extracts raw bytes from a Python {@code bytes} object.
+   *
+   * @param varName The Python bytes object (e.g. {@code sendRef->value}).
+   * @param originalType Unused.
+   */
+  @Override
+  public StringBuilder generateNetworkSerializerCode(String varName, String originalType) {
+    StringBuilder code = new StringBuilder();
+    code.append("char* " + BUF_VAR + ";\n");
+    code.append("Py_ssize_t " + LEN_VAR + ";\n");
+    code.append(
+        "if (PyBytes_AsStringAndSize("
+            + varName
+            + ", &"
+            + BUF_VAR
+            + ", &"
+            + LEN_VAR
+            + ") == -1) {\n");
+    code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
+    code.append(
+        "    lf_print_error_and_exit(\"Could not extract bytes from Python proto value for"
+            + " serialization.\");\n");
+    code.append("}\n");
+    return code;
+  }
+
+  /**
+   * Generate code that wraps raw network bytes in a Python {@code bytes} object.
+   *
+   * @param varName The action variable name (accessed as {@code varName->token->value}).
+   * @param targetType Unused.
+   */
+  @Override
+  public StringBuilder generateNetworkDeserializerCode(String varName, String targetType) {
+    StringBuilder code = new StringBuilder();
+    code.append(
+        "PyObject* "
+            + deserializedVarName
+            + " = PyBytes_FromStringAndSize((char*)"
+            + varName
+            + "->token->value, "
+            + varName
+            + "->token->length);\n");
+    code.append("if (" + deserializedVarName + " == NULL) {\n");
+    code.append("    if (PyErr_Occurred()) PyErr_Print();\n");
+    code.append(
+        "    lf_print_error_and_exit(\"Could not create Python bytes object for proto"
+            + " deserialization.\");\n");
+    code.append("}\n");
+    return code;
+  }
+
+  @Override
+  public StringBuilder generatePreambleForSupport() {
+    return new StringBuilder();
+  }
+
+  @Override
+  public StringBuilder generateCompilerExtensionForSupport() {
+    return new StringBuilder();
+  }
+}

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 import org.lflang.FileConfig;
 import org.lflang.generator.CodeBuilder;
 import org.lflang.generator.LFGeneratorContext;
+import org.lflang.target.Target;
 import org.lflang.target.property.AuthProperty;
 import org.lflang.target.property.BuildTypeProperty;
 import org.lflang.target.property.CmakeIncludeProperty;
@@ -456,8 +457,9 @@ public class CCmakeGenerator {
       cMakeCode.newLine();
     }
 
-    // link protobuf
-    if (!targetConfig.get(ProtobufsProperty.INSTANCE).isEmpty()) {
+    // link protobuf (C only — Python handles protobuf via the Python runtime, not protobuf-c)
+    if (!targetConfig.get(ProtobufsProperty.INSTANCE).isEmpty()
+        && targetConfig.target != Target.Python) {
       cMakeCode.pr("include(FindPackageHandleStandardArgs)");
       cMakeCode.pr("FIND_PATH( PROTOBUF_INCLUDE_DIR protobuf-c/protobuf-c.h)");
       cMakeCode.pr(

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -301,10 +302,23 @@ public class PythonGenerator extends CGenerator implements CCmakeGenerator.SetUp
    */
   @Override
   public void processProtoFile(String filename) {
+    var protoPath = Paths.get(filename);
+    var absProto =
+        (protoPath.isAbsolute() ? protoPath : fileConfig.srcPath.resolve(protoPath))
+            .toAbsolutePath()
+            .normalize();
+    var absSrc = fileConfig.srcPath.toAbsolutePath().normalize();
+    // If the proto file is under srcPath use srcPath as the include root; otherwise (e.g. in
+    // federated builds where the path has ../ components) use the file's own parent directory.
+    Path includeRoot = absProto.startsWith(absSrc) ? absSrc : absProto.getParent();
+
     LFCommand protoc =
         commandFactory.createCommand(
             "protoc",
-            List.of("--python_out=" + fileConfig.getSrcGenPath(), filename),
+            List.of(
+                "--python_out=" + fileConfig.getSrcGenPath(),
+                "-I" + includeRoot,
+                absProto.toString()),
             fileConfig.srcPath);
 
     if (protoc == null) {

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -285,8 +285,10 @@ public class PythonGenerator extends CGenerator implements CCmakeGenerator.SetUp
   protected void handleProtoFiles() {
     for (String name : targetConfig.get(ProtobufsProperty.INSTANCE)) {
       this.processProtoFile(name);
-      int dotIndex = name.lastIndexOf(".");
-      String rootFilename = dotIndex > 0 ? name.substring(0, dotIndex) : name;
+      // Extract just the basename (no directory, no extension) for the Python import statement.
+      String basename = Paths.get(name).getFileName().toString();
+      int dotIndex = basename.lastIndexOf(".");
+      String rootFilename = dotIndex > 0 ? basename.substring(0, dotIndex) : basename;
       pythonPreamble.pr("import " + rootFilename + "_pb2 as " + rootFilename);
       protoNames.add(rootFilename);
     }
@@ -327,7 +329,7 @@ public class PythonGenerator extends CGenerator implements CCmakeGenerator.SetUp
     }
     int returnCode = protoc.run();
     if (returnCode == 0) {
-      pythonRequiredModules.add("google-api-python-client");
+      pythonRequiredModules.add("protobuf");
     } else {
       messageReporter.nowhere().error("protoc returns error code " + returnCode);
     }

--- a/test/Python/src/serialization/ProtoBuiltInSerialization.lf
+++ b/test/Python/src/serialization/ProtoBuiltInSerialization.lf
@@ -1,15 +1,10 @@
 /**
- * This test showcases automatic protobuf serialization and deserialization in federated C programs.
- * The sender federate sends a ProtoHelloWorld message to the receiver federate using serializer
- * "proto".
+ * This test showcases automatic protobuf serialization and deserialization in federated Python
+ * programs. The sender serializes a ProtoHelloWorld message to bytes using SerializeToString() and
+ * sends it to the receiver using serializer "proto". The receiver deserializes the bytes back into
+ * a ProtoHelloWorld message using ParseFromString().
  *
- * The port type is a pointer (ProtoHelloWorld*); the sender allocates and initializes the message
- * and uses lf_set to transfer ownership. On the receiver, the runtime manages the lifetime of the
- * deserialized message via the standard LF token mechanism and frees it with
- * protobuf_c_message_free_unpacked when the token reference count drops to zero.
- *
- * To run this test, install protoc, protoc-c, and libprotobuf-c. See PersonProtocolBuffers.lf for
- * details.
+ * To run this test, install protoc and the Python protobuf package (pip install protobuf).
  */
 target Python {
   protobufs: ProtoHelloWorld.proto,
@@ -24,7 +19,7 @@ reactor Sender {
   timer t(0, 1 sec)
 
   reaction(t) -> out {=
-    self.count++
+    self.count += 1
     protoHelloWorld = ProtoHelloWorld.ProtoHelloWorld()
     protoHelloWorld.name = "Hello World"
     protoHelloWorld.number = self.count
@@ -41,15 +36,10 @@ reactor Receiver {
   reaction(inp) {=
     unpacked = ProtoHelloWorld.ProtoHelloWorld()
     unpacked.ParseFromString(inp.value)
-    lf_print(
-      "Received: name=\"%s\", number=%d.",
-      unpacked.name,
-      unpacked.number
-    );
-    if (unpacked.number != self.count + 1) {
-      sys.stderr.write("Expected number " + str(self.count + 1) + ".")
-    }
-    self.count++
+    print(f"Received: name=\"{unpacked.name}\", number={unpacked.number}.")
+    if unpacked.number != self.count + 1:
+      sys.stderr.write("Expected number " + str(self.count + 1) + ".\n")
+    self.count += 1
   =}
 }
 

--- a/test/Python/src/serialization/ProtoBuiltInSerialization.lf
+++ b/test/Python/src/serialization/ProtoBuiltInSerialization.lf
@@ -31,7 +31,7 @@ reactor Sender {
 reactor Receiver {
   input inp
 
-  state count= 0
+  state count = 0
 
   reaction(inp) {=
     unpacked = ProtoHelloWorld.ProtoHelloWorld()

--- a/test/Python/src/serialization/ProtoBuiltInSerialization.lf
+++ b/test/Python/src/serialization/ProtoBuiltInSerialization.lf
@@ -1,0 +1,61 @@
+/**
+ * This test showcases automatic protobuf serialization and deserialization in federated C programs.
+ * The sender federate sends a ProtoHelloWorld message to the receiver federate using serializer
+ * "proto".
+ *
+ * The port type is a pointer (ProtoHelloWorld*); the sender allocates and initializes the message
+ * and uses lf_set to transfer ownership. On the receiver, the runtime manages the lifetime of the
+ * deserialized message via the standard LF token mechanism and frees it with
+ * protobuf_c_message_free_unpacked when the token reference count drops to zero.
+ *
+ * To run this test, install protoc, protoc-c, and libprotobuf-c. See PersonProtocolBuffers.lf for
+ * details.
+ */
+target Python {
+  protobufs: [ProtoHelloWorld.proto],
+  timeout: 2 sec
+}
+
+reactor Sender {
+  output out
+
+  state count = 0
+
+  timer t(0, 1 sec)
+
+  reaction(t) -> out {=
+    self.count++
+    protoHelloWorld = ProtoHelloWorld.ProtoHelloWorld()
+    protoHelloWorld.name = "Hello World"
+    protoHelloWorld.number = self.count
+    msg = protoHelloWorld.SerializeToString()
+    out.set(msg)
+  =}
+}
+
+reactor Receiver {
+  input inp
+
+  state count= 0
+
+  reaction(inp) {=
+    unpacked = ProtoHelloWorld.ProtoHelloWorld()
+    unpacked.ParseFromString(inp.value)
+    lf_print(
+      "Received: name=\"%s\", number=%d.",
+      unpacked.name,
+      unpacked.number
+    );
+    if (unpacked.number != self.count + 1) {
+      sys.stderr.write("Expected number " + str(self.count + 1) + ".")
+    }
+    self.count++
+  =}
+}
+
+federated reactor {
+  sender = new Sender()
+  receiver = new Receiver()
+
+  sender.out -> receiver.inp after 100 msec serializer "proto"
+}

--- a/test/Python/src/serialization/ProtoBuiltInSerialization.lf
+++ b/test/Python/src/serialization/ProtoBuiltInSerialization.lf
@@ -12,7 +12,7 @@
  * details.
  */
 target Python {
-  protobufs: [ProtoHelloWorld.proto],
+  protobufs: ProtoHelloWorld.proto,
   timeout: 2 sec
 }
 

--- a/test/Python/src/serialization/ProtoBuiltInSerialization.lf
+++ b/test/Python/src/serialization/ProtoBuiltInSerialization.lf
@@ -1,8 +1,9 @@
 /**
  * This test showcases automatic protobuf serialization and deserialization in federated Python
- * programs. The sender serializes a ProtoHelloWorld message to bytes using SerializeToString() and
- * sends it to the receiver using serializer "proto". The receiver deserializes the bytes back into
- * a ProtoHelloWorld message using ParseFromString().
+ * programs. The sender sets the port with a proto object and the generated code calls
+ * SerializeToString() transparently before sending. On the receiver side, the generated code
+ * reconstructs the proto object via ParseFromString() so the reaction receives the original proto
+ * object directly via inp.value.
  *
  * To run this test, install protoc and the Python protobuf package (pip install protobuf).
  */
@@ -23,8 +24,7 @@ reactor Sender {
     protoHelloWorld = ProtoHelloWorld.ProtoHelloWorld()
     protoHelloWorld.name = "Hello World"
     protoHelloWorld.number = self.count
-    msg = protoHelloWorld.SerializeToString()
-    out.set(msg)
+    out.set(protoHelloWorld)
   =}
 }
 
@@ -34,10 +34,8 @@ reactor Receiver {
   state count = 0
 
   reaction(inp) {=
-    unpacked = ProtoHelloWorld.ProtoHelloWorld()
-    unpacked.ParseFromString(inp.value)
-    print(f"Received: name=\"{unpacked.name}\", number={unpacked.number}.")
-    if unpacked.number != self.count + 1:
+    print(f"Received: name=\"{inp.value.name}\", number={inp.value.number}.")
+    if inp.value.number != self.count + 1:
       sys.stderr.write("Expected number " + str(self.count + 1) + ".\n")
     self.count += 1
   =}


### PR DESCRIPTION
> NOTE: This PR passes all Python tests, except for "Report to CodeCov", which failed due to a network connection error, not because of the changes in this PR. Please see https://github.com/lf-lang/lingua-franca/issues/2633 for more details about this flaky test issue.

This PR implements the protobuf serialization between LF federates in the Python target. This PR also adds a simple test to make sure that protobuf serialization works.