### PR TITLE
Support numbers in import package names

### DIFF
--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -37,7 +37,7 @@ Model:
 /**
  * Import declaration.
  */
-Import: 'import' reactorClasses+=ImportedReactor (',' reactorClasses+=ImportedReactor)* 'from' (importURI=STRING | '<' importPackage=Path '>') ';'?;
+Import: 'import' reactorClasses+=ImportedReactor (',' reactorClasses+=ImportedReactor)* 'from' (importURI=STRING | '<' importPackage=PackagePath '>') ';'?;
 
 ReactorDecl: Reactor | ImportedReactor;
 
@@ -468,6 +468,15 @@ FSName:
 // Absolute or relative directory path in Windows, Linux, or MacOS.
 Path:
     (FSName ':\\')? ('\\' | '/')? FSName (('\\' | '/') FSName)*
+;
+
+// Like Path, but allows numeric segments (INT/NEGINT). Used only for
+// package imports inside <...>, so Element's Literal vs Path stay unambiguous.
+PackageFSName:
+    (ID | INT | NEGINT | '.' | '_' | '-')+
+;
+PackagePath:
+    (PackageFSName ':\\')? ('\\' | '/')? PackageFSName (('\\' | '/') PackageFSName)*
 ;
 
 /////////// Enums

--- a/test/Python/lf-packages/library-test-3-numeric-name/src/lib/Import.lf
+++ b/test/Python/lf-packages/library-test-3-numeric-name/src/lib/Import.lf
@@ -1,0 +1,12 @@
+target Python
+
+reactor Count(offset=0, period = 1 sec) {
+  state count = 1
+  output out
+  timer t(offset, period)
+
+  reaction(t) -> out {=
+    out.set(self.count)
+    self.count += 1
+  =}
+}

--- a/test/Python/lf-packages/library-test-3numeric-name/src/lib/Import.lf
+++ b/test/Python/lf-packages/library-test-3numeric-name/src/lib/Import.lf
@@ -1,0 +1,12 @@
+target Python
+
+reactor Count(offset=0, period = 1 sec) {
+  state count = 1
+  output out
+  timer t(offset, period)
+
+  reaction(t) -> out {=
+    out.set(self.count)
+    self.count += 1
+  =}
+}

--- a/test/Python/src/lf_package_imports/TestImportPackagesNumeric.lf
+++ b/test/Python/src/lf_package_imports/TestImportPackagesNumeric.lf
@@ -1,0 +1,21 @@
+# Test the import statement for packages installed in the local lf-packages directory with the import
+# path enclosed in angle brackets
+target Python {
+  timeout: 2 sec
+}
+
+import Count from <library-test-3-numeric-name/Import.lf>
+
+reactor Actuator {
+  input results
+
+  reaction(results) {=
+    print(f"Count: {results.value}")
+  =}
+}
+
+main reactor {
+  count = new Count()
+  act = new Actuator()
+  count.out -> act.results
+}

--- a/test/Python/src/lf_package_imports/TestImportPackagesNumeric2.lf
+++ b/test/Python/src/lf_package_imports/TestImportPackagesNumeric2.lf
@@ -1,0 +1,21 @@
+# Test the import statement for packages installed in the local lf-packages directory with the import
+# path enclosed in angle brackets
+target Python {
+  timeout: 2 sec
+}
+
+import Count from <library-test-3numeric-name/Import.lf>
+
+reactor Actuator {
+  input results
+
+  reaction(results) {=
+    print(f"Count: {results.value}")
+  =}
+}
+
+main reactor {
+  count = new Count()
+  act = new Actuator()
+  count.out -> act.results
+}


### PR DESCRIPTION
This PR allows imported package names to have numbers so that package names like `pololu-3pi-c` are supported. This required adjusting the grammar so that such names work after tokenizing.