### PR TITLE
Patmos fixes suggested by Cursor to correct CI hanging

### DIFF
--- a/.github/actions/setup-patmos/action.yml
+++ b/.github/actions/setup-patmos/action.yml
@@ -32,6 +32,6 @@ runs:
         mkdir ~/t-crest
         cd ~/t-crest
         git clone https://github.com/t-crest/patmos-misc.git misc
-        ./misc/build.sh -qm toolchain1
+        ./misc/build.sh -q toolchain1
         patmos-clang --version
         which patmos-clang

--- a/.github/workflows/trace-plugin-tests.yml
+++ b/.github/workflows/trace-plugin-tests.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: trace-plugin-${{ github.ref }}-${{ github.run_id }}
+  group: trace-plugin-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CPatmosTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CPatmosTest.java
@@ -17,16 +17,17 @@ import org.lflang.util.LFCommand;
 /**
  * Collection of tests for the Patmos target.
  *
- * <p>Uses {@code pasim} (ISA simulator) rather than cycle-accurate {@code patemu}. Busy-waiting for
- * physical time on {@code patemu} is pathologically slow in CI and previously appeared as hangs
- * unless sleep loops performed I/O (e.g. debug {@code printf}s).
+ * <p>Runs under cycle-accurate {@code patemu} (not {@code pasim}): with the toolchain used in CI,
+ * {@code pasim} is known to fail on binaries that {@code patemu} accepts. Physical busy-waits on
+ * {@code patemu} are avoided for these smoke tests via {@code fast: true} in {@link
+ * Configurators#makePatmosCompatible}.
  *
  * @ingroup Tests
  */
 public class CPatmosTest extends TestBase {
 
-  /** Patmos ISA simulator; prefer over cycle-accurate {@code patemu} for smoke tests. */
-  private static final String SIMULATOR = "pasim";
+  /** Cycle-accurate Patmos emulator used by CI smoke tests. */
+  private static final String SIMULATOR = "patemu";
 
   public CPatmosTest() {
     super(Target.C);

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CPatmosTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CPatmosTest.java
@@ -34,6 +34,13 @@ public class CPatmosTest extends TestBase {
   }
 
   @Override
+  protected long getMaxExecutionTimeSeconds() {
+    // patemu is cycle-accurate and much slower than native execution; 300s is often insufficient
+    // even when physical waits are skipped via fast: true.
+    return 600;
+  }
+
+  @Override
   protected ProcessBuilder getExecCommand(LFTest test) throws TestError {
     LFCommand command = test.getFileConfig().getCommand();
     if (command == null) {

--- a/core/src/integrationTest/java/org/lflang/tests/runtime/CPatmosTest.java
+++ b/core/src/integrationTest/java/org/lflang/tests/runtime/CPatmosTest.java
@@ -17,9 +17,16 @@ import org.lflang.util.LFCommand;
 /**
  * Collection of tests for the Patmos target.
  *
+ * <p>Uses {@code pasim} (ISA simulator) rather than cycle-accurate {@code patemu}. Busy-waiting for
+ * physical time on {@code patemu} is pathologically slow in CI and previously appeared as hangs
+ * unless sleep loops performed I/O (e.g. debug {@code printf}s).
+ *
  * @ingroup Tests
  */
 public class CPatmosTest extends TestBase {
+
+  /** Patmos ISA simulator; prefer over cycle-accurate {@code patemu} for smoke tests. */
+  private static final String SIMULATOR = "pasim";
 
   public CPatmosTest() {
     super(Target.C);
@@ -27,67 +34,22 @@ public class CPatmosTest extends TestBase {
 
   @Override
   protected ProcessBuilder getExecCommand(LFTest test) throws TestError {
-    final String SIMULATOR = "patemu";
-
-    System.out.println("DEBUG: Entering getExecCommand");
-
     LFCommand command = test.getFileConfig().getCommand();
     if (command == null) {
-      System.err.println("ERROR: Command is null");
       throw new TestError("File: " + test.getFileConfig().getExecutable(), Result.NO_EXEC_FAIL);
-    }
-    // Print which simulator command will be used
-    ProcessBuilder whichSim = new ProcessBuilder("which", SIMULATOR);
-    try {
-      Process proc = whichSim.start();
-      int exitCode = proc.waitFor();
-      if (exitCode == 0) {
-        try (java.io.BufferedReader reader =
-            new java.io.BufferedReader(new java.io.InputStreamReader(proc.getInputStream()))) {
-          String simLocation = reader.readLine();
-          System.out.println("DEBUG: Simulator found at: " + simLocation);
-        }
-      } else {
-        System.out.println("DEBUG: Simulator not found in PATH.");
-      }
-    } catch (Exception e) {
-      System.out.println("DEBUG: Exception while locating simulator: " + e.getMessage());
     }
 
     List<String> fullCommand = new ArrayList<>();
-    fullCommand.add(SIMULATOR); // Prepend simulator to the command
-    fullCommand.addAll(command.command()); // Add the rest of the command
+    fullCommand.add(SIMULATOR);
+    fullCommand.addAll(command.command());
 
-    System.out.println(
-        "DEBUG: Full command constructed: "
-            + fullCommand
-            + " in directory: "
-            + command.directory());
-
-    // Run the full command to check if it executes correctly
-    try {
-      Process testProc =
-          new ProcessBuilder(fullCommand).directory(command.directory()).inheritIO().start();
-      int testExit = testProc.waitFor();
-      System.out.println("DEBUG: Test command exited with code: " + testExit);
-    } catch (Exception e) {
-      System.out.println("DEBUG: Exception while running full command: " + e.getMessage());
-    }
-
-    // Create the ProcessBuilder
     ProcessBuilder processBuilder = new ProcessBuilder(fullCommand).directory(command.directory());
 
-    // Add the directory containing simulator to the PATH environment variable
+    // Patmos tools are installed under ~/t-crest/local/bin by the CI setup action.
     String simPath = System.getProperty("user.home") + "/t-crest/local/bin";
     processBuilder
         .environment()
         .put("PATH", simPath + ":" + processBuilder.environment().get("PATH"));
-
-    System.out.println(
-        "DEBUG: ProcessBuilder command: "
-            + processBuilder.command()
-            + " directory: "
-            + processBuilder.directory());
 
     return processBuilder;
   }

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -230,6 +230,13 @@ public class CCmakeGenerator {
         cMakeCode.pr("set(CMAKE_C_COMPILER ${CLANG_EXECUTABLE})");
         cMakeCode.pr(
             "set(CMAKE_C_FLAGS_RELEASE \"-O2 -DNDEBUG\")"); // patmos-clang cannot compile -O3
+        // Default linker layout only gives 0x8000 (32KB) combined for the stack cache and shadow
+        // stack (_stack_cache_base=0x200000, _shadow_stack_base=0x1f8000), even though there is
+        // ~1.9MB of unused address space between that and __heap_end (0x100000). Move
+        // _shadow_stack_base down to reclaim some of that headroom as stack, since a stack-cache
+        // overflow silently corrupts adjacent heap memory (no MMU/guard page on Patmos).
+        cMakeCode.pr(
+            "set(CMAKE_EXE_LINKER_FLAGS \"-Xgold --defsym -Xgold _shadow_stack_base=0x180000\")");
         cMakeCode.pr("project(" + executableName + " LANGUAGES C)");
         cMakeCode.newLine();
         break;

--- a/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CCmakeGenerator.java
@@ -230,13 +230,6 @@ public class CCmakeGenerator {
         cMakeCode.pr("set(CMAKE_C_COMPILER ${CLANG_EXECUTABLE})");
         cMakeCode.pr(
             "set(CMAKE_C_FLAGS_RELEASE \"-O2 -DNDEBUG\")"); // patmos-clang cannot compile -O3
-        // Default linker layout only gives 0x8000 (32KB) combined for the stack cache and shadow
-        // stack (_stack_cache_base=0x200000, _shadow_stack_base=0x1f8000), even though there is
-        // ~1.9MB of unused address space between that and __heap_end (0x100000). Move
-        // _shadow_stack_base down to reclaim some of that headroom as stack, since a stack-cache
-        // overflow silently corrupts adjacent heap memory (no MMU/guard page on Patmos).
-        cMakeCode.pr(
-            "set(CMAKE_EXE_LINKER_FLAGS \"-Xgold --defsym -Xgold _shadow_stack_base=0x180000\")");
         cMakeCode.pr("project(" + executableName + " LANGUAGES C)");
         cMakeCode.newLine();
         break;

--- a/core/src/testFixtures/java/org/lflang/tests/Configurators.java
+++ b/core/src/testFixtures/java/org/lflang/tests/Configurators.java
@@ -1,6 +1,7 @@
 package org.lflang.tests;
 
 import org.lflang.target.TargetConfig;
+import org.lflang.target.property.FastProperty;
 import org.lflang.target.property.LoggingProperty;
 import org.lflang.target.property.PlatformProperty;
 import org.lflang.target.property.PlatformProperty.Option;
@@ -117,6 +118,11 @@ public class Configurators {
      * <p>This is to avoid failing tests that have e.g., `workers: 16`.
      */
     WorkersProperty.INSTANCE.override(config, 0);
+
+    // Skip physical busy-waits in the simulator. Cycle-accurate patemu (and even pasim) can spend
+    // unbounded wall time spinning for millisecond-scale timeouts; smoke tests validate logical
+    // behavior, not real-time pacing on the emulator.
+    FastProperty.INSTANCE.override(config, true);
 
     var platform = config.get(PlatformProperty.INSTANCE);
     PlatformProperty.INSTANCE.override(

--- a/core/src/testFixtures/java/org/lflang/tests/Configurators.java
+++ b/core/src/testFixtures/java/org/lflang/tests/Configurators.java
@@ -124,6 +124,11 @@ public class Configurators {
     // behavior, not real-time pacing on the emulator.
     FastProperty.INSTANCE.override(config, true);
 
+    // NOTE: like Zephyr emulations (see makeZephyrCompatible), debug log-levels are suspected to
+    // cause hangs/crashes on Patmos's constrained, MMU-less memory (extra stack depth from
+    // variadic debug-print marshaling). Use WARN instead.
+    LoggingProperty.INSTANCE.override(config, LogLevel.WARN);
+
     var platform = config.get(PlatformProperty.INSTANCE);
     PlatformProperty.INSTANCE.override(
         config,

--- a/core/src/testFixtures/java/org/lflang/tests/TestBase.java
+++ b/core/src/testFixtures/java/org/lflang/tests/TestBase.java
@@ -68,8 +68,15 @@ public abstract class TestBase extends LfInjectedTestBase {
 
   @Inject TestRegistry testRegistry;
 
-  /** Execution timeout enforced for all tests. */
-  private static final long MAX_EXECUTION_TIME_SECONDS = 300;
+  /**
+   * Maximum wall-clock seconds allowed for executing a single test binary.
+   *
+   * <p>Subclasses may override this for platforms whose simulators/emulators are much slower than
+   * native execution (e.g. cycle-accurate Patmos {@code patemu}).
+   */
+  protected long getMaxExecutionTimeSeconds() {
+    return 300;
+  }
 
   /** Content separator used in test output, 78 characters wide. */
   public static final String THIN_LINE =
@@ -523,7 +530,7 @@ public abstract class TestBase extends LfInjectedTestBase {
       stderr.start();
       stdout.start();
       long t0 = System.nanoTime();
-      var timeout = !p.waitFor(MAX_EXECUTION_TIME_SECONDS, TimeUnit.SECONDS);
+      var timeout = !p.waitFor(getMaxExecutionTimeSeconds(), TimeUnit.SECONDS);
       test.setExecutionTimeNanoseconds(System.nanoTime() - t0);
       stdout.interrupt();
       stderr.interrupt();

--- a/test/C/src/patmos/HelloPatmos.lf
+++ b/test/C/src/patmos/HelloPatmos.lf
@@ -1,8 +1,7 @@
 target C {
   platform: "Patmos",
   single-threaded: true,
-  // Skip physical busy-waits; required for cycle-accurate patemu in CI.
-  fast: true
+  fast: true  // Skip physical busy-waits; required for cycle-accurate patemu in CI.
 }
 
 main reactor {

--- a/test/C/src/patmos/HelloPatmos.lf
+++ b/test/C/src/patmos/HelloPatmos.lf
@@ -1,6 +1,8 @@
 target C {
   platform: "Patmos",
-  single-threaded: true
+  single-threaded: true,
+  // Skip physical busy-waits; required for cycle-accurate patemu in CI.
+  fast: true
 }
 
 main reactor {

--- a/test/C/src/patmos/SrcSink.lf
+++ b/test/C/src/patmos/SrcSink.lf
@@ -16,9 +16,11 @@ reactor Source {
   output out: int
   timer t(0, 1 msec)
   state s: int = 1
+
   reaction(startup) {=
     lf_print("Source starting up, initial value: %d", self->s);
   =}
+
   reaction(t) -> out {=
     lf_set(out, self->s);
     ++self->s;
@@ -28,7 +30,7 @@ reactor Source {
 reactor Sink {
   input in: int
   state last_received: int = 0
-  
+
   reaction(in) {=
     self->last_received = in->value;
     lf_print("Received %d at %lld", in->value, lf_time_logical_elapsed());

--- a/test/C/src/patmos/SrcSink.lf
+++ b/test/C/src/patmos/SrcSink.lf
@@ -5,8 +5,7 @@
 target C {
   platform: "Patmos",
   single-threaded: true,
-  // Skip physical busy-waits; required for cycle-accurate patemu in CI.
-  fast: true,
+  fast: true,  // Skip physical busy-waits; required for cycle-accurate patemu in CI.
   timeout: 3 msec
 }
 

--- a/test/C/src/patmos/SrcSink.lf
+++ b/test/C/src/patmos/SrcSink.lf
@@ -5,6 +5,8 @@
 target C {
   platform: "Patmos",
   single-threaded: true,
+  // Skip physical busy-waits; required for cycle-accurate patemu in CI.
+  fast: true,
   timeout: 3 msec
 }
 

--- a/test/C/src/patmos/Ssimple.lf
+++ b/test/C/src/patmos/Ssimple.lf
@@ -12,8 +12,7 @@
 target C {
   platform: "Patmos",
   single-threaded: true,
-  // Skip physical busy-waits; required for cycle-accurate patemu in CI.
-  fast: true,
+  fast: true,  // Skip physical busy-waits; required for cycle-accurate patemu in CI.
   timeout: 5 msec
 }
 

--- a/test/C/src/patmos/Ssimple.lf
+++ b/test/C/src/patmos/Ssimple.lf
@@ -12,6 +12,8 @@
 target C {
   platform: "Patmos",
   single-threaded: true,
+  // Skip physical busy-waits; required for cycle-accurate patemu in CI.
+  fast: true,
   timeout: 5 msec
 }
 


### PR DESCRIPTION
# CI hang diagnosis
_Exported on 7/24/2026 at 09:13:58 PDT from Cursor (3.12.30)_

---

**User**

This test: @test/C/src/patmos/simple.lf hangs in CI if the `printf` statements are removed from this file: @core/src/main/resources/lib/c/reactor-c/low_level_platform/impl/src/lf_patmos_support.c .  I have not been able to reproduce this hang locally, but it occurs reliably in CI.  The CI output of a successful run (with the `printf`s) is here: https://github.com/lf-lang/lingua-franca/actions/runs/30030890559/job/89287106148#step:6:434  An unsuccessful run that hangs until canceled (with the `printf`s removed) is here: https://github.com/lf-lang/lingua-franca/actions/runs/30026397055/job/89272007908#step:6:225 Can you diagnose this and propose a fix? The hang apparently does not occur in the master branch of this repo, so I suspect it due to something in this `transient-fed` branch, probably in the `reactor-c` submodule.

---

**Cursor**

I'll investigate the Patmos hang by comparing the support file, the test, and what changed on `transient-fed` (especially in `reactor-c`) versus master.

CI log fetch came back empty — I'll dig into reactor-c sleep/timing changes and compare this branch to master.

Those Patmos-related commits look like prior attempts at this same hang — I'll inspect them and compare wait/sleep behavior to master.

Those `effective_start_tag` commits look like a strong lead — I'll compare single-threaded startup wait logic between this branch and main.

Checking how Patmos CI runs the emulator and whether clock advancement depends on I/O yielding.

Checking whether the parent repo or always-linked runtime paths changed in ways that could interact with Patmos sleep.

## Diagnosis

The hang is almost certainly in the Patmos busy-wait sleeps in `lf_patmos_support.c`, under cycle-accurate **`patemu`**, not in transient-federate coordination logic itself.

Evidence already on this branch:

| Experiment | Result |
|---|---|
| Debug `printf`s in the sleep loops | CI passes ([successful run](https://github.com/lf-lang/lingua-franca/actions/runs/30030890559/job/89287106148#step:6:434)) |
| Remove `printf`s | Hangs until cancel ([failed run](https://github.com/lf-lang/lingua-franca/actions/runs/30026397055/job/89272007908#step:6:225)) |
| `volatile instant_t now` | Still hangs |
| `__attribute__((noinline))` | Still hangs |

So this is **not** a classic “compiler hoisted the loop variable” bug. `printf` is acting as a Heisenbug workaround: it forces simulator/I/O work that advances (or effectively jumps) `get_cpu_usecs()`, so `now` reaches `wakeup`. A pure spin does not make useful progress in CI wall time.

That matches `simple.lf`: periodic 1 ms timer + 5 ms timeout ⇒ many physical waits. `HelloPatmos.lf` has no timed waits, so it is a weak probe.

Also amplifying the “hang forever” look: `CPatmosTest.getExecCommand()` runs the binary once with `waitFor()` **and no timeout** before the normal 300 s harness timeout. A stuck busy-wait becomes a 1 h+ canceled job instead of a clean 5 min failure.

### Why it shows up on `transient-fed`

For unfederated single-threaded Patmos, federated code is not linked. The meaningful always-linked deltas vs `main` are small (`effective_start_tag`, `pqueue_tag_max_tag`, and the sleep `printf`s). Earlier “init `effective_start_tag` in `reactor.c`” was a misdiagnosis (single-threaded never waits on it; that change was later removed).

So the branch correlation is real in CI history, but the mechanism is almost certainly **Patmos sleep × `patemu`**, with `printf` masking it—not a transient-fed deadlock. Master likely survives because waits are often already satisfied after reaction I/O / different timing, which is fragile; this branch’s CI experiments exposed the underlying busy-wait problem.

Local non-repro is expected if you use **`pasim`** (ISA sim). CI uses **`patemu`** (cycle-accurate), which the [Patmos docs](https://www.lf-lang.org/docs/embedded/patmos/) already call out as much slower.

---

## Proposed fixes (best first)

### 1. Fix the platform sleep (real fix)

In `lf_patmos_support.c`:

1. Remove the debug `printf`s.
2. Match Linux: return immediately if `now >= wakeup`.
3. Use a widening multiply: `(instant_t)get_cpu_usecs() * 1000LL`.
4. For emulator CI, do **not** busy-wait full physical intervals. Practical options:
   - **Preferred for CI:** run smoke tests under `pasim`, or
   - Compile with a define when `board: emulator` and make `_lf_interruptable_sleep_until_locked` / `lf_sleep` no-ops (logical time still advances), or
   - Keep physical waits only for `board: fpga`.

Example shape for (2)+(3) and dropping printfs:

```c
int _lf_clock_gettime(instant_t* t) {
  assert(t != NULL);
  *t = (instant_t)get_cpu_usecs() * 1000LL;
  return 0;
}

int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup) {
  (void)env;
  instant_t now;
  _lf_async_event = false;
  lf_enable_interrupts_nested();

  _lf_clock_gettime(&now);
  while ((now < wakeup) && !_lf_async_event) {
    _lf_clock_gettime(&now);
  }

  lf_disable_interrupts_nested();
  if (_lf_async_event) {
    _lf_async_event = false;
    return -1;
  }
  return 0;
}
```

…but that alone may still be too slow on `patemu` for a 5 ms timeout. Pair it with (2) or (3) below.

### 2. Change CI simulator: `patemu` → `pasim`

In `CPatmosTest.java`, `SIMULATOR` is hard-coded to `"patemu"`. Switching smoke tests to `pasim` validates Patmos codegen without cycle-accurate busy-wait cost. That is the highest-leverage CI change.

### 3. Fix the test harness

In `CPatmosTest.getExecCommand()`:

- Delete the debug pre-run that calls `waitFor()` with no timeout (or give it a short timeout).
- Rely on `TestBase`’s 300 s timeout.

### 4. Optional smoke-test configurator

In `makePatmosCompatibleUnthreaded`, set `fast: true` so `wait_until` skips physical sleep. Good for logical smoke tests; not a substitute for a real platform sleep on FPGA.

---

## Suggested verification

1. On CI with printfs removed: switch only `patemu`→`pasim` — if green, root cause is confirmed.
2. Or keep `patemu` but enable `fast` for Patmos tests — should also go green.
3. Add one CI log line (once) at sleep entry with `delta_ns`; if you ever see enormous deltas, that is a separate wakeup bug. Given printf/noinline/volatile results, expect finite ~1 ms deltas and a stuck/slow spin instead.

I would implement **(2)+(3)** immediately for CI stability, then clean **(1)** and drop the printfs. I can apply that patch set if you want.

---

**User**

Yes, please apply the patch set.

---

**Cursor**

I'll apply the platform sleep cleanup, switch CI to `pasim`, and remove the unbounded debug `waitFor` in the Patmos test harness.

Applied the full patch set:

1. **`lf_patmos_support.c`** (reactor-c submodule)  
   - Removed debug `printf`s  
   - Early-out when wakeup is already past / duration ≤ 0  
   - Widening multiply: `(instant_t)get_cpu_usecs() * 1000LL`

2. **`CPatmosTest.java`**  
   - Simulator: `patemu` → `pasim`  
   - Removed the unbounded debug `waitFor()` pre-run and related debug noise

3. **`Configurators.makePatmosCompatible`**  
   - Sets `fast: true` so smoke tests skip physical busy-waits on the emulator

Note: the sleep change is in the `reactor-c` submodule working tree (`m` in git status). You’ll need a submodule commit (and pointer bump in the parent) before CI picks that part up; the Java changes are in the parent repo only.
