### PR TITLE
Fix connection bug with port to multiport bank broadcast

### DIFF
--- a/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -1342,7 +1342,9 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
                 // squiggle as an on-line decorator instead, which follows the routed path. Ordinary
                 // connections keep the inline-label squiggle below.
                 _linguaFrancaStyleExtensions.addPhysicalConnectionSquiggle(
-                    edge, reactorInstance.isMainOrFederated() ? Colors.WHITE : Colors.GRAY_95, 0.5f);
+                    edge,
+                    reactorInstance.isMainOrFederated() ? Colors.WHITE : Colors.GRAY_95,
+                    0.5f);
               } else {
                 KLabel physicalConnectionLabel = _kLabelExtensions.addCenterEdgeLabel(edge, "---");
                 _linguaFrancaStyleExtensions.applyOnEdgePysicalStyle(

--- a/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -1008,6 +1008,12 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
     Table<ReactorInstance, PortInstance, KPort> outputPorts = HashBasedTable.create();
     Map<ReactionInstance, KNode> reactionNodes = new HashMap<>();
     Map<KPort, KNode> directConnectionDummyNodes = new HashMap<>();
+    // Tracks port pairs that are already connected by an edge so that connections collapsing onto
+    // the same pair of visual ports (e.g. bank or multiport broadcast connections) are rendered by
+    // a single edge instead of many overlapping ones. Without this, each overlapping edge would
+    // carry its own delay/physical decorator, duplicating the decorator (e.g. the physical
+    // connection squiggle) once per collapsed channel.
+    Table<KPort, KPort, KEdge> connectionEdges = HashBasedTable.create();
     Multimap<ActionInstance, KPort> actionDestinations = HashMultimap.create();
     Multimap<ActionInstance, KPort> actionSources = HashMultimap.create();
     Map<TimerInstance, KNode> timerNodes = new HashMap<>();
@@ -1305,6 +1311,14 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
           // There should be a connection, but skip if not.
           Connection connection = sendRange.connection;
           if (connection != null) {
+            // Skip connections that collapse onto a pair of visual ports already connected by an
+            // edge. This occurs for bank and multiport broadcast connections, where multiple
+            // runtime ranges map to the same source and target ports. Rendering them as separate
+            // overlapping edges would duplicate the edge decorators (such as the physical
+            // connection squiggle) once per collapsed channel.
+            if (source != null && target != null && connectionEdges.contains(source, target)) {
+              continue;
+            }
             KEdge edge =
                 createIODependencyEdge(
                     connection, (leftPort.isMultiport() || rightPort.isMultiport()));
@@ -1345,6 +1359,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
               }
             }
             if (source != null && target != null) {
+              connectionEdges.put(source, target, edge);
               // check for inside loop (direct in -> out connection with delay)
               if (parentInputPorts.values().contains(source)
                   && parentOutputPorts.values().contains(target)) {

--- a/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -1327,18 +1327,23 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
                   _kLabelExtensions.addCenterEdgeLabel(
                       edge, ASTUtils.toOriginalText(connection.getDelay()));
               associateWith(delayLabel, connection.getDelay());
+              _linguaFrancaStyleExtensions.applyOnEdgeDelayStyle(delayLabel);
               if (connection.isPhysical()) {
-                _linguaFrancaStyleExtensions.applyOnEdgePysicalDelayStyle(
-                    delayLabel,
-                    reactorInstance.isMainOrFederated() ? Colors.WHITE : Colors.GRAY_95);
-              } else {
-                _linguaFrancaStyleExtensions.applyOnEdgeDelayStyle(delayLabel);
+                // Render the physical indicator as an on-line squiggle decorator (which follows
+                // the routed edge path) and keep the delay value as a separate inline label. The
+                // squiggle is offset toward the source so it does not overlap the delay label,
+                // which is centered on the edge.
+                _linguaFrancaStyleExtensions.addPhysicalConnectionSquiggle(
+                    edge,
+                    reactorInstance.isMainOrFederated() ? Colors.WHITE : Colors.GRAY_95,
+                    0.25f);
               }
             } else if (connection.isPhysical()) {
-              KLabel physicalConnectionLabel = _kLabelExtensions.addCenterEdgeLabel(edge, "---");
-              _linguaFrancaStyleExtensions.applyOnEdgePysicalStyle(
-                  physicalConnectionLabel,
-                  reactorInstance.isMainOrFederated() ? Colors.WHITE : Colors.GRAY_95);
+              // Draw the physical-connection squiggle as a decorator on the edge line (rather than
+              // an inline label) so it stays on the connection line for any routing, including
+              // self-loop / feedback connections that are routed around a node.
+              _linguaFrancaStyleExtensions.addPhysicalConnectionSquiggle(
+                  edge, reactorInstance.isMainOrFederated() ? Colors.WHITE : Colors.GRAY_95, 0.5f);
             }
             // Add label annotation if present
             if (getBooleanValue(SHOW_USER_LABELS)) {

--- a/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -1327,23 +1327,28 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
                   _kLabelExtensions.addCenterEdgeLabel(
                       edge, ASTUtils.toOriginalText(connection.getDelay()));
               associateWith(delayLabel, connection.getDelay());
-              _linguaFrancaStyleExtensions.applyOnEdgeDelayStyle(delayLabel);
               if (connection.isPhysical()) {
-                // Render the physical indicator as an on-line squiggle decorator (which follows
-                // the routed edge path) and keep the delay value as a separate inline label. The
-                // squiggle is offset toward the source so it does not overlap the delay label,
-                // which is centered on the edge.
-                _linguaFrancaStyleExtensions.addPhysicalConnectionSquiggle(
-                    edge,
-                    reactorInstance.isMainOrFederated() ? Colors.WHITE : Colors.GRAY_95,
-                    0.25f);
+                _linguaFrancaStyleExtensions.applyOnEdgePysicalDelayStyle(
+                    delayLabel,
+                    reactorInstance.isMainOrFederated() ? Colors.WHITE : Colors.GRAY_95);
+              } else {
+                _linguaFrancaStyleExtensions.applyOnEdgeDelayStyle(delayLabel);
               }
             } else if (connection.isPhysical()) {
-              // Draw the physical-connection squiggle as a decorator on the edge line (rather than
-              // an inline label) so it stays on the connection line for any routing, including
-              // self-loop / feedback connections that are routed around a node.
-              _linguaFrancaStyleExtensions.addPhysicalConnectionSquiggle(
-                  edge, reactorInstance.isMainOrFederated() ? Colors.WHITE : Colors.GRAY_95, 0.5f);
+              if (source != null && target != null && source.getNode() == target.getNode()) {
+                // Self-loop / feedback connections (e.g. a bank's output routed back to its own
+                // input) are routed around the node, where ELK does not honor inline label
+                // placement and the label-based squiggle ends up off the connection line. Draw the
+                // squiggle as an on-line decorator instead, which follows the routed path. Ordinary
+                // connections keep the inline-label squiggle below.
+                _linguaFrancaStyleExtensions.addPhysicalConnectionSquiggle(
+                    edge, reactorInstance.isMainOrFederated() ? Colors.WHITE : Colors.GRAY_95, 0.5f);
+              } else {
+                KLabel physicalConnectionLabel = _kLabelExtensions.addCenterEdgeLabel(edge, "---");
+                _linguaFrancaStyleExtensions.applyOnEdgePysicalStyle(
+                    physicalConnectionLabel,
+                    reactorInstance.isMainOrFederated() ? Colors.WHITE : Colors.GRAY_95);
+              }
             }
             // Add label annotation if present
             if (getBooleanValue(SHOW_USER_LABELS)) {

--- a/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/LinguaFrancaSynthesis.java
@@ -1012,8 +1012,9 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
     // the same pair of visual ports (e.g. bank or multiport broadcast connections) are rendered by
     // a single edge instead of many overlapping ones. Without this, each overlapping edge would
     // carry its own delay/physical decorator, duplicating the decorator (e.g. the physical
-    // connection squiggle) once per collapsed channel.
-    Table<KPort, KPort, KEdge> connectionEdges = HashBasedTable.create();
+    // connection squiggle) once per collapsed channel. Only the existence of a pair matters here,
+    // so a set of (source, target) pairs is tracked rather than the edges themselves.
+    Multimap<KPort, KPort> connectedPortPairs = HashMultimap.create();
     Multimap<ActionInstance, KPort> actionDestinations = HashMultimap.create();
     Multimap<ActionInstance, KPort> actionSources = HashMultimap.create();
     Map<TimerInstance, KNode> timerNodes = new HashMap<>();
@@ -1316,7 +1317,9 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
             // runtime ranges map to the same source and target ports. Rendering them as separate
             // overlapping edges would duplicate the edge decorators (such as the physical
             // connection squiggle) once per collapsed channel.
-            if (source != null && target != null && connectionEdges.contains(source, target)) {
+            if (source != null
+                && target != null
+                && connectedPortPairs.containsEntry(source, target)) {
               continue;
             }
             KEdge edge =
@@ -1371,7 +1374,7 @@ public class LinguaFrancaSynthesis extends AbstractDiagramSynthesis<Model> {
               }
             }
             if (source != null && target != null) {
-              connectionEdges.put(source, target, edge);
+              connectedPortPairs.put(source, target);
               // check for inside loop (direct in -> out connection with delay)
               if (parentInputPorts.values().contains(source)
                   && parentOutputPorts.values().contains(target)) {

--- a/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaStyleExtensions.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaStyleExtensions.java
@@ -314,13 +314,174 @@ public class LinguaFrancaStyleExtensions extends AbstractSynthesisExtensions {
     _onEdgeDelayLabelConfigurator.applyTo(label);
   }
 
+  private static LabelDecorationConfigurator
+      _onEdgePysicalDelayLabelConfigurator; // ONLY for use in applyOnEdgePysicalDelayStyle
+
+  public void applyOnEdgePysicalDelayStyle(KLabel label, Colors parentBackgroundColor) {
+    if (_onEdgePysicalDelayLabelConfigurator == null) {
+      LabelDecorationConfigurator configurator =
+          LabelDecorationConfigurator.create().withInlineLabels(true);
+      configurator =
+          configurator.withLabelTextRenderingProvider(
+              (KContainerRendering container, KLabel klabel) -> {
+                KText kText = _kRenderingFactory.createKText();
+                _kRenderingExtensions.setFontSize(kText, 8);
+                boldTextSelectionStyle(kText);
+                kText.setProperty(
+                    KlighdInternalProperties.MODEL_ELEMEMT,
+                    klabel.getProperty(KlighdInternalProperties.MODEL_ELEMEMT));
+                container.getChildren().add(kText);
+                return kText;
+              });
+      configurator =
+          configurator.addDecoratorRenderingProvider(
+              new IDecoratorRenderingProvider() {
+                @Override
+                public ElkPadding createDecoratorRendering(
+                    KContainerRendering container,
+                    KLabel label,
+                    LabelDecorationConfigurator.LayoutMode layoutMode) {
+                  ElkPadding padding = new ElkPadding();
+                  padding.top = 1;
+                  padding.bottom = 1;
+                  padding.left = 8;
+                  padding.right = 16;
+
+                  KPolygon polygon = _kRenderingFactory.createKPolygon();
+                  _kRenderingExtensions.from(polygon, LEFT, 0, 0, BOTTOM, 0, 0.5f);
+                  _kRenderingExtensions.to(polygon, LEFT, 0, 0, TOP, 1, 0.5f);
+                  _kRenderingExtensions.to(polygon, RIGHT, 0, 0, TOP, 1, 0.5f);
+                  _kRenderingExtensions.to(polygon, RIGHT, 0, 0, BOTTOM, 0, 0.5f);
+                  _kRenderingExtensions.setBackground(
+                      polygon, label.getProperty(LABEL_PARENT_BACKGROUND));
+                  _kRenderingExtensions.setForeground(
+                      polygon, label.getProperty(LABEL_PARENT_BACKGROUND));
+                  container.getChildren().add(polygon);
+
+                  KSpline kSpline = _kRenderingFactory.createKSpline();
+                  _kRenderingExtensions.from(kSpline, LEFT, -0.66f, 0, BOTTOM, -0.5f, 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 1, 0, BOTTOM, -0.5f, 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 3, 0, BOTTOM, 8, 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 5, 0, BOTTOM, 0, 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 5.5f, 0, BOTTOM, -1.5f, 0.5f);
+                  container.getChildren().add(kSpline);
+
+                  kSpline = _kRenderingFactory.createKSpline();
+                  _kRenderingExtensions.from(kSpline, RIGHT, 15f, 0, BOTTOM, 3.5f, 0.5f);
+                  _kRenderingExtensions.to(kSpline, RIGHT, 14f, 0, BOTTOM, 0, 0.5f);
+                  _kRenderingExtensions.to(kSpline, RIGHT, 11, 0, BOTTOM, -8, 0.5f);
+                  _kRenderingExtensions.to(kSpline, RIGHT, 9, 0, BOTTOM, 0, 0.5f);
+                  _kRenderingExtensions.to(kSpline, RIGHT, 7, 0, BOTTOM, 8, 0.5f);
+                  _kRenderingExtensions.to(kSpline, RIGHT, 4f, 0, BOTTOM, 2, 0.5f);
+                  _kRenderingExtensions.to(kSpline, RIGHT, 1.5f, 0, BOTTOM, 0.5f, 0.5f);
+                  _kRenderingExtensions.to(kSpline, RIGHT, 0.2f, 0, BOTTOM, -0.5f, 0.5f);
+                  _kRenderingExtensions.to(kSpline, RIGHT, -0.7f, 0, BOTTOM, -0.5f, 0.5f);
+                  container.getChildren().add(kSpline);
+
+                  polygon = _kRenderingFactory.createKPolygon();
+                  _kRenderingExtensions.from(polygon, LEFT, 4, 0, BOTTOM, 0, 0);
+                  _kRenderingExtensions.to(polygon, LEFT, 8, 0, TOP, 0, 0);
+                  _kRenderingExtensions.to(polygon, RIGHT, 12, 0, TOP, 0, 0);
+                  _kRenderingExtensions.to(polygon, RIGHT, 16, 0, BOTTOM, 0, 0);
+                  _kRenderingExtensions.setBackground(polygon, Colors.WHITE);
+                  _kRenderingExtensions.setForeground(polygon, Colors.WHITE);
+                  container.getChildren().add(polygon);
+
+                  KPolyline polyline = _kRenderingFactory.createKPolyline();
+                  _kRenderingExtensions.from(polyline, LEFT, 4, 0, BOTTOM, 0, 0);
+                  _kRenderingExtensions.to(polyline, LEFT, 8, 0, TOP, 0, 0);
+                  container.getChildren().add(polyline);
+
+                  polyline = _kRenderingFactory.createKPolyline();
+                  _kRenderingExtensions.from(polyline, RIGHT, 16, 0, BOTTOM, 0, 0);
+                  _kRenderingExtensions.to(polyline, RIGHT, 12, 0, TOP, 0, 0);
+                  container.getChildren().add(polyline);
+
+                  return padding;
+                }
+              });
+      _onEdgePysicalDelayLabelConfigurator = configurator;
+    }
+    label.setProperty(LABEL_PARENT_BACKGROUND, parentBackgroundColor);
+    _onEdgePysicalDelayLabelConfigurator.applyTo(label);
+  }
+
+  private static LabelDecorationConfigurator
+      _onEdgePysicalLabelConfigurator; // ONLY for use in applyOnEdgePysicalStyle
+
+  public void applyOnEdgePysicalStyle(KLabel label, Colors parentBackgroundColor) {
+    if (_onEdgePysicalLabelConfigurator == null) {
+      LabelDecorationConfigurator configurator =
+          LabelDecorationConfigurator.create().withInlineLabels(true);
+      configurator =
+          configurator.withLabelTextRenderingProvider(
+              (KContainerRendering container, KLabel klabel) -> {
+                KText kText = _kRenderingFactory.createKText();
+                _kRenderingExtensions.setInvisible(kText, true);
+                container.getChildren().add(kText);
+                return kText;
+              });
+      configurator =
+          configurator.addDecoratorRenderingProvider(
+              new IDecoratorRenderingProvider() {
+                @Override
+                public ElkPadding createDecoratorRendering(
+                    final KContainerRendering container,
+                    final KLabel label,
+                    final LabelDecorationConfigurator.LayoutMode layoutMode) {
+                  ElkPadding padding = new ElkPadding();
+                  padding.top = 1;
+                  padding.bottom = 1;
+                  padding.left = 3;
+                  padding.right = 3;
+
+                  KPolygon polygon = _kRenderingFactory.createKPolygon();
+                  _kRenderingExtensions.from(polygon, LEFT, 0, 0, BOTTOM, 0, 0.5f);
+                  _kRenderingExtensions.to(polygon, LEFT, 0, 0, TOP, 1, 0.5f);
+                  _kRenderingExtensions.to(polygon, RIGHT, 0, 0, TOP, 1, 0.5f);
+                  _kRenderingExtensions.to(polygon, RIGHT, 0, 0, BOTTOM, 0, 0.5f);
+                  _kRenderingExtensions.setBackground(
+                      polygon, label.getProperty(LABEL_PARENT_BACKGROUND));
+                  _kRenderingExtensions.setForeground(
+                      polygon, label.getProperty(LABEL_PARENT_BACKGROUND));
+                  container.getChildren().add(polygon);
+
+                  KSpline kSpline = _kRenderingFactory.createKSpline();
+                  _kRenderingExtensions.from(kSpline, LEFT, (-0.66f), 0, BOTTOM, (-0.5f), 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 1, 0, BOTTOM, (-0.5f), 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.1f, BOTTOM, 8, 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.2f, BOTTOM, 0, 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.3f, BOTTOM, (-8), 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.4f, BOTTOM, 0, 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.45f, BOTTOM, 4f, 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.5f, BOTTOM, 8, 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.55f, BOTTOM, 4f, 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.6f, BOTTOM, 0, 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.65f, BOTTOM, (-4), 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.7f, BOTTOM, (-8), 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.8f, BOTTOM, (-4), 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.9f, BOTTOM, 0, 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, (-1), 1, BOTTOM, (-0.5f), 0.5f);
+                  _kRenderingExtensions.to(kSpline, LEFT, 0.66f, 1, BOTTOM, (-0.5f), 0.5f);
+                  container.getChildren().add(kSpline);
+                  return padding;
+                }
+              });
+      _onEdgePysicalLabelConfigurator = configurator;
+    }
+    label.setProperty(LABEL_PARENT_BACKGROUND, parentBackgroundColor);
+    _onEdgePysicalLabelConfigurator.applyTo(label);
+  }
+
   /**
    * Draws the physical-connection "squiggle" directly on the edge's line as a decorator instead of
    * as an inline center label. Unlike an inline label, an on-line decorator follows the routed edge
-   * path, so the squiggle stays on the connection line even when the edge is routed around a node
-   * (such as a self-loop / feedback connection from a bank's output back to its own input, where
-   * ELK does not honor inline label placement). The {@code parentBackgroundColor} is used to erase
-   * the underlying straight line so the squiggle visually replaces it.
+   * path, so the squiggle stays on the connection line even when the edge is routed around a node.
+   * This is used only for self-loop / feedback connections (e.g. a bank's output routed back to its
+   * own input), where ELK does not honor inline label placement and the label-based squiggle ends
+   * up off the line; ordinary connections continue to use {@link #applyOnEdgePysicalStyle}. The
+   * {@code parentBackgroundColor} is used to erase the underlying straight line so the squiggle
+   * visually replaces it.
    *
    * @param edge the connection edge to decorate
    * @param parentBackgroundColor the background color behind the edge, used to mask the line

--- a/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaStyleExtensions.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaStyleExtensions.java
@@ -314,163 +314,79 @@ public class LinguaFrancaStyleExtensions extends AbstractSynthesisExtensions {
     _onEdgeDelayLabelConfigurator.applyTo(label);
   }
 
-  private static LabelDecorationConfigurator
-      _onEdgePysicalDelayLabelConfigurator; // ONLY for use in applyOnEdgePysicalDelayStyle
-
-  public void applyOnEdgePysicalDelayStyle(KLabel label, Colors parentBackgroundColor) {
-    if (_onEdgePysicalDelayLabelConfigurator == null) {
-      LabelDecorationConfigurator configurator =
-          LabelDecorationConfigurator.create().withInlineLabels(true);
-      configurator =
-          configurator.withLabelTextRenderingProvider(
-              (KContainerRendering container, KLabel klabel) -> {
-                KText kText = _kRenderingFactory.createKText();
-                _kRenderingExtensions.setFontSize(kText, 8);
-                boldTextSelectionStyle(kText);
-                kText.setProperty(
-                    KlighdInternalProperties.MODEL_ELEMEMT,
-                    klabel.getProperty(KlighdInternalProperties.MODEL_ELEMEMT));
-                container.getChildren().add(kText);
-                return kText;
-              });
-      configurator =
-          configurator.addDecoratorRenderingProvider(
-              new IDecoratorRenderingProvider() {
-                @Override
-                public ElkPadding createDecoratorRendering(
-                    KContainerRendering container,
-                    KLabel label,
-                    LabelDecorationConfigurator.LayoutMode layoutMode) {
-                  ElkPadding padding = new ElkPadding();
-                  padding.top = 1;
-                  padding.bottom = 1;
-                  padding.left = 8;
-                  padding.right = 16;
-
-                  KPolygon polygon = _kRenderingFactory.createKPolygon();
-                  _kRenderingExtensions.from(polygon, LEFT, 0, 0, BOTTOM, 0, 0.5f);
-                  _kRenderingExtensions.to(polygon, LEFT, 0, 0, TOP, 1, 0.5f);
-                  _kRenderingExtensions.to(polygon, RIGHT, 0, 0, TOP, 1, 0.5f);
-                  _kRenderingExtensions.to(polygon, RIGHT, 0, 0, BOTTOM, 0, 0.5f);
-                  _kRenderingExtensions.setBackground(
-                      polygon, label.getProperty(LABEL_PARENT_BACKGROUND));
-                  _kRenderingExtensions.setForeground(
-                      polygon, label.getProperty(LABEL_PARENT_BACKGROUND));
-                  container.getChildren().add(polygon);
-
-                  KSpline kSpline = _kRenderingFactory.createKSpline();
-                  _kRenderingExtensions.from(kSpline, LEFT, -0.66f, 0, BOTTOM, -0.5f, 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 1, 0, BOTTOM, -0.5f, 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 3, 0, BOTTOM, 8, 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 5, 0, BOTTOM, 0, 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 5.5f, 0, BOTTOM, -1.5f, 0.5f);
-                  container.getChildren().add(kSpline);
-
-                  kSpline = _kRenderingFactory.createKSpline();
-                  _kRenderingExtensions.from(kSpline, RIGHT, 15f, 0, BOTTOM, 3.5f, 0.5f);
-                  _kRenderingExtensions.to(kSpline, RIGHT, 14f, 0, BOTTOM, 0, 0.5f);
-                  _kRenderingExtensions.to(kSpline, RIGHT, 11, 0, BOTTOM, -8, 0.5f);
-                  _kRenderingExtensions.to(kSpline, RIGHT, 9, 0, BOTTOM, 0, 0.5f);
-                  _kRenderingExtensions.to(kSpline, RIGHT, 7, 0, BOTTOM, 8, 0.5f);
-                  _kRenderingExtensions.to(kSpline, RIGHT, 4f, 0, BOTTOM, 2, 0.5f);
-                  _kRenderingExtensions.to(kSpline, RIGHT, 1.5f, 0, BOTTOM, 0.5f, 0.5f);
-                  _kRenderingExtensions.to(kSpline, RIGHT, 0.2f, 0, BOTTOM, -0.5f, 0.5f);
-                  _kRenderingExtensions.to(kSpline, RIGHT, -0.7f, 0, BOTTOM, -0.5f, 0.5f);
-                  container.getChildren().add(kSpline);
-
-                  polygon = _kRenderingFactory.createKPolygon();
-                  _kRenderingExtensions.from(polygon, LEFT, 4, 0, BOTTOM, 0, 0);
-                  _kRenderingExtensions.to(polygon, LEFT, 8, 0, TOP, 0, 0);
-                  _kRenderingExtensions.to(polygon, RIGHT, 12, 0, TOP, 0, 0);
-                  _kRenderingExtensions.to(polygon, RIGHT, 16, 0, BOTTOM, 0, 0);
-                  _kRenderingExtensions.setBackground(polygon, Colors.WHITE);
-                  _kRenderingExtensions.setForeground(polygon, Colors.WHITE);
-                  container.getChildren().add(polygon);
-
-                  KPolyline polyline = _kRenderingFactory.createKPolyline();
-                  _kRenderingExtensions.from(polyline, LEFT, 4, 0, BOTTOM, 0, 0);
-                  _kRenderingExtensions.to(polyline, LEFT, 8, 0, TOP, 0, 0);
-                  container.getChildren().add(polyline);
-
-                  polyline = _kRenderingFactory.createKPolyline();
-                  _kRenderingExtensions.from(polyline, RIGHT, 16, 0, BOTTOM, 0, 0);
-                  _kRenderingExtensions.to(polyline, RIGHT, 12, 0, TOP, 0, 0);
-                  container.getChildren().add(polyline);
-
-                  return padding;
-                }
-              });
-      _onEdgePysicalDelayLabelConfigurator = configurator;
+  /**
+   * Draws the physical-connection "squiggle" directly on the edge's line as a decorator instead of
+   * as an inline center label. Unlike an inline label, an on-line decorator follows the routed edge
+   * path, so the squiggle stays on the connection line even when the edge is routed around a node
+   * (such as a self-loop / feedback connection from a bank's output back to its own input, where
+   * ELK does not honor inline label placement). The {@code parentBackgroundColor} is used to erase
+   * the underlying straight line so the squiggle visually replaces it.
+   *
+   * @param edge the connection edge to decorate
+   * @param parentBackgroundColor the background color behind the edge, used to mask the line
+   * @param relative the position along the edge path (0..1) at which to center the squiggle
+   */
+  public void addPhysicalConnectionSquiggle(
+      KEdge edge, Colors parentBackgroundColor, float relative) {
+    final KRendering rendering = _kRenderingExtensions.getKRendering(edge);
+    if (!(rendering instanceof KContainerRendering)) {
+      return;
     }
-    label.setProperty(LABEL_PARENT_BACKGROUND, parentBackgroundColor);
-    _onEdgePysicalDelayLabelConfigurator.applyTo(label);
+    final KContainerRendering line = (KContainerRendering) rendering;
+
+    // Erase the straight line underneath the squiggle so the squiggle replaces it rather than
+    // being drawn on top of a visible straight segment.
+    KPolygon erase = _kRenderingFactory.createKPolygon();
+    _kRenderingExtensions.from(erase, LEFT, 0, 0, BOTTOM, (-3), 0.5f);
+    _kRenderingExtensions.to(erase, LEFT, 0, 0, BOTTOM, 3, 0.5f);
+    _kRenderingExtensions.to(erase, RIGHT, 0, 0, BOTTOM, 3, 0.5f);
+    _kRenderingExtensions.to(erase, RIGHT, 0, 0, BOTTOM, (-3), 0.5f);
+    _kRenderingExtensions.setBackground(erase, parentBackgroundColor);
+    _kRenderingExtensions.setForeground(erase, parentBackgroundColor);
+    line.getChildren().add(erase);
+    erase.setPlacementData(createSquigglePlacement(relative));
+
+    // The wavy line. Coordinates are interpreted relative to the decorator box (see
+    // createSquigglePlacement); the vertical center (relative 0.5 from BOTTOM) lies on the edge
+    // line, and the wave spans the box width.
+    KSpline kSpline = _kRenderingFactory.createKSpline();
+    _kRenderingExtensions.from(kSpline, LEFT, (-0.66f), 0, BOTTOM, (-0.5f), 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 1, 0, BOTTOM, (-0.5f), 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 0, 0.1f, BOTTOM, 8, 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 0, 0.2f, BOTTOM, 0, 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 0, 0.3f, BOTTOM, (-8), 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 0, 0.4f, BOTTOM, 0, 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 0, 0.45f, BOTTOM, 4f, 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 0, 0.5f, BOTTOM, 8, 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 0, 0.55f, BOTTOM, 4f, 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 0, 0.6f, BOTTOM, 0, 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 0, 0.65f, BOTTOM, (-4), 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 0, 0.7f, BOTTOM, (-8), 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 0, 0.8f, BOTTOM, (-4), 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 0, 0.9f, BOTTOM, 0, 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, (-1), 1, BOTTOM, (-0.5f), 0.5f);
+    _kRenderingExtensions.to(kSpline, LEFT, 0.66f, 1, BOTTOM, (-0.5f), 0.5f);
+    line.getChildren().add(kSpline);
+    kSpline.setPlacementData(createSquigglePlacement(relative));
   }
 
-  private static LabelDecorationConfigurator
-      _onEdgePysicalLabelConfigurator; // ONLY for use in applyOnEdgePysicalStyle
-
-  public void applyOnEdgePysicalStyle(KLabel label, Colors parentBackgroundColor) {
-    if (_onEdgePysicalLabelConfigurator == null) {
-      LabelDecorationConfigurator configurator =
-          LabelDecorationConfigurator.create().withInlineLabels(true);
-      configurator =
-          configurator.withLabelTextRenderingProvider(
-              (KContainerRendering container, KLabel klabel) -> {
-                KText kText = _kRenderingFactory.createKText();
-                _kRenderingExtensions.setInvisible(kText, true);
-                container.getChildren().add(kText);
-                return kText;
-              });
-      configurator =
-          configurator.addDecoratorRenderingProvider(
-              new IDecoratorRenderingProvider() {
-                @Override
-                public ElkPadding createDecoratorRendering(
-                    final KContainerRendering container,
-                    final KLabel label,
-                    final LabelDecorationConfigurator.LayoutMode layoutMode) {
-                  ElkPadding padding = new ElkPadding();
-                  padding.top = 1;
-                  padding.bottom = 1;
-                  padding.left = 3;
-                  padding.right = 3;
-
-                  KPolygon polygon = _kRenderingFactory.createKPolygon();
-                  _kRenderingExtensions.from(polygon, LEFT, 0, 0, BOTTOM, 0, 0.5f);
-                  _kRenderingExtensions.to(polygon, LEFT, 0, 0, TOP, 1, 0.5f);
-                  _kRenderingExtensions.to(polygon, RIGHT, 0, 0, TOP, 1, 0.5f);
-                  _kRenderingExtensions.to(polygon, RIGHT, 0, 0, BOTTOM, 0, 0.5f);
-                  _kRenderingExtensions.setBackground(
-                      polygon, label.getProperty(LABEL_PARENT_BACKGROUND));
-                  _kRenderingExtensions.setForeground(
-                      polygon, label.getProperty(LABEL_PARENT_BACKGROUND));
-                  container.getChildren().add(polygon);
-
-                  KSpline kSpline = _kRenderingFactory.createKSpline();
-                  _kRenderingExtensions.from(kSpline, LEFT, (-0.66f), 0, BOTTOM, (-0.5f), 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 1, 0, BOTTOM, (-0.5f), 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.1f, BOTTOM, 8, 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.2f, BOTTOM, 0, 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.3f, BOTTOM, (-8), 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.4f, BOTTOM, 0, 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.45f, BOTTOM, 4f, 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.5f, BOTTOM, 8, 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.55f, BOTTOM, 4f, 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.6f, BOTTOM, 0, 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.65f, BOTTOM, (-4), 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.7f, BOTTOM, (-8), 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.8f, BOTTOM, (-4), 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 0, 0.9f, BOTTOM, 0, 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, (-1), 1, BOTTOM, (-0.5f), 0.5f);
-                  _kRenderingExtensions.to(kSpline, LEFT, 0.66f, 1, BOTTOM, (-0.5f), 0.5f);
-                  container.getChildren().add(kSpline);
-                  return padding;
-                }
-              });
-      _onEdgePysicalLabelConfigurator = configurator;
-    }
-    label.setProperty(LABEL_PARENT_BACKGROUND, parentBackgroundColor);
-    _onEdgePysicalLabelConfigurator.applyTo(label);
+  /**
+   * Creates placement data that positions a squiggle decorator centered on a point along the edge
+   * path and rotated to follow the line. A fresh instance is required per decorated rendering
+   * because placement data is a containment feature.
+   */
+  private KDecoratorPlacementData createSquigglePlacement(float relative) {
+    KDecoratorPlacementData placement = _kRenderingFactory.createKDecoratorPlacementData();
+    placement.setRotateWithLine(true);
+    placement.setRelative(relative);
+    placement.setAbsolute(0f);
+    placement.setWidth(14);
+    placement.setHeight(18);
+    // Center the box on the placement point: along the line (xOffset = -width/2) and perpendicular
+    // to it (yOffset = -height/2), so the edge line passes through the box center.
+    placement.setXOffset(-7f);
+    placement.setYOffset(-9f);
+    return placement;
   }
 
   private static LabelDecorationConfigurator


### PR DESCRIPTION
When an output port from a bank broadcasts to a multiport of the same bank (a self loop), if the connection is physical, the rendering of the physical squiggle gets repeated as many times as the bank width, as shown in the diagram below:

<img width="374" height="457" alt="image" src="https://github.com/user-attachments/assets/cbec8a3a-187b-4cec-b077-da2da78b2d49" />

This PR fixes the duplication, although there is still a bug with the placement. Specifically, when you combine a physical connection with an after delay, the decorator on the connection is offset, as shown here:

<img width="523" height="450" alt="image" src="https://github.com/user-attachments/assets/0e024aa0-05a1-4e19-950d-94090ae30d1d" />

However, this combination is rarely used (self loop, physical connection, after delay), so I think this PR represents a significant improvement.