### PR TITLE
Improve handling of zero-delay cycles for decentralized coordination

### DIFF
--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -170,7 +170,7 @@ public class FedASTUtils {
     addNetworkSenderReactor(connection, coordination, resource, messageReporter);
 
     // Add port absent reactions only if the federate is in a zero delay cycle.
-    if (connection.srcFederate.isInZeroDelayCycle()) {
+    if (isInZeroDelayCycle(connection)) {
       FedASTUtils.addPortAbsentReaction(connection);
     }
 
@@ -318,8 +318,7 @@ public class FedASTUtils {
     connection.dstFederate.networkMessageActions.add(networkAction);
     connection.dstFederate.networkMessageSourceFederate.add(connection.srcFederate);
     connection.dstFederate.networkMessageActionDelays.add(connection.getDefinition().getDelay());
-    if (connection.srcFederate.isInZeroDelayCycle()
-        && connection.getDefinition().getDelay() == null) {
+    if (isInZeroDelayCycle(connection)) {
       connection.dstFederate.zeroDelayCycleNetworkMessageActions.add(networkAction);
       connection.dstFederate.zeroDelayCycleNetworkUpstreamFeds.add(connection.srcFederate);
     }
@@ -407,6 +406,18 @@ public class FedASTUtils {
     connection.dstFederate.networkPortToInstantiation.put(
         connection.getDestinationPortInstance(), networkInstance);
     connection.dstFederate.networkActionToInstantiation.put(networkAction, networkInstance);
+  }
+
+  /**
+   * Return true if the connection is in a zero-delay cycle.
+   * @param connection The connection to check.
+   * @return True if the connection is in a zero-delay cycle, false otherwise.
+   */
+  private static boolean isInZeroDelayCycle(FedConnectionInstance connection) {
+    return connection.srcFederate.isInZeroDelayCycle()
+        && connection.dstFederate.isInZeroDelayCycle()
+        && connection.getDefinition().getDelay() == null
+        && !connection.getDefinition().isPhysical();
   }
 
   private static MixedRadixInt getSrcIndex(FedConnectionInstance connection) {
@@ -674,9 +685,7 @@ public class FedASTUtils {
     // On a zero-delay cycle, wait for a present or port-absent message from the
     // peer rather than assuming the input is absent immediately (STAA of 0).
     // An explicit `@absent_after` above remains a safety timeout.
-    if (connection.srcFederate.isInZeroDelayCycle()
-        && connection.dstFederate.isInZeroDelayCycle()
-        && connection.getDefinition().getDelay() == null) {
+    if (isInZeroDelayCycle(connection)) {
       return TimeValue.FOREVER;
     }
     return TimeValue.ZERO;
@@ -759,7 +768,7 @@ public class FedASTUtils {
 
     // The initialization reaction is needed only for the reaction that sends absent, which is
     // not included if the sending federate is not a zero-delay cycle.
-    if (connection.srcFederate.isInZeroDelayCycle()) {
+    if (isInZeroDelayCycle(connection)) {
       sender
           .getReactions()
           .add(getInitializationReaction(extension, extension.outputInitializationBody()));

--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -546,10 +546,10 @@ public class FedASTUtils {
    * If the connection does not have an `absent_after` attribute, find the maximum STP
    * or STAA for the reactions that react to the destination port (for backward compatibility).
    * This maximum may be nested in contained reactors in the federate.
-   * If there is still no offset and the source federate is in a zero-delay cycle with no
-   * `after` delay, return TimeValue.FOREVER so the destination waits for a present or
+   * If there is still no offset and this zero-delay logical connection joins federates that are
+   * each in a zero-delay cycle, return TimeValue.FOREVER so the destination waits for a present or
    * port-absent message instead of assuming the port is absent immediately.
-   * This method returns TimeValue.ZERO if there are no `absent_after` offsets for the port.
+   * Otherwise, this method returns TimeValue.ZERO.
    * @param connection The connection to find the `absent_after` offset for.
    * @param coordination The coordination scheme.
    */

--- a/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedASTUtils.java
@@ -546,6 +546,9 @@ public class FedASTUtils {
    * If the connection does not have an `absent_after` attribute, find the maximum STP
    * or STAA for the reactions that react to the destination port (for backward compatibility).
    * This maximum may be nested in contained reactors in the federate.
+   * If there is still no offset and the source federate is in a zero-delay cycle with no
+   * `after` delay, return TimeValue.FOREVER so the destination waits for a present or
+   * port-absent message instead of assuming the port is absent immediately.
    * This method returns TimeValue.ZERO if there are no `absent_after` offsets for the port.
    * @param connection The connection to find the `absent_after` offset for.
    * @param coordination The coordination scheme.
@@ -558,10 +561,9 @@ public class FedASTUtils {
 
     // Start by checking for an `absent_after` attribute on the connection.
     Connection conn = connection.getDefinition();
-    // If the connection has an `absent_after` attribute, return it.
-    var absentAfter = AttributeUtils.getAbsentAfter(conn);
-    if (absentAfter != TimeValue.ZERO) {
-      return absentAfter;
+    // If the connection has an explicit `absent_after` attribute, use it (including 0).
+    if (AttributeUtils.hasAbsentAfter(conn)) {
+      return AttributeUtils.getAbsentAfter(conn);
     }
 
     // For backward compatibility, check for STP offsets on the reactions that
@@ -660,10 +662,24 @@ public class FedASTUtils {
       }
     }
 
-    return STPList.stream()
-        .map(ASTUtils::getLiteralTimeValue)
-        .filter(Objects::nonNull)
-        .reduce(TimeValue.ZERO, TimeValue::max);
+    TimeValue fromReactions =
+        STPList.stream()
+            .map(ASTUtils::getLiteralTimeValue)
+            .filter(Objects::nonNull)
+            .reduce(TimeValue.ZERO, TimeValue::max);
+    if (fromReactions.compareTo(TimeValue.ZERO) > 0) {
+      return fromReactions;
+    }
+
+    // On a zero-delay cycle, wait for a present or port-absent message from the
+    // peer rather than assuming the input is absent immediately (STAA of 0).
+    // An explicit `@absent_after` above remains a safety timeout.
+    if (connection.srcFederate.isInZeroDelayCycle()
+        && connection.dstFederate.isInZeroDelayCycle()
+        && connection.getDefinition().getDelay() == null) {
+      return TimeValue.FOREVER;
+    }
+    return TimeValue.ZERO;
   }
 
   /**

--- a/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
+++ b/core/src/main/java/org/lflang/federated/generator/FedGenerator.java
@@ -686,8 +686,10 @@ public class FedGenerator {
                       dstFederate,
                       FedUtils.getSerializer(srcRange.connection, srcFederate, dstFederate));
 
-              // Create the maps that specify the delays (or absence of delays)
-              // on non-physical connections (for centralized coordination only).
+              // Record delays on non-physical connections for centralized coordination.
+              // These maps drive RTI neighbor-structure and NET/TAG signaling, so they
+              // must not be populated for decentralized coordination. Zero-delay cycle
+              // detection uses FederateInstance.connections instead, which is always filled.
               if (!connection.getDefinition().isPhysical()
                   && targetConfig.get(CoordinationProperty.INSTANCE)
                       != CoordinationMode.DECENTRALIZED) {

--- a/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
+++ b/core/src/main/java/org/lflang/federated/generator/FederateInstance.java
@@ -573,6 +573,10 @@ public class FederateInstance {
    * determine whether absent messages need to be sent. Note that this is not the same as causality
    * loop detection. A federate may be in a zero-delay cycle (ZDC) even if there is no causality
    * loop.
+   *
+   * <p>This walks {@link #connections} rather than {@link #sendsTo}. The {@code sendsTo} map is
+   * populated only for centralized coordination (it also drives RTI neighbor-structure and NET/TAG
+   * signaling), so using it here would miss zero-delay cycles under decentralized coordination.
    */
   public boolean isInZeroDelayCycle() {
     if (_isInZeroDelayCycleCalculated) return _isInZeroDelayCycle;
@@ -584,28 +588,28 @@ public class FederateInstance {
   /** Internal helper function for isInZeroDelayCycle(). */
   private boolean _isInZeroDelayCycleInternal(
       FederateInstance end, FederateInstance next, HashSet<FederateInstance> visited) {
-    next.sendsTo.forEach(
-        (destination, setOfDelays) -> {
-          // Return if we've already found a cycle or already visited this destination.
-          // Note: zero-delay self-loops (destination == next) are not skipped; they are
-          // genuine ZDCs and must trigger port-absent / MLAA handling even though the
-          // connection still routes through the RTI.
-          if (end._isInZeroDelayCycle || visited.contains(destination)) return;
-          if (setOfDelays.contains(null)) {
-            // Only if we have a zero-delay connection to destination do we add it to visited.
-            // If we have a delayed connection to destination, we should not skip a future
-            // zero-delay
-            // connection there.
-            visited.add(destination);
-            // There is a zero-delay connection to destination.
-            if (destination == end) {
-              // Found a zero delay cycle (including a self-loop on end).
-              end._isInZeroDelayCycle = true;
-              return;
-            }
-            _isInZeroDelayCycleInternal(end, destination, visited);
-          }
-        });
+    for (FedConnectionInstance connection : next.connections) {
+      // connections includes both incoming and outgoing; follow only outgoing edges.
+      if (connection.srcFederate != next) continue;
+      // Physical connections (~>) are not zero-delay logical paths.
+      if (connection.getDefinition().isPhysical()) continue;
+      FederateInstance destination = connection.dstFederate;
+      // Skip if we've already found a cycle or already visited this destination.
+      // Note: zero-delay self-loops (destination == next) are not skipped; they are
+      // genuine ZDCs and must trigger port-absent / MLAA handling even though the
+      // connection still routes through the RTI.
+      if (end._isInZeroDelayCycle || visited.contains(destination)) continue;
+      // Only zero-delay (no `after`) connections count. A delayed connection to
+      // destination must not prevent a future zero-delay path there from being considered.
+      if (connection.getDefinition().getDelay() != null) continue;
+      visited.add(destination);
+      if (destination == end) {
+        // Found a zero delay cycle (including a self-loop on end).
+        end._isInZeroDelayCycle = true;
+        return true;
+      }
+      _isInZeroDelayCycleInternal(end, destination, visited);
+    }
     return end._isInZeroDelayCycle;
   }
 

--- a/test/Python/src/federated/ZDCDecentralized.lf
+++ b/test/Python/src/federated/ZDCDecentralized.lf
@@ -1,0 +1,93 @@
+target Python {
+  timeout: 50 ms,
+  coordination: decentralized
+}
+
+preamble {=
+  import time
+=}
+
+reactor Sensor {
+  output s
+  timer t(0, 10ms)  // Sample at 100 Hz
+
+  reaction s1(t) -> s {=
+    s.set(42)
+    print("Sensor produced output.")
+  =}
+}
+
+reactor Planner {
+  input s
+  output e
+    
+  // Reaction 1: Collect sensor data in buffer
+  reaction p1(s) -> e {=
+    time.sleep(0.02)
+    e.set(42)
+    print("Planner produced output.")
+  =}
+}
+
+/**
+ * Controller that receives high-frequency sensor data and periodic state estimates.
+ * Makes control decisions based on both.
+ */
+reactor Controller {
+  input s
+  input e
+  output p
+  output c
+  state count = 0
+
+  reaction c1(s) -> p {=
+    if self.count % 2 == 0:
+      p.set(42)
+      print("Controller requesting planning.")
+    else:
+      print("Controller skipping planning.")
+    self.count = self.count + 1
+  =}
+    
+  reaction c2(e) {=
+    print("Controller received planning information.")
+  =}
+  
+  reaction c3(s) -> c {=
+    c.set(42)
+    print("Controller sending control signal")
+  =}
+}
+
+/**
+ * Actuator that receives control signals and takes action.
+ */
+reactor Actuator {
+  input c  
+  reaction a1(c) {=
+    print("Actuator received command.")
+  =}
+}
+
+reactor Control {
+  input e
+  output p
+  
+  actuator = new Actuator()
+  sensor = new Sensor()
+  controller = new Controller()
+  sensor.s -> controller.s
+  controller.c -> actuator.c
+  e -> controller.e
+  controller.p -> p
+}
+
+federated reactor {
+  planner = new Planner()
+  @maxwait(0)
+  control = new Control()
+  # absent_after defaults to forever because of ZDC
+  control.p -> planner.s
+  @absent_after(5s)
+  planner.e -> control.e
+}

--- a/test/Python/src/federated/ZDCDecentralized.lf
+++ b/test/Python/src/federated/ZDCDecentralized.lf
@@ -9,7 +9,7 @@ preamble {=
 
 reactor Sensor {
   output s
-  timer t(0, 10ms)  // Sample at 100 Hz
+  timer t(0, 10 ms)  # Sample at 100 Hz
 
   reaction s1(t) -> s {=
     s.set(42)
@@ -20,8 +20,8 @@ reactor Sensor {
 reactor Planner {
   input s
   output e
-    
-  // Reaction 1: Collect sensor data in buffer
+
+  # Reaction 1: Collect sensor data in buffer
   reaction p1(s) -> e {=
     time.sleep(0.02)
     e.set(42)
@@ -30,8 +30,8 @@ reactor Planner {
 }
 
 /**
- * Controller that receives high-frequency sensor data and periodic state estimates.
- * Makes control decisions based on both.
+ * Controller that receives high-frequency sensor data and periodic state estimates. Makes control
+ * decisions based on both.
  */
 reactor Controller {
   input s
@@ -48,22 +48,21 @@ reactor Controller {
       print("Controller skipping planning.")
     self.count = self.count + 1
   =}
-    
+
   reaction c2(e) {=
     print("Controller received planning information.")
   =}
-  
+
   reaction c3(s) -> c {=
     c.set(42)
     print("Controller sending control signal")
   =}
 }
 
-/**
- * Actuator that receives control signals and takes action.
- */
+/** Actuator that receives control signals and takes action. */
 reactor Actuator {
-  input c  
+  input c
+
   reaction a1(c) {=
     print("Actuator received command.")
   =}
@@ -72,7 +71,7 @@ reactor Actuator {
 reactor Control {
   input e
   output p
-  
+
   actuator = new Actuator()
   sensor = new Sensor()
   controller = new Controller()
@@ -86,8 +85,7 @@ federated reactor {
   planner = new Planner()
   @maxwait(0)
   control = new Control()
-  # absent_after defaults to forever because of ZDC
-  control.p -> planner.s
-  @absent_after(5s)
+  control.p -> planner.s  # absent_after defaults to forever because of ZDC
+  @absent_after(5 s)
   planner.e -> control.e
 }


### PR DESCRIPTION
Before this PR, zero-delay cycles in decentralized coordination did not send port-absent messages. This PR changes that so they now do. It also fixes an issue where an idle federate would not forward port-absent messages in response to incoming port-absent messages. It also sets the default `absent_after` to `forever` on the connections on a zero-delay loop, giving a conservative behavior by default.