### PR TITLE
Show `absent_after` in diagrams if explicitly given by the programmer

### DIFF
--- a/core/src/main/java/org/lflang/AttributeUtils.java
+++ b/core/src/main/java/org/lflang/AttributeUtils.java
@@ -363,6 +363,15 @@ public class AttributeUtils {
   }
 
   /**
+   * Return true if the given node has an explicit `@absent_after` attribute.
+   *
+   * @param node The AST node (a Connection).
+   */
+  public static boolean hasAbsentAfter(EObject node) {
+    return findAttributeByName(node, "absent_after") != null;
+  }
+
+  /**
    * Return the value of the `@absent_after` attribute of the given node or TimeValue.ZERO if does not
    * have one.
    *

--- a/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -1335,8 +1335,8 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
                 _linguaFrancaStyleExtensions.applyOnEdgeLabelStyle(connectionLabel);
               }
               // Add absent_after annotation if present
-              TimeValue absentAfter = AttributeUtils.getAbsentAfter(connection);
-              if (!absentAfter.equals(TimeValue.ZERO)) {
+              if (AttributeUtils.hasAbsentAfter(connection)) {
+                TimeValue absentAfter = AttributeUtils.getAbsentAfter(connection);
                 KLabel absentAfterLabel =
                     _kLabelExtensions.addCenterEdgeLabel(
                         edge, "absent_after: " + absentAfter.toString());


### PR DESCRIPTION
This PR changes the diagram generation to show `absent_after` if and only if it is explicitly given by the programmer in the .lf file.