### PR TITLE
Update validator to acknowledge that micro-LF supports multiports

### DIFF
--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -428,7 +428,7 @@ public enum Target {
   /** Return true if the target supports reactor inheritance (extends keyword). */
   public boolean supportsInheritance() {
     return switch (this) {
-      case C, CCPP, Python, Rust -> true;
+      case C, UC, CCPP, Python, Rust -> true;
       default -> false;
     };
   }
@@ -436,7 +436,7 @@ public enum Target {
   /** Return true if the target supports multiports and banks of reactors. */
   public boolean supportsMultiports() {
     return switch (this) {
-      case C, CCPP, CPP, Python, Rust, TS -> true;
+      case C, UC, CCPP, CPP, Python, Rust, TS -> true;
       default -> false;
     };
   }


### PR DESCRIPTION
This updates the validator so that the VS Code plugin does not report errors for features that are actually supported in Micro-LF.