### PR TITLE
Fixed federate self loops.

### DIFF
--- a/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
+++ b/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
@@ -575,12 +575,11 @@ public class FederateInstance {
       FederateInstance end, FederateInstance next, HashSet<FederateInstance> visited) {
     next.sendsTo.forEach(
         (destination, setOfDelays) -> {
-          // Return if we've already found a cycle.
-          // Also skip self loops because these get optimized away.
-          // Also skip any we've visited.
-          if (end._isInZeroDelayCycle
-              || (end == next && destination == next)
-              || visited.contains(destination)) return;
+          // Return if we've already found a cycle or already visited this destination.
+          // Note: zero-delay self-loops (destination == next) are not skipped; they are
+          // genuine ZDCs and must trigger port-absent / MLAA handling even though the
+          // connection still routes through the RTI.
+          if (end._isInZeroDelayCycle || visited.contains(destination)) return;
           if (setOfDelays.contains(null)) {
             // Only if we have a zero-delay connection to destination do we add it to visited.
             // If we have a delayed connection to destination, we should not skip a future
@@ -589,7 +588,7 @@ public class FederateInstance {
             visited.add(destination);
             // There is a zero-delay connection to destination.
             if (destination == end) {
-              // Found a zero delay cycle.
+              // Found a zero delay cycle (including a self-loop on end).
               end._isInZeroDelayCycle = true;
               return;
             }

--- a/test/C/src/federated/FederatedFeedback.lf
+++ b/test/C/src/federated/FederatedFeedback.lf
@@ -1,0 +1,24 @@
+target C {
+  timeout: 1 ms
+}
+
+reactor UI {
+  input current_value: int
+  output out: int
+
+  reaction(startup) -> out {=
+    lf_set(out, 42);
+  =}
+
+  reaction(current_value) {=
+    lf_print("UI: current_value = %d", current_value->value);
+    if (current_value->value != 42) {
+      lf_print_error_and_exit("Expected 42.");
+    }
+  =}
+}
+
+federated reactor {
+  u = new UI()
+  u.out -> u.current_value
+}

--- a/test/Python/src/federated/FederatedFeedback.lf
+++ b/test/Python/src/federated/FederatedFeedback.lf
@@ -1,0 +1,24 @@
+target Python {
+  timeout: 1 ms
+}
+
+reactor UI {
+  input current_value
+  output out
+
+  reaction(startup) -> out {=
+    out.set(42)
+  =}
+
+  reaction(current_value) {=
+    print(f"UI: current_value = {current_value.value}")
+    if current_value.value != 42:
+      print("Expected 42.")
+      self.sys.exit(1)
+  =}
+}
+
+federated reactor {
+  u = new UI()
+  u.out -> u.current_value
+}


### PR DESCRIPTION
This PR fixes a bug where the code generator assumed that a federated self loop would be kept local, but this optimization was never implemented. It turns out that such an optimization is quite complicated because of banks and multiparty: the self loop could involve more than one connection, and not all of them should be local (because of banks). This PR implements a simpler fix which is to treat such self loops as ordinary connections.  The user can always use an extra level of hierarchy to keep such connections local.