### PR TITLE
Embedded device support in Rust target

### DIFF
--- a/core/src/main/java/org/lflang/target/Target.java
+++ b/core/src/main/java/org/lflang/target/Target.java
@@ -642,6 +642,7 @@ public enum Target {
               SingleThreadedProperty.INSTANCE,
               WorkersProperty.INSTANCE,
               RustEditionProperty.INSTANCE,
+              PlatformProperty.INSTANCE,
               DockerProperty.INSTANCE);
       case TS ->
           config.register(

--- a/core/src/main/kotlin/org/lflang/generator/rust/PortEmitter.kt
+++ b/core/src/main/kotlin/org/lflang/generator/rust/PortEmitter.kt
@@ -122,7 +122,7 @@ object PortEmitter : RustEmitterBase() {
         return if (port.isGeneratedAsMultiport) {
             "$ref.iter_mut()"
         } else {
-            "std::iter::once(&mut $ref)"
+            "core::iter::once(&mut $ref)"
         }
     }
 }

--- a/core/src/main/kotlin/org/lflang/generator/rust/RustBoardInfo.kt
+++ b/core/src/main/kotlin/org/lflang/generator/rust/RustBoardInfo.kt
@@ -1,0 +1,122 @@
+package org.lflang.generator.rust
+
+import org.lflang.target.property.PlatformProperty
+
+data class BoardInfo(
+    /**
+     * This implementation is based around
+     * [Embedded-HAL](https://github.com/rust-embedded/embedded-hal).
+     */
+    val boardHal: String = "",
+    val entryMacro: String = "entry",
+    val panicHandler: String = "panic_halt",
+    val bootloader: List<String> = emptyList(),
+    val applicationDescriptor: List<String> = emptyList(),
+    val dependencies: Map<String, CargoDependencySpec> = emptyMap(),
+    val targetTriple: String = "",
+    val linkerScriptTemplate: String? = null,
+    val runner: String,
+    val rustFlags: List<String> = emptyList(),
+    val rustToolChainChannel: String = "Stable"
+)
+
+object RustBoardInfo {
+    fun getBoardInfo(platformProperty: PlatformProperty.PlatformOptions): BoardInfo {
+        return when (platformProperty.board().value()) {
+            "esp32"  -> esp32BoardInfo(platformProperty.board().value())
+            "rp2350" -> rp2350BoardInfo()
+            "rp2040" -> rp2040BoardInfo()
+            else     -> throw IllegalArgumentException("Unsupported board type: ${platformProperty.board().value()}")
+        }
+    }
+
+    private fun esp32BoardInfo(board: String): BoardInfo =
+        BoardInfo(
+            boardHal = "esp_hal::{self as hal, main}",
+            entryMacro = "main",
+            panicHandler = "panic_halt",
+            bootloader = emptyList(),
+            applicationDescriptor = listOf(
+                "esp_bootloader_esp_idf::esp_app_desc!()",
+            ),
+            dependencies = mapOf(
+                "esp-hal" to CargoDependencySpec(
+                    "~1.1.0",
+                    null,
+                    null,
+                    null,
+                    null,
+                    listOf(board)
+                ),
+                "panic-halt" to CargoDependencySpec(
+                    "1.0.0",
+                    null,
+                    null,
+                    null,
+                    null,
+                    emptyList()
+                ),
+                "esp-bootloader-esp-idf" to CargoDependencySpec(
+                    "0.5.0",
+                    null,
+                    null,
+                    null,
+                    null,
+                    listOf(board)
+                ),
+            ),
+            targetTriple = "xtensa-esp32-none-elf",
+            linkerScriptTemplate = null,
+            runner = "espflash flash --monitor --chip $board",
+            rustFlags = listOf(
+                "-C", "link-arg=-nostartfiles"
+            ),
+            rustToolChainChannel = "esp"
+        )
+
+    private fun rp2350BoardInfo(): BoardInfo =
+        BoardInfo(
+            boardHal = "rp235x_hal::{self as hal, entry};",
+            entryMacro = "entry",
+            panicHandler = "panic_halt",
+            bootloader = listOf(
+                "#[link_section = .start_block]",
+                "#[used]",
+                "pub static IMAGE_DEF: hal::block::ImageDef = hal::block::ImageDef::secure_exe()",
+            ),
+            applicationDescriptor = listOf(
+                "#[link_section = \".bi_entries\"]",
+                "#[used]",
+                "pub static PICOTOOL_ENTRIES: [hal::binary_info::EntryAddr; 2] = [",
+                "    hal::binary_info::rp_cargo_bin_name!(),",
+                "    hal::binary_info::rp_cargo_version!(),",
+                "]",
+            ),
+            dependencies = mapOf(),
+            targetTriple = "thumbv8m.main-none-eabihf",
+            linkerScriptTemplate = null,
+            runner = "sudo picotool load -x -t elf",
+            rustFlags = listOf(
+                "-C", "link-arg=-Tlink.x",
+                "-C", "link-arg=--nmagic"
+            ),
+            rustToolChainChannel = "stable"
+        )
+
+    // TODO: test this board once reactor-rt is core
+    private fun rp2040BoardInfo(): BoardInfo =
+        BoardInfo(
+            boardHal = "rp2040_hal::{self as hal, entry}",
+            entryMacro = "entry",
+            panicHandler = "panic_halt",
+            bootloader = listOf(
+                "#[link_section = .boot2]",
+                "#[used]",
+                "pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H",
+            ),
+            applicationDescriptor = emptyList(),
+            runner = "sudo picotool load -x -t elf",
+            rustFlags = emptyList(),
+            rustToolChainChannel = "stable"
+        )
+}

--- a/core/src/main/kotlin/org/lflang/generator/rust/RustCoreMainFileEmitter.kt
+++ b/core/src/main/kotlin/org/lflang/generator/rust/RustCoreMainFileEmitter.kt
@@ -1,0 +1,97 @@
+package org.lflang.generator.rust
+
+import org.lflang.generator.PrependOperator
+import org.lflang.generator.rust.RustBoardInfo.getBoardInfo
+import org.lflang.joinWithLn
+
+object RustCoreMainFileEmitter : RustEmitterBase() {
+
+    // TODO: remember to re add after testing run_main
+    fun Emitter.makeCoreMainFile(gen: GenerationInfo) {
+        val mainReactor = gen.mainReactor
+        val mainReactorNames = mainReactor.names
+        val boardInfo = getBoardInfo(gen.platform)
+        this += with(PrependOperator) {
+            """
+            |${generatedByComment("//")}
+            |#![no_std]
+            |#![no_main]
+            |#![allow(unused_imports)]
+            |#![allow(non_snake_cases)]
+            |
+            |extern crate core;
+            |
+            |use ${boardInfo.panicHandler} as _;
+            |
+            |// Board HAL
+            |use ${boardInfo.boardHal};
+            |
+            |// Board bootloader (required to boot some devices)
+${"         |"..boardInfo.bootloader.joinWithLn { it }}
+            |
+            |// Application descriptor / tooling metadata
+${"         |"..boardInfo.applicationDescriptor.joinWithLn { it }};
+            |
+            |// user dependencies
+${"         |"..gen.crate.dependencies.keys.joinWithLn { "use ${it.replace('-', '_')};" }}
+            |
+            |// user-defined modules
+${"         |"..gen.crate.modulesToIncludeInMain.joinWithLn { "mod ${it.fileName.toString().removeSuffix(".rs")};" }}
+            |
+            |use $rsRuntime;
+            |pub use self::reactors::${mainReactorNames.wrapperName} as __MainReactor;
+            |pub use self::reactors::${mainReactorNames.paramStructName} as __MainParams;
+            |
+            |#[${boardInfo.entryMacro}]
+            |fn main() -> !  {
+            |//   SyncScheduler::run_main::<__MainReactor>(options, main_args);
+            |  loop {
+            |    let _ = 1 + 1;
+            |  }
+            |}
+            |
+        """.trimMargin()
+        }
+        skipLines(2)
+
+        if (gen.properties.singleFile) {
+            makeSingleFileProject(gen)
+        } else {
+            this += "mod reactors;\n"
+        }
+    }
+
+    private fun Emitter.makeSingleFileProject(gen: GenerationInfo) {
+        this += """
+            |//-------------------//
+            |//---- REACTORS -----//
+            |//-------------------//
+            |
+        """.trimMargin()
+
+        this.writeInBlock("mod reactors {") {
+            for (reactor in gen.reactors) {
+                this += with(reactor.names) {
+                    """
+                pub use self::$modName::$wrapperName;
+                pub use self::$modName::$paramStructName;
+                """.trimIndent()
+                }
+                skipLines(1)
+            }
+
+            for (reactor in gen.reactors) {
+                this += """
+                    |//--------------------------------------------//
+                    |//------------ ${reactor.lfName} -------//
+                    |//-------------------//
+                    """.trimMargin()
+
+                this.writeInBlock("mod ${reactor.names.modName} {") {
+                    with(RustReactorEmitter) { emitReactorModule(reactor) }
+                }
+                this.skipLines(2)
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/org/lflang/generator/rust/RustCoreToolChainEmitter.kt
+++ b/core/src/main/kotlin/org/lflang/generator/rust/RustCoreToolChainEmitter.kt
@@ -1,0 +1,95 @@
+package org.lflang.generator.rust
+
+import org.lflang.escapeStringLiteral
+import org.lflang.generator.PrependOperator.rangeTo
+import org.lflang.generator.rust.RustBoardInfo.getBoardInfo
+import org.lflang.joinWithCommas
+import org.lflang.joinWithLn
+import org.lflang.target.property.type.BuildTypeType.BuildType
+import org.lflang.withDQuotes
+import java.nio.file.Paths
+
+object RustCoreToolChainEmitter : RustEmitterBase() {
+    fun Emitter.makeCoreCargoTomlFile(gen: GenerationInfo) {
+        val (crate) = gen
+        val allDependencies = getAllDependencies(gen)
+        this += """
+            |${generatedByComment("#")}
+            |[package]
+            |name = "${crate.name}"
+            |version = "${crate.version}"
+            |authors = [${crate.authors.joinToString(", ") { it.withDQuotes() }}]
+            |edition = "${crate.rustEdition}"
+            |
+            |[dependencies]
+${"         |"..allDependencies.asIterable().joinWithLn { (name, spec) -> name + " = " + spec.toToml() }}
+            |
+            |[[bin]]
+            |name = "${gen.executableName}"
+            |path = "src/main.rs"
+            |
+            |[profile.${BuildType.RELEASE.cargoProfileName}] # use `build-type: ${BuildType.RELEASE}`
+            |lto = "thin"
+            |codegen-units = 1
+            |
+            |[profile.${BuildType.MIN_SIZE_REL.cargoProfileName}] # use `build-type: ${BuildType.MIN_SIZE_REL}`
+            |inherits = "release"
+            |opt-level = "s"
+            |
+            |[profile.${BuildType.REL_WITH_DEB_INFO.cargoProfileName}] # use `build-type: ${BuildType.REL_WITH_DEB_INFO}`
+            |inherits = "release"
+            |debug = true
+            |
+            |[profile.${BuildType.TEST.cargoProfileName}] # use `build-type: ${BuildType.TEST}`
+            |inherits = "dev"
+            |debug = true
+            |
+        """.trimMargin()
+    }
+
+    fun Emitter.makeConfigTomlFile(gen: GenerationInfo) {
+        val (crate) = gen
+        val boardInfo = getBoardInfo(gen.platform)
+        this += """
+            |${generatedByComment("#")}
+            |[target.${boardInfo.targetTriple}]
+            |runner = ${boardInfo.runner.asStringLiteral()}
+            |rustflags = ${boardInfo.rustFlags.toTomlArray()}
+            |
+            |[build]
+            |target = ${boardInfo.targetTriple.asStringLiteral()}
+            |
+            |[unstable]
+            |build-std = ["core", "alloc"]
+            |
+        """.trimMargin()
+    }
+
+    fun Emitter.makeRustToolchainToml(gen: GenerationInfo) {
+        val boardInfo = getBoardInfo(gen.platform)
+        this += """
+            |${generatedByComment("#")}
+            |[toolchain]
+            |channel = ${boardInfo.rustToolChainChannel.asStringLiteral()}
+            |targets = [${boardInfo.targetTriple.asStringLiteral()}]
+        """.trimMargin()
+    }
+
+    private fun getAllDependencies(gen: GenerationInfo): Map<String, CargoDependencySpec> {
+        val boardInfo = getBoardInfo(gen.platform)
+        return gen.crate.dependencies + boardInfo.dependencies
+    }
+
+    private fun CargoDependencySpec.toToml(): String = mutableMapOf<String, String>().apply {
+        if (version != null) this["version"] = version.asStringLiteral()
+        if (localPath != null) this["path"] = Paths.get(localPath).toAbsolutePath().toString().asStringLiteral()
+        if (features != null) this["features"] = features.map { it.asStringLiteral() }.joinWithCommas("[", "]")
+        if (gitRepo != null) this["git"] = gitRepo.asStringLiteral()
+        if (rev != null) this["rev"] = rev.asStringLiteral()
+    }.asIterable().joinWithCommas("{ ", " }", trailing = false) { (k, v) -> "$k = $v" }
+
+    private fun String.asStringLiteral() = escapeStringLiteral().withDQuotes()
+
+    private fun List<String>.toTomlArray(): String = joinToString(", ") { it.withDQuotes() }.let { "[$it]" }
+
+}

--- a/core/src/main/kotlin/org/lflang/generator/rust/RustEmitter.kt
+++ b/core/src/main/kotlin/org/lflang/generator/rust/RustEmitter.kt
@@ -26,7 +26,6 @@ package org.lflang.generator.rust
 
 import org.lflang.generator.CodeMap
 import org.lflang.generator.PrependOperator
-import org.lflang.generator.rust.RustEmitter.generateRustProject
 import org.lflang.joinWithLn
 import org.lflang.util.FileUtil
 import java.nio.file.Files
@@ -44,22 +43,47 @@ object RustEmitter : RustEmitterBase() {
 
     fun generateRustProject(fileConfig: RustFileConfig, gen: GenerationInfo): Map<Path, CodeMap> {
         val codeMaps = mutableMapOf<Path, CodeMap>()
+        val platformOptions = gen.platform
 
-        fileConfig.emit(codeMaps, "Cargo.toml") {
-            with(RustCargoTomlEmitter) {
-                makeCargoTomlFile(gen)
+        if (!platformOptions.board().setByUser()) {
+            fileConfig.emit(codeMaps, "Cargo.toml") {
+                with(RustCargoTomlEmitter) {
+                    makeCargoTomlFile(gen)
+                }
             }
-        }
 
-        // if singleFile, this file will contain every module.
-        fileConfig.emit(codeMaps, "src/main.rs") {
-            with(RustMainFileEmitter) {
-                makeMainFile(gen)
+            // if singleFile, this file will contain every module.
+            fileConfig.emit(codeMaps, "src/main.rs") {
+                with(RustMainFileEmitter) {
+                    makeMainFile(gen)
+                }
+            }
+        } else {
+            fileConfig.emit(codeMaps, "Cargo.toml") {
+                with(RustCoreToolChainEmitter) {
+                    makeCoreCargoTomlFile(gen)
+                }
+            }
+            fileConfig.emit(codeMaps, "rust-toolchain.toml") {
+                with(RustCoreToolChainEmitter) {
+                    makeRustToolchainToml(gen)
+                }
+            }
+            // if singleFile, this file will contain every module.
+            fileConfig.emit(codeMaps, "src/main.rs") {
+                with(RustCoreMainFileEmitter) {
+                    makeCoreMainFile(gen)
+                }
+            }
+            fileConfig.emit(codeMaps, ".cargo/config.toml") {
+                with(RustCoreToolChainEmitter) {
+                    makeConfigTomlFile(gen)
+                }
             }
         }
 
         if (!gen.properties.singleFile) {
-            fileConfig.emit(codeMaps, "src/reactors/mod.rs") { makeReactorsAggregateModule(gen) }
+            fileConfig.emit(codeMaps, "src/reactors.rs") { makeReactorsAggregateModule(gen) }
             for (reactor in gen.reactors) {
                 fileConfig.emit(codeMaps, "src/reactors/${reactor.names.modFileName}.rs") {
                     with(RustReactorEmitter) {

--- a/core/src/main/kotlin/org/lflang/generator/rust/RustEmitterBase.kt
+++ b/core/src/main/kotlin/org/lflang/generator/rust/RustEmitterBase.kt
@@ -24,13 +24,9 @@
 
 package org.lflang.generator.rust
 
-import org.lflang.*
-import org.lflang.*
-import org.lflang.generator.*
-import org.lflang.generator.PrependOperator.rangeTo
-import org.lflang.generator.rust.RustEmitter.generateRustProject
-import java.nio.file.Files
-import java.nio.file.Paths
+import org.lflang.generator.LocationInfo
+import org.lflang.generator.TargetCode
+import org.lflang.joinLines
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 

--- a/core/src/main/kotlin/org/lflang/generator/rust/RustMainFileEmitter.kt
+++ b/core/src/main/kotlin/org/lflang/generator/rust/RustMainFileEmitter.kt
@@ -28,7 +28,6 @@ import org.lflang.camelToSnakeCase
 import org.lflang.escapeStringLiteral
 import org.lflang.generator.PrependOperator
 import org.lflang.generator.PrependOperator.rangeTo
-import org.lflang.generator.UnsupportedGeneratorFeatureException
 import org.lflang.joinWithCommasLn
 import org.lflang.joinWithLn
 import org.lflang.withoutQuotes

--- a/core/src/main/kotlin/org/lflang/generator/rust/RustModel.kt
+++ b/core/src/main/kotlin/org/lflang/generator/rust/RustModel.kt
@@ -37,6 +37,7 @@ import org.lflang.target.property.CargoFeaturesProperty
 import org.lflang.target.property.ExportDependencyGraphProperty
 import org.lflang.target.property.ExternalRuntimePathProperty
 import org.lflang.target.property.KeepaliveProperty
+import org.lflang.target.property.PlatformProperty
 import org.lflang.target.property.RuntimeVersionProperty
 import org.lflang.target.property.RustIncludeProperty
 import org.lflang.target.property.RustEditionProperty
@@ -56,7 +57,8 @@ data class GenerationInfo(
     val reactors: List<ReactorInfo>,
     val mainReactor: ReactorInfo, // it's also in the list
     val executableName: Ident,
-    val properties: RustTargetProperties
+    val properties: RustTargetProperties,
+    val platform: PlatformProperty.PlatformOptions,
 ) {
 
     private val byId = reactors.associateBy { it.globalId }
@@ -462,7 +464,8 @@ object RustModelBuilder {
             // Rust exec names are snake case, otherwise we get a cargo warning
             // https://github.com/rust-lang/rust/issues/45127
             executableName = mainReactor.lfName.camelToSnakeCase(),
-            properties = targetConfig.toRustProperties()
+            properties = targetConfig.toRustProperties(),
+            platform = targetConfig.getOrDefault(PlatformProperty.INSTANCE)
         )
     }
 

--- a/core/src/main/kotlin/org/lflang/generator/rust/RustReactorEmitter.kt
+++ b/core/src/main/kotlin/org/lflang/generator/rust/RustReactorEmitter.kt
@@ -62,7 +62,7 @@ ${"             |"..reactor.preambles.joinToString("\n\n") { "// preamble {=\n${
                 |///
                 |/${loc.lfTextComment()}
                 |pub struct $structName$typeParams {
-                |    pub __phantom: std::marker::PhantomData<(${typeParamList.map { it.lfName }.joinWithCommas()})>,
+                |    pub __phantom: core::marker::PhantomData<(${typeParamList.map { it.lfName }.joinWithCommas()})>,
 ${"             |    "..reactor.stateVars.joinWithCommasLn { it.lfName + ": " + it.type }}
                 |}
                 |
@@ -75,7 +75,7 @@ ${"             |    "..reactions.joinToString("\n\n") { it.toWorkerFunction() }
                 |
                 |/// Parameters for the construction of a [$structName]
                 |pub struct ${names.paramStructName}$typeParams {
-                |    __phantom: std::marker::PhantomData<(${typeParamList.map { it.lfName }.joinWithCommas()})>,
+                |    __phantom: core::marker::PhantomData<(${typeParamList.map { it.lfName }.joinWithCommas()})>,
 ${"             |    "..ctorParams.joinWithCommasLn { "${it.lfName.escapeRustIdent()}: ${it.type}" }}
                 |}
                 |
@@ -83,7 +83,7 @@ ${"             |    "..ctorParams.joinWithCommasLn { "${it.lfName.escapeRustIde
                 |   pub fn new(
 ${"             |       "..ctorParams.joinWithCommasLn { "${it.lfName.escapeRustIdent()}: ${it.type}" }}
                 |   ) -> Self {
-                |       Self { __phantom: std::marker::PhantomData, ${ctorParams.joinWithCommas { it.lfName.escapeRustIdent() }} }
+                |       Self { __phantom: core::marker::PhantomData, ${ctorParams.joinWithCommas { it.lfName.escapeRustIdent() }} }
                 |   }
                 |}
                 |
@@ -113,7 +113,7 @@ ${"             |    "..otherComponents.joinWithCommasLn { it.toStructField() }}
 ${"             |            "..reactor.stateVars.joinWithLn { "let ${it.lfName}: ${it.type} = ${it.init};" }}
                 |
                 |            $structName {
-                |                __phantom: std::marker::PhantomData,
+                |                __phantom: core::marker::PhantomData,
 ${"             |                "..reactor.stateVars.joinWithCommasLn { it.lfName }}
                 |            }
                 |        };


### PR DESCRIPTION
I'm putting this in drafts so eyes can be put on what I have been working on and get opinions.

In the embedded Rust ecosystem there are two main approaches, the blocking [embedded-hal](https://github.com/rust-embedded/embedded-hal) driver ecosystem, and [Embassy](https://embassy.dev/)'s async-first model. There are pros and cons to both but I decided to just work with the Embedded-Hal based drivers.  Embassy makes `async` a first class citizen so everything must be a task. This would need a complete rewrite of how code generation is handled and Embassy does not support OS deployment. Everything provided by Embedded-hal is implemented as a `trait` so you can easily take a crate or driver written into it and deploy it with little to no friction. Embedded-hal is also just a more mature and fleshed out solution. 

Currently I'm starting to work on porting the reactor-rs crate to be `no_std` so it can be detached from a libc or OS. The goal is to move to `core` which is dependency free primitives library that std is built off of. There is also `alloc` which is heap allocated data structures which may need to be used as well. 

my goal is to make adding board as painless as possible but, due to the nature of embedded systems that just might not be possible. I have been working on two boards that I have on hand, esp32 and rp2350 and I'm basing it off of the templates for those that are provided by the [esp-hal](https://github.com/esp-rs/esp-hal) and [rp-hal](https://github.com/rp-rs/rp-hal) teams.

This is mainly a prototype to gauge interest as I still don't know if this approach will be viable once reactor-rs is working.