### PR TITLE
Exclude `FEDERATED_SST` from `runWithThreadingOff` and `runAsFederated` tests

### DIFF
--- a/core/src/integrationTest/java/org/lflang/tests/RuntimeTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/RuntimeTest.java
@@ -111,7 +111,6 @@ public abstract class RuntimeTest extends TestBase {
             // FIXME: also run the multiport tests once these are supported.
             TestCategory.MULTIPORT));
 
-
     runTestsFor(
         List.of(Target.C),
         Message.DESC_AS_FEDERATED,

--- a/core/src/integrationTest/java/org/lflang/tests/RuntimeTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/RuntimeTest.java
@@ -107,8 +107,10 @@ public abstract class RuntimeTest extends TestBase {
         EnumSet.of(
             TestCategory.CONCURRENT,
             TestCategory.FEDERATED,
+            TestCategory.FEDERATED_SST,
             // FIXME: also run the multiport tests once these are supported.
             TestCategory.MULTIPORT));
+
 
     runTestsFor(
         List.of(Target.C),
@@ -250,6 +252,7 @@ public abstract class RuntimeTest extends TestBase {
         category == TestCategory.CONCURRENT
             || category == TestCategory.SERIALIZATION
             || category == TestCategory.FEDERATED
+            || category == TestCategory.FEDERATED_SST
             || category == TestCategory.DOCKER_FEDERATED
             || category == TestCategory.DOCKER
             || category == TestCategory.ENCLAVE


### PR DESCRIPTION
Exclude the `FEDERATED_SST` test category from single-threaded (`runWithThreadingOff`) and as-federated (`runAsFederated`) test runs. 

This resolves CI failures on Windows runners, where C-target federated code generation is not supported.

Fixing problems [here](https://github.com/lf-lang/reactor-c/actions/runs/26664122058/job/78593605635).