### PR TITLE
Fix race conditions and deadlocks in transient federates

### DIFF
--- a/core/src/main/java/org/lflang/federated/extensions/CExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtension.java
@@ -902,10 +902,10 @@ public class CExtension implements FedTargetExtension {
           "lf_connect_to_federate("
               + remoteFederate.id
               + ", "
-              + remoteFederate.isTransient
+              + (remoteFederate.isTransient ? "FOREVER_TAG" : "NEVER_TAG")
               + ", -1, 0);");
       code.pr(
-          "_fed.outbound_p2p_connection_is_transient["
+          "_fed.downstream_p2p_joined_tag["
               + remoteFederate.id
               + "] = "
               + (remoteFederate.isTransient ? "FOREVER_TAG" : "NEVER_TAG")

--- a/core/src/main/java/org/lflang/federated/extensions/CExtension.java
+++ b/core/src/main/java/org/lflang/federated/extensions/CExtension.java
@@ -830,7 +830,7 @@ public class CExtension implements FedTargetExtension {
             "_fed.number_of_inbound_p2p_transients = "
                 + numberOfInboundConnectionsToTransients
                 + ";",
-            "_fed.number_of_outbound_p2p_transients = "
+            "_fed.number_of_downstream_p2p_transients = "
                 + numberOfOutboundConnectionsToTransients
                 + ";"));
 
@@ -840,7 +840,7 @@ public class CExtension implements FedTargetExtension {
             "// Initialize the array of network abstractions for incoming connections to -1.",
             "for (int i = 0; i < NUMBER_OF_FEDERATES; i++) {",
             "    _fed.net_for_inbound_p2p_connections[i] = NULL;",
-            "    _fed.inbound_p2p_connection_is_transient[i] = false;",
+            "    _fed.upstream_fed_is_transient[i] = false;",
             "}"));
     code.pr(
         String.join(

--- a/core/src/main/java/org/lflang/validation/LFValidator.java
+++ b/core/src/main/java/org/lflang/validation/LFValidator.java
@@ -1573,6 +1573,13 @@ public class LFValidator extends BaseLFValidator {
           "The @transient attribute can only be applied inside a federated reactor.",
           attr,
           Literals.ATTRIBUTE__ATTR_NAME);
+      return;
+    }
+    if (!isCBasedTarget() && this.target != Target.Python) {
+      error(
+          "The @transient attribute is only supported for the C and Python targets.",
+          attr,
+          Literals.ATTRIBUTE__ATTR_NAME);
     }
   }
 

--- a/test/C/src/federated/TransientDecentralizedDownstreamWithTimer.lf
+++ b/test/C/src/federated/TransientDecentralizedDownstreamWithTimer.lf
@@ -6,29 +6,27 @@
  * `in`,
  * - the downstream of the transient federate has only one transient as upstream.
  *
- *  * The timing behavior of this test can be very confusing. Three scenarior occur:
+ * * The timing behavior of this test can be very confusing. Three scenarior occur:
  *
- * - Most of the time, after joining, when an event arrives on `in`, mid will wait 400 ms
- *   (because of the absent_after on `in_from_persistence`) before producing `out` and
- *   `out_to_persistence`.  Down has a maxwait of forever, so it will likely not process
- *   its message until shutdown time (unless a `join` arrives).  Persistence will receive
- *   `in_from_middle` at least 400 ms late, so its maxwait of 200 will have already expired
- *   and it will process the message right away.
+ * - Most of the time, after joining, when an event arrives on `in`, mid will wait 400 ms (because
+ * of the absent_after on `in_from_persistence`) before producing `out` and `out_to_persistence`.
+ * Down has a maxwait of forever, so it will likely not process its message until shutdown time
+ * (unless a `join` arrives). Persistence will receive `in_from_middle` at least 400 ms late, so its
+ * maxwait of 200 will have already expired and it will process the message right away.
  *
- * - When a join occurs that is not aligned with the timers, the behavior is different:
- *   mid runs reaction 1 right away, so Persistence sees `in_middle_join` quickly.
- *   (reaction 2 in mid has a higher level than the network sender because of the
- *   zero-delay loop). Persistence may then wait 200 ms (its maxwait) before actually
- *   sending because of level scheduling. The absent_after of 400ms on the feedback
- *   path absorbs that 200 ms plus any networking overhead.
+ * - When a join occurs that is not aligned with the timers, the behavior is different: mid runs
+ * reaction 1 right away, so Persistence sees `in_middle_join` quickly. (reaction 2 in mid has a
+ * higher level than the network sender because of the zero-delay loop). Persistence may then wait
+ * 200 ms (its maxwait) before actually sending because of level scheduling. The absent_after of
+ * 400ms on the feedback path absorbs that 200 ms plus any networking overhead.
  *
- * - When a join occurs that _is_ aligned with the timers (likely only at (0,0)),
- *   then the behavior is still different. mid will send `join` immediately, as above.
- *   It will receive `in_from_persistence` within 400ms (or else a tardy error will occur).
- *   It will then send `out_to_persistence`. The maxwait of 200 ms at Persistence keeps
- *   it from processing the `join` event until it receives both or 200 ms goes by.
- *   It can't receive both, so this will take 200 ms. Then Persistence sends its output.
- *  The absent_after on its connection into `in_from_middle` helps protect against tardiness.
+ * - When a join occurs that _is_ aligned with the timers (likely only at (0,0)), then the behavior
+ * is still different. mid will send `join` immediately, as above. It will receive
+ * `in_from_persistence` within 400ms (or else a tardy error will occur). It will then send
+ * `out_to_persistence`. The maxwait of 200 ms at Persistence keeps it from processing the `join`
+ * event until it receives both or 200 ms goes by. It can't receive both, so this will take 200 ms.
+ * Then Persistence sends its output. The absent_after on its connection into `in_from_middle` helps
+ * protect against tardiness.
  *
  * @author Chadlia Jerad
  */

--- a/test/C/src/federated/TransientDecentralizedDownstreamWithTimer.lf
+++ b/test/C/src/federated/TransientDecentralizedDownstreamWithTimer.lf
@@ -51,8 +51,8 @@ reactor Middle {
       lf_stop();
     }
   =} tardy {=
-    lf_print_error_and_exit("Received a tardy in event at relative tag " PRINTF_TAG ".",
-        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in event at intended tag " PRINTF_TAG ". Current tag is " PRINTF_TAG ".",
+        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep, lf_time_logical() - lf_time_start(), lf_tag().microstep);
   =}
 }
 
@@ -77,15 +77,15 @@ reactor Down {
   reaction(join) {=
     self->count_join++;
   =} tardy {=
-    lf_print_error_and_exit("Received a tardy join event at relative tag " PRINTF_TAG ".",
-        join->intended_tag.time - lf_time_start(), join->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy join event at intended tag " PRINTF_TAG ". Current tag is " PRINTF_TAG ".",
+        join->intended_tag.time - lf_time_start(), join->intended_tag.microstep, lf_time_logical() - lf_time_start(), lf_tag().microstep);
   =}
 
   reaction(in) {=
     self->count_in_mid_reactions++;
   =} tardy {=
-    lf_print_error_and_exit("Received a tardy in event at relative tag " PRINTF_TAG ".",
-        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in event at intended tag " PRINTF_TAG ". Current tag is " PRINTF_TAG ".",
+        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep, lf_time_logical() - lf_time_start(), lf_tag().microstep);
   =}
 
   reaction(shutdown) {=
@@ -102,7 +102,7 @@ reactor Down {
 
     // Check that `Middle` have reacted correctly
     if (self->count_in_mid_reactions < 4) {
-      lf_print_error_and_exit("Transient federate Mid did not execute and pass values from up corretly! Expected >= 4, but had: %d.",
+      lf_print_error_and_exit("Transient federate Mid did not execute and pass values from up correctly! Expected >= 4, but had: %d.",
           self->count_in_mid_reactions);
     }
   =}

--- a/test/C/src/federated/TransientDecentralizedDownstreamWithTimer.lf
+++ b/test/C/src/federated/TransientDecentralizedDownstreamWithTimer.lf
@@ -48,6 +48,7 @@ reactor Middle {
   reaction(in) -> out {=
     self->count++;
     lf_set(out, in->value);
+    lf_print("Middle forwarded value %d at tag " PRINTF_TAG ".", in->value, lf_time_logical_elapsed(), lf_tag().microstep);
 
     if (self->count == 2) {
       lf_stop();
@@ -115,9 +116,9 @@ federated reactor {
   midExec = new TransientExec(launch_time = 3 s, fed_instance_name="mid")
 
   // Persistent downstream and upstream federates of the transient
-  up = new Up(period = 1500 ms)
+  up = new Up(period = 500 ms)
   @maxwait(800 ms)
-  down = new Down(period = 1500 ms)
+  down = new Down(period = 500 ms)
 
   // Transient federate
   @transient

--- a/test/C/src/federated/TransientDecentralizedDownstreamWithTimer.lf
+++ b/test/C/src/federated/TransientDecentralizedDownstreamWithTimer.lf
@@ -51,8 +51,8 @@ reactor Middle {
       lf_stop();
     }
   =} tardy {=
-    lf_print_error_and_exit("Fatal error: Federate Middle received a tardy in event at tag " PRINTF_TAG ".",
-        in->intended_tag.time, in->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in event at relative tag " PRINTF_TAG ".",
+        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep);
   =}
 }
 
@@ -77,15 +77,15 @@ reactor Down {
   reaction(join) {=
     self->count_join++;
   =} tardy {=
-    lf_print_error_and_exit("Fatal error: federate Down received a tardy join event at tag " PRINTF_TAG ".",
-        join->intended_tag.time, join->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy join event at relative tag " PRINTF_TAG ".",
+        join->intended_tag.time - lf_time_start(), join->intended_tag.microstep);
   =}
 
   reaction(in) {=
     self->count_in_mid_reactions++;
   =} tardy {=
-    lf_print_error_and_exit("Fatal error: federate Down received a tardy in event at tag " PRINTF_TAG ".",
-        in->intended_tag.time, in->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in event at relative tag " PRINTF_TAG ".",
+        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep);
   =}
 
   reaction(shutdown) {=

--- a/test/C/src/federated/TransientDecentralizedDownstreamWithTimer.lf
+++ b/test/C/src/federated/TransientDecentralizedDownstreamWithTimer.lf
@@ -6,6 +6,30 @@
  * `in`,
  * - the downstream of the transient federate has only one transient as upstream.
  *
+ *  * The timing behavior of this test can be very confusing. Three scenarior occur:
+ *
+ * - Most of the time, after joining, when an event arrives on `in`, mid will wait 400 ms
+ *   (because of the absent_after on `in_from_persistence`) before producing `out` and
+ *   `out_to_persistence`.  Down has a maxwait of forever, so it will likely not process
+ *   its message until shutdown time (unless a `join` arrives).  Persistence will receive
+ *   `in_from_middle` at least 400 ms late, so its maxwait of 200 will have already expired
+ *   and it will process the message right away.
+ *
+ * - When a join occurs that is not aligned with the timers, the behavior is different:
+ *   mid runs reaction 1 right away, so Persistence sees `in_middle_join` quickly.
+ *   (reaction 2 in mid has a higher level than the network sender because of the
+ *   zero-delay loop). Persistence may then wait 200 ms (its maxwait) before actually
+ *   sending because of level scheduling. The absent_after of 400ms on the feedback
+ *   path absorbs that 200 ms plus any networking overhead.
+ *
+ * - When a join occurs that _is_ aligned with the timers (likely only at (0,0)),
+ *   then the behavior is still different. mid will send `join` immediately, as above.
+ *   It will receive `in_from_persistence` within 400ms (or else a tardy error will occur).
+ *   It will then send `out_to_persistence`. The maxwait of 200 ms at Persistence keeps
+ *   it from processing the `join` event until it receives both or 200 ms goes by.
+ *   It can't receive both, so this will take 200 ms. Then Persistence sends its output.
+ *  The absent_after on its connection into `in_from_middle` helps protect against tardiness.
+ *
  * @author Chadlia Jerad
  */
 target C {

--- a/test/C/src/federated/TransientDecentralizedDownstreamWithTimer.lf
+++ b/test/C/src/federated/TransientDecentralizedDownstreamWithTimer.lf
@@ -116,18 +116,16 @@ federated reactor {
 
   // Persistent downstream and upstream federates of the transient
   up = new Up(period = 1500 ms)
-  @maxwait(0)
+  @maxwait(800 ms)
   down = new Down(period = 1500 ms)
 
   // Transient federate
   @transient
-  @maxwait(300 ms)
+  @maxwait(500 ms)
   mid = new Middle()
 
   // Connections
   up.out -> mid.in
-  @absent_after(400 ms)
   mid.join -> down.join
-  @absent_after(500 ms)
   mid.out -> down.in
 }

--- a/test/C/src/federated/TransientDecentralizedDownstreamWithTwoUpstream.lf
+++ b/test/C/src/federated/TransientDecentralizedDownstreamWithTwoUpstream.lf
@@ -1,5 +1,5 @@
 /**
- * This LF program tests whether a transient federate corretly leaves then joins the federation. It
+ * This LF program tests whether a transient federate correctly leaves then joins the federation. It
  * also tests whether the transient's downstream executes as expected, that is it received correct
  * TAGs, regardless of the transient being absent or present. In this test:
  * - the transient federate spontaneously leaves the federation after 2 reactions to input port in,
@@ -46,22 +46,22 @@ reactor Down {
   reaction(in_up) {=
     self->count_in_up_reactions++;
   =} tardy {=
-    lf_print_error_and_exit("Received a tardy in_up event at relative tag " PRINTF_TAG ".",
-        in_up->intended_tag.time - lf_time_start(), in_up->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in_up event at intended tag " PRINTF_TAG ". Current tag is " PRINTF_TAG ".",
+        in_up->intended_tag.time - lf_time_start(), in_up->intended_tag.microstep, lf_time_logical() - lf_time_start(), lf_tag().microstep);
   =}
 
   reaction(join) {=
     self->count_join++;
   =} tardy {=
-    lf_print_error_and_exit("Received a tardy join event at relative tag " PRINTF_TAG ".",
-        join->intended_tag.time - lf_time_start(), join->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy join event at intended tag " PRINTF_TAG ". Current tag is " PRINTF_TAG ".",
+        join->intended_tag.time - lf_time_start(), join->intended_tag.microstep, lf_time_logical() - lf_time_start(), lf_tag().microstep);
   =}
 
   reaction(in_mid) {=
     self->count_in_mid_reactions++;
   =} tardy {=
-    lf_print_error_and_exit("Received a tardy in_mid event at relative tag " PRINTF_TAG ".",
-        in_mid->intended_tag.time - lf_time_start(), in_mid->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in_mid event at intended tag " PRINTF_TAG ". Current tag is " PRINTF_TAG ".",
+        in_mid->intended_tag.time - lf_time_start(), in_mid->intended_tag.microstep, lf_time_logical() - lf_time_start(), lf_tag().microstep);
   =}
 
   reaction(shutdown) {=
@@ -84,7 +84,7 @@ reactor Down {
 
     // Check that Middle have reacted correctly
     if (self->count_in_mid_reactions < 4) {
-      lf_print_error_and_exit("Transient federate Mid did not execute and pass values from up corretly! Expected >= 4, but had: %d.",
+      lf_print_error_and_exit("Transient federate Mid did not execute and pass values from up correctly! Expected >= 4, but had: %d.",
           self->count_in_mid_reactions);
     }
   =}

--- a/test/C/src/federated/TransientDecentralizedDownstreamWithTwoUpstream.lf
+++ b/test/C/src/federated/TransientDecentralizedDownstreamWithTwoUpstream.lf
@@ -46,22 +46,22 @@ reactor Down {
   reaction(in_up) {=
     self->count_in_up_reactions++;
   =} tardy {=
-    lf_print_error_and_exit("Fatal error: federate Down received a tardy in_up event at tag " PRINTF_TAG ".",
-        in_up->intended_tag.time, in_up->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in_up event at relative tag " PRINTF_TAG ".",
+        in_up->intended_tag.time - lf_time_start(), in_up->intended_tag.microstep);
   =}
 
   reaction(join) {=
     self->count_join++;
   =} tardy {=
-    lf_print_error_and_exit("Fatal error: federate Down received a tardy join event at tag " PRINTF_TAG ".",
-        join->intended_tag.time, join->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy join event at relative tag " PRINTF_TAG ".",
+        join->intended_tag.time - lf_time_start(), join->intended_tag.microstep);
   =}
 
   reaction(in_mid) {=
     self->count_in_mid_reactions++;
   =} tardy {=
-    lf_print_error_and_exit("Fatal error: federate Down received a tardy in_mid event at tag " PRINTF_TAG ".",
-        in_mid->intended_tag.time, in_mid->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in_mid event at relative tag " PRINTF_TAG ".",
+        in_mid->intended_tag.time - lf_time_start(), in_mid->intended_tag.microstep);
   =}
 
   reaction(shutdown) {=

--- a/test/C/src/federated/TransientDecentralizedDownstreamWithTwoUpstream.lf
+++ b/test/C/src/federated/TransientDecentralizedDownstreamWithTwoUpstream.lf
@@ -99,12 +99,18 @@ federated reactor {
   // Persistent downstream and upstream federates of the transient
   up1 = new Up(period = 1500 ms)
   up2 = new Up(period = 800 msec)
-  @maxwait(800 ms)
+
+  // Need a non-zero maxwait here because the join input is asynchronous.
+  // It is rarely present, which means that the choice of maxwait here
+  // introduces a lag in Down that will usually be larger than the maxwait.
+  @maxwait(300 ms)
   down = new Down(period = 1500 ms)
 
   // Transient federate
   @transient
-  @maxwait(500 ms)
+  // Need a non-zero maxwait here to prevent the start tag from completing
+  // before receiving the initial message from up1.
+  @maxwait(150 ms)
   mid = new Middle()
 
   // Connections

--- a/test/C/src/federated/TransientDecentralizedDownstreamWithTwoUpstream.lf
+++ b/test/C/src/federated/TransientDecentralizedDownstreamWithTwoUpstream.lf
@@ -99,7 +99,7 @@ federated reactor {
   // Persistent downstream and upstream federates of the transient
   up1 = new Up(period = 1500 ms)
   up2 = new Up(period = 800 msec)
-  @maxwait(0)
+  @maxwait(800 ms)
   down = new Down(period = 1500 ms)
 
   // Transient federate
@@ -109,10 +109,7 @@ federated reactor {
 
   // Connections
   up1.out -> mid.in
-  @absent_after(400 ms)
   mid.join -> down.join
-  @absent_after(500 ms)
   mid.out -> down.in_mid
-  @absent_after(300 ms)
   up2.out -> down.in_up
 }

--- a/test/C/src/federated/TransientDecentralizedHotSwap.lf
+++ b/test/C/src/federated/TransientDecentralizedHotSwap.lf
@@ -63,18 +63,16 @@ federated reactor {
 
   // Persistent downstream and upstream federates of the transient
   up = new Up(period = 1500 ms)
-  @maxwait(0)
+  @maxwait(800 ms)
   down = new Down(period = 1500 ms)
 
   // Transient federate
   @transient
-  @maxwait(400 ms)
+  @maxwait(500 ms)
   mid = new Middle()
 
   // Connections
   up.out -> mid.in
-  @absent_after(500 ms)
   mid.join -> down.join
-  @absent_after(600 ms)
   mid.out -> down.in
 }

--- a/test/C/src/federated/TransientDecentralizedHotSwap.lf
+++ b/test/C/src/federated/TransientDecentralizedHotSwap.lf
@@ -50,8 +50,8 @@ reactor Middle {
     self->count++;
     lf_set(out, in->value);
   =} tardy {=
-    lf_print_error_and_exit("Fatal error: federate Middle received a tardy in event at tag " PRINTF_TAG ".",
-        in->intended_tag.time, in->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in event at relative tag " PRINTF_TAG ".",
+        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep);
   =}
 }
 

--- a/test/C/src/federated/TransientDecentralizedHotSwap.lf
+++ b/test/C/src/federated/TransientDecentralizedHotSwap.lf
@@ -50,8 +50,8 @@ reactor Middle {
     self->count++;
     lf_set(out, in->value);
   =} tardy {=
-    lf_print_error_and_exit("Received a tardy in event at relative tag " PRINTF_TAG ".",
-        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in event at intended tag " PRINTF_TAG ". Current tag is " PRINTF_TAG ".",
+        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep, lf_time_logical() - lf_time_start(), lf_tag().microstep);
   =}
 }
 

--- a/test/C/src/federated/TransientDecentralizedStatePersistence.lf
+++ b/test/C/src/federated/TransientDecentralizedStatePersistence.lf
@@ -46,8 +46,8 @@ reactor Persistence {
     }
     self->middle_first_join = false;
   =} tardy {=
-    lf_print_error_and_exit("Fatal error: Federate Persistence received a tardy in_middle_join event at tag " PRINTF_TAG ".",
-        in_middle_join->intended_tag.time, in_middle_join->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in_middle_join event at relative tag " PRINTF_TAG ".",
+        in_middle_join->intended_tag.time - lf_time_start(), in_middle_join->intended_tag.microstep);
   =}
 
   reaction(in_from_middle) {=
@@ -56,8 +56,8 @@ reactor Persistence {
     lf_print("Latest received state: {%c,%d}", self->middle_state.state_char,
               self->middle_state.state_count);
   =} tardy {=
-    lf_print_error_and_exit("Fatal error: Federate Persistence received a tardy in_from_middle event at tag " PRINTF_TAG ".",
-        in_from_middle->intended_tag.time, in_from_middle->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in_from_middle event at relative tag " PRINTF_TAG ".",
+        in_from_middle->intended_tag.time - lf_time_start(), in_from_middle->intended_tag.microstep);
   =}
 }
 
@@ -87,8 +87,8 @@ reactor Middle {
           self->middle_state.state_count,
           lf_time_logical_elapsed());
   =} tardy {=
-    lf_print_error_and_exit("Fatal error: Federate Middle received a tardy in_from_persistence event at tag " PRINTF_TAG ".",
-        in_from_persistence->intended_tag.time, in_from_persistence->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in_from_persistence event at relative tag " PRINTF_TAG ".",
+        in_from_persistence->intended_tag.time - lf_time_start(), in_from_persistence->intended_tag.microstep);
   =}
 
   // When an input is received, the internal state is updated, and then sent to
@@ -106,8 +106,8 @@ reactor Middle {
       lf_stop();
     }
   =} tardy {=
-    lf_print_error_and_exit("Fatal error: Federate Middle received a tardy in event at tag " PRINTF_TAG ".",
-        in->intended_tag.time, in->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in event at relative tag " PRINTF_TAG ".",
+        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep);
   =}
 }
 

--- a/test/C/src/federated/TransientDecentralizedStatePersistence.lf
+++ b/test/C/src/federated/TransientDecentralizedStatePersistence.lf
@@ -136,5 +136,6 @@ federated reactor {
   mid.out -> down.in
   @absent_after(400 ms)
   persistence.out_to_middle -> mid.in_from_persistence
+  @absent_after(200 ms)
   mid.out_to_persistence -> persistence.in_from_middle
 }

--- a/test/C/src/federated/TransientDecentralizedStatePersistence.lf
+++ b/test/C/src/federated/TransientDecentralizedStatePersistence.lf
@@ -46,8 +46,8 @@ reactor Persistence {
     }
     self->middle_first_join = false;
   =} tardy {=
-    lf_print_error_and_exit("Received a tardy in_middle_join event at relative tag " PRINTF_TAG ".",
-        in_middle_join->intended_tag.time - lf_time_start(), in_middle_join->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in_middle_join event at intended tag " PRINTF_TAG ". Current tag is " PRINTF_TAG ".",
+        in_middle_join->intended_tag.time - lf_time_start(), in_middle_join->intended_tag.microstep, lf_time_logical() - lf_time_start(), lf_tag().microstep);
   =}
 
   reaction(in_from_middle) {=
@@ -56,8 +56,8 @@ reactor Persistence {
     lf_print("Latest received state: {%c,%d}", self->middle_state.state_char,
               self->middle_state.state_count);
   =} tardy {=
-    lf_print_error_and_exit("Received a tardy in_from_middle event at relative tag " PRINTF_TAG ".",
-        in_from_middle->intended_tag.time - lf_time_start(), in_from_middle->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in_from_middle event at intended tag " PRINTF_TAG ". Current tag is " PRINTF_TAG ".",
+        in_from_middle->intended_tag.time - lf_time_start(), in_from_middle->intended_tag.microstep, lf_time_logical() - lf_time_start(), lf_tag().microstep);
   =}
 }
 
@@ -87,8 +87,8 @@ reactor Middle {
           self->middle_state.state_count,
           lf_time_logical_elapsed());
   =} tardy {=
-    lf_print_error_and_exit("Received a tardy in_from_persistence event at relative tag " PRINTF_TAG ".",
-        in_from_persistence->intended_tag.time - lf_time_start(), in_from_persistence->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in_from_persistence event at intended tag " PRINTF_TAG ". Current tag is " PRINTF_TAG ".",
+        in_from_persistence->intended_tag.time - lf_time_start(), in_from_persistence->intended_tag.microstep, lf_time_logical() - lf_time_start(), lf_tag().microstep);
   =}
 
   // When an input is received, the internal state is updated, and then sent to
@@ -106,8 +106,8 @@ reactor Middle {
       lf_stop();
     }
   =} tardy {=
-    lf_print_error_and_exit("Received a tardy in event at relative tag " PRINTF_TAG ".",
-        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in event at intended tag " PRINTF_TAG ". Current tag is " PRINTF_TAG ".",
+        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep, lf_time_logical() - lf_time_start(), lf_tag().microstep);
   =}
 }
 

--- a/test/C/src/federated/TransientDecentralizedStatePersistence.lf
+++ b/test/C/src/federated/TransientDecentralizedStatePersistence.lf
@@ -2,8 +2,12 @@
  * This LF program showcases and tests the persistance of the internal state of a transient federate
  * across executions. Using the hot swap mechanism, the transient federate `Middle` leaves and then
  * joins. Whenever the state (of type `federate_state_t`) changes, it notifies `Persistence`.
- * `Middle` notifies `Persistence` also when it joins. When `Middle` joins the second time or after,
- * it receives the saved state and sets it. In this, the order of the reactions is important.
+ * `Middle` notifies `Persistence` also when it joins. When `Middle` joins, it receives the saved
+ * state and sets it. In this, the order of the reactions is important.
+ *
+ * Note that this test is intrinsically flaky. The `maxwait` and `absent_after` parameters are
+ * chosen to be large enough to cover the flakiness most of the time, but it is not guaranteed to
+ * pass every time.
  *
  * @author Chadlia Jerad
  */
@@ -33,20 +37,17 @@ preamble {=
 
 reactor Persistence {
   state middle_state: federate_state_t = {'A', 0}
-  state middle_first_join: bool = true
 
   input in_from_middle: federate_state_t
   input in_middle_join: bool
   output out_to_middle: federate_state_t
 
-  // Only send the previous state if it not the first time Middle joins
+  // Need to send the previous state even the first time Middle joins because
+  // otherwise, Middle will delay by the absent_after before sending out_to_persistence.
   reaction(in_middle_join) -> out_to_middle {=
-    if (!self->middle_first_join) {
-        lf_set(out_to_middle, self->middle_state);
-        lf_print("Notifying Mid of the latest state: {%c,%d}", self->middle_state.state_char,
-              self->middle_state.state_count);
-    }
-    self->middle_first_join = false;
+    lf_set(out_to_middle, self->middle_state);
+    lf_print("Notifying Mid of the latest state: {%c,%d}", self->middle_state.state_char,
+          self->middle_state.state_count);
   =} tardy {=
     lf_print_error_and_exit("Received a tardy in_middle_join event at intended tag " PRINTF_TAG ". Current tag is " PRINTF_TAG ".",
         in_middle_join->intended_tag.time - lf_time_start(), in_middle_join->intended_tag.microstep, lf_time_logical() - lf_time_start(), lf_tag().microstep);
@@ -115,8 +116,8 @@ reactor Middle {
 
 federated reactor {
   // Persistent downstream and upstream federates of the transient
-  up = new Up(period = 1500 ms)
-  down = new Down(period = 1500 ms)
+  up = new Up(period = 500 ms)
+  down = new Down(period = 500 ms)
   @maxwait(200 ms)
   persistence = new Persistence()
   // Persistent federate that is responsible for lauching the transient once, after 1s
@@ -127,14 +128,13 @@ federated reactor {
   @maxwait(0)
   mid = new Middle()
 
-  // Connections
-  @absent_after(400 ms)
+  // Give time for Up to start up and provide its first output.
+  @absent_after(200 ms)
   up.out -> mid.in
   mid.join -> down.join
   mid.join -> persistence.in_middle_join
   mid.out -> down.in
-  @absent_after(300 ms)
+  @absent_after(400 ms)
   persistence.out_to_middle -> mid.in_from_persistence
-  @absent_after(450 ms)
   mid.out_to_persistence -> persistence.in_from_middle
 }

--- a/test/C/src/federated/TransientDecentralizedWithPhysicalConnection.lf
+++ b/test/C/src/federated/TransientDecentralizedWithPhysicalConnection.lf
@@ -69,8 +69,8 @@ reactor Middle {
       lf_stop();
     }
   =} tardy {=
-    lf_print_error_and_exit("Received a tardy in event at relative tag " PRINTF_TAG ".",
-        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in event at intended tag " PRINTF_TAG ". Current tag is " PRINTF_TAG ".",
+        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep, lf_time_logical() - lf_time_start(), lf_tag().microstep);
   =}
 
   reaction(inp) {=

--- a/test/C/src/federated/TransientDecentralizedWithPhysicalConnection.lf
+++ b/test/C/src/federated/TransientDecentralizedWithPhysicalConnection.lf
@@ -69,8 +69,8 @@ reactor Middle {
       lf_stop();
     }
   =} tardy {=
-    lf_print_error_and_exit("Fatal error: federate Middle received a tardy in event at tag " PRINTF_TAG ".",
-        in->intended_tag.time, in->intended_tag.microstep);
+    lf_print_error_and_exit("Received a tardy in event at relative tag " PRINTF_TAG ".",
+        in->intended_tag.time - lf_time_start(), in->intended_tag.microstep);
   =}
 
   reaction(inp) {=

--- a/test/C/src/federated/TransientDecentralizedWithPhysicalConnection.lf
+++ b/test/C/src/federated/TransientDecentralizedWithPhysicalConnection.lf
@@ -87,19 +87,17 @@ federated reactor {
 
   // Persistent downstream and upstream federates of the transient
   up = new Up(period = 1500 ms)
-  @maxwait(0)
+  @maxwait(800 ms)
   down = new Down()
 
   // Transient federate
   @transient
-  @maxwait(400 ms)
+  @maxwait(500 ms)
   mid = new Middle()
 
   // Connections
   up.out -> mid.in
-  @absent_after(500 ms)
   mid.join -> down.join
-  @absent_after(600 ms)
   mid.out -> down.in
   up.outp ~> mid.inp
 }

--- a/test/C/src/federated/TransientDownstreamWithTimer.lf
+++ b/test/C/src/federated/TransientDownstreamWithTimer.lf
@@ -1,9 +1,8 @@
 /**
- * This LF program tests if a transient federate correctly leaves then joins the federation. It also
- * tests whether the transient's downstream executes as expected, that is it receives correct TAGs,
+ * This LF program tests whether a transient federate correctly leaves then joins the federation. It also
+ * tests whether the transient's downstream executes as expected, that is, it receives correct TAGs,
  * regardless of the transient being absent or present. In this test:
- * - the transient federate spontaneously leaves the federation after 2 reactions to input port
- * `in`,
+ * - the transient federate spontaneously leaves the federation after 2 reactions to input port `in`,
  * - the downstream of the transient federate has only one transient as upstream.
  */
 target C {
@@ -11,8 +10,12 @@ target C {
 }
 
 preamble {=
+  #include <errno.h>
   #include <stdlib.h>
   #include <string.h>
+  #include <sys/stat.h>
+  #include <sys/wait.h>
+  #include <unistd.h>
 =}
 
 /**
@@ -35,26 +38,78 @@ reactor TransientExec(launch_time: time = 0, fed_instance_name: char* = "instanc
   timer t(launch_time)
 
   reaction(t) {=
-    // Construct the command to launch the transient federate
-    char mid_launch_cmd[512];
-    snprintf(mid_launch_cmd, sizeof(mid_launch_cmd),
-        "%s/bin/federate__%s -i %s",
+    // Construct the path to the transient federate executable and the launch command
+    char mid_exe[512];
+    char mid_launch_cmd[576];
+    snprintf(mid_exe, sizeof(mid_exe),
+        "%s/bin/federate__%s",
         LF_FED_PACKAGE_DIRECTORY,
-        self->fed_instance_name,
+        self->fed_instance_name
+    );
+    snprintf(mid_launch_cmd, sizeof(mid_launch_cmd),
+        "%s -i %s",
+        mid_exe,
         lf_get_federation_id()
     );
+
+    // Check that the executable exists
+    if (access(mid_exe, F_OK) != 0) {
+      lf_print_error_and_exit(
+          "Unable to launch federate__%s: executable '%s' does not exist "
+          "(errno %d: %s). Package directory: %s. Command: %s",
+          self->fed_instance_name, mid_exe, errno, strerror(errno),
+          LF_FED_PACKAGE_DIRECTORY, mid_launch_cmd);
+    }
+
+    // Check that it is executable
+    if (access(mid_exe, X_OK) != 0) {
+      lf_print_error_and_exit(
+          "Unable to launch federate__%s: '%s' exists but is not executable "
+          "(errno %d: %s). Command: %s",
+          self->fed_instance_name, mid_exe, errno, strerror(errno), mid_launch_cmd);
+    }
+
+    struct stat st;
+    if (stat(mid_exe, &st) == 0) {
+      lf_print("Executable '%s' found (size %lld bytes, mode %o).",
+          mid_exe, (long long)st.st_size, (unsigned)(st.st_mode & 0777));
+    } else {
+      lf_print_warning(
+          "stat('%s') failed (errno %d: %s); proceeding with launch anyway.",
+          mid_exe, errno, strerror(errno));
+    }
 
     lf_print("Launching federate federate__%s at physical time " PRINTF_TIME ".",
         self->fed_instance_name, lf_time_physical());
     lf_print("**** Launch command: %s", mid_launch_cmd);
 
+    errno = 0;
     int status = system(mid_launch_cmd);
 
-    // Exit if error
-    if (status == 0) {
+    if (status == -1) {
+      lf_print_error_and_exit(
+          "Unable to launch federate__%s: system() failed "
+          "(errno %d: %s). Command: %s",
+          self->fed_instance_name, errno, strerror(errno), mid_launch_cmd);
+    } else if (WIFEXITED(status)) {
+      int exit_status = WEXITSTATUS(status);
+      if (exit_status == 0) {
         lf_print("Successfully launched federate__%s.", self->fed_instance_name);
+      } else {
+        lf_print_error_and_exit(
+            "Unable to launch federate__%s: process exited with status %d "
+            "(wait status %d). Command: %s",
+            self->fed_instance_name, exit_status, status, mid_launch_cmd);
+      }
+    } else if (WIFSIGNALED(status)) {
+      lf_print_error_and_exit(
+          "Unable to launch federate__%s: process killed by signal %d "
+          "(wait status %d). Command: %s",
+          self->fed_instance_name, WTERMSIG(status), status, mid_launch_cmd);
     } else {
-        lf_print_error_and_exit("Unable to launch federate__%s. Abort!", self->fed_instance_name);
+      lf_print_error_and_exit(
+          "Unable to launch federate__%s: unexpected wait status %d. Command: %s",
+          self->fed_instance_name, status, mid_launch_cmd);
     }
   =}
 }

--- a/test/C/src/federated/TransientDownstreamWithTimer.lf
+++ b/test/C/src/federated/TransientDownstreamWithTimer.lf
@@ -32,7 +32,7 @@ reactor Up(period: time = 500 ms) {
 
 /** Persistent federate that is responsible for lauching the transient federate */
 reactor TransientExec(launch_time: time = 0, fed_instance_name: char* = "instance") {
-  timer t(launch_time, 0)
+  timer t(launch_time)
 
   reaction(t) {=
     // Construct the command to launch the transient federate

--- a/test/C/src/federated/TransientDownstreamWithTimer.lf
+++ b/test/C/src/federated/TransientDownstreamWithTimer.lf
@@ -1,8 +1,9 @@
 /**
- * This LF program tests whether a transient federate correctly leaves then joins the federation. It also
- * tests whether the transient's downstream executes as expected, that is, it receives correct TAGs,
- * regardless of the transient being absent or present. In this test:
- * - the transient federate spontaneously leaves the federation after 2 reactions to input port `in`,
+ * This LF program tests whether a transient federate correctly leaves then joins the federation. It
+ * also tests whether the transient's downstream executes as expected, that is, it receives correct
+ * TAGs, regardless of the transient being absent or present. In this test:
+ * - the transient federate spontaneously leaves the federation after 2 reactions to input port
+ * `in`,
  * - the downstream of the transient federate has only one transient as upstream.
  *
  * @author Chadlia Jerad

--- a/test/C/src/federated/TransientDownstreamWithTimer.lf
+++ b/test/C/src/federated/TransientDownstreamWithTimer.lf
@@ -115,10 +115,10 @@ reactor TransientExec(launch_time: time = 0, fed_instance_name: char* = "instanc
 }
 
 /**
- * Transient federate that forwards whatever it receives from `Up` to `Down`. It reacts twice to
+ * Transient federate that forwards whatever it receives from `in` to `out`. It reacts twice to
  * input port `in`, then stops. It will execute twice during the lifetime of the federation. The
- * second launch is done by `TransientExec` at logical time 1 s. Each time `Middle` joins, it
- * notifies `Down`.
+ * second launch is done by `TransientExec` at logical time 1 s. Each time this reactor joins, it
+ * sends a notification via the `join` output port.
  */
 reactor Middle {
   input in: int
@@ -126,12 +126,12 @@ reactor Middle {
   output join: int
   state count: int = 0
 
-  // Middle notifies its downstream that he joined, but make sure first that the effective start
+  // Middle notifies its downstream that it joined, but make sure first that the effective start
   // tag is correct
   reaction(startup) -> join {=
     tag_t t = lf_tag_start_effective();
     if(t.time < lf_time_start()) {
-      lf_print_error_and_exit("Fatal error: the transient's effective start time is less than the federation start time");
+      lf_print_error_and_exit("The transient's effective start time is less than the federation start time");
     }
 
     lf_set(join, 0);
@@ -188,7 +188,7 @@ reactor Down {
 
     // Check that `Middle` have reacted correctly
     if (self->count_in_mid_reactions < 4) {
-      lf_print_error_and_exit("Transient federate Mid did not execute and pass values from up corretly! Expected >= 4, but had: %d.",
+      lf_print_error_and_exit("Transient federate Mid did not execute and pass values from up correctly! Expected >= 4, but had: %d.",
           self->count_in_mid_reactions);
     }
   =}

--- a/test/C/src/federated/TransientDownstreamWithTwoUpstream.lf
+++ b/test/C/src/federated/TransientDownstreamWithTwoUpstream.lf
@@ -1,5 +1,5 @@
 /**
- * This LF program tests whether a transient federate corretly leaves then joins the federation. It
+ * This LF program tests whether a transient federate correctly leaves then joins the federation. It
  * also tests whether the transient's downstream executes as expected, that is it received correct
  * TAGs, regardless of the transient being absent or present. In this test:
  * - the transient federate spontaneously leaves the federation after 2 reactions to input port in,
@@ -74,7 +74,7 @@ reactor Down {
 
     // Check that Middle have reacted correctly
     if (self->count_in_mid_reactions < 4) {
-      lf_print_error_and_exit("Transient federate Mid did not execute and pass values from up corretly! Expected >= 4, but had: %d.",
+      lf_print_error_and_exit("Transient federate Mid did not execute and pass values from up correctly! Expected >= 4, but had: %d.",
           self->count_in_mid_reactions);
     }
   =}

--- a/test/C/src/federated/TransientStatePersistence.lf
+++ b/test/C/src/federated/TransientStatePersistence.lf
@@ -130,8 +130,8 @@ reactor Down(period = 500 ms) {
 
   reaction(shutdown) {=
     if(self->count_join == 2 && self->count_in_mid_reactions < 4) {
-        lf_print_error_and_exit("Mid Joined twice, but the state did not persist \
-                across executions! state_count is %d, while is should be > then %d.",
+        lf_print_error_and_exit("Mid Joined twice, but the state did not persist "
+                "across executions! state_count is %d, while is should be > than %d.",
                 self->count_in_mid_reactions,
                 4);
     }

--- a/test/C/src/federated/TransientStatePersistenceWithPhysicalConnection.lf
+++ b/test/C/src/federated/TransientStatePersistenceWithPhysicalConnection.lf
@@ -128,8 +128,8 @@ reactor Down {
 
   reaction(shutdown) {=
     if(self->count_join == 2 && self->count_in_mid_reactions < 4) {
-        lf_print_error_and_exit("Mid Joined twice, but the state did not persist \
-                across executions! state_count is %d, while is should be > then %d.",
+        lf_print_error_and_exit("Mid Joined twice, but the state did not persist "
+                "across executions! state_count is %d, while is should be > than %d.",
                 self->count_in_mid_reactions,
                 4);
     }

--- a/test/Python/src/federated/TransientDecentralizedDownstreamWithTimer.lf
+++ b/test/Python/src/federated/TransientDecentralizedDownstreamWithTimer.lf
@@ -41,6 +41,7 @@ reactor Middle {
   reaction(inp) -> out {=
     self.count += 1
     out.set(inp.value)
+    print("Middle forwarded value {} at tag ({}, {}).".format(inp.value, lf.time.logical_elapsed(), lf.tag().microstep))
 
     if self.count == 2:
       lf.stop()
@@ -96,7 +97,7 @@ reactor Down(period = 1500 ms) {
 
     # Check that `Middle` have reacted correctly
     if self.count_in_mid_reactions < 4:
-      sys.stderr.write("Transient federate Mid did not execute and pass values from up corretly! Expected >= 4, but had: {}.\n".format(
+      sys.stderr.write("Transient federate Mid did not execute and pass values from up correctly! Expected >= 4, but had: {}.\n".format(
           self.count_in_mid_reactions))
       sys.exit(1)
   =}
@@ -109,9 +110,9 @@ federated reactor {
       federation_name="TransientDecentralizedDownstreamWithTimer",
       fed_instance_name="mid")
 
-  up = new Up(period = 1500 ms)  # Persistent downstream and upstream federates of the transient
+  up = new Up(period = 500 ms)  # Persistent downstream and upstream federates of the transient
   @maxwait(800 ms)
-  down = new Down(period = 1500 ms)
+  down = new Down(period = 500 ms)
 
   # Transient federate
   @transient

--- a/test/Python/src/federated/TransientDecentralizedDownstreamWithTimer.lf
+++ b/test/Python/src/federated/TransientDecentralizedDownstreamWithTimer.lf
@@ -7,7 +7,7 @@
  * - the downstream of the transient federate has only one transient as upstream.
  */
 target Python {
-  timeout: 6 s,
+  timeout: 9 s,
   coordination: decentralized
 }
 
@@ -54,8 +54,8 @@ reactor Middle {
  * Persistent federate, which is downstream of the transient. It has to keep reacting to its
  * internal timer and also to inputs from the tansient, if any.
  */
-reactor Down {
-  timer t(0, 500 ms)
+reactor Down(period = 1500 ms) {
+  timer t(0, period)
 
   input inp
   input join
@@ -105,22 +105,20 @@ reactor Down {
 federated reactor {
   # Persistent federate that is responsible for lauching the transient once, after 1s
   midExec = new TransientExec(
-      launch_time = 1 s,
+      launch_time = 3 s,
       federation_name="TransientDecentralizedDownstreamWithTimer",
       fed_instance_name="mid")
 
-  up = new Up()  # Persistent downstream and upstream federates of the transient
-  @maxwait(0)
-  down = new Down()
+  up = new Up(period = 1500 ms)  # Persistent downstream and upstream federates of the transient
+  @maxwait(800 ms)
+  down = new Down(period = 1500 ms)
 
   # Transient federate
   @transient
-  @maxwait(250 ms)
+  @maxwait(500 ms)
   mid = new Middle()
 
   up.out -> mid.inp  # Connections
-  @absent_after(300 ms)
   mid.join -> down.join
-  @absent_after(350 ms)
   mid.out -> down.inp
 }

--- a/test/Python/src/federated/TransientDecentralizedDownstreamWithTwoUpstream.lf
+++ b/test/Python/src/federated/TransientDecentralizedDownstreamWithTwoUpstream.lf
@@ -92,19 +92,16 @@ federated reactor {
 
   up1 = new Up()  # Persistent downstream and upstream federates of the transient
   up2 = new Up(period = 300 msec)
-  @maxwait(0)
+  @maxwait(300 ms)
   down = new Down()
 
   # Transient federate
   @transient
-  @maxwait(250 ms)
+  @maxwait(150 ms)
   mid = new Middle()
 
   up1.out -> mid.inp  # Connections
-  @absent_after(300 ms)
   mid.join -> down.join
-  @absent_after(350 ms)
   mid.out -> down.in_mid
-  @absent_after(100 ms)
   up2.out -> down.in_up
 }

--- a/test/Python/src/federated/TransientDecentralizedDownstreamWithTwoUpstream.lf
+++ b/test/Python/src/federated/TransientDecentralizedDownstreamWithTwoUpstream.lf
@@ -1,5 +1,5 @@
 /**
- * This LF program tests whether a transient federate corretly leaves then joins the federation. It
+ * This LF program tests whether a transient federate correctly leaves then joins the federation. It
  * also tests whether the transient's downstream executes as expected, that is it received correct
  * TAGs, regardless of the transient being absent or present. In this test:
  * - the transient federate spontaneously leaves the federation after 2 reactions to input port inp,
@@ -77,7 +77,7 @@ reactor Down {
 
     # Check that Middle have reacted correctly
     if self.count_in_mid_reactions < 4:
-      sys.stderr.write("Transient federate Mid did not execute and pass values from up corretly! Expected >= 4, but had: {}.\n".format(
+      sys.stderr.write("Transient federate Mid did not execute and pass values from up correctly! Expected >= 4, but had: {}.\n".format(
           self.count_in_mid_reactions))
       sys.exit(1)
   =}

--- a/test/Python/src/federated/TransientDecentralizedHotSwap.lf
+++ b/test/Python/src/federated/TransientDecentralizedHotSwap.lf
@@ -8,7 +8,7 @@
  * swap.
  */
 target Python {
-  timeout: 6 s,
+  timeout: 9 s,
   auth: true,
   coordination: decentralized
 }
@@ -57,18 +57,16 @@ federated reactor {
       federation_name="TransientDecentralizedHotSwap",
       fed_instance_name="mid")
 
-  up = new Up()  # Persistent downstream and upstream federates of the transient
-  @maxwait(0)
-  down = new Down()
+  up = new Up(period = 1500 ms)  # Persistent downstream and upstream federates of the transient
+  @maxwait(800 ms)
+  down = new Down(period = 1500 ms)
 
   # Transient federate
   @transient
-  @maxwait(250 ms)
+  @maxwait(500 ms)
   mid = new Middle()
 
   up.out -> mid.inp  # Connections
-  @absent_after(300 ms)
   mid.join -> down.join
-  @absent_after(350 ms)
   mid.out -> down.inp
 }

--- a/test/Python/src/federated/TransientDecentralizedStatePersistence.lf
+++ b/test/Python/src/federated/TransientDecentralizedStatePersistence.lf
@@ -2,8 +2,12 @@
  * This LF program showcases and tests the persistance of the internal state of a transient federate
  * across executions. Using the hot swap mechanism, the transient federate `Middle` leaves and then
  * joins. Whenever the state (of type `FederateState`) changes, it notifies `Persistence`. `Middle`
- * notifies `Persistence` also when it joins. When `Middle` joins the second time or after, it
- * receives the saved state and sets it. In this, the order of the reactions is important.
+ * notifies `Persistence` also when it joins. When `Middle` joins, it receives the saved state and
+ * sets it. In this, the order of the reactions is important.
+ *
+ * Note that this test is intrinsically flaky. The `maxwait` and `absent_after` parameters are
+ * chosen to be large enough to cover the flakiness most of the time, but it is not guaranteed to
+ * pass every time.
  */
 target Python {
   timeout: 9 s,

--- a/test/Python/src/federated/TransientDecentralizedStatePersistence.lf
+++ b/test/Python/src/federated/TransientDecentralizedStatePersistence.lf
@@ -8,6 +8,30 @@
  * Note that this test is intrinsically flaky. The `maxwait` and `absent_after` parameters are
  * chosen to be large enough to cover the flakiness most of the time, but it is not guaranteed to
  * pass every time.
+ *
+ * The timing behavior of this test can be very confusing. Three scenarior occur:
+ *
+ * - Most of the time, after joining, when an event arrives on `in`, mid will wait 400 ms
+ *   (because of the absent_after on `in_from_persistence`) before producing `out` and
+ *   `out_to_persistence`.  Down has a maxwait of forever, so it will likely not process
+ *   its message until shutdown time (unless a `join` arrives).  Persistence will receive
+ *   `in_from_middle` at least 400 ms late, so its maxwait of 200 will have already expired
+ *   and it will process the message right away.
+ *
+ * - When a join occurs that is not aligned with the timers, the behavior is different:
+ *   mid runs reaction 1 right away, so Persistence sees `in_middle_join` quickly.
+ *   (reaction 2 in mid has a higher level than the network sender because of the
+ *   zero-delay loop). Persistence may then wait 200 ms (its maxwait) before actually
+ *   sending because of level scheduling. The absent_after of 400ms on the feedback
+ *   path absorbs that 200 ms plus any networking overhead.
+ *
+ * - When a join occurs that _is_ aligned with the timers (likely only at (0,0)),
+ *   then the behavior is still different. mid will send `join` immediately, as above.
+ *   It will receive `in_from_persistence` within 400ms (or else a tardy error will occur).
+ *   It will then send `out_to_persistence`. The maxwait of 200 ms at Persistence keeps
+ *   it from processing the `join` event until it receives both or 200 ms goes by.
+ *   It can't receive both, so this will take 200 ms. Then Persistence sends its output.
+ *  The absent_after on its connection into `in_from_middle` helps protect against tardiness.
  */
 target Python {
   timeout: 9 s,
@@ -124,5 +148,6 @@ federated reactor {
   mid.out -> down.inp
   @absent_after(400 ms)
   persistence.out_to_middle -> mid.in_from_persistence
+  @absent_after(200 ms)
   mid.out_to_persistence -> persistence.in_from_middle
 }

--- a/test/Python/src/federated/TransientDecentralizedStatePersistence.lf
+++ b/test/Python/src/federated/TransientDecentralizedStatePersistence.lf
@@ -11,27 +11,25 @@
  *
  * The timing behavior of this test can be very confusing. Three scenarior occur:
  *
- * - Most of the time, after joining, when an event arrives on `in`, mid will wait 400 ms
- *   (because of the absent_after on `in_from_persistence`) before producing `out` and
- *   `out_to_persistence`.  Down has a maxwait of forever, so it will likely not process
- *   its message until shutdown time (unless a `join` arrives).  Persistence will receive
- *   `in_from_middle` at least 400 ms late, so its maxwait of 200 will have already expired
- *   and it will process the message right away.
+ * - Most of the time, after joining, when an event arrives on `in`, mid will wait 400 ms (because
+ * of the absent_after on `in_from_persistence`) before producing `out` and `out_to_persistence`.
+ * Down has a maxwait of forever, so it will likely not process its message until shutdown time
+ * (unless a `join` arrives). Persistence will receive `in_from_middle` at least 400 ms late, so its
+ * maxwait of 200 will have already expired and it will process the message right away.
  *
- * - When a join occurs that is not aligned with the timers, the behavior is different:
- *   mid runs reaction 1 right away, so Persistence sees `in_middle_join` quickly.
- *   (reaction 2 in mid has a higher level than the network sender because of the
- *   zero-delay loop). Persistence may then wait 200 ms (its maxwait) before actually
- *   sending because of level scheduling. The absent_after of 400ms on the feedback
- *   path absorbs that 200 ms plus any networking overhead.
+ * - When a join occurs that is not aligned with the timers, the behavior is different: mid runs
+ * reaction 1 right away, so Persistence sees `in_middle_join` quickly. (reaction 2 in mid has a
+ * higher level than the network sender because of the zero-delay loop). Persistence may then wait
+ * 200 ms (its maxwait) before actually sending because of level scheduling. The absent_after of
+ * 400ms on the feedback path absorbs that 200 ms plus any networking overhead.
  *
- * - When a join occurs that _is_ aligned with the timers (likely only at (0,0)),
- *   then the behavior is still different. mid will send `join` immediately, as above.
- *   It will receive `in_from_persistence` within 400ms (or else a tardy error will occur).
- *   It will then send `out_to_persistence`. The maxwait of 200 ms at Persistence keeps
- *   it from processing the `join` event until it receives both or 200 ms goes by.
- *   It can't receive both, so this will take 200 ms. Then Persistence sends its output.
- *  The absent_after on its connection into `in_from_middle` helps protect against tardiness.
+ * - When a join occurs that _is_ aligned with the timers (likely only at (0,0)), then the behavior
+ * is still different. mid will send `join` immediately, as above. It will receive
+ * `in_from_persistence` within 400ms (or else a tardy error will occur). It will then send
+ * `out_to_persistence`. The maxwait of 200 ms at Persistence keeps it from processing the `join`
+ * event until it receives both or 200 ms goes by. It can't receive both, so this will take 200 ms.
+ * Then Persistence sends its output. The absent_after on its connection into `in_from_middle` helps
+ * protect against tardiness.
  */
 target Python {
   timeout: 9 s,

--- a/test/Python/src/federated/TransientDecentralizedStatePersistence.lf
+++ b/test/Python/src/federated/TransientDecentralizedStatePersistence.lf
@@ -6,7 +6,7 @@
  * receives the saved state and sets it. In this, the order of the reactions is important.
  */
 target Python {
-  timeout: 6 s,
+  timeout: 9 s,
   coordination: decentralized
 }
 
@@ -100,13 +100,13 @@ reactor Middle {
 }
 
 federated reactor {
-  up = new Up()  # Persistent downstream and upstream federates of the transient
-  down = new Down()
-  @maxwait(100 ms)
+  up = new Up(period = 1500 ms)  # Persistent downstream and upstream federates of the transient
+  down = new Down(period = 1500 ms)
+  @maxwait(200 ms)
   persistence = new Persistence()
   # Persistent federate that is responsible for lauching the transient once, after 1s
   midExec = new TransientExec(
-      launch_time = 1 s,
+      launch_time = 3 s,
       federation_name="TransientDecentralizedStatePersistence",
       fed_instance_name="mid")
 
@@ -116,13 +116,13 @@ federated reactor {
   mid = new Middle()
 
   # Connections
-  @absent_after(300 ms)
+  @absent_after(400 ms)
   up.out -> mid.inp
   mid.join -> down.join
   mid.join -> persistence.in_middle_join
   mid.out -> down.inp
-  @absent_after(200 ms)
+  @absent_after(300 ms)
   persistence.out_to_middle -> mid.in_from_persistence
-  @absent_after(350 ms)
+  @absent_after(450 ms)
   mid.out_to_persistence -> persistence.in_from_middle
 }

--- a/test/Python/src/federated/TransientDecentralizedStatePersistence.lf
+++ b/test/Python/src/federated/TransientDecentralizedStatePersistence.lf
@@ -24,7 +24,6 @@ preamble {=
 
 reactor Persistence {
   state middle_state = {= FederateState('A', 0) =}
-  state middle_first_join = True
 
   input in_from_middle
   input in_middle_join
@@ -32,11 +31,9 @@ reactor Persistence {
 
   # Only send the previous state if it not the first time Middle joins
   reaction(in_middle_join) -> out_to_middle {=
-    if not self.middle_first_join:
-      out_to_middle.set(self.middle_state)
-      print("Notifying Mid of the latest state: {{{},{}}}".format(
-          self.middle_state.state_char, self.middle_state.state_count))
-    self.middle_first_join = False
+    out_to_middle.set(self.middle_state)
+    print("Notifying Mid of the latest state: {{{},{}}}".format(
+        self.middle_state.state_char, self.middle_state.state_count))
   =} tardy {=
     sys.stderr.write("Fatal error: Federate Persistence received a tardy in_middle_join event.\n")
     sys.exit(1)
@@ -100,8 +97,8 @@ reactor Middle {
 }
 
 federated reactor {
-  up = new Up(period = 1500 ms)  # Persistent downstream and upstream federates of the transient
-  down = new Down(period = 1500 ms)
+  up = new Up(period = 500 ms)  # Persistent downstream and upstream federates of the transient
+  down = new Down(period = 500 ms)
   @maxwait(200 ms)
   persistence = new Persistence()
   # Persistent federate that is responsible for lauching the transient once, after 1s
@@ -116,13 +113,12 @@ federated reactor {
   mid = new Middle()
 
   # Connections
-  @absent_after(400 ms)
+  @absent_after(200 ms)
   up.out -> mid.inp
   mid.join -> down.join
   mid.join -> persistence.in_middle_join
   mid.out -> down.inp
-  @absent_after(300 ms)
+  @absent_after(400 ms)
   persistence.out_to_middle -> mid.in_from_persistence
-  @absent_after(450 ms)
   mid.out_to_persistence -> persistence.in_from_middle
 }

--- a/test/Python/src/federated/TransientDecentralizedWithPhysicalConnection.lf
+++ b/test/Python/src/federated/TransientDecentralizedWithPhysicalConnection.lf
@@ -7,7 +7,7 @@
  * - the downstream of the transient federate has only one transient as upstream.
  */
 target Python {
-  timeout: 6 s,
+  timeout: 9 s,
   coordination: decentralized
 }
 
@@ -60,23 +60,21 @@ reactor Middle {
 federated reactor {
   # Persistent federate that is responsible for lauching the transient once, after 1s
   midExec = new TransientExec(
-      launch_time = 1 s,
+      launch_time = 3 s,
       federation_name="TransientDecentralizedWithPhysicalConnection",
       fed_instance_name="mid")
 
-  up = new Up()  # Persistent downstream and upstream federates of the transient
-  @maxwait(0)
-  down = new Down()
+  up = new Up(period = 1500 ms)  # Persistent downstream and upstream federates of the transient
+  @maxwait(800 ms)
+  down = new Down(period = 1500 ms)
 
   # Transient federate
   @transient
-  @maxwait(250 ms)
+  @maxwait(500 ms)
   mid = new Middle()
 
   up.out -> mid.inp_val  # Connections
-  @absent_after(300 ms)
   mid.join -> down.join
-  @absent_after(350 ms)
   mid.out -> down.inp
   up.out ~> mid.inp
 }

--- a/test/Python/src/federated/TransientDownstreamWithTimer.lf
+++ b/test/Python/src/federated/TransientDownstreamWithTimer.lf
@@ -121,7 +121,7 @@ reactor Down(period = 500 ms) {
 
     # Check that `Middle` have reacted correctly
     if self.count_in_mid_reactions < 4:
-      sys.stderr.write("Transient federate Mid did not execute and pass values from up corretly! Expected >= 4, but had: {}.\n".format(
+      sys.stderr.write("Transient federate Mid did not execute and pass values from up correctly! Expected >= 4, but had: {}.\n".format(
           self.count_in_mid_reactions))
       sys.exit(1)
   =}

--- a/test/Python/src/federated/TransientDownstreamWithTimer.lf
+++ b/test/Python/src/federated/TransientDownstreamWithTimer.lf
@@ -85,8 +85,8 @@ reactor Middle {
  * Persistent federate, which is downstream of the transient. It has to keep reacting to its
  * internal timer and also to inputs from the tansient, if any.
  */
-reactor Down {
-  timer t(0, 500 ms)
+reactor Down(period = 500 ms) {
+  timer t(0, period)
 
   input inp
   input join

--- a/test/Python/src/federated/TransientDownstreamWithTwoUpstream.lf
+++ b/test/Python/src/federated/TransientDownstreamWithTwoUpstream.lf
@@ -1,5 +1,5 @@
 /**
- * This LF program tests whether a transient federate corretly leaves then joins the federation. It
+ * This LF program tests whether a transient federate correctly leaves then joins the federation. It
  * also tests whether the transient's downstream executes as expected, that is it received correct
  * TAGs, regardless of the transient being absent or present. In this test:
  * - the transient federate spontaneously leaves the federation after 2 reactions to input port inp,
@@ -67,7 +67,7 @@ reactor Down {
 
     # Check that Middle have reacted correctly
     if self.count_in_mid_reactions < 4:
-      sys.stderr.write("Transient federate Mid did not execute and pass values from up corretly! Expected >= 4, but had: {}.\n".format(
+      sys.stderr.write("Transient federate Mid did not execute and pass values from up correctly! Expected >= 4, but had: {}.\n".format(
           self.count_in_mid_reactions))
       sys.exit(1)
   =}

--- a/test/Python/src/federated/TransientStatePersistence.lf
+++ b/test/Python/src/federated/TransientStatePersistence.lf
@@ -89,8 +89,8 @@ reactor Middle {
  * Persistent federate, which is downstream of the transient. It has to keep reacting to its
  * internal timer and also to inputs from the tansient, if any.
  */
-reactor Down {
-  timer t(0, 500 ms)
+reactor Down(period = 500 ms) {
+  timer t(0, period)
 
   input inp
   input join

--- a/test/Python/src/federated/TransientStatePersistence.lf
+++ b/test/Python/src/federated/TransientStatePersistence.lf
@@ -117,7 +117,7 @@ reactor Down(period = 500 ms) {
   reaction(shutdown) {=
     if self.count_join == 2 and self.count_in_mid_reactions < 4:
       sys.stderr.write("Mid Joined twice, but the state did not persist "
-          "across executions! state_count is {}, while is should be > then {}.\n".format(
+          "across executions! state_count is {}, while is should be > than {}.\n".format(
               self.count_in_mid_reactions, 4))
       sys.exit(1)
   =}

--- a/test/Python/src/federated/TransientStatePersistenceWithPhysicalConnection.lf
+++ b/test/Python/src/federated/TransientStatePersistenceWithPhysicalConnection.lf
@@ -96,7 +96,7 @@ reactor Down {
   reaction(shutdown) {=
     if self.count_join == 2 and self.count_in_mid_reactions < 4:
       sys.stderr.write("Mid Joined twice, but the state did not persist "
-          "across executions! state_count is {}, while is should be > then {}.\n".format(
+          "across executions! state_count is {}, while is should be > than {}.\n".format(
               self.count_in_mid_reactions, 4))
       sys.exit(1)
   =}


### PR DESCRIPTION
This PR pulls in fixes in reactor-c to the handling of transient federates.