### PR TITLE
Add startup delay for local SST Auth server

### DIFF
--- a/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
+++ b/core/src/main/java/org/lflang/federated/launcher/FedLauncherGenerator.java
@@ -420,7 +420,9 @@ public class FedLauncherGenerator {
         launchCodeWithoutLogging,
         "fi",
         "# Store the PID of the Auth",
-        "AUTH=$!");
+        "AUTH=$!",
+        "# Wait for Auth to boot up before starting RTI/federates",
+        "sleep 2");
   }
 
   private String getDistHeader() {


### PR DESCRIPTION
The generated launcher script immediately starts the RTI after launching the SST Auth server in the background without any delay. Because the Auth server (a Java process) takes time to initialize and listen on its port, the RTI frequently fails to connect during startup, leading to flaky execution failures.

I added a `sleep 2` delay after launching the local SST Auth server in `FedLauncherGenerator.java` before initiating the RTI. This aligns the local launcher behavior with the remote launcher, which already sleeps for 2 seconds to allow the Auth server to boot up properly.

This fixes the failure [here](https://github.com/lf-lang/reactor-c/actions/runs/26920503915/job/79419770897?pr=583).