### PR TITLE
Make target declaration optional for .ulf files

### DIFF
--- a/cli/lfc/src/test/resources/org/lflang/cli/emptyFile.stderr
+++ b/cli/lfc/src/test/resources/org/lflang/cli/emptyFile.stderr
@@ -1,8 +1,1 @@
-lfc: error: mismatched input '<EOF>' expecting 'target'
---> %%%PATH.lf%%%:1:1
-  |
-1 | 
-  | ^ mismatched input '<EOF>' expecting 'target'
-  |
-2 | 
-
+lfc: error: required (...)+ loop did not match anything at input '<EOF>'

--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -26,7 +26,7 @@ generate lf "https://lf-lang.org"
  * Top-level AST node.
  */
 Model:
-    target=TargetDecl
+    (target=TargetDecl)?
     (imports+=Import)*
     (preambles+=Preamble)*
     (reactors+=Reactor)+

--- a/core/src/main/java/org/lflang/ModelInfo.java
+++ b/core/src/main/java/org/lflang/ModelInfo.java
@@ -93,8 +93,13 @@ public class ModelInfo {
       }
     }
 
-    // may be null if the target is invalid
-    var target = Target.forName(model.getTarget().getName()).orElse(null);
+    // may be null if the target is invalid or missing in a non-.ulf file
+    Target target = null;
+    if (model.getTarget() != null) {
+      target = Target.forName(model.getTarget().getName()).orElse(null);
+    } else if ("ulf".equalsIgnoreCase(model.eResource().getURI().fileExtension())) {
+      target = Target.UC;
+    }
 
     // Perform C-specific traversals.
     if (target == Target.C) {

--- a/core/src/main/java/org/lflang/federated/extensions/CExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtension.java
@@ -232,6 +232,12 @@ public class CExtension implements FedTargetExtension {
           result.pr("lf_set(" + receiveRef + ", std::move(" + value + "));");
         }
       }
+      case CUSTOM -> {
+        messageReporter
+            .at(connection.getDefinition())
+            .error("Custom serialization is not supported for the C target.");
+        return;
+      }
     }
   }
 
@@ -468,6 +474,12 @@ public class CExtension implements FedTargetExtension {
                 sendRef, typeStr, CExtensionUtils.isSharedPtrType(type, types)));
         result.pr("size_t _lf_message_length = " + lengthExpression + ";");
         result.pr(sendingFunction + "(" + commonArgs + ", " + pointerExpression + ");");
+      }
+      case CUSTOM -> {
+        messageReporter
+            .at(connection.getDefinition())
+            .error("Custom serialization is not supported for the C target.");
+        return;
       }
     }
   }

--- a/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java
@@ -547,6 +547,9 @@ public class CExtensionUtils {
           var ROSSerializer = new FedROS2CPPSerialization();
           code.pr(ROSSerializer.generatePreambleForSupport().toString());
         }
+        case CUSTOM -> {
+          // Custom serialization is only supported for the Python target.
+        }
       }
     }
     return code.getCode();
@@ -557,7 +560,7 @@ public class CExtensionUtils {
     CodeBuilder code = new CodeBuilder();
     for (SupportedSerializers serializer : federate.enabledSerializers) {
       switch (serializer) {
-        case NATIVE, PROTO -> {
+        case NATIVE, PROTO, CUSTOM -> {
           // No CMake code is needed for now
         }
         case ROS2 -> {

--- a/core/src/main/java/org/lflang/generator/LFGenerator.java
+++ b/core/src/main/java/org/lflang/generator/LFGenerator.java
@@ -67,7 +67,8 @@ public class LFGenerator extends AbstractGenerator {
         case TS -> new TSFileConfig(resource, srcGenBasePath, useHierarchicalBin);
         case UC ->
             throw new RuntimeException(
-                "Please refer to https://github.com/lf-lang/reactor-uc for code-generation for micro-LF target.");
+                "Please refer to https://github.com/lf-lang/reactor-uc for code-generation for"
+                    + " micro-LF target.");
         case Polyglot ->
             throw new RuntimeException(
                 "Polyglot programs must use a 'federated reactor'. No non-federated Polyglot"
@@ -95,7 +96,8 @@ public class LFGenerator extends AbstractGenerator {
       case Rust -> new RustGenerator(context, scopeProvider);
       case UC ->
           throw new RuntimeException(
-              "Please refer to https://github.com/lf-lang/reactor-uc for code-generation for micro-LF target.");
+              "Please refer to https://github.com/lf-lang/reactor-uc for code-generation for"
+                  + " micro-LF target.");
       case Polyglot ->
           throw new RuntimeException(
               "Polyglot programs must use a 'federated reactor' and are compiled via"

--- a/core/src/main/java/org/lflang/generator/LFGenerator.java
+++ b/core/src/main/java/org/lflang/generator/LFGenerator.java
@@ -67,8 +67,7 @@ public class LFGenerator extends AbstractGenerator {
         case TS -> new TSFileConfig(resource, srcGenBasePath, useHierarchicalBin);
         case UC ->
             throw new RuntimeException(
-                "Please refer to www.github.com/lf-lang/reactor-uc for code-generation for the uC"
-                    + " target.");
+                "Please refer to https://github.com/lf-lang/reactor-uc for code-generation for micro-LF target.");
         case Polyglot ->
             throw new RuntimeException(
                 "Polyglot programs must use a 'federated reactor'. No non-federated Polyglot"
@@ -96,8 +95,7 @@ public class LFGenerator extends AbstractGenerator {
       case Rust -> new RustGenerator(context, scopeProvider);
       case UC ->
           throw new RuntimeException(
-              "Please refer to www.github.com/lf-lang/reactor-uc for code-generation for the uC"
-                  + " target.");
+              "Please refer to https://github.com/lf-lang/reactor-uc for code-generation for micro-LF target.");
       case Polyglot ->
           throw new RuntimeException(
               "Polyglot programs must use a 'federated reactor' and are compiled via"

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -754,6 +754,13 @@ public class LFValidator extends BaseLFValidator {
 
   @Check(CheckType.FAST)
   public void checkModel(Model model) {
+    if (model.getTarget() == null) {
+      if (isUlfFile(model)) {
+        this.target = Target.UC;
+      } else {
+        error("Target declaration is required in .lf files.", Literals.MODEL__TARGET);
+      }
+    }
     // Since we're doing a fast check, we only want to update
     // if the model info hasn't been initialized yet. If it has,
     // we use the old information and update it during a normal
@@ -1319,6 +1326,9 @@ public class LFValidator extends BaseLFValidator {
 
   @Check(CheckType.FAST)
   public void checkTargetDecl(TargetDecl target) throws IOException {
+    if (isUlfFile(target) && target.getConfig() != null) {
+      error("Target properties are not allowed in .ulf files.", Literals.TARGET_DECL__CONFIG);
+    }
     Optional<Target> targetOpt = Target.forName(target.getName());
     if (targetOpt.isEmpty()) {
       error("Unrecognized target: " + target.getName(), Literals.TARGET_DECL__NAME);
@@ -2159,6 +2169,11 @@ public class LFValidator extends BaseLFValidator {
     }
     // Type must be given in a code body
     return type1.getCode().getBody().equals(type2.getCode().getBody());
+  }
+
+  /** Return true if the given object is in a file with the .ulf extension. */
+  private boolean isUlfFile(EObject object) {
+    return "ulf".equalsIgnoreCase(object.eResource().getURI().fileExtension());
   }
 
   //////////////////////////////////////////////////////////////

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -759,6 +759,8 @@ public class LFValidator extends BaseLFValidator {
         this.target = Target.UC;
       } else {
         error("Target declaration is required in .lf files.", Literals.MODEL__TARGET);
+        // Avoid NPEs in subsequent @Check methods that rely on `this.target`.
+        this.target = Target.Python;
       }
     }
     // Since we're doing a fast check, we only want to update

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaParsingTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaParsingTest.java
@@ -28,9 +28,9 @@ class LinguaFrancaParsingTest {
             }
         """;
     Model result = parser.parse(testCase);
-    Assertions.assertNotNull(result);
-    Assertions.assertFalse(
-        result.eResource().getErrors().isEmpty(), "Failed to catch misspelled target keyword.");
+    Assertions.assertTrue(
+        result == null || !result.eResource().getErrors().isEmpty(),
+        "Misspelled target keyword should cause a parse error.");
   }
 
   @Test

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -85,7 +85,11 @@ public class LinguaFrancaValidationTest {
    * errors.
    */
   private Model parseWithoutError(String s, String fileName) throws Exception {
-    Model model = parser.parse(s, URI.createURI(fileName), resourceSetProvider.get());
+    URI uri = URI.createURI(fileName);
+    if (!uri.isFile() && !uri.isPlatform()) {
+      uri = URI.createURI("file:/" + fileName);
+    }
+    Model model = parser.parse(s, uri, resourceSetProvider.get());
     Assertions.assertNotNull(model);
     Assertions.assertTrue(
         model.eResource().getErrors().isEmpty(),

--- a/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
+++ b/core/src/test/java/org/lflang/tests/compiler/LinguaFrancaValidationTest.java
@@ -1,12 +1,15 @@
 package org.lflang.tests.compiler;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.xtext.diagnostics.Severity;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.extensions.InjectionExtension;
@@ -59,6 +62,8 @@ public class LinguaFrancaValidationTest {
 
   @Inject ParseHelper<Model> parser;
 
+  @Inject Provider<ResourceSet> resourceSetProvider;
+
   @Inject ValidationTestHelper validator;
 
   /**
@@ -68,6 +73,19 @@ public class LinguaFrancaValidationTest {
    */
   private Model parseWithoutError(String s) throws Exception {
     Model model = parser.parse(s);
+    Assertions.assertNotNull(model);
+    Assertions.assertTrue(
+        model.eResource().getErrors().isEmpty(),
+        "Encountered unexpected error while parsing: " + model.eResource().getErrors());
+    return model;
+  }
+
+  /**
+   * Helper function to parse a Lingua Franca program with a specific file name and expect no parse
+   * errors.
+   */
+  private Model parseWithoutError(String s, String fileName) throws Exception {
+    Model model = parser.parse(s, URI.createURI(fileName), resourceSetProvider.get());
     Assertions.assertNotNull(model);
     Assertions.assertTrue(
         model.eResource().getErrors().isEmpty(),
@@ -2133,6 +2151,44 @@ public class LinguaFrancaValidationTest {
         LfPackage.eINSTANCE.getTargetDecl(),
         null,
         "Unrecognized target: Pjthon");
+  }
+
+  @Test
+  public void testMissingTargetDeclInLfFile() throws Exception {
+    String testCase =
+        """
+            main reactor {}
+        """;
+    validator.assertError(
+        parseWithoutError(testCase),
+        LfPackage.eINSTANCE.getModel(),
+        null,
+        "Target declaration is required in .lf files.");
+  }
+
+  @Test
+  public void testMissingTargetDeclInUlfFile() throws Exception {
+    String testCase =
+        """
+            main reactor {}
+        """;
+    validator.assertNoIssues(parseWithoutError(testCase, "Foo.ulf"));
+  }
+
+  @Test
+  public void testTargetPropertiesInUlfFile() throws Exception {
+    String testCase =
+        """
+            target uC {
+              platform: "Zephyr"
+            }
+            main reactor {}
+        """;
+    validator.assertError(
+        parseWithoutError(testCase, "Foo.ulf"),
+        LfPackage.eINSTANCE.getTargetDecl(),
+        null,
+        "Target properties are not allowed in .ulf files.");
   }
 
   @Test

--- a/test/C/Makefile
+++ b/test/C/Makefile
@@ -1,0 +1,50 @@
+# This file lets you format the code-base with a single command.
+FILES := $(shell find . -name '*.lf' -not -path "*/fed-gen/*")
+
+.PHONY: help
+help:
+	@echo "Available commands:"
+	@echo "  make clean         - Clean up build and documentation"
+	@echo "  make format        - Format all Lingua Franca files using lff"
+	@echo "  make format-dev    - Format all Lingua Franca files using lff-dev"
+	@echo "  make build-all     - Build all Lingua Franca files using lfc"
+	@echo "  make build-all-dev - Build all Lingua Franca files using lfc-dev"
+	
+.PHONY: format
+format:
+	@for file in $(FILES); do \
+		echo "========== Formatting $$file =========="; \
+		lff $$file; \
+	done
+
+.PHONY: format-dev
+format-dev:
+	@for file in $(FILES); do \
+		echo "========== Formatting $$file =========="; \
+		lff-dev $$file; \
+	done
+
+.PHONY: build-all
+build-all:
+	@for file in $(FILES); do \
+		echo "================================================"; \
+		echo "Building $$file"; \
+		echo "================================================"; \
+		lfc $$file; \
+	done
+
+.PHONY: build-all-dev
+build-all-dev:
+	@for file in $(FILES); do \
+		echo "================================================"; \
+		echo "Building $$file"; \
+		echo "================================================"; \
+		lfc-dev $$file; \
+	done
+
+.PHONY: clean
+clean:
+	rm -rf *.lft *.csv *.log src-gen fed-gen include bin
+	
+# Set help as the default target
+.DEFAULT_GOAL := help

--- a/test/Python/Makefile
+++ b/test/Python/Makefile
@@ -1,0 +1,50 @@
+# This file lets you format the code-base with a single command.
+FILES := $(shell find . -name '*.lf' -not -path "*/fed-gen/*")
+
+.PHONY: help
+help:
+	@echo "Available commands:"
+	@echo "  make clean         - Clean up build and documentation"
+	@echo "  make format        - Format all Lingua Franca files using lff"
+	@echo "  make format-dev    - Format all Lingua Franca files using lff-dev"
+	@echo "  make build-all     - Build all Lingua Franca files using lfc"
+	@echo "  make build-all-dev - Build all Lingua Franca files using lfc-dev"
+	
+.PHONY: format
+format:
+	@for file in $(FILES); do \
+		echo "========== Formatting $$file =========="; \
+		lff $$file; \
+	done
+
+.PHONY: format-dev
+format-dev:
+	@for file in $(FILES); do \
+		echo "========== Formatting $$file =========="; \
+		lff-dev $$file; \
+	done
+
+.PHONY: build-all
+build-all:
+	@for file in $(FILES); do \
+		echo "================================================"; \
+		echo "Building $$file"; \
+		echo "================================================"; \
+		lfc $$file; \
+	done
+
+.PHONY: build-all-dev
+build-all-dev:
+	@for file in $(FILES); do \
+		echo "================================================"; \
+		echo "Building $$file"; \
+		echo "================================================"; \
+		lfc-dev $$file; \
+	done
+
+.PHONY: clean
+clean:
+	rm -rf *.lft *.csv *.log src-gen fed-gen include bin
+	
+# Set help as the default target
+.DEFAULT_GOAL := help


### PR DESCRIPTION
To support the micro-LF target in the VS Code extension, this PR makes the target declaration optional if the filename has a `.ulf` extension. It also disallows target options in `.ulf` files (checked in the validator). It also updates reactor-c to include message cleanups on socket closings and adds a couple of convenience makefiles.