### PR TITLE
Raising error for unsupported decentralized coordination for TypeScript target.

### DIFF
--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -425,6 +425,14 @@ public enum Target {
     };
   }
 
+  /** Return true if the target supports decentralized coordination. */
+  public boolean supportsDecentralizedCoordination() {
+    return switch (this) {
+      case C, CCPP, Python, Polyglot -> true;
+      default -> false;
+    };
+  }
+
   /** Return true if the target supports reactor inheritance (extends keyword). */
   public boolean supportsInheritance() {
     return switch (this) {

--- a/core/src/main/java/org/lflang/target/property/CoordinationProperty.java
+++ b/core/src/main/java/org/lflang/target/property/CoordinationProperty.java
@@ -3,6 +3,9 @@ package org.lflang.target.property;
 import org.lflang.MessageReporter;
 import org.lflang.ast.ASTUtils;
 import org.lflang.lf.Element;
+import org.lflang.lf.LfPackage.Literals;
+import org.lflang.target.Target;
+import org.lflang.target.TargetConfig;
 import org.lflang.target.property.type.CoordinationModeType;
 import org.lflang.target.property.type.CoordinationModeType.CoordinationMode;
 
@@ -33,6 +36,19 @@ public final class CoordinationProperty
   @Override
   protected CoordinationMode fromString(String string, MessageReporter reporter) {
     return ((CoordinationModeType) this.type).forName(string);
+  }
+
+  @Override
+  public void validate(TargetConfig config, MessageReporter reporter) {
+    if (config.get(this) == CoordinationMode.DECENTRALIZED
+        && !config.target.supportsDecentralizedCoordination()) {
+      reporter
+          .at(config.lookup(this), Literals.KEY_VALUE_PAIR__VALUE)
+          .error(
+              "The "
+                  + config.target.getDisplayName()
+                  + " target does not support decentralized coordination.");
+    }
   }
 
   @Override

--- a/core/src/main/java/org/lflang/target/property/CoordinationProperty.java
+++ b/core/src/main/java/org/lflang/target/property/CoordinationProperty.java
@@ -4,7 +4,6 @@ import org.lflang.MessageReporter;
 import org.lflang.ast.ASTUtils;
 import org.lflang.lf.Element;
 import org.lflang.lf.LfPackage.Literals;
-import org.lflang.target.Target;
 import org.lflang.target.TargetConfig;
 import org.lflang.target.property.type.CoordinationModeType;
 import org.lflang.target.property.type.CoordinationModeType.CoordinationMode;

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -119,6 +119,8 @@ import org.lflang.lf.WidthSpec;
 import org.lflang.lf.WidthTerm;
 import org.lflang.target.Target;
 import org.lflang.target.TargetConfig;
+import org.lflang.target.property.CoordinationProperty;
+import org.lflang.target.property.type.CoordinationModeType.CoordinationMode;
 import org.lflang.util.FileUtil;
 
 /**
@@ -1328,6 +1330,19 @@ public class LFValidator extends BaseLFValidator {
     String lfFileName = FileUtil.nameWithoutExtension(target.eResource());
     if (Character.isDigit(lfFileName.charAt(0))) {
       errorReporter.nowhere().error("LF file names must not start with a number");
+    }
+    if (targetOpt.isPresent() && targetOpt.get() == Target.TS && target.getConfig() != null) {
+      for (var pair : target.getConfig().getPairs()) {
+        if (CoordinationProperty.INSTANCE.name().equals(pair.getName())) {
+          String value = ASTUtils.elementToSingleString(pair.getValue());
+          if (CoordinationMode.DECENTRALIZED.toString().equals(value)) {
+            error(
+                "The TypeScript target does not support decentralized coordination.",
+                Literals.TARGET_DECL__CONFIG);
+          }
+          break;
+        }
+      }
     }
   }
 

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -119,8 +119,6 @@ import org.lflang.lf.WidthSpec;
 import org.lflang.lf.WidthTerm;
 import org.lflang.target.Target;
 import org.lflang.target.TargetConfig;
-import org.lflang.target.property.CoordinationProperty;
-import org.lflang.target.property.type.CoordinationModeType.CoordinationMode;
 import org.lflang.util.FileUtil;
 
 /**
@@ -1330,19 +1328,6 @@ public class LFValidator extends BaseLFValidator {
     String lfFileName = FileUtil.nameWithoutExtension(target.eResource());
     if (Character.isDigit(lfFileName.charAt(0))) {
       errorReporter.nowhere().error("LF file names must not start with a number");
-    }
-    if (targetOpt.isPresent() && targetOpt.get() == Target.TS && target.getConfig() != null) {
-      for (var pair : target.getConfig().getPairs()) {
-        if (CoordinationProperty.INSTANCE.name().equals(pair.getName())) {
-          String value = ASTUtils.elementToSingleString(pair.getValue());
-          if (CoordinationMode.DECENTRALIZED.toString().equals(value)) {
-            error(
-                "The TypeScript target does not support decentralized coordination.",
-                Literals.TARGET_DECL__CONFIG);
-          }
-          break;
-        }
-      }
     }
   }
 

--- a/core/src/main/resources/lib/ts/pnpm-workspace.yaml
+++ b/core/src/main/resources/lib/ts/pnpm-workspace.yaml
@@ -1,3 +1,1 @@
-onlyBuiltDependencies:
-  - '@lf-lang/reactor-ts'
-  - 'microtime'
+dangerouslyAllowAllBuilds: true

--- a/core/src/main/resources/lib/ts/pnpm-workspace.yaml
+++ b/core/src/main/resources/lib/ts/pnpm-workspace.yaml
@@ -1,3 +1,1 @@
-allowBuilds:
-  '@lf-lang/reactor-ts': true
-  'microtime': true
+dangerouslyAllowAllBuilds: true

--- a/core/src/main/resources/lib/ts/pnpm-workspace.yaml
+++ b/core/src/main/resources/lib/ts/pnpm-workspace.yaml
@@ -1,1 +1,3 @@
-dangerouslyAllowAllBuilds: true
+onlyBuiltDependencies:
+  - '@lf-lang/reactor-ts'
+  - 'microtime'

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -1102,7 +1102,7 @@ public class LinguaFrancaValidationTest {
                 }
                 main reactor {}
             """),
-        LfPackage.eINSTANCE.getTargetDecl(),
+        LfPackage.eINSTANCE.getKeyValuePair(),
         null,
         TestBase.Message.NO_DECENTRALIZED_COORDINATION_SUPPORT);
   }

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -40,6 +40,7 @@ import org.lflang.target.property.type.StringDictionaryType;
 import org.lflang.target.property.type.TargetPropertyType;
 import org.lflang.target.property.type.UnionType;
 import org.lflang.tests.LFInjectorProvider;
+import org.lflang.tests.TestBase;
 import org.lflang.util.StringUtil;
 
 /**
@@ -1089,6 +1090,21 @@ public class LinguaFrancaValidationTest {
             "The " + target.getDisplayName() + " target does not support federated execution.");
       }
     }
+  }
+
+  @Test
+  public void testDecentralizedCoordinationNotSupportedForTypeScript() throws Exception {
+    validator.assertError(
+        parseWithoutError(
+            """
+                target TypeScript {
+                  coordination: decentralized
+                }
+                main reactor {}
+            """),
+        LfPackage.eINSTANCE.getTargetDecl(),
+        null,
+        TestBase.Message.NO_DECENTRALIZED_COORDINATION_SUPPORT);
   }
 
   /** Tests for state and parameter declarations, including native lists. */

--- a/core/src/testFixtures/java/org/lflang/tests/TestBase.java
+++ b/core/src/testFixtures/java/org/lflang/tests/TestBase.java
@@ -125,6 +125,8 @@ public abstract class TestBase extends LfInjectedTestBase {
         "Target does not support single-threaded execution.";
     public static final String NO_FEDERATION_SUPPORT =
         "Target does not support federated execution.";
+    public static final String NO_DECENTRALIZED_COORDINATION_SUPPORT =
+        "The TypeScript target does not support decentralized coordination.";
     public static final String NO_ENCLAVE_SUPPORT = "Targeet does not support the enclave feature.";
     public static final String NO_DOCKER_SUPPORT = "Target does not support the 'docker' property.";
     public static final String NO_DOCKER_TEST_SUPPORT = "Docker tests are only supported on Linux.";


### PR DESCRIPTION
Problem: Currently, `lfc` compiles a TypeScript LF program with decentralized coordination in the target config without any error, even though decentralized coordination is not supported for TypeScript. Federated execution is supported with TypeScript, but only with centralized coordination. 

- Relevant PR for fixing the handbook documentation: https://github.com/lf-lang/lf-lang.github.io/pull/340