### PR TITLE
For lfc-dev etc, do not build lsp and use cache if possible

### DIFF
--- a/bin/lfc-dev
+++ b/bin/lfc-dev
@@ -70,7 +70,7 @@ while [[ $# -gt 0 ]]; do
             echo "Build and run the Lingua Franca compiler (lfc)."
             echo ""
             echo "Options:"
-            echo "  --offline    Run Gradle in offline mode"
+            echo "  --offline    Run Gradle in offline mode only (no network fallback)"
             echo "  -h, --help   Show this help message"
             echo ""
             echo "All other arguments are passed to the lfc compiler."
@@ -83,6 +83,16 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Launch the tool.
-"${gradlew}" --quiet ${gradle_args} -p "${base}" assemble ":cli:lfc:assemble"
-"${base}/build/install/lf-cli/bin/lfc" "${lfc_args[@]}"
+# Build only the lfc CLI (not the whole project, which would also build :lsp).
+# Try offline first so dev workflows work without network after an initial build.
+build_lfc() {
+    "${gradlew}" --quiet "$@" -p "${base}" ":cli:lfc:installDist"
+}
+
+if [[ "${gradle_args}" == *"--offline"* ]]; then
+    build_lfc --offline
+elif ! build_lfc --offline; then
+    build_lfc
+fi
+
+"${base}/cli/lfc/build/install/lfc/bin/lfc" "${lfc_args[@]}"

--- a/bin/lfc-dev.ps1
+++ b/bin/lfc-dev.ps1
@@ -10,6 +10,11 @@
 $base="$PSScriptRoot\..\"
 $gradlew="${base}/gradlew.bat"
 
-# invoke script
-& "${gradlew}" --quiet -p "${base}" assemble ":cli:lfc:assemble"
-& "${base}/build/install/lf-cli/bin/lfc" @args
+# Build only the lfc CLI (not the whole project, which would also build :lsp).
+# Try offline first so dev workflows work without network after an initial build.
+$buildArgs = @("--quiet", "-p", "${base}", ":cli:lfc:installDist")
+& "${gradlew}" @buildArgs --offline
+if ($LASTEXITCODE -ne 0) {
+    & "${gradlew}" @buildArgs
+}
+& "${base}/cli/lfc/build/install/lfc/bin/lfc" @args

--- a/bin/lfd-dev
+++ b/bin/lfd-dev
@@ -54,6 +54,14 @@ fi
 
 gradlew="${base}/gradlew"
 
-# Launch the tool.
-"${gradlew}" --quiet -p "${base}" assemble ":cli:lfd:assemble"
-"${base}/build/install/lf-cli/bin/lfd" "$@"
+# Build only the lfd CLI (not the whole project, which would also build :lsp).
+# Try offline first so dev workflows work without network after an initial build.
+build_lfd() {
+    "${gradlew}" --quiet "$@" -p "${base}" ":cli:lfd:installDist"
+}
+
+if ! build_lfd --offline; then
+    build_lfd
+fi
+
+"${base}/cli/lfd/build/install/lfd/bin/lfd" "$@"

--- a/bin/lfd-dev.ps1
+++ b/bin/lfd-dev.ps1
@@ -10,6 +10,11 @@
 $base="$PSScriptRoot\..\"
 $gradlew="${base}/gradlew.bat"
 
-# invoke script
-& "${gradlew}" --quiet -p "${base}" assemble ":cli:lfd:assemble"
-& "${base}/build/install/lf-cli/bin/lfd" @args
+# Build only the lfd CLI (not the whole project, which would also build :lsp).
+# Try offline first so dev workflows work without network after an initial build.
+$buildArgs = @("--quiet", "-p", "${base}", ":cli:lfd:installDist")
+& "${gradlew}" @buildArgs --offline
+if ($LASTEXITCODE -ne 0) {
+    & "${gradlew}" @buildArgs
+}
+& "${base}/cli/lfd/build/install/lfd/bin/lfd" @args

--- a/bin/lff-dev
+++ b/bin/lff-dev
@@ -54,6 +54,14 @@ fi
 
 gradlew="${base}/gradlew"
 
-# Launch the tool.
-"${gradlew}" --quiet -p "${base}" assemble ":cli:lff:assemble"
-"${base}/build/install/lf-cli/bin/lff" "$@"
+# Build only the lff CLI (not the whole project, which would also build :lsp).
+# Try offline first so dev workflows work without network after an initial build.
+build_lff() {
+    "${gradlew}" --quiet "$@" -p "${base}" ":cli:lff:installDist"
+}
+
+if ! build_lff --offline; then
+    build_lff
+fi
+
+"${base}/cli/lff/build/install/lff/bin/lff" "$@"

--- a/bin/lff-dev.ps1
+++ b/bin/lff-dev.ps1
@@ -10,6 +10,11 @@
 $base="$PSScriptRoot\..\"
 $gradlew="${base}/gradlew.bat"
 
-# invoke script
-& "${gradlew}" --quiet -p "${base}" assemble ":cli:lff:assemble"
-& "${base}/build/install/lf-cli/bin/lff" @args
+# Build only the lff CLI (not the whole project, which would also build :lsp).
+# Try offline first so dev workflows work without network after an initial build.
+$buildArgs = @("--quiet", "-p", "${base}", ":cli:lff:installDist")
+& "${gradlew}" @buildArgs --offline
+if ($LASTEXITCODE -ne 0) {
+    & "${gradlew}" @buildArgs
+}
+& "${base}/cli/lff/build/install/lff/bin/lff" @args

--- a/buildSrc/src/main/groovy/org.lflang.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.lflang.java-conventions.gradle
@@ -36,6 +36,11 @@ java {
 
 configurations.all {
     resolutionStrategy {
+        // Pin version ranges from transitive Eclipse/sprotty dependencies so Gradle
+        // does not need to fetch maven-metadata.xml (required for offline builds).
+        force 'jakarta.platform:jakarta.jakartaee-api:10.0.0'
+        force 'log4j:log4j:1.2.17'
+
         dependencySubstitution {
             // The maven property ${osgi.platform} is not handled by Gradle
             // so we replace the dependency, using the osgi platform from the project settings


### PR DESCRIPTION
Previously, if you wanted to use `lfc-dev` (and `lfd-dev` and `lff-dev`) while offline, you could specify the `--offline` argument, and it would attempt to use locally cached metadata from previous builds rather than downloading fresh metadata. This PR changes these scripts to attempt to use locally cached metadata regardless of the argument and to resort to downloading data only if the local cache is missing.

In addition, the scripts now run `cli:lfc:installDist` instead of the root `./gradlew assemble`, so it does not build the `:lsp` (language-server protocol) module.

This also pins the dynamic version ranges in `org.lflang.java-conventions.gradle` so Gradle doesn't need metadata lookups for them:

```
force 'jakarta.platform:jakarta.jakartaee-api:10.0.0'
force 'log4j:log4j:1.2.17'
```