### PR TITLE
Deflake test by using default maxwait

### DIFF
--- a/test/C/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
+++ b/test/C/src/federated/DecentralizedP2PUnbalancedTimeoutPhysical.lf
@@ -47,9 +47,8 @@ reactor Destination {
 
 federated reactor(period: time = 10 usec) {
   c = new Clock(period=period)
-  // This needs a `maxwait` because otherwise it may advance to the stop time while the
-  // physical connection is in the process of assigning a timestamp.
-  @maxwait(1 ms)
+  // THe default `maxwait` of forever ensures that the Destination does not shut
+  // down before the Clock has even had a chance to start up, which would make the test flaky.
   d = new Destination()
   c.y ~> d.x
 }


### PR DESCRIPTION
This test occasionally would fail because the Destination would exit before the Clock even had a chance to start up. This revision adopts the (new) default maxwait of forever, which prevents the Destination from exiting prematurely.