### PR TITLE
Add support for Docker in the Rust target

### DIFF
--- a/core/src/integrationTest/java/org/lflang/tests/runtime/RustTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/RustTest.java
@@ -25,4 +25,15 @@ public class RustTest extends RuntimeTest {
   protected boolean supportsGenericTypes() {
     return true;
   }
+
+  @Override
+  protected boolean supportsDockerOption() {
+    return true;
+  }
+
+  @Test
+  @Override
+  public void runDockerTests() {
+    super.runDockerTests();
+  }
 }

--- a/core/src/main/java/org/lflang/generator/docker/DockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/DockerGenerator.java
@@ -261,7 +261,8 @@ public abstract class DockerGenerator {
       case C, CCPP -> new CDockerGenerator(context);
       case TS -> new TSDockerGenerator(context);
       case Python -> new PythonDockerGenerator(context);
-      case CPP, Rust, UC, Polyglot ->
+      case Rust -> new RustDockerGenerator(context);
+      case CPP, UC, Polyglot ->
           throw new IllegalArgumentException("No Docker support for " + target + " yet.");
     };
   }

--- a/core/src/main/java/org/lflang/generator/docker/RustDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/RustDockerGenerator.java
@@ -17,7 +17,7 @@ public class RustDockerGenerator extends DockerGenerator {
 
   @Override
   protected String generateRunForInstallingDeps() {
-    return "RUN set -ex & apk add --no-cache musl-dev";
+    return "RUN set -ex && apk add --no-cache musl-dev";
   }
 
   @Override

--- a/core/src/main/java/org/lflang/generator/docker/RustDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/RustDockerGenerator.java
@@ -1,0 +1,54 @@
+package org.lflang.generator.docker;
+
+import java.util.List;
+import org.lflang.generator.LFGeneratorContext;
+
+/**
+ * Generate the docker file code for the Rust target.
+ *
+ * @author Eggsrael / Adam Bonnet
+ * @ingroup Docker
+ */
+public class RustDockerGenerator extends DockerGenerator {
+
+  public RustDockerGenerator(LFGeneratorContext context) {
+    super(context);
+  }
+
+  @Override
+  protected String generateRunForInstallingDeps() {
+    return "RUN set -ex & apk add --no-cache musl-dev";
+  }
+
+  @Override
+  protected List<String> defaultBuildCommands() {
+    String executableName = context.getFileConfig().name;
+    return List.of(
+        "cd src-gen",
+        "cargo build --release",
+        "mkdir ../bin",
+        "mv target/release/" + camelToSnakeCase(executableName) + " ../bin/" + executableName);
+  }
+
+  @Override
+  public List<String> defaultEntryPoint() {
+    return List.of("./bin/" + context.getFileConfig().name);
+  }
+
+  @Override
+  public String defaultImage() {
+    return "rust:alpine";
+  }
+
+
+  /**
+   *  Converts name stored in the file config to snake_case
+   *  Cargo's default executable output is snake_case so this needed to access the executable.
+   *
+   *  <p>Regex test/edit: https://regexr.com/8ndjc
+   *
+   */
+  private String camelToSnakeCase(String fileName) {
+    return fileName.replaceAll("(?<=[a-z0-9])([A-Z])", "_$1").toLowerCase();
+  }
+}

--- a/core/src/main/java/org/lflang/generator/docker/RustDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/RustDockerGenerator.java
@@ -40,12 +40,12 @@ public class RustDockerGenerator extends DockerGenerator {
     return "rust:alpine";
   }
 
-
   /**
-   *  Converts name stored in the file config to snake_case
+   *  Converts name stored in the file config to snake_case.
    *  Cargo's default executable output is snake_case so this needed to access the executable.
    *
-   *  <p>Regex test/edit: https://regexr.com/8ndjc
+   *  <p>Regex test/edit:
+   *  <a href="https://regexr.com/8ndjc">https://regexr.com/8ndjc</a>
    *
    */
   private String camelToSnakeCase(String fileName) {

--- a/core/src/main/java/org/lflang/generator/docker/RustDockerGenerator.java
+++ b/core/src/main/java/org/lflang/generator/docker/RustDockerGenerator.java
@@ -35,6 +35,7 @@ public class RustDockerGenerator extends DockerGenerator {
     return List.of("./bin/" + context.getFileConfig().name);
   }
 
+  // use rust:alpine to have easier time making docker images.
   @Override
   public String defaultImage() {
     return "rust:alpine";

--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -641,7 +641,8 @@ public enum Target {
               SingleFileProjectProperty.INSTANCE,
               SingleThreadedProperty.INSTANCE,
               WorkersProperty.INSTANCE,
-              RustEditionProperty.INSTANCE);
+              RustEditionProperty.INSTANCE,
+              DockerProperty.INSTANCE);
       case TS ->
           config.register(
               CoordinationOptionsProperty.INSTANCE,

--- a/core/src/main/kotlin/org/lflang/generator/rust/RustGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/rust/RustGenerator.kt
@@ -28,7 +28,9 @@ import org.eclipse.emf.ecore.resource.Resource
 import org.lflang.target.Target
 import org.lflang.generator.*
 import org.lflang.generator.GeneratorUtils.canGenerate
+import org.lflang.generator.docker.DockerComposeGenerator
 import org.lflang.generator.docker.DockerGenerator
+import org.lflang.generator.docker.RustDockerGenerator
 import org.lflang.joinWithCommas
 import org.lflang.scoping.LFGlobalScopeProvider
 import org.lflang.target.property.*
@@ -73,6 +75,11 @@ class RustGenerator(
 
         val gen = RustModelBuilder.makeGenerationInfo(targetConfig, reactors, messageReporter)
         val codeMaps: Map<Path, CodeMap> = RustEmitter.generateRustProject(fileConfig, gen)
+        if (targetConfig.get(DockerProperty.INSTANCE).enabled) {
+            val dockerData = RustDockerGenerator(context).generateDockerData()
+            dockerData.writeDockerFile()
+            DockerComposeGenerator(context).writeDockerComposeFile(listOf(dockerData))
+        }
 
         if (targetConfig.get(NoCompileProperty.INSTANCE) || errorsOccurred()) {
             context.finish(GeneratorResult.GENERATED_NO_EXECUTABLE.apply(context, codeMaps))
@@ -149,8 +156,9 @@ class RustGenerator(
     override fun getTarget(): Target = Target.Rust
 
     override fun getTargetTypes(): TargetTypes = RustTypes
+
     override fun getDockerGenerator(context: LFGeneratorContext?): DockerGenerator {
-        TODO("Not yet implemented")
+        return RustDockerGenerator(context)
     }
 
 }

--- a/test/Rust/src-gen/Cargo.toml
+++ b/test/Rust/src-gen/Cargo.toml
@@ -16,7 +16,7 @@
 # If it causes problems, we can throw it away or hide it.
 [workspace]
 members = ["*"]
-exclude = ["concurrent", "target", "multiport", "generics", "reactor-rs"]
+exclude = ["concurrent", "target", "multiport", "generics", "reactor-rs", "docker"]
 
 [profile.release-with-min-size] # use `build-type: MinSizeRel`
 inherits = "release"

--- a/test/Rust/src/HelloWorld.lf
+++ b/test/Rust/src/HelloWorld.lf
@@ -1,0 +1,22 @@
+target Rust
+
+reactor HelloWorld2 {
+  state success: bool = false
+
+  reaction(startup) {=
+    println!("Hello World.");
+    self.success = true;
+  =}
+
+  reaction(shutdown) {=
+    println!("Shutdown invoked.");
+    if !self.success {
+        eprintln!("ERROR: startup reaction not executed.");
+        ctx.request_stop(Asap);
+    }
+  =}
+}
+
+main reactor HelloWorld {
+  a = new HelloWorld2()
+}

--- a/test/Rust/src/docker/DockerMinimal.lf
+++ b/test/Rust/src/docker/DockerMinimal.lf
@@ -1,0 +1,10 @@
+// This is a smoke test of a minimal reactor.
+target Rust {
+  docker: true
+}
+
+main reactor DockerMinimal {
+  reaction(startup) {=
+    println!("Hello World.");
+  =}
+}

--- a/test/Rust/src/docker/HelloWorldContainerized.lf
+++ b/test/Rust/src/docker/HelloWorldContainerized.lf
@@ -1,0 +1,9 @@
+target Rust {
+  docker: "true"
+}
+
+import HelloWorld2 from "../HelloWorld.lf"
+
+main reactor HelloWorldContainerized {
+  a = new HelloWorld2()
+}


### PR DESCRIPTION
Added support for Docker in the Rust target. This was done as a push to feature parity with the other reactors. 