### PR TITLE
Support the `.ulf` file extension for micro-LF programs

### DIFF
--- a/core/src/main/java/org/lflang/GenerateLinguaFranca.mwe2
+++ b/core/src/main/java/org/lflang/GenerateLinguaFranca.mwe2
@@ -47,7 +47,7 @@ Workflow {
          */
         language = StandardLanguage {
             name = "org.lflang.LinguaFranca"
-            fileExtensions = "lf"
+            fileExtensions = "lf,ulf"
             serializer = {
                 generateStub = false
             }

--- a/core/src/main/java/org/lflang/scoping/LFGlobalScopeProvider.java
+++ b/core/src/main/java/org/lflang/scoping/LFGlobalScopeProvider.java
@@ -98,9 +98,8 @@ public class LFGlobalScopeProvider extends ImportUriGlobalScopeProvider {
    */
   protected URI resolve(String uriStr, Resource resource) {
     var uriObj = URI.createURI(uriStr);
-    if (uriObj != null
-        && ("lf".equalsIgnoreCase(uriObj.fileExtension())
-            || "ulf".equalsIgnoreCase(uriObj.fileExtension()))) {
+    var fileExtension = uriObj.fileExtension();
+    if ("lf".equalsIgnoreCase(fileExtension) || "ulf".equalsIgnoreCase(fileExtension)) {
       // FIXME: If this doesn't work, try other things:
       // (1) Look for a .project file up the file structure and try to
       // resolve relative to the directory in which it is found.

--- a/core/src/main/java/org/lflang/scoping/LFGlobalScopeProvider.java
+++ b/core/src/main/java/org/lflang/scoping/LFGlobalScopeProvider.java
@@ -98,7 +98,9 @@ public class LFGlobalScopeProvider extends ImportUriGlobalScopeProvider {
    */
   protected URI resolve(String uriStr, Resource resource) {
     var uriObj = URI.createURI(uriStr);
-    if (uriObj != null && "lf".equalsIgnoreCase(uriObj.fileExtension())) {
+    if (uriObj != null
+        && ("lf".equalsIgnoreCase(uriObj.fileExtension())
+            || "ulf".equalsIgnoreCase(uriObj.fileExtension()))) {
       // FIXME: If this doesn't work, try other things:
       // (1) Look for a .project file up the file structure and try to
       // resolve relative to the directory in which it is found.

--- a/lsp/src/main/java/org/lflang/diagram/lsp/LanguageDiagramServer.java
+++ b/lsp/src/main/java/org/lflang/diagram/lsp/LanguageDiagramServer.java
@@ -100,7 +100,9 @@ public class LanguageDiagramServer extends AbstractLanguageServer {
 
     @Override
     public List<Language> getLanguageExtensions() {
-      return List.of(new Language("lf", "Lingua Franca", List.of()));
+      return List.of(
+          new Language("lf", "Lingua Franca", List.of()),
+          new Language("ulf", "Lingua Franca", List.of()));
     }
   }
 


### PR DESCRIPTION
This PR adds support for the `.ulf` filename extension, which will be used by micro-LF.
There is a companion PR in the vscode-lingua-franca repo that completes the support in the VS Code and Cursor extensions.