### PR TITLE
Support bodyless deadlines

### DIFF
--- a/core/src/main/java/org/lflang/LinguaFranca.xtext
+++ b/core/src/main/java/org/lflang/LinguaFranca.xtext
@@ -188,7 +188,7 @@ BuiltinTriggerRef:
     type = BuiltinTrigger;
 
 Deadline:
-    'deadline' '(' delay=Expression ')' code=Code;
+    'deadline' '(' delay=Expression ')' (code=Code)?;
 
 Watchdog:
     (attributes+=Attribute)*

--- a/core/src/main/java/org/lflang/ast/ToLf.java
+++ b/core/src/main/java/org/lflang/ast/ToLf.java
@@ -721,8 +721,12 @@ public class ToLf extends LfSwitch<MalleableString> {
 
   @Override
   public MalleableString caseDeadline(Deadline object) {
-    // 'deadline' '(' delay=Expression ')' code=Code
-    return handler(object, "deadline", Deadline::getDelay, Deadline::getCode);
+    // 'deadline' '(' delay=Expression ')' (code=Code)?
+    if (object.getCode() != null) {
+      return handler(object, "deadline", Deadline::getDelay, Deadline::getCode);
+    } else {
+      return new Builder().append("deadline").append(list(false, object.getDelay())).get();
+    }
   }
 
   @Override

--- a/core/src/main/java/org/lflang/ast/ToSExpr.java
+++ b/core/src/main/java/org/lflang/ast/ToSExpr.java
@@ -509,7 +509,7 @@ public class ToSExpr extends LfSwitch<SExpr> {
   @Override
   public SExpr caseDeadline(Deadline object) {
     //        Deadline:
-    //        'deadline' '(' delay=Expression ')' code=Code;
+    //        'deadline' '(' delay=Expression ')' (code=Code)?;
     return sList("deadline", object.getDelay(), object.getCode());
   }
 

--- a/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
+++ b/core/src/main/java/org/lflang/diagram/synthesis/styles/LinguaFrancaShapeExtensions.java
@@ -460,6 +460,7 @@ public class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
     if (reaction.declaredDeadline != null) {
       boolean hasDeadlineCode =
           getBooleanValue(LinguaFrancaSynthesis.SHOW_REACTION_CODE)
+              && reaction.getDefinition().getDeadline().getCode() != null
               && !StringExtensions.isNullOrEmpty(
                   reaction.getDefinition().getDeadline().getCode().getBody());
       if (hasCode || hasDeadlineCode) {

--- a/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/c/CReactionGenerator.java
@@ -928,8 +928,15 @@ public class CReactionGenerator {
 
       var deadlineFunctionPointer = "NULL";
       if (reaction.getDeadline() != null) {
-        // The following has to match the name chosen in generateReactions
-        var deadlineFunctionName = generateDeadlineFunctionName(tpr, reactionCount);
+        String deadlineFunctionName;
+        if (reaction.getDeadline().getCode() != null) {
+          // There is a deadline violation handler.
+          // The following has to match the name chosen in generateReactions
+          deadlineFunctionName = generateDeadlineFunctionName(tpr, reactionCount);
+        } else {
+          // There is no deadline handler body. Invoke the ordinary reaction.
+          deadlineFunctionName = generateReactionFunctionName(tpr, reactionCount);
+        }
         deadlineFunctionPointer = "&" + deadlineFunctionName;
       }
 
@@ -1228,7 +1235,7 @@ public class CReactionGenerator {
     }
 
     // Now generate code for the deadline violation function, if there is one.
-    if (reaction.getDeadline() != null) {
+    if (reaction.getDeadline() != null && reaction.getDeadline().getCode() != null) {
       code.pr(
           generateFunction(
               generateDeadlineFunctionHeader(tpr, reactionIndex),

--- a/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonGenerator.java
@@ -582,7 +582,7 @@ public class PythonGenerator extends CGenerator implements CCmakeGenerator.SetUp
                 + PythonReactionGenerator.generateCPythonSTPFunctionName(reactionIndex)
                 + ";");
       }
-      if (reaction.getDeadline() != null) {
+      if (reaction.getDeadline() != null && reaction.getDeadline().getCode() != null) {
         selfStructBody.pr(
             "PyObject* "
                 + PythonReactionGenerator.generateCPythonDeadlineFunctionName(reactionIndex)

--- a/core/src/main/java/org/lflang/generator/python/PythonReactionGenerator.java
+++ b/core/src/main/java/org/lflang/generator/python/PythonReactionGenerator.java
@@ -200,7 +200,7 @@ public class PythonReactionGenerator {
               generateCPythonSTPCaller(tpr, reactionIndex, pyObjects)));
     }
     // Generate code for the deadline violation function, if there is one.
-    if (reaction.getDeadline() != null) {
+    if (reaction.getDeadline() != null && reaction.getDeadline().getCode() != null) {
       code.pr(
           generateFunction(
               CReactionGenerator.generateDeadlineFunctionHeader(tpr, reactionIndex),
@@ -476,7 +476,8 @@ public class PythonReactionGenerator {
               nameOfSelfStruct, generateCPythonSTPFunctionName(reaction.index),
               instance, generatePythonSTPFunctionName(reaction.index)));
     }
-    if (reaction.getDefinition().getDeadline() != null) {
+    if (reaction.getDefinition().getDeadline() != null
+        && reaction.getDefinition().getDeadline().getCode() != null) {
       code.pr(
           generateCPythonFunctionLinker(
               nameOfSelfStruct, generateCPythonDeadlineFunctionName(reaction.index),
@@ -596,7 +597,7 @@ public class PythonReactionGenerator {
               reactionParameters));
     }
     // Generate code for the deadline violation function, if there is one.
-    if (reaction.getDeadline() != null) {
+    if (reaction.getDeadline() != null && reaction.getDeadline().getCode() != null) {
       code.pr(
           generatePythonFunction(
               generatePythonDeadlineFunctionName(reactionIndex),

--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppAssembleMethodGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppAssembleMethodGenerator.kt
@@ -141,7 +141,10 @@ class CppAssembleMethodGenerator(private val reactor: Reactor) {
     private fun setDeadline(reaction: Reaction): String {
         val delay = reaction.deadline.delay
         val value = if (delay is ParameterReference) "__lf_inner.${delay.parameter.name}" else delay.toCppTime()
-        return "${reaction.codeName}.set_deadline($value, [this]() { ${reaction.codeName}_deadline_handler(); });"
+        val handler =
+            if (reaction.deadline.code != null) "${reaction.codeName}_deadline_handler()"
+            else "${reaction.codeName}_body()"
+        return "${reaction.codeName}.set_deadline($value, [this]() { $handler; });"
     }
 
     private fun assembleReaction(reaction: Reaction): String {

--- a/core/src/main/kotlin/org/lflang/generator/cpp/CppReactionGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/cpp/CppReactionGenerator.kt
@@ -48,7 +48,8 @@ class CppReactionGenerator(
     private val portGenerator: CppPortGenerator
 ) {
 
-    private val reactionsWithDeadlines = reactor.reactions.filter { it.deadline != null }
+    private val reactionsWithDeadlineHandlers =
+        reactor.reactions.filter { it.deadline != null && it.deadline.code != null }
 
     private val VarRef.isContainedRef: Boolean get() = container != null
     private val TriggerRef.isContainedRef: Boolean get() = this is VarRef && isContainedRef
@@ -106,7 +107,7 @@ class CppReactionGenerator(
             val deadlineHandler =
                 "void ${codeName}_deadline_handler() { __lf_inner.${codeName}_deadline_handler(${parameters.joinToString(", ")}); }"
 
-            return if (deadline == null)
+            return if (deadline == null || deadline.code == null)
                 """
                     $body
                     reactor::Reaction $codeName{"$label", $priority, this, [this]() { ${codeName}_body(); }};
@@ -259,11 +260,11 @@ class CppReactionGenerator(
 
     /** Get all declarations of deadline handlers. */
     fun generateDeadlineHandlerDeclarations(): String =
-        reactionsWithDeadlines.joinToString("\n", "// deadline handlers\n", "\n") {
+        reactionsWithDeadlineHandlers.joinToString("\n", "// deadline handlers\n", "\n") {
             generateFunctionDeclaration(it, "deadline_handler")
         }
 
     /** Get all definitions of deadline handlers. */
     fun generateDeadlineHandlerDefinitions() =
-        reactionsWithDeadlines.joinToString(separator = "\n", postfix = "\n") { generateDeadlineHandlerDefinition(it) }
+        reactionsWithDeadlineHandlers.joinToString(separator = "\n", postfix = "\n") { generateDeadlineHandlerDefinition(it) }
 }

--- a/core/src/main/kotlin/org/lflang/generator/ts/TSReactionGenerator.kt
+++ b/core/src/main/kotlin/org/lflang/generator/ts/TSReactionGenerator.kt
@@ -67,7 +67,7 @@ class TSReactionGenerator(
         ${" |    "..reactPrologue}
             |    // =============== END deadline prologue
             |    try {
-        ${" |        "..reaction.deadline.code.toText()}
+        ${" |        "..(reaction.deadline.code?.toText() ?: reaction.code.toText())}
             |    } finally {
             |        // =============== START deadline epilogue
         ${" |        "..reactEpilogue}

--- a/test/C/src/DeadlineBodyless.lf
+++ b/test/C/src/DeadlineBodyless.lf
@@ -1,0 +1,57 @@
+/**
+ * Test that a deadline without a handler body still executes the regular reaction body when the
+ * deadline is violated (analogous to body-less `tardy`).
+ */
+target C
+
+preamble {=
+  #ifdef __cplusplus
+  extern "C" {
+  #endif
+  #include "platform.h"
+  #ifdef __cplusplus
+  }
+  #endif
+=}
+
+reactor Deadline(threshold: time = 100 msec) {
+  input x: int
+  output done: bool
+
+  reaction(x) -> done {=
+    printf("Regular reaction body executed despite deadline violation.\n");
+    lf_set(done, true);
+  =} deadline(threshold)
+}
+
+reactor Print {
+  input in: bool
+  state success: bool = false
+
+  reaction(in) {=
+    if (in->value) {
+      printf("Output successfully produced by regular reaction body.\n");
+      self->success = true;
+    }
+  =}
+
+  reaction(shutdown) {=
+    if (!self->success) {
+      fprintf(stderr, "ERROR: Regular reaction body was not executed.\n");
+      exit(1);
+    }
+  =}
+}
+
+main reactor {
+  timer start
+  d = new Deadline(threshold = 10 msec)
+  p = new Print()
+  d.done -> p.in
+
+  reaction(start) -> d.x {=
+    instant_t sleep_time_ns = 20000000;
+    lf_sleep(sleep_time_ns);
+    lf_set(d.x, 42);
+  =}
+}

--- a/test/Cpp/src/DeadlineBodyless.lf
+++ b/test/Cpp/src/DeadlineBodyless.lf
@@ -1,0 +1,48 @@
+/**
+ * Test that a deadline without a handler body still executes the regular reaction body when the
+ * deadline is violated (analogous to body-less `tardy`).
+ */
+target Cpp
+
+reactor Deadline(threshold: time = 100 msec) {
+  private preamble {=
+    #include <thread>
+  =}
+  input x: int
+  output done: bool
+
+  reaction(x) -> done {=
+    std::cout << "Regular reaction body executed despite deadline violation." << std::endl;
+    done.set(true);
+  =} deadline(threshold)
+}
+
+reactor Print {
+  input in: bool
+  state success: bool = false
+
+  reaction(in) {=
+    if (*in.get()) {
+      std::cout << "Output successfully produced by regular reaction body." << std::endl;
+      success = true;
+    }
+  =}
+
+  reaction(shutdown) {=
+    if (!success) {
+      std::cerr << "ERROR: Regular reaction body was not executed." << std::endl;
+      exit(1);
+    }
+  =}
+}
+
+main reactor {
+  d = new Deadline(threshold = 10 msec)
+  p = new Print()
+  d.done -> p.in
+
+  reaction(startup) -> d.x {=
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    d.x.set(42);
+  =}
+}

--- a/test/Python/src/DeadlineBodyless.lf
+++ b/test/Python/src/DeadlineBodyless.lf
@@ -1,0 +1,47 @@
+/**
+ * Test that a deadline without a handler body still executes the regular reaction body when the
+ * deadline is violated (analogous to body-less `tardy`).
+ */
+target Python
+
+reactor Deadline(threshold = 100 msec) {
+  input x
+  output done
+
+  reaction(x) -> done {=
+    print("Regular reaction body executed despite deadline violation.")
+    done.set(True)
+  =} deadline(threshold)
+}
+
+reactor Print {
+  input inp
+  state success = False
+
+  reaction(inp) {=
+    if inp.value is True:
+      print("Output successfully produced by regular reaction body.")
+      self.success = True
+  =}
+
+  reaction(shutdown) {=
+    if not self.success:
+      sys.stderr.write("ERROR: Regular reaction body was not executed.\n")
+      exit(1)
+  =}
+}
+
+main reactor {
+  timer start
+  d = new Deadline(threshold = 10 msec)
+  p = new Print()
+  d.done -> p.inp
+  preamble {=
+    import time
+  =}
+
+  reaction(start) -> d.x {=
+    self.time.sleep(0.02)
+    d.x.set(42)
+  =}
+}

--- a/test/TypeScript/src/DeadlineBodyless.lf
+++ b/test/TypeScript/src/DeadlineBodyless.lf
@@ -1,0 +1,49 @@
+/**
+ * Test that a deadline without a handler body still executes the regular reaction body when the
+ * deadline is violated (analogous to body-less `tardy`).
+ */
+target TypeScript
+
+reactor Deadline(threshold: time = 100 msec) {
+  input x: number
+  output done: boolean
+
+  reaction(x) -> done {=
+    console.log("Regular reaction body executed despite deadline violation.");
+    done = true;
+  =} deadline(threshold)
+}
+
+reactor Print {
+  input x: boolean
+  state success: boolean = false
+
+  reaction(x) {=
+    if (x) {
+      console.log("Output successfully produced by regular reaction body.");
+      success = true;
+    }
+  =}
+
+  reaction(shutdown) {=
+    if (!success) {
+      util.requestErrorStop("ERROR: Regular reaction body was not executed.");
+    }
+  =}
+}
+
+main reactor {
+  timer start
+  d = new Deadline(threshold = 10 msec)
+  p = new Print()
+  d.done -> p.x
+
+  reaction(start) -> d.x {=
+    let sleep_time = TimeValue.msec(20);
+    let startTime = util.getCurrentPhysicalTime();
+    let finishTime = startTime.add(sleep_time)
+    // Busy wait
+    while(util.getCurrentPhysicalTime().isEarlierThan(finishTime));
+    d.x = 42;
+  =}
+}


### PR DESCRIPTION
Like `tardy` handlers, `deadline` can now leave off the handler body as in the following example:
```
reaction(trigger) {=
   ...
}= deadline(50 ms)
```
 In this case, if the deadline is violated, the regular reaction body should be executed even though the deadline is violated.